### PR TITLE
Updating Build docs for OSX and clarifying.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -109,7 +109,7 @@ __Note__ Successfully building from source requires attending to all of the prer
 
   Java:
   ```console
-  dev@dev:~$ brew cask install java10
+  dev@dev:~$ brew cask install java
 
   dev@dev:~$ java -version
   ```
@@ -123,7 +123,7 @@ __Note__ Successfully building from source requires attending to all of the prer
   ```console
   dev@dev:~$ brew install rustup
   ...
-
+  
   dev@dev:~$rustup-init
   Welcome to Rust!
 
@@ -150,7 +150,9 @@ __Note__ Successfully building from source requires attending to all of the prer
   environment variable. Next time you log in this will be done automatically.
 
   To configure your current shell run source $HOME/.cargo/env
+  ```
 
+  ```console
   dev@dev:~$ source $HOME/.cargo/env
 
   dev@dev:~$ rustup update


### PR DESCRIPTION
## Overview
Corrected failing commands for setting up the build environment on OSX.
Broke apart Rust doc spacing to make a command harder to skip.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/OP-101

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.
