### PR TITLE
EE-193: Extract TransformTypeMismatch from storage::Error enum.

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings.rs
+++ b/execution-engine/comm/src/engine_server/mappings.rs
@@ -6,7 +6,7 @@ use execution_engine::execution::Error as ExecutionError;
 use ipc;
 use shared::newtypes::Blake2bHash;
 use storage::error::{Error::*, RootNotFound};
-use storage::{gs, history, history::CommitResult, op, transform};
+use storage::{gs, history, history::CommitResult, op, transform, transform::TypeMismatch};
 
 /// Helper method for turning instances of Value into Transform::Write.
 fn transform_write(v: common::value::Value) -> Result<transform::Transform, ParsingError> {
@@ -325,6 +325,16 @@ impl From<RootNotFound> for ipc::RootNotFound {
     }
 }
 
+impl From<TypeMismatch> for ipc::TypeMismatch {
+    fn from(type_mismatch: TypeMismatch) -> ipc::TypeMismatch {
+        let TypeMismatch { expected, found } = type_mismatch;
+        let mut tm = ipc::TypeMismatch::new();
+        tm.set_expected(expected);
+        tm.set_found(found);
+        tm
+    }
+}
+
 impl From<ExecutionResult> for ipc::DeployResult {
     fn from(er: ExecutionResult) -> ipc::DeployResult {
         match er {
@@ -349,13 +359,6 @@ impl From<ExecutionResult> for ipc::DeployResult {
                     EngineError::StorageError(storage_err) => {
                         let mut err = match storage_err {
                             RkvError(error_msg) => wasm_error(error_msg),
-                            TransformTypeMismatch(transform::TypeMismatch { expected, found }) => {
-                                let msg = format!(
-                                    "Type mismatch. Expected {:?}, found {:?}",
-                                    expected, found
-                                );
-                                wasm_error(msg)
-                            }
                             BytesRepr(bytesrepr_err) => {
                                 let msg =
                                     format!("Error with byte representation: {:?}", bytesrepr_err);
@@ -424,6 +427,11 @@ where
         Ok(CommitResult::KeyNotFound(key)) => {
             let mut commit_response = ipc::CommitResponse::new();
             commit_response.set_key_not_found((&key).into());
+            commit_response
+        }
+        Ok(CommitResult::TypeMismatch(type_mismatch)) => {
+            let mut commit_response = ipc::CommitResponse::new();
+            commit_response.set_type_mismatch(type_mismatch.into());
             commit_response
         }
         // TODO(mateusz.gorski): We should be more specific about errors here.
@@ -522,11 +530,6 @@ mod tests {
         use storage::error::Error::*;
         let cost: u64 = 100;
         assert_eq!(test_cost(cost, RkvError("Error".to_owned())), cost);
-        let type_mismatch = storage::transform::TypeMismatch {
-            expected: "expected".to_owned(),
-            found: "found".to_owned(),
-        };
-        assert_eq!(test_cost(cost, TransformTypeMismatch(type_mismatch)), cost);
         let bytesrepr_err = common::bytesrepr::Error::EarlyEndOfStream;
         assert_eq!(test_cost(cost, BytesRepr(bytesrepr_err)), cost);
     }

--- a/execution-engine/comm/src/engine_server/mappings.rs
+++ b/execution-engine/comm/src/engine_server/mappings.rs
@@ -161,7 +161,7 @@ impl From<transform::Transform> for super::ipc::Transform {
             }
             transform::Transform::Failure(transform::TypeMismatch { expected, found }) => {
                 let mut fail = super::ipc::TransformFailure::new();
-                let mut typemismatch_err = super::ipc::StorageTypeMismatch::new();
+                let mut typemismatch_err = super::ipc::TypeMismatch::new();
                 typemismatch_err.set_expected(expected.to_owned());
                 typemismatch_err.set_found(found.to_owned());
                 fail.set_error(typemismatch_err);

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -133,6 +133,9 @@ fn main() {
                         "Result for file {}: key {:?} not found.",
                         wasm_bytes.path, key
                     ),
+                    Ok(CommitResult::TypeMismatch(type_mismatch)) => {
+                        println!("Result for file {}: {:?}", wasm_bytes.path, type_mismatch)
+                    }
                     Ok(CommitResult::Success(new_root_hash)) => {
                         println!(
                             "Result for file {}: Success! New post state hash: {:?}",

--- a/execution-engine/storage/src/error.rs
+++ b/execution-engine/storage/src/error.rs
@@ -3,7 +3,6 @@ use std::fmt;
 use common::bytesrepr;
 use rkv::error::StoreError;
 use shared::newtypes::Blake2bHash;
-use transform::TypeMismatch;
 use wasmi::HostError;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -11,7 +10,6 @@ pub struct RootNotFound(pub Blake2bHash);
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Error {
-    TransformTypeMismatch(TypeMismatch),
     // mateusz.gorski: I think that these errors should revert any changes made
     // to Global State and most probably kill the node.
     RkvError(String), //TODO: capture error better
@@ -37,11 +35,5 @@ impl From<StoreError> for GlobalStateError {
 impl From<bytesrepr::Error> for GlobalStateError {
     fn from(e: bytesrepr::Error) -> Self {
         Error::BytesRepr(e)
-    }
-}
-
-impl From<TypeMismatch> for GlobalStateError {
-    fn from(tm: TypeMismatch) -> Self {
-        Error::TransformTypeMismatch(tm)
     }
 }

--- a/execution-engine/storage/src/gs/inmem.rs
+++ b/execution-engine/storage/src/gs/inmem.rs
@@ -99,10 +99,14 @@ impl History for InMemHist<Key, Value> {
                             }
                             _ => return Ok(CommitResult::KeyNotFound(k)),
                         },
-                        Some(curr) => {
-                            let new_value = t.apply(curr)?;
-                            base.insert(k, new_value);
-                        }
+                        Some(curr) => match t.apply(curr) {
+                            Ok(new_value) => {
+                                base.insert(k, new_value);
+                            }
+                            Err(type_mismatch) => {
+                                return Ok(CommitResult::TypeMismatch(type_mismatch))
+                            }
+                        },
                     }
                 }
                 let hash = InMemHist::get_root_hash(&base);

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -2,7 +2,7 @@ use common::key::Key;
 use gs::{DbReader, TrackingCopy};
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
-use transform::Transform;
+use transform::{Transform, TypeMismatch};
 
 // needs to be public for use in the gens crate
 pub mod trie;
@@ -11,6 +11,7 @@ pub enum CommitResult {
     RootNotFound,
     Success(Blake2bHash),
     KeyNotFound(Key),
+    TypeMismatch(TypeMismatch),
 }
 
 pub trait History {

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -46,7 +46,8 @@ message CommitResponse {
         CommitResult success = 1;
         RootNotFound missing_prestate = 2;
         Key key_not_found = 3;
-        PostEffectsError failed_transform = 4;
+        TypeMismatch type_mismatch = 4;
+        PostEffectsError failed_transform = 5;
     }
 }
 
@@ -147,10 +148,8 @@ message TransformFailure {
 //Errors which may occur while interacting with global state
 message StorageError {
     oneof error_instance {
-        Key key_not_found = 1;
-        TypeMismatch type_mismatch = 2;
-        BytesReprError bytes_repr = 3;
-        RkvError rkv = 4;
+        BytesReprError bytes_repr = 1;
+        RkvError rkv = 2;
     }
 }
 message TypeMismatch {

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -141,19 +141,19 @@ message TransformWrite {
     Value value = 1;
 }
 message TransformFailure {
-    StorageTypeMismatch error = 1;
+    TypeMismatch error = 1;
 }
  
 //Errors which may occur while interacting with global state
 message StorageError {
     oneof error_instance {
         Key key_not_found = 1;
-        StorageTypeMismatch type_mismatch = 2;
+        TypeMismatch type_mismatch = 2;
         BytesReprError bytes_repr = 3;
         RkvError rkv = 4;
     }
 }
-message StorageTypeMismatch {
+message TypeMismatch {
     string expected = 1;
     string found = 2;
 }


### PR DESCRIPTION
## Overview
Removes `TransformTypeMismatch` from `storage::Error` enum. This is the last step necessary to make `storage::Error` enum describing only _unexpected_ errors of the storage layer.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-193

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
This PR is created against #256 as the work done there laid the ground for these fixes. Some cleanup will follow up - removing `Transform::Failure` variant, adding associated `Error` type to `DbReader`, tying the knot between `DbReader::Error` and `History::Error` types, 