### PR TITLE
[OP-111] Remove Perl grep in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_PUSH_LATEST ?= false
 $(eval TAGS_OR_SHA = $(shell git tag -l --points-at HEAD | grep -e . || git describe --tags --always --long))
 # Try to use the semantic version with any leading `v` stripped.
 $(eval SEMVER_REGEX = 'v?\K\d+\.\d+(\.\d+)?')
-$(eval VER = $(shell echo $(TAGS_OR_SHA) | awk -F'-' {'print $1'}| sed 's/^.//' || echo $(TAGS_OR_SHA)))
+$(eval VER = $(shell echo $(TAGS_OR_SHA) | awk -F'-' {'print $1'} | sed 's/^.//' || echo $(TAGS_OR_SHA)))
 
 # All rust related source code. If every Rust module depends on everything then transitive dependencies are not a problem.
 # But with comm/build.rs compiling .proto to .rs every time we build the timestamps are updated as well, so filter those and depend on .proto instead.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_PUSH_LATEST ?= false
 $(eval TAGS_OR_SHA = $(shell git tag -l --points-at HEAD | grep -e . || git describe --tags --always --long))
 # Try to use the semantic version with any leading `v` stripped. TODO: MacOS doesn't support -Po
 $(eval SEMVER_REGEX = 'v?\K\d+\.\d+(\.\d+)?')
-$(eval VER = $(shell echo $(TAGS_OR_SHA) | grep -Po $(SEMVER_REGEX) | tail -n 1 | grep -e . || echo $(TAGS_OR_SHA)))
+$(eval VER = $(shell echo $(TAGS_OR_SHA) | awk -F'-' {'print $1'}| sed 's/^.//' || echo $(TAGS_OR_SHA)))
 
 # All rust related source code. If every Rust module depends on everything then transitive dependencies are not a problem.
 # But with comm/build.rs compiling .proto to .rs every time we build the timestamps are updated as well, so filter those and depend on .proto instead.

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKER_USERNAME ?= casperlabs
 DOCKER_PUSH_LATEST ?= false
 # Use the git tag / hash as version. Easy to pinpoint. `git tag` can return more than 1 though. `git rev-parse --short HEAD` would just be the commit.
 $(eval TAGS_OR_SHA = $(shell git tag -l --points-at HEAD | grep -e . || git describe --tags --always --long))
-# Try to use the semantic version with any leading `v` stripped. TODO: MacOS doesn't support -Po
+# Try to use the semantic version with any leading `v` stripped.
 $(eval SEMVER_REGEX = 'v?\K\d+\.\d+(\.\d+)?')
 $(eval VER = $(shell echo $(TAGS_OR_SHA) | awk -F'-' {'print $1'}| sed 's/^.//' || echo $(TAGS_OR_SHA)))
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ DOCKER_PUSH_LATEST ?= false
 $(eval TAGS_OR_SHA = $(shell git tag -l --points-at HEAD | grep -e . || git describe --tags --always --long))
 # Try to use the semantic version with any leading `v` stripped.
 $(eval SEMVER_REGEX = 'v?\K\d+\.\d+(\.\d+)?')
-$(eval VER = $(shell echo $(TAGS_OR_SHA) | awk -F'-' {'print $1'} | sed 's/^.//' || echo $(TAGS_OR_SHA)))
+$(eval VER = $(shell echo $(TAGS_OR_SHA) | grep -oE 'v?[0-9]+(\.[0-9]){1,2}$$' | sed 's/^v//' || echo $(TAGS_OR_SHA)))
 
 # All rust related source code. If every Rust module depends on everything then transitive dependencies are not a problem.
 # But with comm/build.rs compiling .proto to .rs every time we build the timestamps are updated as well, so filter those and depend on .proto instead.


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.
Removes the perl grep in makefile which is not supported in Mac's grep.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.
https://casperlabs.atlassian.net/browse/OP-111

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
