### PR TITLE
NODE-292: Removed duplicate section title for Visualizing the DAG.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -137,8 +137,6 @@ Unfortunately the docker container runs with a different user ID than the one on
 sudo rm -rf images
 ```
 
-## Visualizing the DAG
-
 On Debian/Ubuntu you can also run `sudo apt-get install graphviz` and visualize the DAG like so:
 
 ```console


### PR DESCRIPTION
## Overview
Just noticed that the section title appeared twice in the readme.
The documentation itself was extended with platform agnostic parts in https://github.com/CasperLabs/CasperLabs/pull/205

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-292

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
