### PR TITLE
EE-198: move RootNotFound to engine

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings.rs
+++ b/execution-engine/comm/src/engine_server/mappings.rs
@@ -1,11 +1,11 @@
 use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 
-use execution_engine::engine::{Error as EngineError, ExecutionResult};
+use execution_engine::engine::{Error as EngineError, ExecutionResult, RootNotFound};
 use execution_engine::execution::Error as ExecutionError;
 use ipc;
 use shared::newtypes::Blake2bHash;
-use storage::error::{Error::*, RootNotFound};
+use storage::error::Error::*;
 use storage::{gs, history, history::CommitResult, op, transform, transform::TypeMismatch};
 
 /// Helper method for turning instances of Value into Transform::Write.
@@ -460,7 +460,7 @@ fn wasm_error(msg: String) -> ipc::DeployResult {
 mod tests {
     use super::wasm_error;
     use common::key::Key;
-    use execution_engine::engine::{Error as EngineError, ExecutionResult};
+    use execution_engine::engine::{Error as EngineError, ExecutionResult, RootNotFound};
     use shared::newtypes::Blake2bHash;
     use std::collections::HashMap;
     use std::convert::TryInto;
@@ -483,7 +483,7 @@ mod tests {
     #[test]
     fn deploy_result_to_ipc_missing_root() {
         let root_hash: Blake2bHash = [1u8; 32].into();
-        let mut result: super::ipc::RootNotFound = storage::error::RootNotFound(root_hash).into();
+        let mut result: super::ipc::RootNotFound = RootNotFound(root_hash).into();
         let ipc_missing_hash = result.take_hash();
         assert_eq!(root_hash.to_vec(), ipc_missing_hash);
     }

--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -3,12 +3,15 @@ use execution::{Error as ExecutionError, Executor};
 use parking_lot::Mutex;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
-use storage::error::{GlobalStateError, RootNotFound};
+use storage::error::GlobalStateError;
 use storage::gs::{ExecutionEffect, TrackingCopy};
 use storage::history::*;
 use storage::transform::Transform;
 use vm::wasm_costs::WasmCosts;
 use wasm_prep::Preprocessor;
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct RootNotFound(pub Blake2bHash);
 
 pub struct EngineState<H>
 where

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -11,7 +11,7 @@ use std::iter::Iterator;
 
 use clap::{App, Arg};
 
-use execution_engine::engine::{EngineState, ExecutionResult};
+use execution_engine::engine::{EngineState, ExecutionResult, RootNotFound};
 use execution_engine::execution::WasmiExecutor;
 use shared::newtypes::Blake2bHash;
 use storage::gs::inmem::InMemHist;
@@ -115,7 +115,7 @@ fn main() {
             &wasmi_preprocessor,
         );
         match result {
-            Err(storage::error::RootNotFound(hash)) => println!(
+            Err(RootNotFound(hash)) => println!(
                 "Result for file {}: root {:?} not found.",
                 wasm_bytes.path, hash
             ),

--- a/execution-engine/storage/src/error.rs
+++ b/execution-engine/storage/src/error.rs
@@ -2,11 +2,7 @@ use std::fmt;
 
 use common::bytesrepr;
 use rkv::error::StoreError;
-use shared::newtypes::Blake2bHash;
 use wasmi::HostError;
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct RootNotFound(pub Blake2bHash);
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Error {


### PR DESCRIPTION
## Overview
After #256 and #257, the `RootNotFound` struct does not belong in `storage`, as `storage` no longer uses it.  This PR moves it to `engine`.

### Which JIRA issue does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-198

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
