### PR TITLE
CON-128: Make processed deploy cost type Long

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -220,7 +220,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
     val List(data0, data1) =
       (0 to 1)
-        .flatMap(i => ProtoUtil.sourceDeploy(dummyContract, i, Int.MaxValue).raw)
+        .flatMap(i => ProtoUtil.sourceDeploy(dummyContract, i.toLong, Long.MaxValue).raw)
         .toList
 
     for {

--- a/casper/src/test/scala/io/casperlabs/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/rholang/InterpreterUtilTest.scala
@@ -219,7 +219,7 @@ class InterpreterUtilTest
     """
   """.stripMargin
 
-  def prepareDeploys(v: Vector[ByteString], c: Double) = {
+  def prepareDeploys(v: Vector[ByteString], c: Long) = {
     val genesisDeploys =
       v.map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis(), Integer.MAX_VALUE))
     genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(c))
@@ -514,10 +514,10 @@ class InterpreterUtilTest
 
   "findMultiParentsBlockHashesForReplay" should "filter out duplicate ancestors of main parent block" ignore withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      val genesisDeploysWithCost = prepareDeploys(Vector.empty, 1.0)
-      val b1DeploysWithCost      = prepareDeploys(Vector(ByteString.EMPTY), 1.0)
-      val b2DeploysWithCost      = prepareDeploys(Vector(ByteString.EMPTY), 1.0)
-      val b3DeploysWithCost      = prepareDeploys(Vector(ByteString.EMPTY), 1.0)
+      val genesisDeploysWithCost = prepareDeploys(Vector.empty, 1L)
+      val b1DeploysWithCost      = prepareDeploys(Vector(ByteString.EMPTY), 1L)
+      val b2DeploysWithCost      = prepareDeploys(Vector(ByteString.EMPTY), 1L)
+      val b3DeploysWithCost      = prepareDeploys(Vector(ByteString.EMPTY), 1L)
 
       /*
        * DAG Looks like this:

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -251,7 +251,7 @@ message Header {
 message ProcessedDeploy {
     Deploy deploy = 1;
     //TODO PCost previously
-    double cost = 2;
+    uint64 cost = 2;
     bool errored = 3; //true if deploy encountered a user error
 }
 

--- a/models/src/main/scala/io/casperlabs/models/InternalProcessedDeploy.scala
+++ b/models/src/main/scala/io/casperlabs/models/InternalProcessedDeploy.scala
@@ -3,7 +3,6 @@ import io.casperlabs.casper.protocol.Deploy
 
 final case class InternalProcessedDeploy(
     deploy: Deploy,
-    //TODO: `cost` should be a Long, not a Double
-    cost: Double,
+    cost: Long,
     result: DeployResult
 )


### PR DESCRIPTION
## Overview
Cost never should have been a `double`. Float point arithmetic is not precise enough for cost accounting.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/CON-128

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
