### PR TITLE
NODE-301 NODE-302 Add gossiping configuration options

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -41,7 +41,7 @@ max-message-size = 4194304
 chunk-size = 1048576
 
 # Number of new nodes to which try to gossip a new block.
-relay-factor = 1
+relay-factor = 2
 
 # Percentage (in between 0 and 100) of nodes required to have already seen a new block before stopping to try to gossip it to new nodes.
 relay-saturation = 100

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -43,7 +43,7 @@ chunk-size = 1048576
 # Number of new nodes to which try to gossip a new block.
 relay-factor = 1
 
-# Maximum percentage (in between 0 and 100) of total amount of known nodes to which try to gossip a new block.
+# Percentage (in between 0 and 100) of nodes required to have already seen a new block before stopping to try to gossip it to new nodes.
 relay-saturation = 1
 
 # io.casperlabs.blockstorage.LMDBBlockStore.Config

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -44,7 +44,7 @@ chunk-size = 1048576
 relay-factor = 1
 
 # Percentage (in between 0 and 100) of nodes required to have already seen a new block before stopping to try to gossip it to new nodes.
-relay-saturation = 1
+relay-saturation = 100
 
 # io.casperlabs.blockstorage.LMDBBlockStore.Config
 [lmdb]

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -40,7 +40,7 @@ max-message-size = 4194304
 # Size of chunks to split larger payloads into when streamed via transport layer.
 chunk-size = 1048576
 
-# Maximum amount of nodes to which try to gossip a new block.
+# Number of new nodes to which try to gossip a new block.
 relay-factor = 1
 
 # Maximum percentage (in between 0 and 100) of total amount of known nodes to which try to gossip a new block.

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -40,6 +40,11 @@ max-message-size = 4194304
 # Size of chunks to split larger payloads into when streamed via transport layer.
 chunk-size = 1048576
 
+# Maximum amount of nodes to which try to gossip a new block.
+relay-factor = 1
+
+# Maximum percentage (in between 0 and 100) of total amount of known nodes to which try to gossip a new block.
+relay-saturation = 1
 
 # io.casperlabs.blockstorage.LMDBBlockStore.Config
 [lmdb]

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -63,7 +63,9 @@ object Configuration extends ParserImplicits {
       storeType: StoreType,
       maxNumOfConnections: Int,
       maxMessageSize: Int,
-      chunkSize: Int
+      chunkSize: Int,
+      relayFactor: Int,
+      relaySaturation: Int
   ) extends SubConfig
   case class GrpcServer(
       host: String,
@@ -153,7 +155,7 @@ object Configuration extends ParserImplicits {
             relativePath.fold(p.typeclass.update(p.dereference(t)))(
               ann => dataDir.resolve(ann.relativePath).asInstanceOf[p.PType]
             )
-          }
+        }
 
       def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
         t => sealedTrait.dispatch(t)(s => s.typeclass.update(s.cast(t)))

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -94,7 +94,7 @@ private[configuration] final case class Options private (
     * Filled by [[io.casperlabs.configuration.cli.scallop]] macro
     */
   private val fields =
-    mutable.Map.empty[(ScallopConfBase, String), () => ScallopOption[String]]
+    mutable.Map.empty[(ScallopConfBase, CamelCase), () => ScallopOption[String]]
 
   def fieldByName(fieldName: CamelCase): Option[String] =
     subcommand
@@ -269,9 +269,11 @@ private[configuration] final case class Options private (
     @scallop
     val casperMinimumBond =
       gen[Long]("Minimum bond accepted by the PoS contract in the genesis block.")
+
     @scallop
     val casperMaximumBond =
       gen[Long]("Maximum bond accepted by the PoS contract in the genesis block.")
+
     @scallop
     val casperHasFaucet =
       gen[Flag]("True if there should be a public access CSPR faucet in the genesis block.")
@@ -281,6 +283,16 @@ private[configuration] final case class Options private (
       gen[PeerNode](
         "Bootstrap casperlabs node address for initial seed.",
         'b'
+      )
+
+    @scallop
+    val serverRelayFactor =
+      gen[Int]("Maximum amount of nodes to which try to gossip a new block.")
+
+    @scallop
+    val serverRelaySaturation =
+      gen[Int](
+        "Maximum percentage (in between 0 and 100) of total amount of known nodes to which try to gossip a new block."
       )
 
     @scallop

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -287,12 +287,12 @@ private[configuration] final case class Options private (
 
     @scallop
     val serverRelayFactor =
-      gen[Int]("Maximum amount of nodes to which try to gossip a new block.")
+      gen[Int]("Number of new nodes to which try to gossip a new block.")
 
     @scallop
     val serverRelaySaturation =
       gen[Int](
-        "Maximum percentage (in between 0 and 100) of total amount of known nodes to which try to gossip a new block."
+        "Percentage (in between 0 and 100) of nodes required to have already seen a new block before stopping to try to gossip it to new nodes."
       )
 
     @scallop

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -14,6 +14,8 @@ data-dir = "/tmp"
 max-num-of-connections = 1
 max-message-size = 1
 chunk-size = 1
+relay-factor = 1
+relay-saturation = 1
 
 [lmdb]
 block-store-size = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -53,7 +53,9 @@ class ConfigurationSpec
       dataDir = Paths.get("/tmp"),
       maxNumOfConnections = 1,
       maxMessageSize = 1,
-      chunkSize = 1
+      chunkSize = 1,
+      relayFactor = 1,
+      relaySaturation = 1
     )
     val grpcServer = Configuration.GrpcServer(
       host = "test",
@@ -325,7 +327,7 @@ class ConfigurationSpec
             case (Some(a), None)    => a.some
             case (None, Some(b))    => b.some
             case (None, None)       => None
-          }
+        }
       implicit def optionPlain[A: NotSubConfig: NotOption]: Merge[Option[A]] = _ orElse _
     }
 
@@ -414,8 +416,8 @@ class ConfigurationSpec
                   List.empty
                 } else {
                   p.typeclass.flatten(path :+ p.label, p.dereference(v))
-                }
-            )
+              }
+          )
       def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = ???
       implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
 


### PR DESCRIPTION
## Overview
Adds 2 new options: --server-relay-saturation --server-relay-factor. We may also consider creating a separate `gossip: GossipConf` config.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-301
https://casperlabs.atlassian.net/browse/NODE-302

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.