### PR TITLE
EE-115: clean up storage::error::Error, introducing failure

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -37,6 +37,28 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "backtrace"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +129,7 @@ dependencies = [
 name = "casperlabs-contract-ffi"
 version = "0.1.1"
 dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wee_alloc 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -248,6 +271,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -882,6 +906,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,6 +1020,7 @@ name = "storage"
 version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.1.1",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gens 0.1.0",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1507,6 +1537,8 @@ dependencies = [
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
+"checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
+"checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bincode 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3efe0b4c8eaeed8600549c29f538a6a11bf422858d0ed435b1d70ec4ab101190"
 "checksum bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f1efcc46c18245a69c38fcc5cc650f16d3a59d034f3106e9ed63748f695730a"
@@ -1599,6 +1631,7 @@ dependencies = [
 "checksum regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "8c2f35eedad5295fdf00a63d7d4b238135723f92b434ec06774dad15c7ab0861"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rkv 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "238764bd8750927754d91e4a27155ac672ba88934a2bf698c992d55e5ae25e5b"
+"checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum rusty-fork 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9591f190d2852720b679c21f66ad929f9f1d7bb09d1193c26167586029d8489c"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"

--- a/execution-engine/common/Cargo.toml
+++ b/execution-engine/common/Cargo.toml
@@ -11,4 +11,5 @@ default = []
 std = []
 
 [dependencies]
+failure = { version = "0.1.5", default-features = false, features = ["failure_derive"] }
 wee_alloc = "0.4.3"

--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -17,10 +17,15 @@ pub trait FromBytes: Sized {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error>;
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Fail, PartialEq, Eq, Clone)]
 pub enum Error {
+    #[fail(display = "Deserialization error: early end of stream")]
     EarlyEndOfStream,
+
+    #[fail(display = "Deserialization error: formatting error")]
     FormattingError,
+
+    #[fail(display = "Deserialization error: left-over bytes")]
     LeftOverBytes,
 }
 

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -11,6 +11,9 @@
 extern crate alloc;
 extern crate wee_alloc;
 
+#[macro_use]
+extern crate failure;
+
 #[cfg(not(feature = "std"))]
 #[global_allocator]
 pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/execution-engine/storage/Cargo.toml
+++ b/execution-engine/storage/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>"]
 
 [dependencies]
+failure = "0.1.5"
 rkv = "0.9.1"
 wasmi = "0.4.2"
 common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }

--- a/execution-engine/storage/src/error.rs
+++ b/execution-engine/storage/src/error.rs
@@ -1,29 +1,21 @@
-use std::fmt;
-
 use common::bytesrepr;
-use rkv::error::StoreError;
-use wasmi::HostError;
+use rkv;
+use wasmi;
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Fail)]
 pub enum Error {
-    // mateusz.gorski: I think that these errors should revert any changes made
-    // to Global State and most probably kill the node.
-    RkvError(String), //TODO: capture error better
-    BytesRepr(bytesrepr::Error),
+    #[fail(display = "{}", _0)]
+    Rkv(#[fail(cause)] rkv::error::StoreError),
+
+    #[fail(display = "{}", _0)]
+    BytesRepr(#[fail(cause)] bytesrepr::Error),
 }
 
+impl wasmi::HostError for Error {}
 
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
-}
-
-impl HostError for Error {}
-
-impl From<StoreError> for Error {
-    fn from(e: StoreError) -> Self {
-        Error::RkvError(e.to_string())
+impl From<rkv::error::StoreError> for Error {
+    fn from(e: rkv::error::StoreError) -> Self {
+        Error::Rkv(e)
     }
 }
 

--- a/execution-engine/storage/src/lib.rs
+++ b/execution-engine/storage/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate failure;
+
 extern crate common;
 extern crate parking_lot;
 extern crate rkv;


### PR DESCRIPTION
## Overview
This PR revamps `storage::error::Error`, introducing `failure`.

`failure` provides a few quality-of-life enhancements, most notably variant annotations which generate `Display` impls and the ability to transparently enrich the `Rkv` variant to capture all `rkv:error::StoreError`s. This change propagates down to `common::bytesrepr`, but thankfully `failure` is `no_std`-compatible.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/EE-115

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
I started using `failure` with the pattern described here, as it's closest to what already have today:
https://rust-lang-nursery.github.io/failure/custom-fail.html
