### PR TITLE
NO-TICKET: common::bytesrepr: clean up a bit

### DIFF
--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -119,7 +119,7 @@ impl FromBytes for Vec<u8> {
 impl ToBytes for Vec<u8> {
     fn to_bytes(&self) -> Vec<u8> {
         let size = self.len() as u32;
-        let mut result: Vec<u8> = Vec::with_capacity(4 + size as usize);
+        let mut result: Vec<u8> = Vec::with_capacity(U32_SIZE + size as usize);
         result.extend(size.to_bytes());
         result.extend(self);
         result
@@ -251,7 +251,7 @@ impl FromBytes for [u8; N32] {
 
 impl<T: ToBytes> ToBytes for [T; N256] {
     fn to_bytes(&self) -> Vec<u8> {
-        let mut result = Vec::with_capacity(4 + (self.len() * size_of::<T>()));
+        let mut result = Vec::with_capacity(U32_SIZE + (self.len() * size_of::<T>()));
         result.extend((N256 as u32).to_bytes());
         result.extend(self.iter().flat_map(ToBytes::to_bytes));
         result

--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -48,6 +48,7 @@ impl ToBytes for u8 {
         result
     }
 }
+
 impl FromBytes for u8 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         match bytes.split_first() {
@@ -62,6 +63,7 @@ impl ToBytes for i32 {
         self.to_le_bytes().to_vec()
     }
 }
+
 impl FromBytes for i32 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let mut container: [u8; I32_SIZE] = [0u8; I32_SIZE];
@@ -76,6 +78,7 @@ impl ToBytes for u32 {
         self.to_le_bytes().to_vec()
     }
 }
+
 impl FromBytes for u32 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let mut container: [u8; U32_SIZE] = [0u8; U32_SIZE];
@@ -90,6 +93,7 @@ impl ToBytes for u64 {
         self.to_le_bytes().to_vec()
     }
 }
+
 impl FromBytes for u64 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let mut container: [u8; 8] = [0u8; 8];
@@ -155,6 +159,7 @@ impl<T: ToBytes> ToBytes for Option<T> {
         }
     }
 }
+
 impl<T: FromBytes> FromBytes for Option<T> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let (size, rest): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
@@ -229,6 +234,7 @@ impl ToBytes for Vec<String> {
         result
     }
 }
+
 impl ToBytes for [u8; N32] {
     fn to_bytes(&self) -> Vec<u8> {
         let mut result = Vec::with_capacity(U32_SIZE + N32);
@@ -237,6 +243,7 @@ impl ToBytes for [u8; N32] {
         result
     }
 }
+
 impl FromBytes for [u8; N32] {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let (bts, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(bytes)?;
@@ -284,6 +291,7 @@ impl ToBytes for String {
         self.as_str().to_bytes()
     }
 }
+
 impl FromBytes for String {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let (str_bytes, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(bytes)?;
@@ -297,6 +305,7 @@ impl ToBytes for () {
         Vec::new()
     }
 }
+
 impl FromBytes for () {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         Ok(((), bytes))
@@ -322,6 +331,7 @@ where
         result
     }
 }
+
 impl<K, V> FromBytes for BTreeMap<K, V>
 where
     K: FromBytes + Ord,

--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -66,10 +66,10 @@ impl ToBytes for i32 {
 
 impl FromBytes for i32 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let mut container: [u8; I32_SIZE] = [0u8; I32_SIZE];
-        let (num_bytes, rem) = safe_split_at(bytes, I32_SIZE)?;
-        container.copy_from_slice(num_bytes);
-        Ok((i32::from_le_bytes(container), rem))
+        let mut result: [u8; I32_SIZE] = [0u8; I32_SIZE];
+        let (bytes, rem) = safe_split_at(bytes, I32_SIZE)?;
+        result.copy_from_slice(bytes);
+        Ok((i32::from_le_bytes(result), rem))
     }
 }
 
@@ -81,10 +81,10 @@ impl ToBytes for u32 {
 
 impl FromBytes for u32 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let mut container: [u8; U32_SIZE] = [0u8; U32_SIZE];
-        let (num_bytes, rem) = safe_split_at(bytes, U32_SIZE)?;
-        container.copy_from_slice(num_bytes);
-        Ok((u32::from_le_bytes(container), rem))
+        let mut result: [u8; U32_SIZE] = [0u8; U32_SIZE];
+        let (bytes, rem) = safe_split_at(bytes, U32_SIZE)?;
+        result.copy_from_slice(bytes);
+        Ok((u32::from_le_bytes(result), rem))
     }
 }
 
@@ -96,18 +96,17 @@ impl ToBytes for u64 {
 
 impl FromBytes for u64 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let mut container: [u8; 8] = [0u8; 8];
-        let (num_bytes, rem) = safe_split_at(bytes, 8)?;
-        container.copy_from_slice(num_bytes);
-        Ok((u64::from_le_bytes(container), rem))
+        let mut result: [u8; 8] = [0u8; 8];
+        let (bytes, rem) = safe_split_at(bytes, 8)?;
+        result.copy_from_slice(bytes);
+        Ok((u64::from_le_bytes(result), rem))
     }
 }
 
 impl FromBytes for Vec<u8> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (size, rest): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (size, mut stream): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
         let mut result: Vec<u8> = Vec::with_capacity(size as usize);
-        let mut stream = rest;
         for _ in 0..size {
             let (t, rem): (u8, &[u8]) = FromBytes::from_bytes(stream)?;
             result.push(t);
@@ -129,9 +128,8 @@ impl ToBytes for Vec<u8> {
 
 impl FromBytes for Vec<i32> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (size, rest): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (size, mut stream): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
         let mut result: Vec<i32> = Vec::with_capacity(I32_SIZE * size as usize);
-        let mut stream = rest;
         for _ in 0..size {
             let (t, rem): (i32, &[u8]) = FromBytes::from_bytes(stream)?;
             result.push(t);
@@ -151,10 +149,8 @@ impl<T: ToBytes> ToBytes for Option<T> {
                 result.append(&mut value);
                 result
             }
-            // if the Option is empty then there
-            // is no value to serialize, but we still
-            // indicate the number of elements that need
-            // to be deserialized.
+            // In the case of None there is no value to serialize, but we still
+            // need to write out a tag to indicate which variant we are using
             None => 0u32.to_bytes(),
         }
     }
@@ -162,11 +158,11 @@ impl<T: ToBytes> ToBytes for Option<T> {
 
 impl<T: FromBytes> FromBytes for Option<T> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (size, rest): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
-        match size {
-            0 => Ok((None, rest)),
+        let (tag, rem): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        match tag {
+            0 => Ok((None, rem)),
             1 => {
-                let (t, rem): (T, &[u8]) = FromBytes::from_bytes(rest)?;
+                let (t, rem): (T, &[u8]) = FromBytes::from_bytes(rem)?;
                 Ok((Some(t), rem))
             }
             _ => Err(Error::FormattingError),
@@ -186,10 +182,9 @@ impl ToBytes for Vec<i32> {
 
 impl FromBytes for Vec<Vec<u8>> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (length, rest): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
-        let mut result: Vec<Vec<u8>> = Vec::with_capacity(length as usize);
-        let mut stream = rest;
-        for _ in 0..length {
+        let (size, mut stream): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let mut result: Vec<Vec<u8>> = Vec::with_capacity(size as usize);
+        for _ in 0..size {
             let (v, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(stream)?;
             result.push(v);
             stream = rem;
@@ -212,9 +207,8 @@ impl ToBytes for Vec<Vec<u8>> {
 
 impl FromBytes for Vec<String> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (size, rest): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (size, mut stream): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
         let mut result: Vec<String> = Vec::with_capacity(size as usize);
-        let mut stream = rest;
         for _ in 0..size {
             let (s, rem): (String, &[u8]) = FromBytes::from_bytes(stream)?;
             result.push(s);
@@ -229,8 +223,7 @@ impl ToBytes for Vec<String> {
         let size = self.len() as u32;
         let mut result = Vec::with_capacity(U32_SIZE);
         result.extend(size.to_bytes());
-        let bytes = self.iter().flat_map(ToBytes::to_bytes);
-        result.extend(bytes);
+        result.extend(self.iter().flat_map(ToBytes::to_bytes));
         result
     }
 }
@@ -246,14 +239,13 @@ impl ToBytes for [u8; N32] {
 
 impl FromBytes for [u8; N32] {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (bts, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(bytes)?;
-        if bts.len() != N32 {
-            Err(Error::FormattingError)
-        } else {
-            let mut array = [0u8; N32];
-            array.copy_from_slice(&bts);
-            Ok((array, rem))
-        }
+        let (bytes, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(bytes)?;
+        if bytes.len() != N32 {
+            return Err(Error::FormattingError);
+        };
+        let mut result = [0u8; N32];
+        result.copy_from_slice(&bytes);
+        Ok((result, rem))
     }
 }
 
@@ -261,8 +253,7 @@ impl<T: ToBytes> ToBytes for [T; N256] {
     fn to_bytes(&self) -> Vec<u8> {
         let mut result = Vec::with_capacity(4 + (self.len() * size_of::<T>()));
         result.extend((N256 as u32).to_bytes());
-        let bytes = self.iter().flat_map(ToBytes::to_bytes);
-        result.extend(bytes);
+        result.extend(self.iter().flat_map(ToBytes::to_bytes));
         result
     }
 }
@@ -273,15 +264,15 @@ impl<T: FromBytes> FromBytes for [T; N256] {
         if size != N256 as u32 {
             return Err(Error::FormattingError);
         }
-        let mut arr: MaybeUninit<[T; N256]> = MaybeUninit::uninitialized();
-        let arr_ptr = arr.as_mut_ptr() as *mut T;
+        let mut result: MaybeUninit<[T; N256]> = MaybeUninit::uninitialized();
+        let result_ptr = result.as_mut_ptr() as *mut T;
         unsafe {
             for i in 0..N256 {
                 let (t, rem): (T, &[u8]) = FromBytes::from_bytes(stream)?;
-                arr_ptr.add(i).write(t);
+                result_ptr.add(i).write(t);
                 stream = rem;
             }
-            Ok((arr.into_initialized(), stream))
+            Ok((result.into_initialized(), stream))
         }
     }
 }
@@ -295,8 +286,8 @@ impl ToBytes for String {
 impl FromBytes for String {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let (str_bytes, rem): (Vec<u8>, &[u8]) = FromBytes::from_bytes(bytes)?;
-        let string = String::from_utf8(str_bytes).map_err(|_| Error::FormattingError)?;
-        Ok((string, rem))
+        let result = String::from_utf8(str_bytes).map_err(|_| Error::FormattingError)?;
+        Ok((result, rem))
     }
 }
 
@@ -324,7 +315,6 @@ where
             b.append(&mut v.to_bytes());
             b
         });
-
         let mut result = Vec::with_capacity(U32_SIZE + bytes.size_hint().0);
         result.append(&mut num_keys.to_bytes());
         result.extend(bytes);
@@ -338,16 +328,15 @@ where
     V: FromBytes,
 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (num_keys, rem): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (num_keys, mut stream): (u32, &[u8]) = FromBytes::from_bytes(bytes)?;
         let mut result = BTreeMap::new();
-        let mut rest = rem;
         for _ in 0..num_keys {
-            let (k, rem1): (K, &[u8]) = FromBytes::from_bytes(rest)?;
-            let (v, rem2): (V, &[u8]) = FromBytes::from_bytes(rem1)?;
+            let (k, rem): (K, &[u8]) = FromBytes::from_bytes(stream)?;
+            let (v, rem): (V, &[u8]) = FromBytes::from_bytes(rem)?;
             result.insert(k, v);
-            rest = rem2;
+            stream = rem;
         }
-        Ok((result, rest))
+        Ok((result, stream))
     }
 }
 


### PR DESCRIPTION
## Overview
This PR does some housekeeping in `common::bytesrepr`, with the aim of making definitions tighter and more consistent, and shadowing variables (_gasp!_) where appropriate.

### Which JIRA issue does this PR relate to?
There is no ticket for this work, but it follows [EE-189](https://casperlabs.atlassian.net/browse/EE-189) and precedes [EE-190](https://casperlabs.atlassian.net/browse/EE-190).

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
