### PR TITLE
EE-199: remove GlobalStateError type alias

### DIFF
--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -3,7 +3,6 @@ use execution::{Error as ExecutionError, Executor};
 use parking_lot::Mutex;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
-use storage::error::GlobalStateError;
 use storage::gs::{ExecutionEffect, TrackingCopy};
 use storage::history::*;
 use storage::transform::Transform;
@@ -48,7 +47,7 @@ impl ExecutionResult {
 pub enum Error {
     PreprocessingError(String),
     ExecError(ExecutionError),
-    StorageError(GlobalStateError),
+    StorageError(storage::error::Error),
 }
 
 impl From<wasm_prep::PreprocessingError> for Error {
@@ -77,8 +76,8 @@ impl From<wasm_prep::PreprocessingError> for Error {
     }
 }
 
-impl From<GlobalStateError> for Error {
-    fn from(error: GlobalStateError) -> Self {
+impl From<storage::error::Error> for Error {
+    fn from(error: storage::error::Error) -> Self {
         Error::StorageError(error)
     }
 }

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -5,7 +5,6 @@ use self::blake2::VarBlake2b;
 use common::bytesrepr::{deserialize, Error as BytesReprError, ToBytes};
 use common::key::Key;
 use common::value::{Account, Value};
-use storage::error::GlobalStateError;
 use storage::gs::trackingcopy::AddResult;
 use storage::gs::{DbReader, ExecutionEffect, TrackingCopy};
 use storage::transform::TypeMismatch;
@@ -27,7 +26,7 @@ use std::fmt;
 #[derive(Debug)]
 pub enum Error {
     Interpreter(InterpreterError),
-    Storage(GlobalStateError),
+    Storage(storage::error::Error),
     BytesRepr(BytesReprError),
     KeyNotFound(Key),
     TypeMismatch(TypeMismatch),
@@ -59,8 +58,8 @@ impl From<InterpreterError> for Error {
     }
 }
 
-impl From<GlobalStateError> for Error {
-    fn from(e: GlobalStateError) -> Self {
+impl From<storage::error::Error> for Error {
+    fn from(e: storage::error::Error) -> Self {
         Error::Storage(e)
     }
 }
@@ -478,9 +477,9 @@ impl<'a, R: DbReader> Runtime<'a, R> {
     }
 }
 
-fn err_on_missing_key<A>(key: Key, r: Result<Option<A>, GlobalStateError>) -> Result<A, Error>
+fn err_on_missing_key<A>(key: Key, r: Result<Option<A>, storage::error::Error>) -> Result<A, Error>
 where
-    GlobalStateError: Into<Error>,
+    Error: Into<Error>,
 {
     match r {
         Ok(None) => Err(Error::KeyNotFound(key)),

--- a/execution-engine/storage/src/error.rs
+++ b/execution-engine/storage/src/error.rs
@@ -12,7 +12,6 @@ pub enum Error {
     BytesRepr(bytesrepr::Error),
 }
 
-pub type GlobalStateError = Error;
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -20,15 +19,15 @@ impl fmt::Display for Error {
     }
 }
 
-impl HostError for GlobalStateError {}
+impl HostError for Error {}
 
-impl From<StoreError> for GlobalStateError {
+impl From<StoreError> for Error {
     fn from(e: StoreError) -> Self {
         Error::RkvError(e.to_string())
     }
 }
 
-impl From<bytesrepr::Error> for GlobalStateError {
+impl From<bytesrepr::Error> for Error {
     fn from(e: bytesrepr::Error) -> Self {
         Error::BytesRepr(e)
     }

--- a/execution-engine/storage/src/gs/inmem.rs
+++ b/execution-engine/storage/src/gs/inmem.rs
@@ -2,7 +2,7 @@ use crate::transform::Transform;
 use common::bytesrepr::*;
 use common::key::Key;
 use common::value::Value;
-use error::GlobalStateError;
+use error::Error;
 use gs::*;
 use history::*;
 use shared::newtypes::Blake2bHash;
@@ -23,7 +23,7 @@ impl<K, V> Clone for InMemGS<K, V> {
 }
 
 impl DbReader for InMemGS<Key, Value> {
-    fn get(&self, k: &Key) -> Result<Option<Value>, GlobalStateError> {
+    fn get(&self, k: &Key) -> Result<Option<Value>, Error> {
         Ok(self.0.get(k).map(Clone::clone))
     }
 }
@@ -66,7 +66,7 @@ impl<K: Ord, V> InMemHist<K, V> {
 }
 
 impl History for InMemHist<Key, Value> {
-    type Error = GlobalStateError;
+    type Error = Error;
     type Reader = InMemGS<Key, Value>;
 
     fn checkout(
@@ -237,6 +237,6 @@ mod tests {
         assert_eq!(tc_2.get(&KEY1).unwrap().unwrap(), VALUE1);
         assert_eq!(tc_2.get(&KEY2).unwrap().unwrap(), VALUE2);
         // test that value inserted later are not visible in the past commits.
-        assert_eq!(tc_2.get(&key3), Ok(None));
+        assert_eq!(tc_2.get(&key3).unwrap(), None);
     }
 }

--- a/execution-engine/storage/src/gs/lmdb.rs
+++ b/execution-engine/storage/src/gs/lmdb.rs
@@ -1,7 +1,7 @@
 use common::bytesrepr::{deserialize, ToBytes};
 use common::key::Key;
 use common::value::Value;
-use error::{Error, GlobalStateError};
+use error::Error;
 use gs::{DbReader, TrackingCopy};
 use history::*;
 use rkv::store::single::SingleStore;
@@ -19,7 +19,7 @@ pub struct LmdbGs {
 }
 
 impl LmdbGs {
-    pub fn new(p: &Path) -> Result<LmdbGs, GlobalStateError> {
+    pub fn new(p: &Path) -> Result<LmdbGs, Error> {
         let env = Manager::singleton()
             .write()
             .map_err(|_| Error::RkvError(String::from("Error while creating LMDB env.")))
@@ -34,7 +34,7 @@ impl LmdbGs {
         Ok(LmdbGs { store, env })
     }
 
-    pub fn read(&self, k: &Key) -> Result<Option<Value>, GlobalStateError> {
+    pub fn read(&self, k: &Key) -> Result<Option<Value>, Error> {
         self.env
             .read()
             .map_err(|_| Error::RkvError(String::from("Couldn't get read lock to LMDB env.")))
@@ -57,7 +57,7 @@ impl LmdbGs {
             })
     }
 
-    pub fn write<'a, I>(&self, mut kvs: I) -> Result<(), GlobalStateError>
+    pub fn write<'a, I>(&self, mut kvs: I) -> Result<(), Error>
     where
         I: Iterator<Item = (Key, &'a Value)>,
     {
@@ -67,7 +67,7 @@ impl LmdbGs {
             .and_then(|rkv| {
                 let mut w = rkv.write()?;
 
-                let result: Result<(), GlobalStateError> = kvs.try_fold((), |_, (k, v)| {
+                let result: Result<(), Error> = kvs.try_fold((), |_, (k, v)| {
                     let bytes = v.to_bytes();
                     self.store.put(&mut w, k, &rkv::Value::Blob(&bytes))?;
                     Ok(())
@@ -86,14 +86,14 @@ impl LmdbGs {
             })
     }
 
-    pub fn write_single(&self, k: Key, v: &Value) -> Result<(), GlobalStateError> {
+    pub fn write_single(&self, k: Key, v: &Value) -> Result<(), Error> {
         let iterator = std::iter::once((k, v));
         self.write(iterator)
     }
 }
 
 impl DbReader for LmdbGs {
-    fn get(&self, k: &Key) -> Result<Option<Value>, GlobalStateError> {
+    fn get(&self, k: &Key) -> Result<Option<Value>, Error> {
         // TODO: The `Reader` should really be static for the DbReader instance,
         // i.e. just by creating a DbReader for LMDB it should create a `Reader`
         // to go with it. This would prevent the database from being modified while
@@ -103,7 +103,7 @@ impl DbReader for LmdbGs {
 }
 
 impl History for LmdbGs {
-    type Error = GlobalStateError;
+    type Error = Error;
     type Reader = Self;
 
     fn checkout(

--- a/execution-engine/storage/src/gs/mod.rs
+++ b/execution-engine/storage/src/gs/mod.rs
@@ -1,4 +1,4 @@
-use super::error::GlobalStateError;
+use super::error::Error;
 use super::op::Op;
 use super::transform::Transform;
 use crate::common::key::Key;
@@ -15,7 +15,7 @@ pub use self::trackingcopy::TrackingCopy;
 pub struct ExecutionEffect(pub HashMap<Key, Op>, pub HashMap<Key, Transform>);
 
 pub trait DbReader {
-    fn get(&self, k: &Key) -> Result<Option<Value>, GlobalStateError>;
+    fn get(&self, k: &Key) -> Result<Option<Value>, Error>;
 }
 
 pub fn mocked_account(account_addr: [u8; 20]) -> BTreeMap<Key, Value> {


### PR DESCRIPTION
## Overview
This PR removes the unnecessary `GlobalStateError` type alias, cleaning up after @goral09's changes in #256 and #257.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/EE-199

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A.
