### PR TITLE
NODE-273 Replace shapeless-scalacheck to magnolia

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -159,7 +159,6 @@ lazy val models = (project in file("models"))
       magnolia,
       scalapbCompiler,
       scalacheck,
-      scalacheckShapeless,
       scalapbRuntimegGrpc
     ),
     PB.targets in Compile := Seq(

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSoftSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSoftSpec.scala
@@ -9,10 +9,10 @@ import cats.syntax.option._
 import io.casperlabs.comm.{Endpoint, NodeIdentifier, PeerNode}
 import io.casperlabs.node.configuration.ConfigurationSoft._
 import io.casperlabs.shared.StoreType
-import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import io.casperlabs.node.configuration.MagnoliaArbitrary._
 import shapeless._
 import shapeless.labelled.FieldType
 import shapeless.ops.hlist._

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSoftSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSoftSpec.scala
@@ -80,7 +80,6 @@ class ConfigurationSoftSpec
         Endpoint("52.119.8.109", 1, 1)
       ).some,
       standalone = false.some,
-      mapSize = 1L.some,
       storeType = StoreType.LMDB.some,
       dataDir = Paths.get("test").some,
       maxNumOfConnections = 1.some,

--- a/node/src/test/scala/io/casperlabs/node/configuration/MagnoliaArbitrary.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/MagnoliaArbitrary.scala
@@ -1,0 +1,36 @@
+package io.casperlabs.node.configuration
+import magnolia._
+
+import scala.language.experimental.macros
+import org.scalacheck.{Arbitrary, Gen, GenHack}
+
+//Borrowed from https://github.com/etaty/scalacheck-magnolia
+//Needed because scalacheck-shapeless very slow
+object MagnoliaArbitrary {
+  type Typeclass[T] = Arbitrary[T]
+
+  def combine[T](caseClass: CaseClass[Arbitrary, T]): Arbitrary[T] = Arbitrary[T] {
+    GenHack.gen[T] { (params, seed) =>
+      try {
+        var acc = seed
+        val a = caseClass.construct { p =>
+          val r = p.typeclass.arbitrary.doPureApply(params, acc)
+          acc = r.seed
+          r.retrieve.get
+        }
+        GenHack.r(Some(a), acc)
+
+      } catch {
+        case _: StackOverflowError =>
+          GenHack.r(None, seed.next)
+      }
+    }
+  }
+
+  def dispatch[T](sealedTrait: SealedTrait[Arbitrary, T])(): Arbitrary[T] = Arbitrary[T] {
+    val gs: Seq[Gen[T]] = sealedTrait.subtypes.map(_.typeclass.arbitrary.asInstanceOf[Gen[T]])
+    Gen.choose(0, gs.size - 1).flatMap(gs(_)).suchThat(x => gs.exists(GenHack.sieveCopy(_, x)))
+  }
+
+  implicit def gen[T]: Arbitrary[T] = macro Magnolia.gen[T]
+}

--- a/node/src/test/scala/org/scalacheck/GenHack.scala
+++ b/node/src/test/scala/org/scalacheck/GenHack.scala
@@ -1,0 +1,19 @@
+package org.scalacheck
+
+import org.scalacheck.Gen.R
+import org.scalacheck.rng.Seed
+
+//Borrowed from https://github.com/etaty/scalacheck-magnolia
+//Needed because scalacheck-shapeless very slow
+object GenHack {
+  // expose some of the org.scalacheck.Gen private methods
+
+  def gen[T](f: (Gen.Parameters, Seed) => R[T]): Gen[T] =
+    Gen.gen(f)
+
+  def r[T](r: Option[T], sd: Seed): R[T] =
+    Gen.r(r, sd)
+
+  def sieveCopy[T](gen: Gen[T], x: Any): Boolean =
+    gen.sieveCopy(x)
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,7 +51,6 @@ object Dependencies {
   val scalaUri               = "io.lemonlabs"               %% "scala-uri"                      % "1.1.5"
   val scalacheck             = "org.scalacheck"             %% "scalacheck"                     % "1.14.0" % "test"
   val scalacheckNoTest       = "org.scalacheck"             %% "scalacheck"                     % "1.14.0"
-  val scalacheckShapeless    = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13"      % "1.1.8" % "test"
   val graphvizJava           = "guru.nidi"                  %  "graphviz-java"                  % "0.8.3"
   val scalactic              = "org.scalactic"              %% "scalactic"                      % "3.0.5" % "test"
   val scalapbCompiler        = "com.thesamet.scalapb"       %% "compilerplugin"                 % scalapb.compiler.Version.scalapbVersion
@@ -72,7 +71,6 @@ object Dependencies {
   val scodecCats             = "org.scodec"                 %% "scodec-cats"                    % "0.8.0"
   val scodecBits             = "org.scodec"                 %% "scodec-bits"                    % "1.1.7"
   val shapeless              = "com.chuusai"                %% "shapeless"                      % "2.3.3"
-  val shapelessScalaCheck    = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14"      % "1.2.0"
   val magnolia               = "com.propensive"             %% "magnolia"                       % "0.10.0"
   val weupnp                 = "org.bitlet"                 % "weupnp"                          % "0.1.4"
   // see https://jitpack.io/#rchain/secp256k1-java
@@ -101,7 +99,7 @@ object Dependencies {
   private val macroParadise = compilerPlugin(
     "org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 
-  private val testing = Seq(scalactic, scalatest, scalacheck, shapelessScalaCheck)
+  private val testing = Seq(scalactic, scalatest, scalacheck)
 
   private val logging = Seq(scalaLogging, logbackClassic, janino)
 


### PR DESCRIPTION
## Overview
Replaces the `scalacheck-shapeless` with Magnolia. I did it because I've used Magnolia instead of Shapeless for writing the configuration parameters parsing typeclass (which's PR I'm going to open soon) and think that Magnolia is better in terms of compilation speed, error messages and maintainability, so decided to put small efforts to replace the `scalacheck-shapeless`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-273

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.