### PR TITLE
EE-177: storage::history::History: add associated Error type

### DIFF
--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -4,7 +4,7 @@ use parking_lot::Mutex;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use storage::error::{GlobalStateError, RootNotFound};
+use storage::error::GlobalStateError;
 use storage::gs::{DbReader, ExecutionEffect, TrackingCopy};
 use storage::history::*;
 use storage::transform::Transform;
@@ -102,7 +102,7 @@ where
         }
     }
 
-    pub fn tracking_copy(&self, hash: Blake2bHash) -> Result<TrackingCopy<R>, RootNotFound> {
+    pub fn tracking_copy(&self, hash: Blake2bHash) -> Result<TrackingCopy<R>, H::Error> {
         self.state.lock().checkout(hash)
     }
 
@@ -119,7 +119,7 @@ where
         gas_limit: u64,
         executor: &E,
         preprocessor: &P,
-    ) -> Result<ExecutionResult, RootNotFound> {
+    ) -> Result<ExecutionResult, H::Error> {
         match preprocessor.preprocess(module_bytes, &self.wasm_costs) {
             Err(error) => Ok(ExecutionResult::failure(error.into(), 0)),
             Ok(module) => {
@@ -137,7 +137,7 @@ where
         &self,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Result<CommitResult, RootNotFound> {
+    ) -> Result<CommitResult, H::Error> {
         self.state.lock().commit(prestate_hash, effects)
     }
 }

--- a/execution-engine/storage/src/gs/inmem.rs
+++ b/execution-engine/storage/src/gs/inmem.rs
@@ -69,6 +69,8 @@ impl<K: Ord, V> InMemHist<K, V> {
 }
 
 impl History<InMemGS<Key, Value>> for InMemHist<Key, Value> {
+    type Error = RootNotFound;
+
     fn checkout(
         &self,
         prestate_hash: Blake2bHash,
@@ -148,17 +150,27 @@ mod tests {
         InMemHist { history }
     }
 
-    fn checkout<R: DbReader, H: History<R>>(hist: &H, hash: Blake2bHash) -> TrackingCopy<R> {
+    fn checkout<R, H>(hist: &H, hash: Blake2bHash) -> TrackingCopy<R>
+    where
+        R: DbReader,
+        H: History<R>,
+        H::Error: std::fmt::Debug,
+    {
         let res = hist.checkout(hash);
         assert!(res.is_ok());
         res.unwrap()
     }
 
-    fn commit<R: DbReader, H: History<R>>(
+    fn commit<R, H>(
         hist: &mut H,
         hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Blake2bHash {
+    ) -> Blake2bHash
+    where
+        R: DbReader,
+        H: History<R>,
+        H::Error: std::fmt::Debug,
+    {
         let res = hist.commit(hash, effects);
         assert!(res.is_ok());
         match res.unwrap() {

--- a/execution-engine/storage/src/gs/lmdb.rs
+++ b/execution-engine/storage/src/gs/lmdb.rs
@@ -103,6 +103,8 @@ impl DbReader for LmdbGs {
 }
 
 impl History<Self> for LmdbGs {
+    type Error = RootNotFound;
+
     fn checkout(&self, _prestate_hash: Blake2bHash) -> Result<TrackingCopy<LmdbGs>, RootNotFound> {
         unimplemented!("LMDB History not implemented")
     }

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -1,5 +1,5 @@
 use common::key::Key;
-use error::{GlobalStateError, RootNotFound};
+use error::GlobalStateError;
 use gs::{DbReader, TrackingCopy};
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
@@ -14,8 +14,10 @@ pub enum CommitResult {
 }
 
 pub trait History<R: DbReader> {
+    type Error;
+
     /// Checkouts to the post state of a specific block.
-    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<TrackingCopy<R>, RootNotFound>;
+    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<TrackingCopy<R>, Self::Error>;
 
     /// Applies changes and returns a new post state hash.
     /// block_hash is used for computing a deterministic and unique keys.
@@ -23,5 +25,5 @@ pub trait History<R: DbReader> {
         &mut self,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Result<CommitResult, RootNotFound>;
+    ) -> Result<CommitResult, Self::Error>;
 }


### PR DESCRIPTION
## Overview
This PR adds an associated type to the `History` trait to allow us to support impls with different error types.  This is needed because an LMDB-based impl will have different errors than an in-memory one.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/EE-177

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
@goral09 did similar work in #240, but we agreed offline that he would rebase some of that work atop this.
