### PR TITLE
NODE-293: Fix the GrpcKademliaRPC test

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/TestRuntime.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/TestRuntime.scala
@@ -1,0 +1,14 @@
+package io.casperlabs.comm
+
+import io.casperlabs.shared.Resources
+import java.net.ServerSocket
+
+trait TestRuntime {
+
+  def getFreePort: Int =
+    Resources.withResource(new ServerSocket(0)) { s =>
+      s.setReuseAddress(true)
+      s.getLocalPort
+    }
+
+}

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/GrpcKademliaRPCSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/GrpcKademliaRPCSpec.scala
@@ -28,14 +28,14 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
       GrpcEnvironment(host, port, peer)
     }
 
-  def createKademliaRPC(env: GrpcEnvironment): Task[KademliaRPC[Task]] = {
+  def createKademliaRPC(env: GrpcEnvironment, timeout: FiniteDuration): Task[KademliaRPC[Task]] = {
     implicit val ask: PeerNodeAsk[Task] =
       new DefaultApplicativeAsk[Task, PeerNode] {
         val applicative: Applicative[Task] = Applicative[Task]
         def ask: Task[PeerNode]            = Task.pure(env.peer)
       }
     CachedConnections[Task, KademliaConnTag].map { implicit cache =>
-      new GrpcKademliaRPC(env.port, 500.millis)
+      new GrpcKademliaRPC(env.port, timeout)
     }
   }
 

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCSpec.scala
@@ -65,7 +65,8 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
       "response takes to long" should {
         "get a negative result" in
           new TwoNodesRuntime[Boolean](
-            pingHandler = Handler.pingHandlerWithDelay(1.second)
+            pingHandler = Handler.pingHandlerWithDelay(1.second),
+            timeout = 500.millis
           ) {
             def execute(
                 kademliaRPC: KademliaRPC[F],

--- a/comm/src/test/scala/io/casperlabs/comm/transport/TransportLayerRuntime.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/transport/TransportLayerRuntime.scala
@@ -1,7 +1,5 @@
 package io.casperlabs.comm.transport
 
-import java.net.ServerSocket
-
 import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.util.Random
@@ -14,9 +12,9 @@ import io.casperlabs.comm._
 import io.casperlabs.comm.protocol.routing.Protocol
 import io.casperlabs.comm.CommError.CommErr
 import io.casperlabs.comm.rp.ProtocolHelper
-import io.casperlabs.shared.Resources
+import io.casperlabs.comm.TestRuntime
 
-abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
+abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] extends TestRuntime {
 
   def createEnvironment(port: Int): F[E]
 
@@ -25,12 +23,6 @@ abstract class TransportLayerRuntime[F[_]: Monad: Timer, E <: Environment] {
   def createDispatcherCallback: F[DispatcherCallback[F]]
 
   def extract[A](fa: F[A]): A
-
-  private def getFreePort: Int =
-    Resources.withResource(new ServerSocket(0)) { s =>
-      s.setReuseAddress(true)
-      s.getLocalPort
-    }
 
   def twoNodesEnvironment[A](block: (E, E) => F[A]): F[A] =
     for {


### PR DESCRIPTION
## Overview
One of the tests in KademliaRPCSpec is flaky. There was another test that similarly opened random ports which was changed to actually try if they are open before picking the port. Maybe this is a similar issue.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-293

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
