### PR TITLE
NODE-210: No longer need to use docker to write the node-id file.

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -111,13 +111,8 @@ slow:
 		--casper-num-validators $(CL_CASPER_NUM_VALIDATORS)
 
 	@# Wait until the node is running, so we know it generated the files. Capture the Node ID fromt the logs.
-	@# Can't write to the bootstrap dir from here as it's owned by the docker user.
 	NODE_ID=`(docker logs -f make-genesis &) | grep -m 1 "Listening for traffic" | awk -F'[//|@]' '{print $$3}'` && \
-	docker run --rm \
-		-v ${PWD}/.bootstrap:/root/.casperlabs \
-		--entrypoint sh \
-		casperlabs/node:$(CL_VERSION) \
-		-c "echo $$NODE_ID > /root/.casperlabs/node-id"
+	echo $$NODE_ID > .bootstrap/node-id
 	docker stop make-genesis
 
 	@# Copy files to where we can mount them separately from.


### PR DESCRIPTION
## Overview
Just made the genesis file generation a bit simpler in `docker/Makefile` by not using docker to run the simple act of writing a value to a file.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
This is just amending what https://github.com/CasperLabs/CasperLabs/pull/192 did.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
