### PR TITLE
NODE-298: GossipService.streamAncestorBlockSummaries

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -141,9 +141,10 @@ object GossipServiceServer {
 
   // Return `true` for the item that is "less important" then the other.
   val breadthFirstOrdering: Ordering[(Int, ByteString)] = Ordering.fromLessThan {
-    case ((d1, h1), (d2, h2)) if d1 == d2 =>
-      h1.hashCode > h2.hashCode // Just want some stable order for hashes
-    case ((d1, _), (d2, _)) =>
-      d1 > d2
+    case ((depth1, hash1), (depth2, hash2)) if depth1 == depth2 =>
+      // Just want some stable order between blocks at the same depth.
+      hash1.hashCode > hash2.hashCode
+    case ((depth1, _), (depth2, _)) =>
+      depth1 > depth2
   }
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -31,6 +31,9 @@ class GossipServiceServer[F[_]: Sync](
     // We return known hashes but not their parents.
     val knownHashes = request.knownBlockHashes.toSet
 
+    def canGoDeeper(depth: Int) =
+      depth < request.maxDepth || request.maxDepth == -1
+
     def loop(
         queue: PriorityQueue[(Int, ByteString)],
         visited: Set[ByteString]
@@ -48,7 +51,7 @@ class GossipServiceServer[F[_]: Sync](
                 loop(queue, visited + blockHash)
 
               case Some(summary) =>
-                if (depth < request.maxDepth && !knownHashes(summary.blockHash)) {
+                if (canGoDeeper(depth) && !knownHashes(summary.blockHash)) {
                   val ancestors =
                     summary.getHeader.parentHashes ++
                       summary.getHeader.justifications.map(_.latestBlockHash)

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -24,7 +24,7 @@ class GossipServiceServer[F[_]: Sync](
   def streamAncestorBlockSummaries(
       request: StreamAncestorBlockSummariesRequest
   ): Iterant[F, BlockSummary] = {
-    // Visit blocks in simple BFS order rather than try to establish topological sorting becuase BFS
+    // Visit blocks in simple BFS order rather than try to establish topological sorting because BFS
     // is invariant in maximum depth, while topological sorting could depend on whether we traversed
     // backwards enough to re-join forks with different lengths of sub-paths.
     implicit val ord = breadthFirstOrdering

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -148,9 +148,9 @@ trait ArbitraryConsensus {
 
       val genChildren =
         for {
-          n  <- Gen.oneOf(0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5)
-          cs <- Gen.listOfN(n, genChild)
-        } yield cs
+          growth   <- Gen.frequency((1, 0), (2, 1), (3, 2), (3, 3), (2, 4), (1, 5))
+          children <- Gen.listOfN(growth, genChild)
+        } yield children
 
       // Continue until no children were generated or we reach maximum height.
       genChildren.flatMap { children =>

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -3,6 +3,9 @@ package io.casperlabs.comm.gossiping
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus._
 import org.scalacheck.{Arbitrary, Gen}
+import scala.collection.JavaConverters._
+
+object ArbitraryConsensus extends ArbitraryConsensus
 
 trait ArbitraryConsensus {
   import Arbitrary.arbitrary
@@ -15,7 +18,7 @@ trait ArbitraryConsensus {
   val genHash = genBytes(20)
   val genKey  = genBytes(32)
 
-  implicit val signatureGen: Arbitrary[Signature] = Arbitrary {
+  implicit val arbSignature: Arbitrary[Signature] = Arbitrary {
     for {
       alg <- Gen.oneOf("ed25519", "secp256k1")
       sig <- genHash
@@ -24,7 +27,7 @@ trait ArbitraryConsensus {
     }
   }
 
-  implicit val blockGen: Arbitrary[Block] = Arbitrary {
+  implicit val arbBlock: Arbitrary[Block] = Arbitrary {
     for {
       summary <- arbitrary[BlockSummary]
       deploys <- Gen.listOfN(summary.getHeader.deployCount, arbitrary[Block.ProcessedDeploy])
@@ -37,7 +40,7 @@ trait ArbitraryConsensus {
     }
   }
 
-  implicit val blockHeaderGen: Arbitrary[Block.Header] = Arbitrary {
+  implicit val arbBlockHeader: Arbitrary[Block.Header] = Arbitrary {
     for {
       parentCount        <- Gen.choose(1, 5)
       parentHashes       <- Gen.listOfN(parentCount, genHash)
@@ -57,7 +60,7 @@ trait ArbitraryConsensus {
     }
   }
 
-  implicit val blockSummaryGen: Arbitrary[BlockSummary] = Arbitrary {
+  implicit val arbBlockSummary: Arbitrary[BlockSummary] = Arbitrary {
     for {
       blockHash <- genHash
       header    <- arbitrary[Block.Header]
@@ -70,7 +73,7 @@ trait ArbitraryConsensus {
     }
   }
 
-  implicit val deployGen: Arbitrary[Deploy] = Arbitrary {
+  implicit val arbDeploy: Arbitrary[Deploy] = Arbitrary {
     for {
       deployHash       <- genHash
       accountPublicKey <- genKey
@@ -104,7 +107,7 @@ trait ArbitraryConsensus {
     }
   }
 
-  implicit val processedDeployGen: Arbitrary[Block.ProcessedDeploy] = Arbitrary {
+  implicit val arbProcessedDeploy: Arbitrary[Block.ProcessedDeploy] = Arbitrary {
     for {
       deploy  <- arbitrary[Deploy]
       isError <- arbitrary[Boolean]
@@ -116,6 +119,56 @@ trait ArbitraryConsensus {
         .withCost(cost)
         .withIsError(isError)
         .withErrorMessage(if (isError) "Kaboom!" else "")
+    }
+  }
+
+  /** Grow a DAG by adding layers on top of the tips. */
+  val genDag: Gen[Vector[BlockSummary]] = {
+    def loop(
+        acc: Vector[BlockSummary],
+        tips: Set[BlockSummary]
+    ): Gen[Vector[BlockSummary]] = {
+      // Each child will choose some parents and some justifications from the tips.
+      val genChild =
+        for {
+          parents        <- Gen.choose(1, tips.size).flatMap(Gen.pick(_, tips))
+          justifications <- Gen.someOf(tips -- parents)
+          block          <- arbitrary[BlockSummary]
+        } yield {
+          val header = block.getHeader
+            .withParentHashes(parents.map(_.blockHash))
+            .withJustifications(justifications.toSeq.map { j =>
+              Block.Justification(
+                latestBlockHash = j.blockHash,
+                validatorPublicKey = j.getHeader.validatorPublicKey
+              )
+            })
+          block.withHeader(header)
+        }
+
+      val genChildren =
+        for {
+          n  <- Gen.oneOf(0, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 5)
+          cs <- Gen.listOfN(n, genChild)
+        } yield cs
+
+      // Continue until no children were generated or we reach maximum height.
+      genChildren.flatMap { children =>
+        val parentHashes = children.flatMap(_.getHeader.parentHashes).toSet
+        val stillTips    = tips.filterNot(tip => parentHashes(tip.blockHash))
+        if (children.isEmpty) Gen.const(acc)
+        else loop(acc ++ children, stillTips ++ children)
+      }
+    }
+    // Always start from the Genesis block.
+    arbitrary[BlockSummary] map { summary =>
+      summary.withHeader(
+        summary.getHeader
+          .withJustifications(Seq.empty)
+          .withParentHashes(Seq.empty)
+      )
+    } flatMap { genesis =>
+      loop(Vector(genesis), Set(genesis))
     }
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -271,6 +271,60 @@ class GrpcGossipServiceSpec
       }
     }
   }
+
+  object StreamAncestorBlockSummariesSpec extends WordSpecLike {
+    implicit val config = PropertyCheckConfiguration(minSuccessful = 10)
+
+    "streamAncestorBlockSummaries" when {
+      "called with unknown target hashes" should {
+        "return an empty stream" in {
+          pending
+        }
+      }
+
+      "called with a depth of 0" should {
+        "return just the target summaries" in {
+          pending
+        }
+      }
+
+      "called with a depth of 1" should {
+        "return the targets and their parents" in {
+          pending
+        }
+      }
+
+      "called with a single target and maximum depth" should {
+        "return all ancestors of the target up to that depth" in {
+          pending
+        }
+
+        "return results in reverse breadth first order" in {
+          pending
+        }
+      }
+
+      "called with many targets and maximum depth" should {
+        "start with the targets" in {
+          pending
+        }
+
+        "return results in the same order regardless of depth" in {
+          pending
+        }
+
+        "return all ancestors up to that depth from any of the targets" in {
+          pending
+        }
+      }
+
+      "called with some known hashes" should {
+        "stop traversing ancestors beyond the known hashes" in {
+          pending
+        }
+      }
+    }
+  }
 }
 
 object GrpcGossipServiceSpec extends TestRuntime {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -404,6 +404,24 @@ class GrpcGossipServiceSpec
         }
       }
 
+      "called with a depth of -1" should {
+        val genTestCase = for {
+          dag     <- genDag
+          targets <- Gen.choose(1, dag.size).flatMap(Gen.pick(_, dag))
+          req = StreamAncestorBlockSummariesRequest(
+            targetBlockHashes = targets.map(_.blockHash),
+            maxDepth = -1
+          )
+        } yield TestCase(dag, req)
+
+        "return everything back to the genesis" in TestFixture(genTestCase) {
+          case TestCase(dag, req) =>
+            stub.streamAncestorBlockSummaries(req).toListL.map { ancestors =>
+              ancestors should contain(dag.head)
+            }
+        }
+      }
+
       "called with a single target and maximum depth" should {
         val genTestCase = for {
           dag    <- genDag

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -364,7 +364,7 @@ class GrpcGossipServiceSpec
         }
       }
 
-      "called with a depth of 0" should {
+      "called with a (default) depth of 0" should {
         val genTestCase = for {
           dag     <- genDag
           targets <- Gen.someOf(dag)
@@ -422,7 +422,7 @@ class GrpcGossipServiceSpec
         }
       }
 
-      "called with a single target and maximum depth" should {
+      "called with a single target and a given maximum depth value" should {
         val genTestCase = for {
           dag    <- genDag
           target <- Gen.oneOf(dag)

--- a/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
+++ b/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
@@ -6,19 +6,32 @@ import "io/casperlabs/casper/consensus/consensus.proto";
 import "io/casperlabs/comm/discovery/node.proto";
 
 service GossipService {
+    // Notify the callee about new blocks being available on the caller.
     rpc NewBlocks(NewBlocksRequest) returns (NewBlocksResponse);
+
+    // Retrieve the ancestors of certain blocks in the DAG; to be called repeatedly
+    // as necessary to synchronize DAGs between peers.
     rpc StreamAncestorBlockSummaries(StreamAncestorBlockSummariesRequest) returns (stream io.casperlabs.casper.consensus.BlockSummary);
+
+    // Retrieve the tips of the DAG as the callee knows them, to kick off synchronization between peers.
     rpc StreamDagTipBlockSummaries(StreamDagTipBlockSummariesRequest) returns (stream io.casperlabs.casper.consensus.BlockSummary);
+
+    // Retrieve arbitrary block summaries, if the callee knows about them.
     rpc StreamBlockSummaries(StreamBlockSummariesRequest) returns (stream io.casperlabs.casper.consensus.BlockSummary);
+
+    // Retrieve an arbitrarily sized block as a stream of chunks, with optionally compressed content.
     rpc GetBlockChunked(GetBlockChunkedRequest) returns (stream Chunk);
 }
 
 message NewBlocksRequest {
+    // Address of the caller from where the callee can download the blocks from.
     io.casperlabs.comm.discovery.Node sender = 1;
     repeated bytes block_hashes = 2;
 }
 
 message NewBlocksResponse {
+    // Indicate that some of the blocks in the notifications were new and the callee will attempt
+    // to gossip them to further nodes when it gets around to downloading them.
     bool is_new = 1;
 }
 
@@ -27,8 +40,18 @@ message StreamBlockSummariesRequest {
 }
 
 message StreamAncestorBlockSummariesRequest {
+    // The identifiers of the blocks the caller wants to get to, typically the ones the callee notified
+    // it about earlier, using `NewBlocks`.
     repeated bytes target_block_hashes = 1;
+
+    // Supply the callee with some block hashes already known to the caller so the traversal can stop early if it hits them.
+    // These can for example be the blocks last seen from each validator and the last finalized blocks.
     repeated bytes known_block_hashes = 2;
+
+    // Limit the traversal to a certain depth, as a checkpoint when the caller can reassess and ask for
+    // any hashes that still couldn't be connected to its own version of the DAG. If the target block
+    // summaries are known then the value can be based on the difference in block sequence numbers between
+    // the target and the last known block from the validator that produced it.
     uint32 max_depth = 3;
 }
 

--- a/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
+++ b/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
@@ -52,6 +52,7 @@ message StreamAncestorBlockSummariesRequest {
     // any hashes that still couldn't be connected to its own version of the DAG. If the target block
     // summaries are known then the value can be based on the difference in block sequence numbers between
     // the target and the last known block from the validator that produced it.
+    // A value of -1 would mean no limit on the depth; 0 just returns the targets themselves.
     uint32 max_depth = 3;
 }
 


### PR DESCRIPTION
## Overview
Implements `GossipService.streamAncestorBlockSummaries`  from the tech spec.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-298

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
