### PR TITLE
NODE-313 Simplifying comm/discovery

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaRPC.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaRPC.scala
@@ -1,20 +1,13 @@
 package io.casperlabs.comm.discovery
 
-import scala.concurrent.duration.Duration
-
-import cats._, cats.data._
-
-import io.casperlabs.catscontrib.{MonadTrans, _}
-import io.casperlabs.catscontrib.Catscontrib._
-import io.casperlabs.comm.PeerNode
-import io.casperlabs.comm.protocol.routing._
+import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 
 trait KademliaRPC[F[_]] {
   def ping(node: PeerNode): F[Boolean]
-  def lookup(key: Seq[Byte], peer: PeerNode): F[Seq[PeerNode]]
+  def lookup(id: NodeIdentifier, peer: PeerNode): F[Seq[PeerNode]]
   def receive(
       pingHandler: PeerNode => F[Unit],
-      lookupHandler: (PeerNode, Array[Byte]) => F[Seq[PeerNode]]
+      lookupHandler: (PeerNode, NodeIdentifier) => F[Seq[PeerNode]]
   ): F[Unit]
   def shutdown(): F[Unit]
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCRuntime.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCRuntime.scala
@@ -146,8 +146,8 @@ final class PingHandler[F[_]: Monad: Timer](
 final class LookupHandler[F[_]: Monad: Timer](
     response: Seq[PeerNode],
     delay: Option[FiniteDuration] = None
-) extends Handler[F, (PeerNode, Array[Byte])] {
-  def handle(peer: PeerNode): (PeerNode, Array[Byte]) => F[Seq[PeerNode]] =
+) extends Handler[F, (PeerNode, NodeIdentifier)] {
+  def handle(peer: PeerNode): (PeerNode, NodeIdentifier) => F[Seq[PeerNode]] =
     (p, a) =>
       for {
         _ <- delay.fold(().pure[F])(implicitly[Timer[F]].sleep)

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCSpec.scala
@@ -101,9 +101,12 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
     }
 
     "doing a lookup to a remote peer" when {
-      val key = Array.ofDim[Byte](40)
-      Random.nextBytes(key)
-      val otherPeer = PeerNode.from(NodeIdentifier(key), "1.2.3.4", 0, 0)
+      val id = {
+        val key = Array.ofDim[Byte](40)
+        Random.nextBytes(key)
+        NodeIdentifier(key)
+      }
+      val otherPeer = PeerNode.from(id, "1.2.3.4", 0, 0)
 
       "everything is fine" should {
         "send and receive a list of peers" in
@@ -114,7 +117,7 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
                 kademliaRPC: KademliaRPC[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
+            ): F[Seq[PeerNode]] = kademliaRPC.lookup(id, remote)
 
             val result: TwoNodesResult = run()
 
@@ -123,7 +126,7 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
             val (receiver, (sender, k)) = lookupHandler.received.head
             receiver shouldEqual result.remoteNode
             sender shouldEqual result.localNode
-            k should be(key)
+            k should be(id)
           }
       }
 
@@ -136,7 +139,7 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
                 kademliaRPC: KademliaRPC[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
+            ): F[Seq[PeerNode]] = kademliaRPC.lookup(id, remote)
 
             val result: TwoNodesResult = run()
 
@@ -145,7 +148,7 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
             val (receiver, (sender, k)) = lookupHandler.received.head
             receiver shouldEqual result.remoteNode
             sender shouldEqual result.localNode
-            k should be(key)
+            k should be(id)
           }
       }
 
@@ -156,7 +159,7 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
                 kademliaRPC: KademliaRPC[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
+            ): F[Seq[PeerNode]] = kademliaRPC.lookup(id, remote)
 
             val result: TwoNodesResult = run()
 

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
@@ -18,11 +18,11 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   val DISTANCE_4 = Some(4)
   val DISTANCE_6 = Some(6)
 
-  var table       = PeerTable[PeerNode](local.key, 3)
+  var table       = PeerTable(local.id, 3)
   var pingedPeers = mutable.MutableList.empty[PeerNode]
 
   override def beforeEach(): Unit = {
-    table = PeerTable[PeerNode](local.key, 3)
+    table = PeerTable(local.id, 3)
     pingedPeers = mutable.MutableList.empty[PeerNode]
     // peer1-4 distance is 4
     table.distance(peer1) shouldBe DISTANCE_4
@@ -149,7 +149,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   }
 
   private def bucketEntriesAt(distance: Option[Int]): Seq[PeerNode] =
-    distance.map(d => table.table(d).map(_.entry)).getOrElse(Seq.empty[PeerNode])
+    distance.map(d => table.table(d).map(_.node)).getOrElse(Seq.empty[PeerNode])
 
   private val pingOk: KademliaRPC[Id]   = new KademliaRPCMock(returns = true)
   private val pingFail: KademliaRPC[Id] = new KademliaRPCMock(returns = false)
@@ -159,10 +159,10 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       pingedPeers += peer
       returns
     }
-    def lookup(key: Seq[Byte], peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
+    def lookup(id: NodeIdentifier, peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
     def receive(
         pingHandler: PeerNode => Id[Unit],
-        lookupHandler: (PeerNode, Array[Byte]) => Id[Seq[PeerNode]]
+        lookupHandler: (PeerNode, NodeIdentifier) => Id[Seq[PeerNode]]
     ): Id[Unit]              = ()
     def shutdown(): Id[Unit] = ()
   }


### PR DESCRIPTION
## Overview
The first attempt making the `discovery` package cleaner and more understandable.
Next steps would be wrapping public APIs into `Resource` in the same way as @DoSOfRedRiver did for `ExecutionEngineService`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-313

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.