### PR TITLE
EE-192: Extract KeyNotFound from storage::Error family.

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings.rs
+++ b/execution-engine/comm/src/engine_server/mappings.rs
@@ -397,13 +397,12 @@ impl From<ExecutionResult> for ipc::DeployResult {
     }
 }
 
-pub fn grpc_response_from_commit_result<R, H>(
+pub fn grpc_response_from_commit_result<H>(
     prestate_hash: Blake2bHash,
     input: Result<Option<Blake2bHash>, H::Error>,
 ) -> ipc::CommitResponse
 where
-    R: gs::DbReader,
-    H: history::History<R>,
+    H: history::History,
     H::Error: Into<EngineError> + std::fmt::Debug,
 {
     match input {

--- a/execution-engine/comm/src/engine_server/mappings.rs
+++ b/execution-engine/comm/src/engine_server/mappings.rs
@@ -6,7 +6,7 @@ use execution_engine::execution::Error as ExecutionError;
 use ipc;
 use shared::newtypes::Blake2bHash;
 use storage::error::{Error::*, RootNotFound};
-use storage::{gs, history, op, transform};
+use storage::{gs, history, history::CommitResult, op, transform};
 
 /// Helper method for turning instances of Value into Transform::Write.
 fn transform_write(v: common::value::Value) -> Result<transform::Transform, ParsingError> {
@@ -348,10 +348,6 @@ impl From<ExecutionResult> for ipc::DeployResult {
                     // so for the time being they are all reported as "wasm errors".
                     EngineError::StorageError(storage_err) => {
                         let mut err = match storage_err {
-                            KeyNotFound(key) => {
-                                let msg = format!("Key {:?} not found.", key);
-                                wasm_error(msg)
-                            }
                             RkvError(error_msg) => wasm_error(error_msg),
                             TransformTypeMismatch(transform::TypeMismatch { expected, found }) => {
                                 let msg = format!(
@@ -383,6 +379,10 @@ impl From<ExecutionResult> for ipc::DeployResult {
                             deploy_result.set_cost(cost);
                             deploy_result
                         }
+                        ExecutionError::KeyNotFound(key) => {
+                            let msg = format!("Key {:?} not found.", key);
+                            wasm_error(msg)
+                        }
                         // TODO(mateusz.gorski): Be more specific about execution errors
                         other => {
                             let msg = format!("{:?}", other);
@@ -399,27 +399,32 @@ impl From<ExecutionResult> for ipc::DeployResult {
 
 pub fn grpc_response_from_commit_result<H>(
     prestate_hash: Blake2bHash,
-    input: Result<Option<Blake2bHash>, H::Error>,
+    input: Result<CommitResult, H::Error>,
 ) -> ipc::CommitResponse
 where
     H: history::History,
     H::Error: Into<EngineError> + std::fmt::Debug,
 {
     match input {
-        Ok(None) => {
+        Ok(CommitResult::RootNotFound) => {
             let mut root = ipc::RootNotFound::new();
             root.set_hash(prestate_hash.to_vec());
             let mut tmp_res = ipc::CommitResponse::new();
             tmp_res.set_missing_prestate(root);
             tmp_res
         }
-        Ok(Some(post_state_hash)) => {
+        Ok(CommitResult::Success(post_state_hash)) => {
             println!("Effects applied. New state hash is: {:?}", post_state_hash);
             let mut commit_result = ipc::CommitResult::new();
             let mut tmp_res = ipc::CommitResponse::new();
             commit_result.set_poststate_hash(post_state_hash.to_vec());
             tmp_res.set_success(commit_result);
             tmp_res
+        }
+        Ok(CommitResult::KeyNotFound(key)) => {
+            let mut commit_response = ipc::CommitResponse::new();
+            commit_response.set_key_not_found((&key).into());
+            commit_response
         }
         // TODO(mateusz.gorski): We should be more specific about errors here.
         Err(storage_error) => {
@@ -516,7 +521,6 @@ mod tests {
     fn storage_error_has_cost() {
         use storage::error::Error::*;
         let cost: u64 = 100;
-        assert_eq!(test_cost(cost, KeyNotFound(Key::Account([1u8; 20]))), cost);
         assert_eq!(test_cost(cost, RkvError("Error".to_owned())), cost);
         let type_mismatch = storage::transform::TypeMismatch {
             expected: "expected".to_owned(),

--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -140,7 +140,7 @@ where
         &self,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Result<Option<Blake2bHash>, H::Error> {
+    ) -> Result<CommitResult, H::Error> {
         self.state.lock().commit(prestate_hash, effects)
     }
 }

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -15,6 +15,7 @@ use execution_engine::engine::{EngineState, ExecutionResult};
 use execution_engine::execution::WasmiExecutor;
 use shared::newtypes::Blake2bHash;
 use storage::gs::inmem::InMemHist;
+use storage::history::CommitResult;
 use wasm_prep::WasmiPreprocessor;
 
 #[derive(Debug)]
@@ -124,11 +125,15 @@ fn main() {
             }) => {
                 println!("Cost of executing the contract was: {}", cost);
                 match engine_state.apply_effect(state_hash, effects.1) {
-                    Ok(None) => println!(
+                    Ok(CommitResult::RootNotFound) => println!(
                         "Result for file {}: root {:?} not found.",
                         wasm_bytes.path, state_hash
                     ),
-                    Ok(Some(new_root_hash)) => {
+                    Ok(CommitResult::KeyNotFound(key)) => println!(
+                        "Result for file {}: key {:?} not found.",
+                        wasm_bytes.path, key
+                    ),
+                    Ok(CommitResult::Success(new_root_hash)) => {
                         println!(
                             "Result for file {}: Success! New post state hash: {:?}",
                             wasm_bytes.path, new_root_hash

--- a/execution-engine/rust-toolchain
+++ b/execution-engine/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2019-03-06
+nightly

--- a/execution-engine/storage/src/error.rs
+++ b/execution-engine/storage/src/error.rs
@@ -1,10 +1,8 @@
 use std::fmt;
 
 use common::bytesrepr;
-use common::key::Key;
 use rkv::error::StoreError;
 use shared::newtypes::Blake2bHash;
-use std::fmt::Debug;
 use transform::TypeMismatch;
 use wasmi::HostError;
 
@@ -12,8 +10,7 @@ use wasmi::HostError;
 pub struct RootNotFound(pub Blake2bHash);
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum Error<K: Debug> {
-    KeyNotFound(K),
+pub enum Error {
     TransformTypeMismatch(TypeMismatch),
     // mateusz.gorski: I think that these errors should revert any changes made
     // to Global State and most probably kill the node.
@@ -21,9 +18,9 @@ pub enum Error<K: Debug> {
     BytesRepr(bytesrepr::Error),
 }
 
-pub type GlobalStateError = Error<Key>;
+pub type GlobalStateError = Error;
 
-impl<A: Debug> fmt::Display for Error<A> {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{:?}", self)
     }

--- a/execution-engine/storage/src/gs/lmdb.rs
+++ b/execution-engine/storage/src/gs/lmdb.rs
@@ -102,13 +102,14 @@ impl DbReader for LmdbGs {
     }
 }
 
-impl History<Self> for LmdbGs {
+impl History for LmdbGs {
     type Error = GlobalStateError;
+    type Reader = Self;
 
     fn checkout(
         &self,
         _prestate_hash: Blake2bHash,
-    ) -> Result<Option<TrackingCopy<LmdbGs>>, Self::Error> {
+    ) -> Result<Option<TrackingCopy<Self::Reader>>, Self::Error> {
         unimplemented!("LMDB History not implemented")
     }
 

--- a/execution-engine/storage/src/gs/mod.rs
+++ b/execution-engine/storage/src/gs/mod.rs
@@ -15,7 +15,7 @@ pub use self::trackingcopy::TrackingCopy;
 pub struct ExecutionEffect(pub HashMap<Key, Op>, pub HashMap<Key, Transform>);
 
 pub trait DbReader {
-    fn get(&self, k: &Key) -> Result<Value, GlobalStateError>;
+    fn get(&self, k: &Key) -> Result<Option<Value>, GlobalStateError>;
 }
 
 pub fn mocked_account(account_addr: [u8; 20]) -> BTreeMap<Key, Value> {

--- a/execution-engine/storage/src/gs/trackingcopy.rs
+++ b/execution-engine/storage/src/gs/trackingcopy.rs
@@ -30,45 +30,60 @@ impl<R: DbReader> TrackingCopy<R> {
         }
     }
 
-    pub fn get(&mut self, k: &Key) -> Result<Value, GlobalStateError> {
+    pub fn get(&mut self, k: &Key) -> Result<Option<Value>, GlobalStateError> {
         if let Some(value) = self.cache.get(k) {
-            return Ok(value.clone());
+            return Ok(Some(value.clone()));
         }
-        let value = self.reader.get(k)?;
-        let _ = self.cache.insert(*k, value.clone());
-        Ok(value)
+        if let Some(value) = self.reader.get(k)? {
+            self.cache.insert(*k, value.clone());
+            Ok(Some(value))
+        } else {
+            Ok(None)
+        }
     }
 
-    pub fn read(&mut self, k: Key) -> Result<Value, GlobalStateError> {
-        let value = self.get(&k)?;
-        add(&mut self.ops, k, Op::Read);
-        Ok(value)
+    pub fn read(&mut self, k: Key) -> Result<Option<Value>, GlobalStateError> {
+        if let Some(value) = self.get(&k)? {
+            add(&mut self.ops, k, Op::Read);
+            Ok(Some(value))
+        } else {
+            Ok(None)
+        }
     }
+
     pub fn write(&mut self, k: Key, v: Value) -> Result<(), GlobalStateError> {
         let _ = self.cache.insert(k, v.clone());
         add(&mut self.ops, k, Op::Write);
         add(&mut self.fns, k, Transform::Write(v));
         Ok(())
     }
-    pub fn add(&mut self, k: Key, v: Value) -> Result<(), GlobalStateError> {
-        let curr = self.get(&k)?;
-        let t = match v {
-            Value::Int32(i) => Ok(Transform::AddInt32(i)),
-            Value::NamedKey(n, k) => {
-                let mut map = BTreeMap::new();
-                map.insert(n, k);
-                Ok(Transform::AddKeys(map))
+
+    /// Ok(None) represents missing key to which we want to "add" some value.
+    /// Ok(Some(unit)) represents successful operation.
+    /// Err(error) is reserved for unexpected errors when accessing global state.
+    pub fn add(&mut self, k: Key, v: Value) -> Result<Option<()>, GlobalStateError> {
+        match self.get(&k)? {
+            None => Ok(None),
+            Some(curr) => {
+                let t = match v {
+                    Value::Int32(i) => Ok(Transform::AddInt32(i)),
+                    Value::NamedKey(n, k) => {
+                        let mut map = BTreeMap::new();
+                        map.insert(n, k);
+                        Ok(Transform::AddKeys(map))
+                    }
+                    other => Err(TypeMismatch::new(
+                        "Int32 or NamedKey".to_string(),
+                        other.type_string(),
+                    )),
+                }?;
+                let new_value = t.clone().apply(curr)?;
+                let _ = self.cache.insert(k, new_value);
+                add(&mut self.ops, k, Op::Add);
+                add(&mut self.fns, k, t);
+                Ok(Some(()))
             }
-            other => Err(TypeMismatch::new(
-                "Int32 or NamedKey".to_string(),
-                other.type_string(),
-            )),
-        }?;
-        let new_value = t.clone().apply(curr)?;
-        let _ = self.cache.insert(k, new_value);
-        add(&mut self.ops, k, Op::Add);
-        add(&mut self.fns, k, t);
-        Ok(())
+        }
     }
 
     pub fn effect(&self) -> ExecutionEffect {
@@ -80,55 +95,86 @@ impl<R: DbReader> TrackingCopy<R> {
         base_key: Key,
         path: &[String],
     ) -> Result<QueryResult, GlobalStateError> {
-        let base_value = self.read(base_key)?;
+        match self.read(base_key)? {
+            None => Ok(QueryResult::ValueNotFound(self.error_path_msg(
+                base_key,
+                path,
+                "".to_owned(),
+                0 as usize,
+            ))),
+            Some(base_value) => {
+                let result = path.iter().enumerate().try_fold(
+                    base_value,
+                    // We encode the two possible short-circuit conditions with
+                    // Result<(usize, String), Error>, where the Ok(_) case corresponds to
+                    // QueryResult::ValueNotFound and Err(_) corresponds to
+                    // a storage-related error. The information in the Ok(_) case is used
+                    // to build an informative error message about why the query was not successful.
+                    |curr_value, (i, name)| -> Result<Value, Result<(usize, String), GlobalStateError>> {
+                        match curr_value {
+                            Value::Account(account) => {
+                                if let Some(key) = account.urefs_lookup().get(name) {
+                                    self.read_key_or_stop(*key, i)
+                                } else {
+                                    Err(Ok((i, format!("Name {} not found in Account at path:", name))))
+                                }
+                            }
 
-        let result = path.iter().enumerate().try_fold(
-            base_value,
-            // We encode the two possible short-circuit conditions with
-            // Result<(usize, String), Error>, where the Ok(_) case corresponds to
-            // QueryResult::ValueNotFound and Err(_) corresponds to
-            // a storage-related error. The information in the Ok(_) case is used
-            // to build an informative error message about why the query was not successful.
-            |curr_value, (i, name)| -> Result<Value, Result<(usize, String), GlobalStateError>> {
-                match curr_value {
-                    Value::Account(account) => {
-                        if let Some(key) = account.urefs_lookup().get(name) {
-                            self.read(*key).map_err(Err)
-                        } else {
-                            Err(Ok((i, format!("Name {} not found in Account at path:", name))))
+                            Value::Contract(contract) => {
+                                if let Some(key) = contract.urefs_lookup().get(name) {
+                                    self.read_key_or_stop(*key, i)
+                                } else {
+                                    Err(Ok((i, format!("Name {} not found in Contract at path:", name))))
+                                }
+                            }
+
+                            other => Err(
+                                Ok((i, format!("Name {} cannot be followed from value {:?} because it is neither an account nor contract. Value found at path:", name, other)))
+                                ),
                         }
-                    }
+                    },
+                );
 
-                    Value::Contract(contract) => {
-                        if let Some(key) = contract.urefs_lookup().get(name) {
-                            self.read(*key).map_err(Err)
-                        } else {
-                            Err(Ok((i, format!("Name {} not found in Contract at path:", name))))
-                        }
-                    }
-
-                    other => Err(
-                        Ok((i, format!("Name {} cannot be followed from value {:?} because it is neither an account nor contract. Value found at path:", name, other)))
-                    ),
+                match result {
+                    Ok(value) => Ok(QueryResult::Success(value)),
+                    Err(Ok((i, s))) => Ok(QueryResult::ValueNotFound(
+                        self.error_path_msg(base_key, path, s, i),
+                    )),
+                    Err(Err(err)) => Err(err),
                 }
-            },
-        );
-
-        match result {
-            Ok(value) => Ok(QueryResult::Success(value)),
-
-            Err(Ok((i, s))) => {
-                let mut error_msg = format!("{} {:?}", s, base_key);
-                //include the partial path to the account/contract/value which failed
-                for p in path.iter().take(i) {
-                    error_msg.push_str("/");
-                    error_msg.push_str(p);
-                }
-                Ok(QueryResult::ValueNotFound(error_msg))
             }
-
-            Err(Err(err)) => Err(err),
         }
+    }
+
+    fn read_key_or_stop(
+        &mut self,
+        key: Key,
+        i: usize,
+    ) -> Result<Value, Result<(usize, String), GlobalStateError>> {
+        match self.read(key) {
+            // continue recursing
+            Ok(Some(value)) => Ok(value),
+            // key not found in the global state; stop recursing
+            Ok(None) => Err(Ok((i, format!("Name {:?} not found: ", key)))),
+            // global state access error; stop recursing
+            Err(error) => Err(Err(error)),
+        }
+    }
+
+    fn error_path_msg(
+        &self,
+        key: Key,
+        path: &[String],
+        missing_key: String,
+        missing_at_index: usize,
+    ) -> String {
+        let mut error_msg = format!("{} {:?}", missing_key, key);
+        //include the partial path to the account/contract/value which failed
+        for p in path.iter().take(missing_at_index) {
+            error_msg.push_str("/");
+            error_msg.push_str(p);
+        }
+        error_msg
     }
 }
 
@@ -171,19 +217,19 @@ mod tests {
     }
 
     impl DbReader for CountingDb {
-        fn get(&self, _k: &Key) -> Result<Value, GlobalStateError> {
+        fn get(&self, _k: &Key) -> Result<Option<Value>, GlobalStateError> {
             let count = self.count.get();
             let value = match self.value {
                 Some(ref v) => v.clone(),
                 None => Value::Int32(count),
             };
             self.count.set(count + 1);
-            Ok(value)
+            Ok(Some(value))
         }
     }
 
     impl DbReader for Rc<CountingDb> {
-        fn get(&self, k: &Key) -> Result<Value, GlobalStateError> {
+        fn get(&self, k: &Key) -> Result<Option<Value>, GlobalStateError> {
             CountingDb::get(self, k)
         }
     }
@@ -205,14 +251,14 @@ mod tests {
         let mut tc = TrackingCopy::new(db_ref.clone());
         let k = Key::Hash([0u8; 32]);
 
-        let zero = Ok(Value::Int32(0));
+        let zero = Value::Int32(0);
         // first read
-        let value = tc.read(k);
+        let value = tc.read(k).unwrap().unwrap();
         assert_eq!(value, zero);
 
         // second read; should use cache instead
         // of going back to the DB
-        let value = tc.read(k);
+        let value = tc.read(k).unwrap().unwrap();
         let db_value = db_ref.count.get();
         assert_eq!(value, zero);
         assert_eq!(db_value, 1);
@@ -224,8 +270,8 @@ mod tests {
         let mut tc = TrackingCopy::new(db);
         let k = Key::Hash([0u8; 32]);
 
-        let zero = Ok(Value::Int32(0));
-        let value = tc.read(k);
+        let zero = Value::Int32(0);
+        let value = tc.read(k).unwrap().unwrap();
         // value read correctly
         assert_eq!(value, zero);
         // read does not cause any transform
@@ -408,7 +454,7 @@ mod tests {
 
             if missing_key != k {
                 let result = tc.query(missing_key, &empty_path);
-                assert_matches!(result, Err(Error::KeyNotFound(_)));
+                assert_matches!(result, Ok(QueryResult::ValueNotFound(_)));
             }
         }
 

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -7,6 +7,12 @@ use transform::Transform;
 // needs to be public for use in the gens crate
 pub mod trie;
 
+pub enum CommitResult {
+    RootNotFound,
+    Success(Blake2bHash),
+    KeyNotFound(Key),
+}
+
 pub trait History {
     type Error;
     type Reader: DbReader;
@@ -23,5 +29,5 @@ pub trait History {
         &mut self,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
-    ) -> Result<Option<Blake2bHash>, Self::Error>;
+    ) -> Result<CommitResult, Self::Error>;
 }

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -7,11 +7,15 @@ use transform::Transform;
 // needs to be public for use in the gens crate
 pub mod trie;
 
-pub trait History<R: DbReader> {
+pub trait History {
     type Error;
+    type Reader: DbReader;
 
     /// Checkouts to the post state of a specific block.
-    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<TrackingCopy<R>>, Self::Error>;
+    fn checkout(
+        &self,
+        prestate_hash: Blake2bHash,
+    ) -> Result<Option<TrackingCopy<Self::Reader>>, Self::Error>;
 
     /// Applies changes and returns a new post state hash.
     /// block_hash is used for computing a deterministic and unique keys.

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -45,7 +45,8 @@ message CommitResponse {
     oneof result {
         CommitResult success = 1;
         RootNotFound missing_prestate = 2;
-        PostEffectsError failed_transform = 3;
+        Key key_not_found = 3;
+        PostEffectsError failed_transform = 4;
     }
 }
 


### PR DESCRIPTION
## Overview
Remove `KeyNotFound` variant from `storage::Error` enum. Any method that reads from the Global State now returns `Result<Ok<Value>, GlobalStateError>`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-192

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
This is another PR (after #251) on the road to clean up `storage::Error` type. This PR will be followed by yet another one that extracts `TransformTypeMismatch` from the `storage::Error` as well.
