### PR TITLE
EE-200: Set rust-toolchain version to 2019-03-15.

### DIFF
--- a/execution-engine/rust-toolchain
+++ b/execution-engine/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2019-03-15


### PR DESCRIPTION
## Overview
Fix missing clippy error.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-200

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
In one of the previous PRs I've merged the rust-toolchain file that set the rust nightly to the latest version. Unfortunately, rust-toolchain is often published without all its components (namely, clippy in this case). This commit sets the toolchain version to one that has all the necessary components (https://rust-lang.github.io/rustup-components-history/index.html).