### PR TITLE
NODE-273 Prepare Configuration.scala class to be parsed by the Magnolia typeclass

### DIFF
--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockDagFileStorage.scala
@@ -1,6 +1,6 @@
 package io.casperlabs.blockstorage
 
-import java.nio.file.{Path, StandardCopyOption}
+import java.nio.file.{Path, Paths, StandardCopyOption}
 import java.nio.{BufferUnderflowException, ByteBuffer}
 
 import cats.Monad
@@ -19,6 +19,7 @@ import io.casperlabs.blockstorage.util.fileIO._
 import io.casperlabs.blockstorage.util.fileIO.IOError
 import io.casperlabs.blockstorage.util.{BlockMessageUtil, Crc32, TopologicalSortUtil}
 import io.casperlabs.casper.protocol.BlockMessage
+import io.casperlabs.configuration.{ignore, relativeToDataDir}
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.models.BlockMetadata
 import io.casperlabs.shared.{AtomicMonadState, Log, LogSource}
@@ -480,13 +481,17 @@ object BlockDagFileStorage {
   private val checkpointPattern: Regex = "([0-9]+)-([0-9]+)".r
 
   final case class Config(
-      latestMessagesLogPath: Path,
-      latestMessagesCrcPath: Path,
-      blockMetadataLogPath: Path,
-      blockMetadataCrcPath: Path,
-      checkpointsDirPath: Path,
+      @ignore
+      @relativeToDataDir("block-dag-file-storage")
+      dir: Path = Paths.get("nonreachable"),
       latestMessagesLogMaxSizeFactor: Int = 10
-  )
+  ) {
+    val latestMessagesLogPath: Path = dir.resolve("latest-messages-log")
+    val latestMessagesCrcPath: Path = dir.resolve("latest-messages-crc")
+    val blockMetadataLogPath: Path  = dir.resolve("block-metadata-log")
+    val blockMetadataCrcPath: Path  = dir.resolve("block-metadata-crc")
+    val checkpointsDirPath: Path    = dir.resolve("checkpoints")
+  }
 
   private[blockstorage] final case class CheckpointedDagInfo(
       childMap: Map[BlockHash, Set[BlockHash]],

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
@@ -99,16 +99,13 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
     }
 
   private def defaultLatestMessagesLog(dagDataDir: Path): Path =
-    dagDataDir.resolve("latest-messsages-data")
-
-  private def defaultLatestMessagesCrc(dagDataDir: Path): Path =
-    dagDataDir.resolve("latest-messsages-checksum")
+    dagDataDir.resolve("latest-messages-log")
 
   private def defaultBlockMetadataLog(dagDataDir: Path): Path =
-    dagDataDir.resolve("block-metadata-data")
+    dagDataDir.resolve("block-metadata-log")
 
   private def defaultBlockMetadataCrc(dagDataDir: Path): Path =
-    dagDataDir.resolve("block-metadata-checksum")
+    dagDataDir.resolve("block-metadata-crc")
 
   private def defaultCheckpointsDir(dagDataDir: Path): Path =
     dagDataDir.resolve("checkpoints")
@@ -126,11 +123,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
     implicit val log = new shared.Log.NOPLog[Task]()
     BlockDagFileStorage.create[Task](
       BlockDagFileStorage.Config(
-        defaultLatestMessagesLog(dagDataDir),
-        defaultLatestMessagesCrc(dagDataDir),
-        defaultBlockMetadataLog(dagDataDir),
-        defaultBlockMetadataCrc(dagDataDir),
-        defaultCheckpointsDir(dagDataDir),
+        dagDataDir,
         maxSizeFactor
       )
     )

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -1,11 +1,12 @@
 package io.casperlabs.casper
 
-import java.nio.file.Path
+import java.nio.file.{Path, Paths}
 
 import cats.Monad
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.catscontrib.Capture
+import io.casperlabs.configuration.{ignore, relativeToDataDir}
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.signatures.{Ed25519, Secp256k1}
 import io.casperlabs.shared.{Log, LogSource}
@@ -15,20 +16,23 @@ import scala.io.Source
 import scala.util.{Failure, Success, Try}
 
 final case class CasperConf(
-    publicKeyBase16: Option[String],
-    privateKey: Option[Either[String, Path]],
-    sigAlgorithm: String,
+    validatorPublicKey: Option[String],
+    validatorPrivateKey: Option[String],
+    validatorPrivateKeyPath: Option[Path],
+    validatorSigAlgorithm: String,
     bondsFile: Path,
-    knownValidatorsFile: Option[String],
+    knownValidatorsFile: Option[Path],
     numValidators: Int,
-    genesisPath: Path,
+    @ignore
+    @relativeToDataDir("genesis")
+    genesisPath: Path = Paths.get("nonreachable"),
     walletsFile: Path,
     minimumBond: Long,
     maximumBond: Long,
     hasFaucet: Boolean,
     requiredSigs: Int,
     shardId: String,
-    createGenesis: Boolean,
+    standalone: Boolean,
     approveGenesis: Boolean,
     approveGenesisInterval: FiniteDuration,
     approveGenesisDuration: FiniteDuration,
@@ -39,18 +43,18 @@ object CasperConf {
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
   def parseValidatorsFile[F[_]: Monad: Capture: Log](
-      knownValidatorsFile: Option[String]
+      knownValidatorsFile: Option[Path]
   ): F[Set[ByteString]] =
     knownValidatorsFile match {
       //TODO: Add default set? Throw error?
       case None => Set.empty[ByteString].pure[F]
 
-      case Some(file) =>
+      case Some(path) =>
         Capture[F]
           .capture {
             Try(
               Source
-                .fromFile(file)
+                .fromFile(path.toFile)
                 .getLines()
                 .map(line => ByteString.copyFrom(Base16.decode(line)))
                 .toSet

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
@@ -80,7 +80,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                )
              )
       } yield new CasperPacketHandlerImpl[F](gv)
-    } else if (conf.createGenesis) {
+    } else if (conf.standalone) {
       for {
         _              <- Log[F].info("Starting in create genesis mode")
         bonds          <- Genesis.getBonds[F](conf.genesisPath, conf.bondsFile, conf.numValidators)

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -58,7 +58,7 @@ class ManyValidatorsTest
       initialLatestMessages = bonds.map { case Bond(validator, _) => validator -> b }.toMap
       _ <- Sync[Task].delay {
             BlockDagStorageTestFixture.writeInitialLatestMessages(
-              blockDagStorageDir.resolve("latest-messages-data"),
+              blockDagStorageDir.resolve("latest-messages-log"),
               blockDagStorageDir.resolve("latest-messages-crc"),
               initialLatestMessages
             )

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockDagStorageFixture.scala
@@ -106,12 +106,6 @@ object BlockDagStorageTestFixture {
       blockStore: BlockStore[Task]
   ): Task[BlockDagStorage[Task]] =
     BlockDagFileStorage.create[Task](
-      BlockDagFileStorage.Config(
-        blockDagStorageDir.resolve("latest-messages-data"),
-        blockDagStorageDir.resolve("latest-messages-crc"),
-        blockDagStorageDir.resolve("block-metadata-data"),
-        blockDagStorageDir.resolve("block-metadata-crc"),
-        blockDagStorageDir.resolve("checkpoints")
-      )
+      BlockDagFileStorage.Config(blockDagStorageDir)
     )
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -174,13 +174,7 @@ object HashSetCasperTestNode {
     for {
       blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
       blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
-                          BlockDagFileStorage.Config(
-                            blockDagDir.resolve("latest-messages-data"),
-                            blockDagDir.resolve("latest-messages-crc"),
-                            blockDagDir.resolve("block-metadata-data"),
-                            blockDagDir.resolve("block-metadata-crc"),
-                            blockDagDir.resolve("checkpoints")
-                          ),
+                          BlockDagFileStorage.Config(blockDagDir),
                           genesis
                         )(Concurrent[F], Log[F], blockStore)
       blockProcessingLock <- Semaphore[F](1)
@@ -260,13 +254,7 @@ object HashSetCasperTestNode {
             for {
               blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
               blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
-                                  BlockDagFileStorage.Config(
-                                    blockDagDir.resolve("latest-messages-data"),
-                                    blockDagDir.resolve("latest-messages-crc"),
-                                    blockDagDir.resolve("block-metadata-data"),
-                                    blockDagDir.resolve("block-metadata-crc"),
-                                    blockDagDir.resolve("checkpoints")
-                                  ),
+                                  BlockDagFileStorage.Config(blockDagDir),
                                   genesis
                                 )(Concurrent[F], Log[F], blockStore)
               semaphore <- Semaphore[F](1)

--- a/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
@@ -2,10 +2,14 @@ package io.casperlabs.comm.transport
 
 import java.nio.file.Path
 
+import io.casperlabs.configuration.ignore
+
 final case class Tls(
     certificate: Path,
     key: Path,
-    customCertificateLocation: Boolean,
-    customKeyLocation: Boolean,
+    @ignore
+    customCertificateLocation: Boolean = false,
+    @ignore
+    customKeyLocation: Boolean = false,
     secureRandomNonBlocking: Boolean
 )

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -1,3 +1,4 @@
+# io.casperlabs.node.configuration.Configuration.Server
 [server]
 
 # Hostname or IP of this node.
@@ -24,9 +25,6 @@ default-timeout = 2000
 # Bootstrap casperlabs node address for initial seed.
 bootstrap = "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=40400&discovery=40404"
 
-# Start a stand-alone node (no bootstrapping).
-standalone = false
-
 # Type of Casperlabs space backing store. Valid values are: lmdb, inmem, mixed.
 store-type = "lmdb"
 
@@ -43,6 +41,7 @@ max-message-size = 4194304
 chunk-size = 1048576
 
 
+# io.casperlabs.blockstorage.LMDBBlockStore.Config
 [lmdb]
 
 # LMDB blockstorage  map size (in bytes).
@@ -58,15 +57,14 @@ max-readers = 126
 use-tls = false
 
 
+# io.casperlabs.blockstorage.BlockDagFileStorage.Config
 [blockstorage]
-
-# Directory for block dag file storage.
-dir = "$HOME/.casperlabs/blockstorage"
 
 # Size factor for squashing block storage latest messages.
 latest-messages-log-max-size-factor = 10
 
 
+# io.casperlabs.node.configuration.Configuration.GrpcServer
 [grpc]
 
 # Externally addressable hostname or IP of node on which gRPC service is running.
@@ -82,6 +80,7 @@ port-external = 40401
 port-internal = 40402
 
 
+# io.casperlabs.comm.transport.Tls
 [tls]
 
 # Path to node's X.509 certificate file, that is being used for identification.
@@ -94,6 +93,7 @@ key = "$HOME/.casperlabs/node.key.pem"
 secure-random-non-blocking = false
 
 
+# io.casperlabs.casper.CasperConf
 [casper]
 
 # Base16 encoding of the public key to use for signing a proposed blocks.
@@ -146,8 +146,11 @@ has-faucet = false
 # Number of signatures from trusted validators required to creating an approved genesis block.
 required-sigs = 0
 
-# Identifier of the shard this node is connected to
+# Identifier of the shard this node is connected to.
 shard-id = "casperlabs"
+
+# Start a stand-alone node (no bootstrapping).
+standalone = false
 
 # Start a node as a genesis validator.
 approve-genesis = false
@@ -162,6 +165,7 @@ approve-genesis-duration = "5minutes"
 # deploy-timestamp =
 
 
+# io.casperlabs.node.configuration.Configuration.Kamon
 [metrics]
 
 # Enable the Prometheus metrics reporter.
@@ -173,7 +177,11 @@ zipkin = false
 # Enable Sigar host system metrics.
 sigar = false
 
+# Enable Influx system metrics.
+influx = false
 
+
+# io.casperlabs.node.configuration.Configuration.Influx
 [influx]
 
 # Hostname or IP of the Influx instance.
@@ -187,9 +195,6 @@ sigar = false
 
 # Protocol used in Influx.
 # protocol = "https"
-
-
-[influx-auth]
 
 # Username for Influx database authentication.
 # user = "user"

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -2,7 +2,6 @@ package io.casperlabs.node
 
 import cats.effect.ExitCode
 import cats.implicits._
-import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.catscontrib._
 import io.casperlabs.comm._
 import io.casperlabs.node.configuration.Configuration.Command.{Diagnostics, Run}
@@ -48,8 +47,8 @@ object Main extends TaskApp {
   private def mainProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] = {
     implicit val diagnosticsService: GrpcDiagnosticsService =
       new diagnostics.client.GrpcDiagnosticsService(
-        conf.grpcServer.host,
-        conf.grpcServer.portInternal,
+        conf.grpc.host,
+        conf.grpc.portInternal,
         conf.server.maxMessageSize
       )
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -77,7 +77,7 @@ class NodeRuntime private[node] (
   // TODO: Resolve scheduler chaos in Runtime, RuntimeManager and CasperPacketHandler
 
   val main = GrpcExecutionEngineService[Effect](
-    conf.grpcServer.socket,
+    conf.grpc.socket,
     conf.server.maxMessageSize
   ).use(runMain)
 
@@ -95,7 +95,7 @@ class NodeRuntime private[node] (
 
       defaultTimeout = conf.server.defaultTimeout.millis
 
-      initPeer             = if (conf.server.standalone) None else Some(conf.server.bootstrap)
+      initPeer             = if (conf.casper.standalone) None else Some(conf.server.bootstrap)
       rpConfState          = effects.rpConfState(rpConf(local, initPeer))
       rpConfAsk            = effects.rpConfAsk(rpConfState)
       peerNodeAsk          = effects.peerNodeAsk(rpConfState)
@@ -219,7 +219,7 @@ class NodeRuntime private[node] (
     for {
       grpcServerExternal <- GrpcServer
                              .acquireExternalServer[Effect](
-                               conf.grpcServer.portExternal,
+                               conf.grpc.portExternal,
                                conf.server.maxMessageSize,
                                grpcScheduler,
                                blockApiLock
@@ -227,7 +227,7 @@ class NodeRuntime private[node] (
 
       grpcServerInternal <- GrpcServer
                              .acquireInternalServer(
-                               conf.grpcServer.portInternal,
+                               conf.grpc.portInternal,
                                conf.server.maxMessageSize,
                                grpcScheduler
                              )
@@ -314,7 +314,7 @@ class NodeRuntime private[node] (
   ): Effect[Unit] = {
 
     val info: Effect[Unit] =
-      if (conf.server.standalone) Log[Effect].info(s"Starting stand-alone node.")
+      if (conf.casper.standalone) Log[Effect].info(s"Starting stand-alone node.")
       else Log[Effect].info(s"Starting node that will bootstrap from ${conf.server.bootstrap}")
 
     val dynamicIpCheck: Task[Unit] =

--- a/node/src/main/scala/io/casperlabs/node/configuration/ConfigurationSoft.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ConfigurationSoft.scala
@@ -20,8 +20,7 @@ case class ConfigurationSoft(
     lmdb: ConfigurationSoft.LmdbBlockStore,
     blockstorage: ConfigurationSoft.BlockDagFileStorage,
     metrics: ConfigurationSoft.Metrics,
-    influx: ConfigurationSoft.Influx,
-    influxAuth: ConfigurationSoft.InfluxAuth
+    influx: ConfigurationSoft.Influx
 ) {
   implicit def fallback[A](implicit ev: LowPriority): Merge[Option[A]] =
     (l: Option[A], r: Option[A]) => l.orElse(r)
@@ -45,7 +44,6 @@ private[configuration] object ConfigurationSoft {
       noUpnp: Option[Boolean],
       defaultTimeout: Option[Int],
       bootstrap: Option[PeerNode],
-      standalone: Option[Boolean],
       storeType: Option[StoreType],
       dataDir: Option[Path],
       maxNumOfConnections: Option[Int],
@@ -65,20 +63,7 @@ private[configuration] object ConfigurationSoft {
   private[configuration] case class BlockDagFileStorage(
       latestMessagesLogMaxSizeFactor: Option[Int]
   ) {
-    val latestMessagesLogPath: RelativePath = RelativePath(
-      "casper-block-dag-file-storage-latest-messages-log"
-    )
-    val latestMessagesCrcPath: RelativePath = RelativePath(
-      "casper-block-dag-file-storage-latest-messages-crc"
-    )
-    val blockMetadataLogPath: RelativePath = RelativePath(
-      "casper-block-dag-file-storage-block-metadata-log"
-    )
-    val blockMetadataCrcPath: RelativePath = RelativePath(
-      "casper-block-dag-file-storage-block-metadata-crc"
-    )
-    val checkpointsDirPath: RelativePath =
-      RelativePath("casper-block-dag-file-storage-checkpoints")
+    val dir: RelativePath = RelativePath("block-dag-file-storage")
   }
 
   private[configuration] case class GrpcServer(
@@ -100,7 +85,7 @@ private[configuration] object ConfigurationSoft {
       validatorPrivateKeyPath: Option[Path],
       validatorSigAlgorithm: Option[String],
       bondsFile: Option[Path],
-      knownValidatorsFile: Option[String],
+      knownValidatorsFile: Option[Path],
       numValidators: Option[Int],
       walletsFile: Option[Path],
       minimumBond: Option[Long],
@@ -108,6 +93,7 @@ private[configuration] object ConfigurationSoft {
       hasFaucet: Option[Boolean],
       requiredSigs: Option[Int],
       shardId: Option[String],
+      standalone: Option[Boolean],
       approveGenesis: Option[Boolean],
       approveGenesisInterval: Option[FiniteDuration],
       approveGenesisDuration: Option[FiniteDuration],
@@ -119,14 +105,17 @@ private[configuration] object ConfigurationSoft {
   private[configuration] case class Metrics(
       prometheus: Option[Boolean],
       zipkin: Option[Boolean],
-      sigar: Option[Boolean]
+      sigar: Option[Boolean],
+      influx: Option[Boolean]
   )
 
   private[configuration] case class Influx(
       hostname: Option[String],
       port: Option[Int],
       database: Option[String],
-      protocol: Option[String]
+      protocol: Option[String],
+      user: Option[String],
+      password: Option[String]
   )
 
   private[configuration] case class InfluxAuth(

--- a/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
@@ -1,0 +1,49 @@
+package io.casperlabs.node.configuration
+
+import java.nio.file.{Path, Paths}
+
+import scala.util.Try
+import cats.syntax.either._
+import io.casperlabs.comm.{CommError, PeerNode}
+import io.casperlabs.shared.StoreType
+
+import scala.concurrent.duration.Duration.Infinite
+import scala.concurrent.duration._
+
+private[configuration] trait Parser[A] {
+  def parse(s: String): Either[String, A]
+}
+
+private[configuration] trait ParserImplicits {
+  implicit val stringParser: Parser[String] = _.asRight[String]
+  implicit val intParser: Parser[Int]       = s => Try(s.toInt).toEither.leftMap(_.getMessage)
+  implicit val longParser: Parser[Long]     = s => Try(s.toLong).toEither.leftMap(_.getMessage)
+  implicit val doubleParser: Parser[Double] = s => Try(s.toDouble).toEither.leftMap(_.getMessage)
+  implicit val booleanParser: Parser[Boolean] = {
+    case "true"  => true.asRight[String]
+    case "false" => false.asRight[String]
+    case s =>
+      s"Failed to parse '$s' as Boolean, must be 'true' or 'false'"
+        .asLeft[Boolean]
+  }
+  implicit val finiteDurationParser: Parser[FiniteDuration] = s =>
+    Try(Duration(s)).toEither
+      .leftMap(_.getMessage)
+      .flatMap {
+        case fd: FiniteDuration => fd.asRight[String]
+        case _: Infinite        => "Got Infinite, expected FiniteDuration".asLeft[FiniteDuration]
+      }
+  implicit val pathParser: Parser[Path] = s =>
+    Try(Paths.get(s.replace("$HOME", sys.props("user.home")))).toEither
+      .leftMap(_.getMessage)
+  implicit val peerNodeParser: Parser[PeerNode] = s =>
+    PeerNode.fromAddress(s).leftMap(CommError.errorMessage)
+  implicit val storeTypeParser: Parser[StoreType] = s =>
+    StoreType
+      .from(s)
+      .fold(s"Failed to parse '$s' as StoreType".asLeft[StoreType])(_.asRight[String])
+}
+
+private[configuration] object Parser {
+  def apply[A](implicit P: Parser[A]): Parser[A] = P
+}

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -10,62 +10,61 @@ bootstrap = "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?
 standalone = false
 map-size = 1
 store-type = "lmdb"
-data-dir = "test"
+data-dir = "/tmp"
 max-num-of-connections = 1
 max-message-size = 1
 chunk-size = 1
 
 [lmdb]
-path = "test"
 block-store-size = 1
 max-dbs = 1
 max-readers = 1
 use-tls = false
 
-[blockstorage]
-latest-messages-log-max-size-factor = 1
-
 [grpc]
 host = "test"
-socket = "test"
+socket = "/tmp/test"
 port-external = 1
 port-internal = 1
 
 [tls]
-certificate = "test"
-key = "test"
+certificate = "/tmp/test"
+key = "/tmp/test"
 secure-random-non-blocking = false
 
 [casper]
 validator-public-key = "test"
 validator-private-key = "test"
-validator-private-key-path = "test"
+validator-private-key-path = "/tmp/test"
 validator-sig-algorithm = "test"
-bonds-file = "test"
-known-validators-file = "test"
+bonds-file = "/tmp/test"
+known-validators-file = "/tmp/test"
 num-validators = 1
-wallets-file = "test"
+wallets-file = "/tmp/test"
 minimum-bond = 1
 maximum-bond = 1
 has-faucet = false
 required-sigs = 1
 shard-id = "test"
+standalone = false
 approve-genesis = false
 approve-genesis-interval = "1second"
 approve-genesis-duration = "1second"
 deploy-timestamp = 1
 
+[blockstorage]
+latest-messages-log-max-size-factor = 1
+
 [metrics]
 prometheus = false
 zipkin = false
 sigar = false
+influx = false
 
 [influx]
 hostname = "0.0.0.0"
 port = 1
 database = "test"
 protocol = "https"
-
-[influx-auth]
 user = "user"
 password = "password"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ArbitraryImplicits.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ArbitraryImplicits.scala
@@ -1,0 +1,49 @@
+package io.casperlabs.node.configuration
+import java.io.File
+import java.nio.file.{Path, Paths}
+
+import io.casperlabs.comm.{Endpoint, NodeIdentifier, PeerNode}
+import org.scalacheck.{Arbitrary, Gen}
+
+import scala.concurrent.duration._
+
+trait ArbitraryImplicits {
+  implicit val pathGen: Arbitrary[Path] = Arbitrary {
+    for {
+      n     <- Gen.choose(1, 10)
+      paths <- Gen.listOfN(n, Gen.listOfN(3, Gen.alphaNumChar)).map(_.flatten.mkString(""))
+    } yield Paths.get("/", paths.mkString(File.pathSeparator))
+  }
+
+  //Needed to pass through CLI options parsing
+  implicit val nonEmptyStringGen: Arbitrary[String] = Arbitrary {
+    for {
+      n   <- Gen.choose(1, 100)
+      seq <- Gen.listOfN(n, Gen.alphaNumChar)
+    } yield seq.mkString("")
+  }
+
+  //There is no way expressing explicit 'false' using CLI options.
+  implicit val optionBooleanGen: Arbitrary[Boolean] = Arbitrary {
+    Gen.const(true)
+  }
+
+  implicit val peerNodeGen: Arbitrary[PeerNode] = Arbitrary {
+    for {
+      n        <- Gen.choose(1, 100)
+      bytes    <- Gen.listOfN(n, Gen.choose(Byte.MinValue, Byte.MaxValue))
+      id       = NodeIdentifier(bytes)
+      host     <- Gen.listOfN(n, Gen.alphaNumChar)
+      tcpPort  <- Gen.posNum[Int]
+      udpPort  <- Gen.posNum[Int]
+      endpoint = Endpoint(host.mkString(""), tcpPort, udpPort)
+    } yield PeerNode(id, endpoint)
+  }
+
+  // There are some comparison problems with default generator
+  implicit val finiteDurationGen: Arbitrary[FiniteDuration] = Arbitrary {
+    for {
+      n <- Gen.choose(0, Int.MaxValue)
+    } yield FiniteDuration(n.toLong, MILLISECONDS)
+  }
+}

--- a/shared/src/main/scala/io/casperlabs/configuration/cli/scallop.scala
+++ b/shared/src/main/scala/io/casperlabs/configuration/cli/scallop.scala
@@ -1,4 +1,4 @@
-package io.casperlabs.shared
+package io.casperlabs.configuration.cli
 
 import scala.annotation.{compileTimeOnly, StaticAnnotation}
 import scala.language.experimental.macros

--- a/shared/src/main/scala/io/casperlabs/configuration/ignore.scala
+++ b/shared/src/main/scala/io/casperlabs/configuration/ignore.scala
@@ -1,0 +1,8 @@
+package io.casperlabs.configuration
+import scala.annotation.StaticAnnotation
+
+/**
+  * Ignores parameter during configuration parameters Magnolia parsing taking default value
+  * TODO: add actual semantics
+  */
+class ignore extends StaticAnnotation

--- a/shared/src/main/scala/io/casperlabs/configuration/relativeToDataDir.scala
+++ b/shared/src/main/scala/io/casperlabs/configuration/relativeToDataDir.scala
@@ -1,0 +1,9 @@
+package io.casperlabs.configuration
+import scala.annotation.StaticAnnotation
+
+/**
+  * Marks a field that will be redefined as a server.dataDir child at Magnolia post-processing
+  * TODO: add actual semantics
+  * @param relativePath child path to server.dataDir
+  */
+class relativeToDataDir(val relativePath: String) extends StaticAnnotation


### PR DESCRIPTION
## Overview
This is the last PR before the PR that will remove boilerplate `ConfigurationSoft.scala`, `EnvVarsParser` and `TomlReader`.
Start reviewing it from the changes in the `Configuration.scala` class.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
