### PR TITLE
Additional conversion methods to assist EE-175

### DIFF
--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -10,15 +10,19 @@ use crate::value::{Contract, Value};
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::convert::{TryFrom, TryInto};
 
 /// Read value under the key in the global state
 pub fn read<T>(u_ptr: UPointer<T>) -> T
 where
-    T: From<Value>,
+    T: TryFrom<Value>,
 {
     let key: Key = u_ptr.into();
     let value = read_untyped(&key);
-    value.into()
+    value
+        .try_into()
+        .map_err(|_| "T could not be derived from Value")
+        .unwrap()
 }
 
 fn read_untyped(key: &Key) -> Value {

--- a/execution-engine/common/src/contract_api/pointers.rs
+++ b/execution-engine/common/src/contract_api/pointers.rs
@@ -3,7 +3,7 @@ use crate::value::Contract;
 use core::marker::PhantomData;
 
 // URef with type information about what value is in the global state
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct UPointer<T>([u8; 32], PhantomData<T>);
 
 impl<T> UPointer<T> {
@@ -12,7 +12,7 @@ impl<T> UPointer<T> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContractPointer {
     Hash([u8; 32]),
     URef(UPointer<Contract>),

--- a/execution-engine/common/src/contract_api/pointers.rs
+++ b/execution-engine/common/src/contract_api/pointers.rs
@@ -3,6 +3,7 @@ use crate::value::Contract;
 use core::marker::PhantomData;
 
 // URef with type information about what value is in the global state
+#[derive(Clone)]
 pub struct UPointer<T>([u8; 32], PhantomData<T>);
 
 impl<T> UPointer<T> {
@@ -11,6 +12,7 @@ impl<T> UPointer<T> {
     }
 }
 
+#[derive(Clone)]
 pub enum ContractPointer {
     Hash([u8; 32]),
     URef(UPointer<Contract>),

--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -1,5 +1,6 @@
 use super::alloc::vec::Vec;
 use super::bytesrepr::{Error, FromBytes, ToBytes};
+use crate::contract_api::pointers::*;
 
 #[repr(C)]
 #[derive(PartialEq, Eq, Clone, Copy, Debug, Hash, PartialOrd, Ord)]
@@ -10,6 +11,24 @@ pub enum Key {
 }
 
 use self::Key::*;
+
+impl Key {
+    pub fn to_u_ptr<T>(self) -> Option<UPointer<T>> {
+        if let URef(id) = self {
+            Some(UPointer::new(id))
+        } else {
+            None
+        }
+    }
+
+    pub fn to_c_ptr(self) -> Option<ContractPointer> {
+        match self {
+            URef(id) => Some(ContractPointer::URef(UPointer::new(id))),
+            Hash(id) => Some(ContractPointer::Hash(id)),
+            _ => None,
+        }
+    }
+}
 
 const ACCOUNT_ID: u8 = 0;
 const HASH_ID: u8 = 1;


### PR DESCRIPTION
## Overview
These are just some conversion methods to make working with the new typed API easier.

- Conversion methods for Key to typed pointers
- Conversion methods for basic data types to/from Value

Example code these changes enable
```rust
#[no_mangle]
pub extern "C" fn counter_ext() {
    let i_key: UPointer<i32> = get_uref("count").to_u_ptr().unwrap();
    let method_name: String = get_arg(0);
    match method_name.as_str() {
        "inc" => add(i_key, 1), //much nicer than before!
        "get" => {
            let result = read(i_key); //also much nicer than before!
            ret(&result, &Vec::new());
        }
        _ => panic!("Unknown method name!"),
    }
}
```

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-175

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
