### PR TITLE
NODE-323: Brought over the Node type from the tech spec.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,8 +9,14 @@ Global / conflictManager := ConflictManager.strict
 //resolve all version conflicts explicitly
 Global / dependencyOverrides := Dependencies.overrides
 
-// Keeping all the .proto definitions in a common catalogue so we can use `include` to factor out common messages.
-val protobufDirectory = file(".") / "protobuf" / "io" / "casperlabs"
+// Keeping all the .proto definitions in a common place so we can use `include` to factor out common messages.
+val protobufDirectory = file("protobuf")
+def protobufSubDirectoryFilter(subdirs: String*) = {
+  import java.nio.file.Paths // Handle backslash on Windows.
+  (f: File) =>
+    f.getName.endsWith(".proto") && // Not directories or other artifacts.
+    subdirs.map(Paths.get(_)).exists(p => f.toPath.getParent.endsWith(p))
+}
 
 lazy val projectSettings = Seq(
   organization := "io.casperlabs",
@@ -130,8 +136,10 @@ lazy val comm = (project in file("comm"))
       monix,
       guava
     ),
-    PB.protoSources in Compile := Seq(
-      protobufDirectory / "comm" / "discovery"),
+    PB.protoSources in Compile := Seq(protobufDirectory),
+    includeFilter in PB.generate := new SimpleFileFilter(
+      protobufSubDirectoryFilter(
+        "io/casperlabs/comm/discovery")),
     PB.targets in Compile := Seq(
       PB.gens.java                              -> (sourceManaged in Compile).value,
       scalapb.gen(javaConversions = true)       -> (sourceManaged in Compile).value,
@@ -170,10 +178,12 @@ lazy val models = (project in file("models"))
     // TODO: As we refactor the interfaces this project should only depend on consensus
     // related models, ones that get stored, passed to client. The client for example
     // shouldn't transitively depend on node-to-node and node-to-EE interfaces.
-    PB.protoSources in Compile := Seq(
-      protobufDirectory / "casper" / "protocol",
-      protobufDirectory / "comm" / "protocol" / "routing",
-      protobufDirectory / "ipc"),
+    PB.protoSources in Compile := Seq(protobufDirectory),
+    includeFilter in PB.generate := new SimpleFileFilter(
+      protobufSubDirectoryFilter(
+        "io/casperlabs/casper/protocol",
+        "io/casperlabs/comm/protocol/routing",
+        "io/casperlabs/ipc")),
     PB.targets in Compile := Seq(
       scalapb.gen(flatPackage = true) -> (sourceManaged in Compile).value,
       grpcmonix.generators
@@ -206,8 +216,10 @@ lazy val node = (project in file("node"))
         scalapbRuntimegGrpc,
         tomlScala
       ),
-    PB.protoSources in Compile := Seq(
-      protobufDirectory / "node" / "model"),
+    PB.protoSources in Compile := Seq(protobufDirectory),
+    includeFilter in PB.generate := new SimpleFileFilter(
+      protobufSubDirectoryFilter(
+        "io/casperlabs/node/model")),
     PB.targets in Compile := Seq(
       PB.gens.java                              -> (sourceManaged in Compile).value / "protobuf",
       scalapb.gen(javaConversions = true)       -> (sourceManaged in Compile).value / "protobuf",

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/GrpcKademliaRPC.scala
@@ -141,12 +141,12 @@ class GrpcKademliaRPC(port: Int, timeout: FiniteDuration)(
   private def node(n: PeerNode): Node =
     Node()
       .withId(ByteString.copyFrom(n.key.toArray))
-      .withHost(ByteString.copyFromUtf8(n.endpoint.host))
-      .withUdpPort(n.endpoint.udpPort)
-      .withTcpPort(n.endpoint.tcpPort)
+      .withHost(n.endpoint.host)
+      .withDiscoveryPort(n.endpoint.udpPort)
+      .withProtocolPort(n.endpoint.tcpPort)
 
   private def toPeerNode(n: Node): PeerNode =
-    PeerNode(NodeIdentifier(n.id.toByteArray), Endpoint(n.host.toStringUtf8, n.tcpPort, n.udpPort))
+    PeerNode(NodeIdentifier(n.id.toByteArray), Endpoint(n.host, n.protocolPort, n.discoveryPort))
 
   class SimpleKademliaRPCService(
       pingHandler: PeerNode => Task[Unit],

--- a/protobuf/io/casperlabs/comm/discovery/kademlia.proto
+++ b/protobuf/io/casperlabs/comm/discovery/kademlia.proto
@@ -2,18 +2,13 @@ syntax = "proto3";
 package io.casperlabs.comm.discovery;
 
 import "scalapb/scalapb.proto";
+import "io/casperlabs/comm/discovery/node.proto";
 
 option (scalapb.options) = {
   package_name: "io.casperlabs.comm.discovery"
   flat_package: true
 };
 
-message Node {
-  bytes  id       = 1;
-  bytes  host     = 2;
-  uint32 tcp_port = 3;
-  uint32 udp_port = 4;
-}
 
 message Ping {
   Node   sender         = 1;
@@ -26,7 +21,7 @@ message Lookup {
   bytes  id     = 1;
   Node   sender = 2;
 }
-        
+
 message LookupResponse {
     repeated Node nodes = 1;
 }

--- a/protobuf/io/casperlabs/comm/discovery/node.proto
+++ b/protobuf/io/casperlabs/comm/discovery/node.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package io.casperlabs.comm.discovery;
+
+import "scalapb/scalapb.proto";
+
+option (scalapb.options) = {
+  package_name: "io.casperlabs.comm.discovery"
+  flat_package: true
+};
+
+message Node {
+    bytes id = 1;
+    string host = 2;
+    uint32 protocol_port = 3;
+    uint32 discovery_port = 4;
+}

--- a/protobuf/io/casperlabs/comm/protocol/routing/routing.proto
+++ b/protobuf/io/casperlabs/comm/protocol/routing/routing.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package io.casperlabs.comm.protocol.routing;
 
 import "scalapb/scalapb.proto";
-import "CasperMessage.proto";
+import "io/casperlabs/casper/protocol/CasperMessage.proto";
 
 option (scalapb.options) = {
   package_name: "io.casperlabs.comm.protocol.routing"


### PR DESCRIPTION
## Overview
In the tech spec the `GossipService` and the `KademliaService` share the `Node` type. It changes as well a little bit so for example `host` is a `String`. There were some necessary changes for the full path import expressions to work with protoc.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-323

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
https://casperlabs.atlassian.net/browse/NODE-314 depends on this.
