### PR TITLE
EE-178: Replace RootNotFound with Option<Blake2b512Hash>

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings.rs
+++ b/execution-engine/comm/src/engine_server/mappings.rs
@@ -4,6 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use execution_engine::engine::{Error as EngineError, ExecutionResult};
 use execution_engine::execution::Error as ExecutionError;
 use ipc;
+use shared::newtypes::Blake2bHash;
 use storage::error::{Error::*, RootNotFound};
 use storage::{gs, history, op, transform};
 
@@ -399,21 +400,24 @@ impl From<ExecutionResult> for ipc::DeployResult {
 }
 
 pub fn grpc_response_from_commit_result<R, H>(
-    input: Result<storage::history::CommitResult, H::Error>,
+    prestate_hash: Blake2bHash,
+    input: Result<Option<Blake2bHash>, H::Error>,
 ) -> ipc::CommitResponse
 where
     R: gs::DbReader,
     H: history::History<R>,
-    H::Error: Into<ipc::RootNotFound>,
+    H::Error: Into<EngineError>,
+    H::Error: std::fmt::Debug,
 {
     match input {
-        Err(err) => {
-            let mut ipc_err = err.into();
+        Ok(None) => {
+            let mut root = ipc::RootNotFound::new();
+            root.set_hash(prestate_hash.to_vec());
             let mut tmp_res = ipc::CommitResponse::new();
-            tmp_res.set_missing_prestate(ipc_err);
+            tmp_res.set_missing_prestate(root);
             tmp_res
         }
-        Ok(history::CommitResult::Success(post_state_hash)) => {
+        Ok(Some(post_state_hash)) => {
             println!("Effects applied. New state hash is: {:?}", post_state_hash);
             let mut commit_result = ipc::CommitResult::new();
             let mut tmp_res = ipc::CommitResponse::new();
@@ -422,7 +426,7 @@ where
             tmp_res
         }
         // TODO(mateusz.gorski): We should be more specific about errors here.
-        Ok(history::CommitResult::Failure(storage_error)) => {
+        Err(storage_error) => {
             println!("Error {:?} when applying effects", storage_error);
             let mut err = ipc::PostEffectsError::new();
             let mut tmp_res = ipc::CommitResponse::new();

--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -4,7 +4,7 @@ use parking_lot::Mutex;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use storage::error::GlobalStateError;
+use storage::error::{GlobalStateError, RootNotFound};
 use storage::gs::{DbReader, ExecutionEffect, TrackingCopy};
 use storage::history::*;
 use storage::transform::Transform;
@@ -93,6 +93,7 @@ impl<H, R> EngineState<R, H>
 where
     H: History<R>,
     R: DbReader,
+    H::Error: Into<self::Error>,
 {
     pub fn new(state: H) -> EngineState<R, H> {
         EngineState {
@@ -102,8 +103,8 @@ where
         }
     }
 
-    pub fn tracking_copy(&self, hash: Blake2bHash) -> Result<TrackingCopy<R>, H::Error> {
-        self.state.lock().checkout(hash)
+    pub fn tracking_copy(&self, hash: Blake2bHash) -> Result<Option<TrackingCopy<R>>, Error> {
+        self.state.lock().checkout(hash).map_err(Into::into)
     }
 
     // TODO run_deploy should perform preprocessing and validation of the deploy.
@@ -119,25 +120,37 @@ where
         gas_limit: u64,
         executor: &E,
         preprocessor: &P,
-    ) -> Result<ExecutionResult, H::Error> {
-        match preprocessor.preprocess(module_bytes, &self.wasm_costs) {
-            Err(error) => Ok(ExecutionResult::failure(error.into(), 0)),
-            Ok(module) => {
-                let mut tc: storage::gs::TrackingCopy<R> =
-                    self.state.lock().checkout(prestate_hash)?;
-                match executor.exec(module, address, timestamp, nonce, gas_limit, &mut tc) {
-                    (Ok(ee), cost) => Ok(ExecutionResult::success(ee, cost)),
-                    (Err(error), cost) => Ok(ExecutionResult::failure(error.into(), cost)),
-                }
-            }
-        }
+    ) -> Result<ExecutionResult, RootNotFound> {
+        preprocessor
+            .preprocess(module_bytes, &self.wasm_costs)
+            .map_or_else(
+                |error| Ok(ExecutionResult::failure(error.into(), 0)),
+                |module| {
+                    self.state.lock().checkout(prestate_hash).map_or_else(
+                        |error| Ok(ExecutionResult::failure(error.into(), 0)),
+                        |checkout_result| match checkout_result {
+                            None => Err(RootNotFound(prestate_hash)),
+                            Some(mut tc) => {
+                                match executor
+                                    .exec(module, address, timestamp, nonce, gas_limit, &mut tc)
+                                {
+                                    (Ok(ee), cost) => Ok(ExecutionResult::success(ee, cost)),
+                                    (Err(error), cost) => {
+                                        Ok(ExecutionResult::failure(error.into(), cost))
+                                    }
+                                }
+                            }
+                        },
+                    )
+                },
+            )
     }
 
     pub fn apply_effect(
         &self,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Result<CommitResult, H::Error> {
+    ) -> Result<Option<Blake2bHash>, H::Error> {
         self.state.lock().commit(prestate_hash, effects)
     }
 }

--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -93,7 +93,7 @@ impl<H, R> EngineState<R, H>
 where
     H: History<R>,
     R: DbReader,
-    H::Error: Into<self::Error>,
+    H::Error: Into<Error>,
 {
     pub fn new(state: H) -> EngineState<R, H> {
         EngineState {

--- a/execution-engine/engine/src/lib.rs
+++ b/execution-engine/engine/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(result_map_or_else)]
 extern crate common;
 extern crate core;
 extern crate parity_wasm;

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -124,20 +124,18 @@ fn main() {
             }) => {
                 println!("Cost of executing the contract was: {}", cost);
                 match engine_state.apply_effect(state_hash, effects.1) {
-                    Err(storage::error::RootNotFound(hash)) => println!(
+                    Ok(None) => println!(
                         "Result for file {}: root {:?} not found.",
-                        wasm_bytes.path, hash
+                        wasm_bytes.path, state_hash
                     ),
-                    Ok(storage::history::CommitResult::Success(new_root_hash)) => {
+                    Ok(Some(new_root_hash)) => {
                         println!(
                             "Result for file {}: Success! New post state hash: {:?}",
                             wasm_bytes.path, new_root_hash
                         );
                         state_hash = new_root_hash; // we need to keep updating the post state hash after each deploy
                     }
-                    Ok(storage::history::CommitResult::Failure(storage_err)) => {
-                        eprintln!("Error when applying effects {:?}", storage_err)
-                    }
+                    Err(storage_err) => eprintln!("Error when applying effects {:?}", storage_err),
                 }
             }
             Ok(ExecutionResult {

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -135,7 +135,8 @@ fn mock_tc(init_key: Key, init_account: &value::Account) -> TrackingCopy<InMemGS
         .expect("Creation of mocked account should be a success.");
 
     hist.checkout(root_hash)
-        .expect("Checkout of root hash should be a success.")
+        .expect("Checkout should not throw errors.")
+        .expect("Root hash should exist.")
 }
 
 fn mock_context<'a>(

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -186,7 +186,7 @@ fn valid_uref() {
 
     // Use uref as the key to perform an action on the global state.
     // This should succeed because the uref is valid.
-    let _ = gs_write(&mut runtime, uref, value).expect("writing using valid uref should succeed");
+    gs_write(&mut runtime, uref, value).expect("writing using valid uref should succeed");
 }
 
 #[test]

--- a/execution-engine/storage/src/gs/lmdb.rs
+++ b/execution-engine/storage/src/gs/lmdb.rs
@@ -1,7 +1,7 @@
 use common::bytesrepr::{deserialize, ToBytes};
 use common::key::Key;
 use common::value::Value;
-use error::{Error, GlobalStateError, RootNotFound};
+use error::{Error, GlobalStateError};
 use gs::{DbReader, TrackingCopy};
 use history::*;
 use rkv::store::single::SingleStore;
@@ -103,9 +103,12 @@ impl DbReader for LmdbGs {
 }
 
 impl History<Self> for LmdbGs {
-    type Error = RootNotFound;
+    type Error = GlobalStateError;
 
-    fn checkout(&self, _prestate_hash: Blake2bHash) -> Result<TrackingCopy<LmdbGs>, RootNotFound> {
+    fn checkout(
+        &self,
+        _prestate_hash: Blake2bHash,
+    ) -> Result<Option<TrackingCopy<LmdbGs>>, Self::Error> {
         unimplemented!("LMDB History not implemented")
     }
 
@@ -113,7 +116,7 @@ impl History<Self> for LmdbGs {
         &mut self,
         _prestate_hash: Blake2bHash,
         _effects: HashMap<Key, Transform>,
-    ) -> Result<CommitResult, RootNotFound> {
+    ) -> Result<Option<Blake2bHash>, Self::Error> {
         unimplemented!("LMDB History not implemented")
     }
 }

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -1,5 +1,4 @@
 use common::key::Key;
-use error::GlobalStateError;
 use gs::{DbReader, TrackingCopy};
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
@@ -8,16 +7,11 @@ use transform::Transform;
 // needs to be public for use in the gens crate
 pub mod trie;
 
-pub enum CommitResult {
-    Success(Blake2bHash),
-    Failure(GlobalStateError),
-}
-
 pub trait History<R: DbReader> {
     type Error;
 
     /// Checkouts to the post state of a specific block.
-    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<TrackingCopy<R>, Self::Error>;
+    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<TrackingCopy<R>>, Self::Error>;
 
     /// Applies changes and returns a new post state hash.
     /// block_hash is used for computing a deterministic and unique keys.
@@ -25,5 +19,5 @@ pub trait History<R: DbReader> {
         &mut self,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Result<CommitResult, Self::Error>;
+    ) -> Result<Option<Blake2bHash>, Self::Error>;
 }


### PR DESCRIPTION
## Overview
This PR encodes missing root in the trie as `None` variant result, rather than erorr.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-178

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Before this PR `RootNotFound` was semantically equivalent to a storage error. This was wrong. Missing root is perfectly _valid_ state and shouldn't pollute the error family. Especially that it made the encoding of storage errors unnecessarily convoluted. In order to simplify (and fix) the error story we want to make `storage::Error` represent only _UNEXPECTED_ states and all the valid states belong to a _expected_ family of results. This PR will be soon followed by one that removes `KeyNotFound` from the `storage::Error` enum.