### PR TITLE
CON-83: Change equivocation detector condition to only check block hash

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EquivocationDetector.scala
@@ -310,8 +310,7 @@ object EquivocationDetector {
       equivocationChildren: Set[BlockMessage],
       genesis: BlockMessage
   ): F[Set[BlockMessage]] =
-    // TODO: Is this a safe check? Or should I just check block hash?
-    if (justificationBlock == genesis) {
+    if (justificationBlock.blockHash == genesis.blockHash) {
       equivocationChildren.pure[F]
     } else if (justificationBlock.sender == equivocatingValidator) {
       // This is a special case as the justificationBlock might be the equivocation child


### PR DESCRIPTION
## Overview
Checking hashes is good enough because we validate the hash is correct relative to the content when a block is received. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/CON-83

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
