### PR TITLE
removing it:compile

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,7 @@ pipeline:
   compile:
     <<: *sbtenv
     commands:
-      - sbt compile test:compile it:compile doc
+      - sbt compile test:compile doc
 
 #  run-unit-tests:
 #    <<: *sbtenv


### PR DESCRIPTION
## Overview
Removes it:compile which is no longer needed.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
OP-6

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
