### PR TITLE
EE-164: remove existing LMDB code

### DIFF
--- a/execution-engine/storage/src/gs/lmdb.rs
+++ b/execution-engine/storage/src/gs/lmdb.rs
@@ -1,11 +1,10 @@
-use common::bytesrepr::{deserialize, ToBytes};
 use common::key::Key;
 use common::value::Value;
 use error::Error;
 use gs::{DbReader, TrackingCopy};
 use history::*;
 use rkv::store::single::SingleStore;
-use rkv::{Manager, Rkv, StoreOptions};
+use rkv::Rkv;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
 use std::fmt;
@@ -13,77 +12,26 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use transform::Transform;
 
+#[allow(dead_code)]
 pub struct LmdbGs {
     store: SingleStore,
     env: Arc<RwLock<Rkv>>,
 }
 
 impl LmdbGs {
-    pub fn new(p: &Path) -> Result<LmdbGs, Error> {
-        let env = Manager::singleton()
-            .write()
-            .map_err(|_| Error::RkvError(String::from("Error while creating LMDB env.")))
-            .and_then(|mut r| r.get_or_create(p, Rkv::new).map_err(Into::into))?;
-        let store = env
-            .read()
-            .map_err(|_| Error::RkvError(String::from("Error when creating LMDB store.")))
-            .and_then(|r| {
-                r.open_single(Some("global_state"), StoreOptions::create())
-                    .map_err(Into::into)
-            })?;
-        Ok(LmdbGs { store, env })
+    pub fn new(_p: &Path) -> Result<LmdbGs, Error> {
+        unimplemented!()
     }
 
-    pub fn read(&self, k: &Key) -> Result<Option<Value>, Error> {
-        self.env
-            .read()
-            .map_err(|_| Error::RkvError(String::from("Couldn't get read lock to LMDB env.")))
-            .and_then(|rkv| {
-                let r = rkv.read()?;
-                let maybe_curr = self.store.get(&r, k)?;
-
-                match maybe_curr {
-                    None => Ok(None),
-                    Some(rkv::Value::Blob(bytes)) => {
-                        let value = deserialize(bytes)?;
-                        Ok(Some(value))
-                    }
-                    // If we always store values as Blobs this case will never come
-                    // up. TODO: Use other variants of rkb::Value (e.g. I64, Str)?
-                    Some(_) => Err(Error::RkvError(String::from(
-                        "Value stored in LMDB was != Blob",
-                    ))),
-                }
-            })
+    pub fn read(&self, _k: &Key) -> Result<Option<Value>, Error> {
+        unimplemented!()
     }
 
-    pub fn write<'a, I>(&self, mut kvs: I) -> Result<(), Error>
+    pub fn write<'a, I>(&self, mut _kvs: I) -> Result<(), Error>
     where
         I: Iterator<Item = (Key, &'a Value)>,
     {
-        self.env
-            .read()
-            .map_err(|_| Error::RkvError(String::from("Couldn't get read lock to LMDB env.")))
-            .and_then(|rkv| {
-                let mut w = rkv.write()?;
-
-                let result: Result<(), Error> = kvs.try_fold((), |_, (k, v)| {
-                    let bytes = v.to_bytes();
-                    self.store.put(&mut w, k, &rkv::Value::Blob(&bytes))?;
-                    Ok(())
-                });
-
-                match result {
-                    Ok(_) => {
-                        w.commit()?;
-                        Ok(())
-                    }
-                    e @ Err(_) => {
-                        w.abort();
-                        e
-                    }
-                }
-            })
+        unimplemented!()
     }
 
     pub fn write_single(&self, k: Key, v: &Value) -> Result<(), Error> {
@@ -125,37 +73,5 @@ impl History for LmdbGs {
 impl fmt::Debug for LmdbGs {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "LMDB({:?})", self.env)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use gens::gens::*;
-    use gs::lmdb::LmdbGs;
-    use tempfile::tempdir;
-
-    #[test]
-    fn lmdb_new() {
-        // Note: the directory created by `temp_dir`
-        // is automatically deleted when it goes out of scope.
-        let temp_dir = tempdir().unwrap();
-        let path = temp_dir.path();
-        let lmdb = LmdbGs::new(&path);
-
-        assert_matches!(lmdb, Ok(_));
-    }
-
-    #[test]
-    fn lmdb_rw() {
-        let temp_dir = tempdir().unwrap();
-        let path = temp_dir.path();
-        let lmdb = LmdbGs::new(&path).unwrap();
-
-        proptest!(|(k in key_arb(), v in value_arb())| {
-          let write = lmdb.write_single(k, &v);
-          let read = lmdb.read(&k).unwrap().unwrap();
-          assert_matches!(write, Ok(_));
-          prop_assert_eq!(read, v.clone());
-        });
     }
 }


### PR DESCRIPTION
## Overview
This PR removes the existing LMDB code.  I am going to rewrite it in upcoming PRs, and having it there complicates my ability to clean up `storage::error::Error`.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/EE-164

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
