### PR TITLE
NODE-210: Fixed image names in the docker Makefile. Added version variable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docker-push-all: \
 
 docker-build/node: .make/docker-build/universal/node .make/docker-build/test/node
 docker-build/client: .make/docker-build/universal/client
-docker-build/execution-engine: .make/docker-build/execution-engine
+docker-build/execution-engine: .make/docker-build/execution-engine .make/docker-build/test/execution-engine
 
 # Tag the `latest` build with the version from git and push it.
 # Call it like `DOCKER_PUSH_LATEST=true make docker-push/node`
@@ -112,6 +112,12 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 		.make/docker-build/universal/node \
 		docker/test-node.Dockerfile
 	docker build -f docker/test-node.Dockerfile -t $(DOCKER_USERNAME)/node:test docker
+	mkdir -p $(dir $@) && touch $@
+
+# Make a test version for the execution engine as well just so we can swith version easily.
+.make/docker-build/test/execution-engine: \
+		.make/docker-build/execution-engine
+	docker tag $(DOCKER_USERNAME)/execution-engine:latest $(DOCKER_USERNAME)/execution-engine:test
 	mkdir -p $(dir $@) && touch $@
 
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,6 @@
 CL_CASPER_NUM_VALIDATORS ?= 10
 CL_SERVER_HTTP_PORT ?= 40403
+CL_VERSION ?= latest
 
 REFRESH_TARGETS := ./monitoring/prometheus/refresh-targets.sh
 
@@ -9,12 +10,6 @@ REFRESH_TARGETS := ./monitoring/prometheus/refresh-targets.sh
 # Remove all node-N environments.
 clean: down $(shell find . -type d -name "node-*" | awk -F '/' '{print $$2"/down"}')
 	docker network rm casperlabs || exit 0
-	@# Removing genesis created by docker, using docker, due to permissions.
-	docker run --rm \
-		-v ${PWD}/.casperlabs:/root/.casperlabs \
-		--entrypoint sh \
-		io.casperlabs/node:latest \
-		-c "rm -rf /root/.casperlabs/*"
 	rm -rf .casperlabs
 	rm -rf .make
 
@@ -32,6 +27,7 @@ node-%: .casperlabs
 
 	@# Create an .env file to hold template variables for docker-compose.
 	echo NODE_NUMBER=$(N) > $(ENV)
+	echo CL_VERSION=$(CL_VERSION) >> $(ENV)
 
 	@# The name of the file is the public key. Content is the private key.
 	echo CL_VALIDATOR_PUBLIC_KEY=$(shell echo "$(KEY_FILE)" | awk -F '[/.]' '{print $$4}') >> $(ENV)
@@ -77,11 +73,25 @@ down:
 # https://alexei-led.github.io/post/pumba_docker_netem/
 delay:
 	docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock gaiaadm/pumba \
-	    netem --duration 5m --interface eth0 \
+	    netem \
+	      --duration 5m \
+	      --interface eth0 \
+	      --tc-image gaiadocker/iproute2 \
 	      delay \
 	        --time 500 \
 	        --jitter 100 \
 	        --distribution normal \
+	      re2:^node
+
+# Use the `rate` function to limit bandwidth.
+slow:
+	docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock gaiaadm/pumba \
+	    netem \
+	      --duration 5m \
+	      --interface eth0 \
+	      --tc-image gaiadocker/iproute2 \
+	      rate \
+	        --rate 100kbit \
 	      re2:^node
 
 
@@ -92,24 +102,37 @@ delay:
 # Generate keys and bonds.
 .casperlabs:
 	@# Start a node to generate keys.
+	mkdir -p .bootstrap
 	docker run --rm -d \
 		--name make-genesis \
-		-v ${PWD}/.casperlabs/genesis:/root/.casperlabs/genesis \
-		-v ${PWD}/.casperlabs/bootstrap:/root/.casperlabs/bootstrap \
-		io.casperlabs/node:latest \
+		-v ${PWD}/.bootstrap:/root/.casperlabs \
+		casperlabs/node:$(CL_VERSION) \
 		run -s \
-		--casper-num-validators $(CL_CASPER_NUM_VALIDATORS) \
-		--tls-certificate /root/.casperlabs/bootstrap/node.certificate.pem \
-		--tls-key /root/.casperlabs/bootstrap/node.key.pem
+		--casper-num-validators $(CL_CASPER_NUM_VALIDATORS)
+
 	@# Wait until the node is running, so we know it generated the files. Capture the Node ID fromt the logs.
 	@# Can't write to the bootstrap dir from here as it's owned by the docker user.
 	NODE_ID=`(docker logs -f make-genesis &) | grep -m 1 -Po 'Listening for traffic on casperlabs://\K[^@]+'` && \
 	docker run --rm \
-		-v ${PWD}/.casperlabs/bootstrap:/root/.casperlabs/bootstrap \
+		-v ${PWD}/.bootstrap:/root/.casperlabs \
 		--entrypoint sh \
-		io.casperlabs/node:latest \
-		-c "echo $$NODE_ID > /root/.casperlabs/bootstrap/node-id"
+		casperlabs/node:$(CL_VERSION) \
+		-c "echo $$NODE_ID > /root/.casperlabs/node-id"
 	docker stop make-genesis
+
+	@# Copy files to where we can mount them separately from.
+	mkdir -p .casperlabs/bootstrap
+	cp -r .bootstrap/genesis .casperlabs
+	cp .bootstrap/node* .casperlabs/bootstrap
+
+	@# Removing genesis created by docker, using docker, due to permissions.
+	docker run --rm \
+		-v ${PWD}/.bootstrap:/root/.casperlabs \
+		--entrypoint sh \
+		casperlabs/node:$(CL_VERSION) \
+		-c "rm -rf /root/.casperlabs/*"
+	rm -rf .bootstrap
+
 	@# Check that the files we wanted exist and aren't empty.
 	[ -s .casperlabs/genesis/bonds.txt ]
 	[ -s .casperlabs/bootstrap/node-id ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -49,7 +49,7 @@ Note that you'll need to run `docker login` with your DockerHub username and pas
 
 ## Network Effects
 
-You can slow the network down a bit by running `make delay` in one terminal while issuing deploys in another one. You should see that now it takes longer for nodes to catch up after a block is created; even just sending the deploy is going to take a bit more time.
+You can slow the network down a bit by running `make delay` or `make slow` in one terminal while issuing deploys in another one. You should see that now it takes longer for nodes to catch up after a block is created; even just sending the deploy is going to take a bit more time.
 
 Another way to introduce a network partition is to for example create two networks, put the bootstrap node in both of them, but the rest of the nodes in just one, half here, half there. Then either slow down just the bootstrap node by introducing packet loss using the [netem](https://alexei-led.github.io/post/pumba_docker_netem/) tool, or by running `docker exec -it --privileged node-0 sh` and using `iptables`:
 
@@ -63,6 +63,8 @@ iptables --delete INPUT --protocol tcp --destination-port 40400 --jump DROP
 The effect should be that because the bootstrap node never sees any gossiping the two halves of the network can build the chain independently for a while. When the bootstrap node is restored and sees a new block, it will try to catch up with the missing parts of the DAG and forward it to its peers, reconnecting the two halves.
 
 You can also have a look at [using tc to slow down a specific port](https://stackoverflow.com/questions/10694730/in-linux-simulate-slow-traffic-incoming-traffic-to-port-e-g-54000). The benefit of using `iptables` and `tc` on individual port rather than the node level like `make delay` is that the deployment and metrics endpoints can stay unaffected.
+
+_NOTE_: For these tecniques to work you'll need to run the `test` version of the node image which you should have if you built the images yourself with `make docker-build-all` in the top directory, and subsequently set `export CL_VERSION=test` before creating the containers. You can set the the environment variable later as well, then run run `make node-0/up` again and see `docker-compose` recreating the containers with the new version.
 
 
 ## Visualizing the DAG

--- a/docker/template/docker-compose.yml
+++ b/docker/template/docker-compose.yml
@@ -22,7 +22,7 @@ services:
   # and pick one particular node.
 
   node:
-    image: casperlabs/node:test
+    image: casperlabs/node:${CL_VERSION}
     container_name: node-${NODE_NUMBER}
     hostname: node-${NODE_NUMBER}
     volumes:
@@ -53,7 +53,7 @@ services:
       - execution-engine
 
   execution-engine:
-    image: casperlabs/execution-engine:latest
+    image: casperlabs/execution-engine:${CL_VERSION}
     container_name: execution-engine-${NODE_NUMBER}
     hostname: execution-engine-${NODE_NUMBER}
     volumes:


### PR DESCRIPTION
## Overview
* Fixes the remaining `io.casperlabs/node` to `casperlabs/node`. 
* Adds a `CL_VERSION` env var that can be used to override the default `latest` to maybe a previous version or `test`. 
* Changes the way `make delay` works so it doesn't need the `test` version any more.
* Adds a `make slow` command that slows things down using `rate`.
* Fixes the establishing of the certificates and the genesis files since the node no longer generates certs at a non-default location.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
No issue for this, it's a quick fix.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
