### PR TITLE
EE-163: add {To,From}Bytes impls for storage::history::trie::Trie

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -305,6 +305,8 @@ version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.1.1",
  "proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "shared 0.1.0",
+ "storage 0.1.0",
 ]
 
 [[package]]
@@ -927,6 +929,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "casperlabs-contract-ffi 0.1.1",
 ]
 
 [[package]]

--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -1,6 +1,7 @@
 use super::alloc::collections::BTreeMap;
 use super::alloc::string::String;
 use super::alloc::vec::Vec;
+use core::mem::size_of;
 
 pub trait ToBytes {
     fn to_bytes(&self) -> Vec<u8>;
@@ -245,7 +246,7 @@ impl FromBytes for [u8; 32] {
 
 impl<T: ToBytes> ToBytes for [T; 256] {
     fn to_bytes(&self) -> Vec<u8> {
-        let mut result = Vec::with_capacity(self.len() + 4);
+        let mut result = Vec::with_capacity(4 + (self.len() * size_of::<T>()));
         result.extend((256u32).to_bytes());
         let bytes = self.iter().flat_map(ToBytes::to_bytes);
         result.extend(bytes);

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -1,5 +1,12 @@
 #![no_std]
-#![feature(alloc, allocator_api, core_intrinsics, lang_items, alloc_error_handler)]
+#![feature(
+    alloc,
+    allocator_api,
+    core_intrinsics,
+    lang_items,
+    alloc_error_handler,
+    maybe_uninit
+)]
 
 extern crate alloc;
 extern crate wee_alloc;

--- a/execution-engine/gens/Cargo.toml
+++ b/execution-engine/gens/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2018"
 [dependencies]
 proptest = "0.8.7"
 common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }
+shared = { path = "../shared" }
+storage = { path = "../storage" }

--- a/execution-engine/gens/src/gens.rs
+++ b/execution-engine/gens/src/gens.rs
@@ -90,7 +90,7 @@ pub fn trie_arb() -> impl Strategy<Value = trie::Trie<Key, Value>> {
         trie_pointer_block_arb().prop_map(|pointer_block| trie::Trie::Node {
             pointer_block: Box::new(pointer_block)
         }),
-        (vec(any::<u8>(), 1..32), trie_pointer_arb())
+        (vec(any::<u8>(), 0..32), trie_pointer_arb())
             .prop_map(|(affix, pointer)| trie::Trie::Extension { affix, pointer })
     ]
 }

--- a/execution-engine/gens/src/gens.rs
+++ b/execution-engine/gens/src/gens.rs
@@ -1,8 +1,11 @@
 use common::key::*;
 use common::value::*;
 use proptest::collection::{btree_map, vec};
+use proptest::option;
 use proptest::prelude::*;
+use shared::newtypes::Blake2bHash;
 use std::collections::BTreeMap;
+use storage::history::trie;
 
 pub fn u8_slice_20() -> impl Strategy<Value = [u8; 20]> {
     vec(any::<u8>(), 20).prop_map(|b| {
@@ -59,5 +62,35 @@ pub fn value_arb() -> impl Strategy<Value = common::value::Value> {
         ("\\PC*", key_arb()).prop_map(|(n, k)| Value::NamedKey(n, k)),
         account_arb().prop_map(Value::Acct),
         contract_arb()
+    ]
+}
+
+pub fn blake2b_hash_arb() -> impl Strategy<Value = Blake2bHash> {
+    vec(any::<u8>(), 0..1000).prop_map(|b| Blake2bHash::new(&b))
+}
+
+pub fn trie_pointer_arb() -> impl Strategy<Value = trie::Pointer> {
+    prop_oneof![
+        blake2b_hash_arb().prop_map(trie::Pointer::LeafPointer),
+        blake2b_hash_arb().prop_map(trie::Pointer::NodePointer)
+    ]
+}
+
+pub fn trie_pointer_block_arb() -> impl Strategy<Value = trie::PointerBlock> {
+    (vec(option::of(trie_pointer_arb()), 256).prop_map(|vec| {
+        let mut ret: [Option<trie::Pointer>; 256] = [Default::default(); 256];
+        ret.clone_from_slice(vec.as_slice());
+        ret.into()
+    }))
+}
+
+pub fn trie_arb() -> impl Strategy<Value = trie::Trie<Key, Value>> {
+    prop_oneof![
+        (key_arb(), value_arb()).prop_map(|(key, value)| trie::Trie::Leaf { key, value }),
+        trie_pointer_block_arb().prop_map(|pointer_block| trie::Trie::Node {
+            pointer_block: Box::new(pointer_block)
+        }),
+        (vec(any::<u8>(), 1..32), trie_pointer_arb())
+            .prop_map(|(affix, pointer)| trie::Trie::Extension { affix, pointer })
     ]
 }

--- a/execution-engine/gens/src/lib.rs
+++ b/execution-engine/gens/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate proptest;
 extern crate common;
+extern crate shared;
+extern crate storage;
 
 pub mod gens;

--- a/execution-engine/shared/Cargo.toml
+++ b/execution-engine/shared/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 blake2 = "0.8"
+common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }

--- a/execution-engine/shared/src/lib.rs
+++ b/execution-engine/shared/src/lib.rs
@@ -1,3 +1,4 @@
 extern crate blake2;
+extern crate common;
 
 pub mod newtypes;

--- a/execution-engine/shared/src/newtypes.rs
+++ b/execution-engine/shared/src/newtypes.rs
@@ -2,6 +2,7 @@
 
 use blake2::digest::{Input, VariableOutput};
 use blake2::VarBlake2b;
+use common::bytesrepr;
 use core::array::TryFromSliceError;
 use std::convert::TryFrom;
 
@@ -39,5 +40,17 @@ impl<'a> TryFrom<&'a [u8]> for Blake2bHash {
 
     fn try_from(slice: &[u8]) -> Result<Blake2bHash, Self::Error> {
         <[u8; BLAKE2B_DIGEST_LENGTH]>::try_from(slice).map(Blake2bHash)
+    }
+}
+
+impl bytesrepr::ToBytes for Blake2bHash {
+    fn to_bytes(&self) -> Vec<u8> {
+        bytesrepr::ToBytes::to_bytes(&self.0)
+    }
+}
+
+impl bytesrepr::FromBytes for Blake2bHash {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        bytesrepr::FromBytes::from_bytes(bytes).map(|(arr, rem)| (Blake2bHash(arr), rem))
     }
 }

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -5,9 +5,8 @@ use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
 use transform::Transform;
 
-// TODO: remove annotation
-#[allow(dead_code)]
-mod trie;
+// needs to be public for use in the gens crate
+pub mod trie;
 
 pub enum CommitResult {
     Success(Blake2bHash),

--- a/execution-engine/storage/src/history/trie.rs
+++ b/execution-engine/storage/src/history/trie.rs
@@ -1,6 +1,8 @@
 //! Core types for a Merkle Trie
 
+use common::bytesrepr::{self, FromBytes, ToBytes};
 use shared::newtypes::Blake2bHash;
+use std::ops::Deref;
 
 const RADIX: usize = 256;
 
@@ -11,9 +13,64 @@ pub enum Pointer {
     NodePointer(Blake2bHash),
 }
 
+impl Pointer {
+    fn hash(&self) -> &Blake2bHash {
+        match self {
+            Pointer::LeafPointer(hash) => hash,
+            Pointer::NodePointer(hash) => hash,
+        }
+    }
+
+    fn tag(&self) -> u32 {
+        match self {
+            Pointer::LeafPointer(_) => 0,
+            Pointer::NodePointer(_) => 1,
+        }
+    }
+}
+
+impl ToBytes for Pointer {
+    fn to_bytes(&self) -> Vec<u8> {
+        let mut hash_bytes = self.hash().to_bytes();
+        let mut ret = Vec::with_capacity(4 + hash_bytes.len());
+        ret.append(&mut self.tag().to_bytes());
+        ret.append(&mut hash_bytes);
+        ret
+    }
+}
+
+impl FromBytes for Pointer {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, rem): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            0 => {
+                let (hash, rem): (Blake2bHash, &[u8]) = FromBytes::from_bytes(rem)?;
+                Ok((Pointer::LeafPointer(hash), rem))
+            }
+            1 => {
+                let (hash, rem): (Blake2bHash, &[u8]) = FromBytes::from_bytes(rem)?;
+                Ok((Pointer::NodePointer(hash), rem))
+            }
+            _ => Err(bytesrepr::Error::FormattingError),
+        }
+    }
+}
+
 /// Represents the underlying structure of a node in a Merkle Trie
 #[derive(Copy, Clone)]
 pub struct PointerBlock([Option<Pointer>; RADIX]);
+
+impl PointerBlock {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl From<[Option<Pointer>; RADIX]> for PointerBlock {
+    fn from(src: [Option<Pointer>; RADIX]) -> Self {
+        PointerBlock(src)
+    }
+}
 
 impl PartialEq for PointerBlock {
     #[inline]
@@ -30,9 +87,15 @@ impl Default for PointerBlock {
     }
 }
 
-impl PointerBlock {
-    pub fn new() -> Self {
-        Default::default()
+impl ToBytes for PointerBlock {
+    fn to_bytes(&self) -> Vec<u8> {
+        ToBytes::to_bytes(&self.0)
+    }
+}
+
+impl FromBytes for PointerBlock {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        FromBytes::from_bytes(bytes).map(|(arr, rem)| (PointerBlock(arr), rem))
     }
 }
 
@@ -54,12 +117,93 @@ impl ::std::ops::IndexMut<usize> for PointerBlock {
     }
 }
 
+impl ::std::fmt::Debug for PointerBlock {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "{}(", stringify!(PointerBlock))?;
+        for item in self.0[..].iter() {
+            write!(f, "{:?}", item)?;
+        }
+        write!(f, ")")
+    }
+}
+
 /// Represents a Merkle Trie
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Trie<K, V> {
     Leaf { key: K, value: V },
     Node { pointer_block: Box<PointerBlock> },
     Extension { affix: Vec<u8>, pointer: Pointer },
+}
+
+impl<K, V> Trie<K, V> {
+    fn tag(&self) -> u32 {
+        match self {
+            Trie::Leaf { .. } => 0,
+            Trie::Node { .. } => 1,
+            Trie::Extension { .. } => 2,
+        }
+    }
+}
+
+impl<K: ToBytes, V: ToBytes> ToBytes for Trie<K, V> {
+    fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            Trie::Leaf { key, value } => {
+                let mut key_bytes = ToBytes::to_bytes(key);
+                let mut value_bytes = ToBytes::to_bytes(value);
+                let mut ret: Vec<u8> = Vec::with_capacity(4 + key_bytes.len() + value_bytes.len());
+                ret.append(&mut self.tag().to_bytes());
+                ret.append(&mut key_bytes);
+                ret.append(&mut value_bytes);
+                ret
+            }
+            Trie::Node { pointer_block } => {
+                let mut pointer_block_bytes = ToBytes::to_bytes(pointer_block.deref());
+                let mut ret: Vec<u8> = Vec::with_capacity(4 + pointer_block_bytes.len());
+                ret.append(&mut self.tag().to_bytes());
+                ret.append(&mut pointer_block_bytes);
+                ret
+            }
+            Trie::Extension { affix, pointer } => {
+                let mut affix_bytes = ToBytes::to_bytes(affix);
+                let mut pointer_bytes = ToBytes::to_bytes(pointer);
+                let mut ret: Vec<u8> =
+                    Vec::with_capacity(4 + affix_bytes.len() + pointer_bytes.len());
+                ret.append(&mut self.tag().to_bytes());
+                ret.append(&mut affix_bytes);
+                ret.append(&mut pointer_bytes);
+                ret
+            }
+        }
+    }
+}
+
+impl<K: FromBytes, V: FromBytes> FromBytes for Trie<K, V> {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (tag, rem): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            0 => {
+                let (key, rem): (K, &[u8]) = FromBytes::from_bytes(rem)?;
+                let (value, rem): (V, &[u8]) = FromBytes::from_bytes(rem)?;
+                Ok((Trie::Leaf { key, value }, rem))
+            }
+            1 => {
+                let (pointer_block, rem): (PointerBlock, &[u8]) = FromBytes::from_bytes(rem)?;
+                Ok((
+                    Trie::Node {
+                        pointer_block: Box::new(pointer_block),
+                    },
+                    rem,
+                ))
+            }
+            2 => {
+                let (affix, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(rem)?;
+                let (pointer, rem): (Pointer, &[u8]) = FromBytes::from_bytes(rem)?;
+                Ok((Trie::Extension { affix, pointer }, rem))
+            }
+            _ => Err(bytesrepr::Error::FormattingError),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/execution-engine/tests/src/bytesrepr.rs
+++ b/execution-engine/tests/src/bytesrepr.rs
@@ -64,6 +64,11 @@ proptest! {
     }
 
     #[test]
+    fn test_array_u8_32(arr in any::<[u8; 32]>()) {
+        assert!(test_serialization_roundtrip(&arr));
+    }
+
+    #[test]
     fn test_string(s in "\\PC*") {
         assert!(test_serialization_roundtrip(&s));
     }
@@ -91,5 +96,25 @@ proptest! {
     #[test]
     fn test_value_serialization(v in value_arb()) {
         assert!(test_serialization_roundtrip(&v));
+    }
+
+    #[test]
+    fn test_blake2b_hash(hash in blake2b_hash_arb()) {
+        assert!(test_serialization_roundtrip(&hash));
+    }
+
+    #[test]
+    fn test_trie_pointer(pointer in trie_pointer_arb()) {
+        assert!(test_serialization_roundtrip(&pointer));
+    }
+
+    #[test]
+    fn test_trie_pointer_block(pointer_block in trie_pointer_block_arb()) {
+        assert!(test_serialization_roundtrip(&pointer_block));
+    }
+
+    #[test]
+    fn test_trie(trie in trie_arb()) {
+        assert!(test_serialization_roundtrip(&trie));
     }
 }


### PR DESCRIPTION
## Overview
This PR adds impls of the `ToBytes` and `FromBytes` traits for the the `Trie` type (and all of its constituent parts).

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/EE-163

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
