### PR TITLE
CON-95: Remove TODO message as work in that TODO was already completed.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -400,11 +400,7 @@ class MultiParentCasperImpl[F[_]: Sync: ConnectionsCell: TransportLayer: Log: Ti
 
   implicit val functorRaiseInvalidBlock = Validate.raiseValidateErrorThroughSync[F]
 
-  /*
-   * TODO: Pass in blockDag. We should only call _blockDag.get at one location.
-   * This would require returning the updated block DAG with the block status.
-   *
-   * We want to catch equivocations only after we confirm that the block completing
+  /* We want to catch equivocations only after we confirm that the block completing
    * the equivocation is otherwise valid.
    */
   private def attemptAdd(


### PR DESCRIPTION
## Overview
TODO talks about accepting the DAG as an argument and including the updated dag in the return type. Both of these have already been done, as can be seen in the function signature.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/CON-95

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
