### PR TITLE
NODE-288: Build execution-engine docker image from .deb package

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -158,6 +158,16 @@ pipeline:
       - make cargo-package-all
       - cp execution-engine/target/debian/casperlabs-engine-grpc-server_*.deb /artifacts/${DRONE_BRANCH}
       - cp execution-engine/target/release/rpmbuild/RPMS/x86_64/casperlabs-engine-grpc-server-*.rpm /artifacts/${DRONE_BRANCH}
+      - >-
+        cd execution-engine/target/release/rpmbuild/SOURCES ;
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]') ;
+        ARCH=$(uname -p) ;
+        SOURCE=$(ls casperlabs-engine-grpc-server-*.tar.gz | sed "s/.tar.gz//") ;
+        TARGET=$(ls $SOURCE*.tar.gz | sed "s/.tar.gz/_${OS}_${ARCH}.tar.gz/") ;
+        tar -xzf $SOURCE.tar.gz ;
+        tar -czf $TARGET -C $SOURCE/usr/bin/ . &&
+        cp $TARGET /artifacts/${DRONE_BRANCH}
+
     volumes:
       - /artifacts/:/artifacts/
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -158,7 +158,6 @@ pipeline:
       - make cargo-package-all
       - cp execution-engine/target/debian/casperlabs-engine-grpc-server_*.deb /artifacts/${DRONE_BRANCH}
       - cp execution-engine/target/release/rpmbuild/RPMS/x86_64/casperlabs-engine-grpc-server-*.rpm /artifacts/${DRONE_BRANCH}
-      - cp execution-engine/target/release/rpmbuild/SOURCES/casperlabs-engine-grpc-server-*.tar.gz /artifacts/${DRONE_BRANCH}
     volumes:
       - /artifacts/:/artifacts/
     when:
@@ -167,7 +166,7 @@ pipeline:
   cleanup:
     <<: *sbtenv
     commands:
-      - docker images --filter "dangling=true" -q --no-trunc | xargs --no-run-if-empty docker rmi -f 
+      - docker images --filter "dangling=true" -q --no-trunc | xargs --no-run-if-empty docker rmi -f
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     when:

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ cargo-package-all: \
 # Drone is already running commands in the `builderenv`, no need to delegate.
 cargo-native-packager/%:
 	if [ -z "${DRONE_BRANCH}" ]; then \
-		make .make/cargo-docker-packager/$* ; \
+		$(MAKE) .make/cargo-docker-packager/$* ; \
 	else \
-		make .make/cargo-native-packager/$* ; \
+		$(MAKE) .make/cargo-native-packager/$* ; \
 	fi
 
 # We need to publish the libraries the contracts are supposed to use.

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 		useradd -u $(USERID) -m builder ; \
 		cp -r /root/. /home/builder/ ; \
 		chown -R builder /home/builder ; \
-		sudo -u builder sh -c '\
+		sudo -u builder bash -c '\
 			export HOME=/home/builder ; \
 			export PATH=/home/builder/.cargo/bin:$$PATH ; \
 			cd /CasperLabs/$* ; \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,15 @@ docker-push/%: docker-build/%
 
 cargo-package-all: \
 	.make/cargo-package/execution-engine/common \
-	.make/cargo-docker-packager/execution-engine/comm
+	cargo-native-packager/execution-engine/comm
+
+# Drone is already running commands in the `builderenv`, no need to delegate.
+cargo-native-packager/%:
+	if [ -z "${DRONE_BRANCH}" ]; then \
+		make .make/cargo-docker-packager/$* ; \
+	else \
+		make .make/cargo-native-packager/$* ; \
+	fi
 
 # We need to publish the libraries the contracts are supposed to use.
 cargo-publish-all: \
@@ -148,6 +156,7 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 		echo $$RESULT && exit $$CODE ; \
 	fi
 	mkdir -p $(dir $@) && touch $@
+
 
 # Create .rpm and .deb packages natively. `cargo rpm build` doesn't work on MacOS.
 .make/cargo-native-packager/%: $(RUST_SRC) .make/install/protoc .make/install/cargo-native-packager

--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,10 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 	@# Need to use the same user ID as outside if we want to continue working with these files,
 	@# otherwise the user running in docker will own them.
 	$(eval USERID = $(shell id -u))
+	docker pull $(DOCKER_USERNAME)/buildenv:latest
 	docker run -it --rm --entrypoint sh \
 		-v ${PWD}:/CasperLabs \
-		casperlabs/buildenv:latest \
+		$(DOCKER_USERNAME)/buildenv:latest \
 		-c "\
 		apt-get install sudo ; \
 		useradd -u $(USERID) -m builder ; \

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,7 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 	@# .deb will be at execution-engine/target/debian/casperlabs-engine-grpc-server_0.1.0_amd64.deb
 	@# Need to use the same user ID as outside if we want to continue working with these files,
 	@# otherwise the user running in docker will own them.
+	@# Going to ignore errors with the rpm build here so that we can get the .deb package for docker.
 	$(eval USERID = $(shell id -u))
 	docker pull $(DOCKER_USERNAME)/buildenv:latest
 	docker run -it --rm --entrypoint sh \
@@ -192,8 +193,8 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 			export HOME=/home/builder ; \
 			export PATH=/home/builder/.cargo/bin:$$PATH ; \
 			cd /CasperLabs/$* ; \
-			([ -d .rpm ] || cargo rpm init) && cargo rpm build && \
-			cargo deb --no-build \
+			([ -d .rpm ] || cargo rpm init) && cargo rpm build ; \
+			cargo deb \
 		'"
 	mkdir -p $(dir $@) && touch $@
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -64,7 +64,7 @@ The effect should be that because the bootstrap node never sees any gossiping th
 
 You can also have a look at [using tc to slow down a specific port](https://stackoverflow.com/questions/10694730/in-linux-simulate-slow-traffic-incoming-traffic-to-port-e-g-54000). The benefit of using `iptables` and `tc` on individual port rather than the node level like `make delay` is that the deployment and metrics endpoints can stay unaffected.
 
-_NOTE_: For these tecniques to work you'll need to run the `test` version of the node image which you should have if you built the images yourself with `make docker-build-all` in the top directory, and subsequently set `export CL_VERSION=test` before creating the containers. You can set the the environment variable later as well, then run run `make node-0/up` again and see `docker-compose` recreating the containers with the new version.
+_NOTE_: For the techniques that use `iptables` and `tc` to work you'll need to run the `test` version of the node image which you should have if you built the images yourself with `make docker-build-all` in the top directory, and subsequently set `export CL_VERSION=test` before creating the containers. You can set the the environment variable later as well, then run run `make node-0/up` again and see `docker-compose` recreating the containers with the new version.
 
 
 ## Visualizing the DAG

--- a/execution-engine/Dockerfile
+++ b/execution-engine/Dockerfile
@@ -5,9 +5,11 @@ LABEL MAINTAINER="CasperLabs, LLC. <info@casperlabs.io>"
 
 USER root
 WORKDIR /opt/docker
+
 # Will need to mount a common volume to be used as a socket.
-ENTRYPOINT ["./casperlabs-engine-grpc-server"]
+ENTRYPOINT ["casperlabs-engine-grpc-server"]
 CMD [".casper-node.sock"]
 
-COPY casperlabs-engine-grpc-server /opt/docker/casperlabs-engine-grpc-server
-RUN chmod +x /opt/docker/casperlabs-engine-grpc-server
+# Install from debian package.
+ADD ./casperlabs-engine-grpc-server*.deb /opt/docker/
+RUN dpkg -i /opt/docker/casperlabs-engine-grpc-server*.deb

--- a/execution-engine/Dockerfile
+++ b/execution-engine/Dockerfile
@@ -12,4 +12,12 @@ CMD [".casper-node.sock"]
 
 # Install from debian package.
 ADD ./casperlabs-engine-grpc-server*.deb /opt/docker/
-RUN dpkg -i /opt/docker/casperlabs-engine-grpc-server*.deb
+# TODO: If I build on Ubuntu 16.04 the package installs without a problem,
+# 		but if I use the casperlabs:buildenv image for packaging I get unmet dependencies.
+# RUN apt-get update && \
+#     apt install /opt/docker/casperlabs-engine-grpc-server*.deb && \
+#     apt-get clean
+RUN dpkg -i \
+    --ignore-depends libgcc1 \
+    --ignore-depends libc6 \
+    /opt/docker/casperlabs-engine-grpc-server*.deb


### PR DESCRIPTION
## Overview
I forgot that the execution engine executable is not going to be portable and copied it into the Docker image, which worked fine on Ubuntu but if built on Mac the container will fail.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-288

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
