### PR TITLE
NO-TICKET: Custom empty protobuf message type 

### DIFF
--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -143,7 +143,7 @@ where
         match pay_mod.and(ses_mod) {
             Ok(_) => {
                 let mut result = ValidateResponse::new();
-                result.set_success(::protobuf::well_known_types::Empty::new());
+                result.set_success(ValidateResponse_ValidateSuccess::new());
                 grpc::SingleResponse::completed(result)
             },
             Err(cause) => {

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -134,23 +134,29 @@ where
         }
     }
 
-    fn validate(&self, _o: ::grpc::RequestOptions, p: ValidateRequest) -> grpc::SingleResponse<ValidateResponse> {
-        let pay_mod = wabt::Module::read_binary(p.payment_code, &wabt::ReadBinaryOptions::default())
-            .and_then(|x| x.validate());
-        let ses_mod = wabt::Module::read_binary(p.session_code, &wabt::ReadBinaryOptions::default())
-            .and_then(|x| x.validate());
+    fn validate(
+        &self,
+        _o: ::grpc::RequestOptions,
+        p: ValidateRequest,
+    ) -> grpc::SingleResponse<ValidateResponse> {
+        let pay_mod =
+            wabt::Module::read_binary(p.payment_code, &wabt::ReadBinaryOptions::default())
+                .and_then(|x| x.validate());
+        let ses_mod =
+            wabt::Module::read_binary(p.session_code, &wabt::ReadBinaryOptions::default())
+                .and_then(|x| x.validate());
 
         match pay_mod.and(ses_mod) {
             Ok(_) => {
                 let mut result = ValidateResponse::new();
                 result.set_success(ValidateResponse_ValidateSuccess::new());
                 grpc::SingleResponse::completed(result)
-            },
+            }
             Err(cause) => {
                 let mut result = ValidateResponse::new();
                 result.set_failure(cause.to_string());
                 grpc::SingleResponse::completed(result)
-            },
+            }
         }
     }
 }

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -5,8 +5,8 @@ extern crate grpc;
 extern crate protobuf;
 extern crate shared;
 extern crate storage;
-extern crate wasm_prep;
 extern crate wabt;
+extern crate wasm_prep;
 
 pub mod engine_server;
 
@@ -28,7 +28,8 @@ fn main() {
     }
 
     let init_state = storage::gs::mocked_account([48u8; 20]);
-    let engine_state = EngineState::new(InMemHist::new_initialized(&([0u8; 32].into()), init_state));
+    let engine_state =
+        EngineState::new(InMemHist::new_initialized(&([0u8; 32].into()), init_state));
     let server_builder = engine_server::new(socket, engine_state);
     let _server = server_builder.build().expect("Start server");
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/ConfParser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ConfParser.scala
@@ -70,7 +70,7 @@ private[configuration] trait ConfParserImplicits {
       C.parse(cliByName, envVars, configFile, defaultConfigFile, pathToField) match {
         case Invalid(e) if e.toList.exists(_.contains("must be defined")) => Valid(none[A])
         case x                                                            => x.map(_.some)
-    }
+      }
 
   implicit def strict[A: NotSubConfig](
       implicit
@@ -91,7 +91,7 @@ private[configuration] trait ConfParserImplicits {
               .invalidNel[A]
           )(_.validNel)
         case invalid @ Invalid(_) => invalid
-    }
+      }
 
   implicit def fallbacking[A: NotSubConfig](
       implicit P: Parser[A]

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -155,7 +155,7 @@ object Configuration extends ParserImplicits {
             relativePath.fold(p.typeclass.update(p.dereference(t)))(
               ann => dataDir.resolve(ann.relativePath).asInstanceOf[p.PType]
             )
-        }
+          }
 
       def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] =
         t => sealedTrait.dispatch(t)(s => s.typeclass.update(s.cast(t)))

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -327,7 +327,7 @@ class ConfigurationSpec
             case (Some(a), None)    => a.some
             case (None, Some(b))    => b.some
             case (None, None)       => None
-        }
+          }
       implicit def optionPlain[A: NotSubConfig: NotOption]: Merge[Option[A]] = _ orElse _
     }
 
@@ -416,8 +416,8 @@ class ConfigurationSpec
                   List.empty
                 } else {
                   p.typeclass.flatten(path :+ p.label, p.dereference(v))
-              }
-          )
+                }
+            )
       def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = ???
       implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
 

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package io.casperlabs.ipc;
 
-import "google/protobuf/empty.proto";
-
 message Deploy {
     bytes address = 1; // length 20 bytes
     uint64 timestamp = 2;
@@ -233,8 +231,9 @@ message QueryResponse {
 
 
 message ValidateResponse {
+    message ValidateSuccess {};
     oneof result {
-        google.protobuf.Empty success = 1;
+        ValidateSuccess success = 1;
         string failure = 2;
     }
 }


### PR DESCRIPTION
## Overview
There are various problems with google's empty protobuf message type. I've replaced it with custom `ValidateSuccess` message. 
This PR also does some maintenance (scalafmt, cargo fmt).

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
