### PR TITLE
NODE-313 Replace threads blocking to cats.effect.concurrent.Ref in Kademlia PeerTable

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -1,44 +1,31 @@
 package io.casperlabs.comm.discovery
 
-import cats.data._
+import cats.Monad
 import cats.effect.Sync
-import cats.implicits._
-import io.casperlabs.comm.{NodeIdentifier, PeerNode}
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
 import io.casperlabs.comm.discovery.PeerTable.Entry
+import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 
 import scala.annotation.tailrec
-import scala.collection.mutable
+import scala.util.Sorting
 
 object PeerTable {
-  final case class Entry(node: PeerNode) {
-    var pinging           = false
+  final case class Entry(node: PeerNode, pinging: Boolean = false) {
     override def toString = s"#{PeerTableEntry $node}"
   }
 
-  def apply(
+  def apply[F[_]: Sync](
       local: NodeIdentifier,
-      k: Int = PeerTable.Redundancy,
-      alpha: Int = PeerTable.Alpha
-  ): PeerTable =
-    new PeerTable(local, k, alpha)
-
-  // Number of bits considered in the distance function. Taken from the
-  // passed-in "home" value to the table.
-  //
-  // val Width = 256
+      k: Int = PeerTable.Redundancy
+  ): F[PeerTable[F]] =
+    for {
+      //160 buckets with at most 20 elements in each of them
+      buckets <- Ref.of(Vector.fill(8 * local.key.size)(List.empty[Entry]))
+    } yield new PeerTable(local, k, buckets)
 
   // Maximum length of each row of the routing table.
   val Redundancy = 20
-
-  // Concurrency factor: system allows up to alpha outstanding network
-  // requests at a time.
-  val Alpha = 3
-
-  // UNIMPLEMENTED: this parameter controls an optimization that can
-  // reduce the number hops required to find an address in the network
-  // by grouping keys in buckets of a size larger than one.
-  //
-  // val BucketWidth = 1
 
   // Lookup table for log 2 (highest bit set) of an 8-bit unsigned
   // integer. Entry 0 is unused.
@@ -55,16 +42,12 @@ object PeerTable {
   * network discovery and routing protocol.
   *
   */
-final class PeerTable(
+final class PeerTable[F[_]: Monad](
     local: NodeIdentifier,
     private[discovery] val k: Int,
-    alpha: Int
+    private[discovery] val tableRef: Ref[F, Vector[List[Entry]]]
 ) {
-
   private[discovery] val width = local.key.size // in bytes
-  private[discovery] val table = Array.fill(8 * width) {
-    new mutable.ListBuffer[Entry]
-  }
 
   /** Computes Kademlia XOR distance.
     *
@@ -75,7 +58,7 @@ final class PeerTable(
     * @return `Some(Int)` if `a` and `b` are comparable in this table,
     * `None` otherwise.
     */
-  private[discovery] def distance(a: NodeIdentifier, b: NodeIdentifier): Option[Int] = {
+  private[discovery] def distance(a: NodeIdentifier, b: NodeIdentifier): Int = {
     @tailrec
     def highBit(idx: Int): Int =
       if (idx == width) 8 * width
@@ -84,143 +67,70 @@ final class PeerTable(
           case 0 => highBit(idx + 1)
           case n => 8 * idx + PeerTable.dlut(n & 0xff)
         }
-
-    if (a.key.size != width || b.key.size != width) None
-    else Some(highBit(0))
+    highBit(0)
   }
 
-  private[discovery] def distance(other: PeerNode): Option[Int]       = distance(local, other.id)
-  private[discovery] def distance(other: NodeIdentifier): Option[Int] = distance(local, other)
+  private[discovery] def distance(other: PeerNode): Int       = distance(local, other.id)
+  private[discovery] def distance(other: NodeIdentifier): Int = distance(local, other)
 
-  def updateLastSeen[F[_]: Sync: KademliaRPC](peer: PeerNode): F[Unit] = {
-
-    def bucket: F[Option[mutable.ListBuffer[Entry]]] =
-      Sync[F].delay(distance(local, peer.id).filter(_ < 8 * width).map(table.apply))
-
-    def addUpdateOrPickOldPeer(ps: mutable.ListBuffer[Entry]): F[Option[Entry]] =
-      Sync[F].delay {
-        ps synchronized {
-          ps.find(_.node.key == peer.key) match {
-            case Some(entry) =>
-              ps -= entry
-              ps += Entry(peer)
-              None
-            case None =>
-              if (ps.size < k) {
-                ps += Entry(peer)
-                None
-              } else {
-                // ping first (oldest) element that isn't already being
-                // pinged. If it responds, move it to back (newest
-                // position); if it doesn't respond, remove it and place
-                // a in back instead
-                ps.find(!_.pinging).map { candidate =>
-                  candidate.pinging = true
-                  candidate
-                }
-              }
-          }
-        }
-      }
-
-    def pingAndUpdate(ps: mutable.ListBuffer[Entry], older: Entry): F[Unit] =
-      KademliaRPC[F].ping(older.node).map { response =>
-        val winner = if (response) older else Entry(peer)
-        ps synchronized {
-          ps -= older
-          ps += winner
-          winner.pinging = false
-        }
-      }
-
-    def upsert: OptionT[F, Unit] =
-      for {
-        ps    <- OptionT(bucket)
-        older <- OptionT(addUpdateOrPickOldPeer(ps))
-        _     <- OptionT.liftF(pingAndUpdate(ps, older))
-      } yield ()
-
-    upsert.value.void
-  }
-
-  /**
-    * Remove a peer with the given key.
-    */
-  def remove(toRemove: NodeIdentifier): Unit =
-    distance(local, toRemove) match {
-      case Some(index) =>
-        if (index < 8 * width) {
-          val ps = table(index)
-          ps synchronized {
-            ps.find(_.node.key == toRemove.key) match {
-              case Some(entry) =>
-                ps -= entry
-                ()
-              case _ => ()
-            }
-          }
-        }
-      case None => ()
-    }
-
-  /**
-    * Return the `k` nodes closest to `key` that this table knows
-    * about, sorted ascending by distance to `key`.
-    */
-  def lookup(toLookup: NodeIdentifier): Seq[PeerNode] = {
-
-    def sorter(a: PeerNode, b: PeerNode) =
-      (distance(toLookup, a.id), distance(toLookup, b.id)) match {
-        case (Some(d0), Some(d1)) => d0 > d1
-        case _                    => false
-      }
-
-    distance(local, toLookup) match {
-      case Some(index) =>
-        val entries = new mutable.ListBuffer[Entry]
-
-        for (i <- index until 8 * width; if entries.size < k) {
-          table(i) synchronized {
-            entries ++= table(i).filter(_.node.id != toLookup)
-          }
-        }
-
-        for (i <- index - 1 to 0 by -1; if entries.size < k) {
-          table(i) synchronized {
-            entries ++= table(i)
-          }
-        }
-
-        entries.map(_.node).sortWith(sorter).take(k).toVector
-      case None => Vector.empty
-    }
-  }
-
-  /**
-    * Return `Some[A]` if `key` names an entry in the table.
-    */
-  def find(toFind: NodeIdentifier): Option[PeerNode] =
+  def updateLastSeen(peer: PeerNode)(implicit K: KademliaRPC[F]): F[Unit] = {
+    val index = distance(peer)
     for {
-      d <- distance(toFind)
-      e <- table(d) synchronized { table(d).find(_.node.id == toFind) }
-    } yield e.node
+      maybeCandidate <- tableRef.modify { table =>
+                         val bucket = table(index)
+                         val (updatedBucket, maybeCandidate) =
+                           bucket.find(_.node.key == peer.key) match {
+                             case Some(previous) =>
+                               (Entry(peer) :: bucket.filter(_.node.key != previous.node.key),
+                                none[Entry])
+                             case None if bucket.size < k =>
+                               (Entry(peer) :: bucket, none[Entry])
+                             // Ping oldest element that isn't already being pinged.
+                             // If it responds, move it to newest position;
+                             // If it doesn't, remove it and place new in newest
+                             case _ =>
+                               val maybeCandidate =
+                                 bucket.reverse.find(!_.pinging).map(_.copy(pinging = true))
+                               val updatedBucket = maybeCandidate.fold(bucket) { candidate =>
+                                 bucket.map(p =>
+                                   if (p.node.key == candidate.node.key) candidate else p)
+                               }
+                               (updatedBucket, maybeCandidate)
+                           }
+                         (table.updated(index, updatedBucket), maybeCandidate)
+                       }
+      _ <- maybeCandidate.fold(().pure[F])(candidate =>
+            K.ping(candidate.node).flatMap { responded =>
+              tableRef.update { table =>
+                val bucket = table(index)
+                val winner = if (responded) candidate else Entry(peer)
+                val updated = winner.copy(pinging = false) :: bucket.filter(
+                  _.node.key != candidate.node.key)
+                table.updated(index, updated)
+              }
+          })
+    } yield ()
+  }
 
-  /**
-    * Return a sequence of all the `A`s in the table.
-    */
-  def peers: Seq[PeerNode] =
-    table.flatMap(l => l synchronized { l.map(_.node) })
+  def lookup(toLookup: NodeIdentifier): F[Seq[PeerNode]] =
+    tableRef.get.map { table =>
+      val flattenedArray = table.flatten.filterNot(_.node.key == toLookup.key).toArray
+      Sorting.quickSort(flattenedArray)((x: Entry, y: Entry) =>
+        (distance(toLookup, x.node.id), distance(toLookup, y.node.id)) match {
+          case (d0, d1) => Ordering[Int].compare(d0, d1)
+      })
+      flattenedArray.take(k).toList.map(_.node)
+    }
 
-  /**
-    * Return all distances in order from least to most filled.
-    *
-    * Optionally, ignore any distance closer than [[limit]].
-    */
-  def sparseness(limit: Int = 255): Seq[Int] =
-    table
-      .take(limit + 1)
-      .zipWithIndex
-      .map { case (l, i) => (l.size, i) }
-      .sortWith(_._1 < _._1)
-      .map(_._2)
+  def find(toFind: NodeIdentifier): F[Option[PeerNode]] =
+    tableRef.get.map(_(distance(toFind)).find(_.node.id == toFind).map(_.node))
+
+  def peers: F[Seq[PeerNode]] = tableRef.get.map(_.flatMap(_.map(_.node)))
+
+  def sparseness(limit: Int = 255): F[Seq[Int]] =
+    tableRef.get.map(
+      _.take(limit + 1).zipWithIndex
+        .map { case (l, i) => (l.size, i) }
+        .sortWith(_._1 < _._1)
+        .map(_._2))
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -34,7 +34,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     for (i <- 1 to 64) {
       val home = PeerNode(NodeIdentifier(b.rand(i)), endpoint)
       val nt   = PeerTable(home.id)
-      nt.distance(home) should be(Some(8 * nt.width))
+      nt.distance(home) should be(8 * nt.width)
     }
   }
 
@@ -58,7 +58,6 @@ class DistanceSpec extends FlatSpec with Matchers {
       val id    = NodeIdentifier(key)
       val table = PeerTable(id)
       oneOffs(id).map(table.distance) == (0 until 8 * width)
-        .map(Option[Int])
     }
 
     def keyString(key: Seq[Byte]): String =
@@ -81,7 +80,7 @@ class DistanceSpec extends FlatSpec with Matchers {
 
     s"An empty table of width $width" should "have no peers" in {
       val table = PeerTable(kr)
-      assert(table.table.forall(_.isEmpty))
+      assert(table.tableRef.get.forall(_.isEmpty))
     }
 
     it should "return no peers" in {
@@ -97,25 +96,25 @@ class DistanceSpec extends FlatSpec with Matchers {
     s"A table of width $width" should "add a key at most once" in {
       val table = PeerTable(kr)
       val toAdd = oneOffs(kr).head
-      val dist  = table.distance(toAdd).get
-      for (i <- 1 to 10) {
-        table.updateLastSeen[Id](PeerNode(toAdd, endpoint))
-        table.table(dist).size should be(1)
+      val dist  = table.distance(toAdd)
+      for (_ <- 1 to 10) {
+        table.updateLastSeen(PeerNode(toAdd, endpoint))
+        table.tableRef.get(dist).size should be(1)
       }
     }
 
     s"A table of width $width with peers at all distances" should "have no empty buckets" in {
       val table = PeerTable(kr)
       for (k <- oneOffs(kr)) {
-        table.updateLastSeen[Id](PeerNode(k, endpoint))
+        table.updateLastSeen(PeerNode(k, endpoint))
       }
-      assert(table.table.forall(_.nonEmpty))
+      assert(table.tableRef.get.forall(_.nonEmpty))
     }
 
     it should s"return min(k, ${8 * width}) peers on lookup" in {
       val table = PeerTable(kr)
       for (k <- oneOffs(kr)) {
-        table.updateLastSeen[Id](PeerNode(k, endpoint))
+        table.updateLastSeen(PeerNode(k, endpoint))
       }
       table.lookup(NodeIdentifier(b.rand(width))).size should be(scala.math.min(table.k, 8 * width))
     }
@@ -123,9 +122,9 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should "not return sought peer on lookup" in {
       val table = PeerTable(kr)
       for (k <- oneOffs(kr)) {
-        table.updateLastSeen[Id](PeerNode(k, endpoint))
+        table.updateLastSeen(PeerNode(k, endpoint))
       }
-      val target = table.table(table.width * 4).head
+      val target = table.tableRef.get(table.width * 4).head
       val resp   = table.lookup(target.node.id)
       assert(resp.forall(_.key != target.node.key))
     }
@@ -133,7 +132,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should s"return ${8 * width} peers when sequenced" in {
       val table = PeerTable(kr)
       for (k <- oneOffs(kr)) {
-        table.updateLastSeen[Id](PeerNode(k, endpoint))
+        table.updateLastSeen(PeerNode(k, endpoint))
       }
       table.peers.size should be(8 * width)
     }
@@ -141,7 +140,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     it should "find each added peer" in {
       val table = PeerTable(kr)
       for (k <- oneOffs(kr)) {
-        table.updateLastSeen[Id](PeerNode(k, endpoint))
+        table.updateLastSeen(PeerNode(k, endpoint))
       }
       for (k <- oneOffs(kr)) {
         table.find(k) should be(Some(PeerNode(k, endpoint)))

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
@@ -15,10 +15,10 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
   val peer3 = createPeer("00001010")
   val peer4 = createPeer("00001100")
 
-  val DISTANCE_4 = Some(4)
-  val DISTANCE_6 = Some(6)
+  val DISTANCE_4 = 4
+  val DISTANCE_6 = 6
 
-  var table       = PeerTable(local.id, 3)
+  var table       = PeerTable[Id](local.id, 3)
   var pingedPeers = mutable.MutableList.empty[PeerNode]
 
   override def beforeEach(): Unit = {
@@ -38,18 +38,18 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
         implicit val ping: KademliaRPC[Id] = pingOk
         table.distance(peer0) shouldBe DISTANCE_6
         // when
-        table.updateLastSeen[Id](peer0)
+        table.updateLastSeen(peer0)
         // then
-        bucketEntriesAt(DISTANCE_6) shouldEqual Seq(peer0)
+        bucketEntriesAt(DISTANCE_6) should contain theSameElementsAs Seq(peer0)
       }
 
       it("should not ping the peer") {
         // given
         implicit val ping: KademliaRPC[Id] = pingOk
         // when
-        table.updateLastSeen[Id](peer0)
+        table.updateLastSeen(peer0)
         // then
-        pingedPeers shouldEqual Seq.empty[PeerNode]
+        pingedPeers should contain theSameElementsAs Seq.empty[PeerNode]
       }
     }
 
@@ -57,26 +57,26 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       it("should replace peer with new entry (the one with new IP)") {
         // given
         implicit val ping: KademliaRPC[Id] = pingOk
-        table.updateLastSeen[Id](peer1)
+        table.updateLastSeen(peer1)
         // when
         val newPeer1 = peer1.copy(endpoint = Endpoint("otherIP", 0, 0))
-        table.updateLastSeen[Id](newPeer1)
+        table.updateLastSeen(newPeer1)
         // then
-        bucketEntriesAt(DISTANCE_4) shouldEqual Seq(newPeer1)
+        bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(newPeer1)
       }
 
       it("should move peer to the end of the bucket (meaning it's been seen lately)") {
         // given
         implicit val ping: KademliaRPC[Id] = pingOk
-        table.updateLastSeen[Id](peer2)
-        table.updateLastSeen[Id](peer1)
-        table.updateLastSeen[Id](peer3)
-        bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer1, peer3)
+        table.updateLastSeen(peer2)
+        table.updateLastSeen(peer1)
+        table.updateLastSeen(peer3)
+        bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer1, peer3)
         // when
         val newPeer1 = peer1.copy(endpoint = Endpoint("otherIP", 0, 0))
-        table.updateLastSeen[Id](newPeer1)
+        table.updateLastSeen(newPeer1)
         // then
-        bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3, newPeer1)
+        bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer3, newPeer1)
       }
     }
 
@@ -84,25 +84,25 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       it("should add peer to the end of the bucket (meaning it's been seen lately)") {
         // given
         implicit val ping: KademliaRPC[Id] = pingOk
-        table.updateLastSeen[Id](peer2)
-        table.updateLastSeen[Id](peer3)
-        bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3)
+        table.updateLastSeen(peer2)
+        table.updateLastSeen(peer3)
+        bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer3)
         // when
-        table.updateLastSeen[Id](peer1)
+        table.updateLastSeen(peer1)
         // then
-        bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3, peer1)
+        bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer3, peer1)
       }
 
       it("no peers should be pinged") {
         // given
         implicit val ping: KademliaRPC[Id] = pingOk
-        table.updateLastSeen[Id](peer2)
-        table.updateLastSeen[Id](peer3)
-        bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3)
+        table.updateLastSeen(peer2)
+        table.updateLastSeen(peer3)
+        bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer3)
         // when
-        table.updateLastSeen[Id](peer1)
+        table.updateLastSeen(peer1)
         // then
-        pingedPeers shouldEqual Seq.empty[PeerNode]
+        pingedPeers should contain theSameElementsAs Seq.empty[PeerNode]
       }
     }
 
@@ -112,9 +112,9 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
         implicit val ping: KademliaRPC[Id] = pingOk
         thatBucket4IsFull
         // when
-        table.updateLastSeen[Id](peer4)
+        table.updateLastSeen(peer4)
         // then
-        pingedPeers shouldEqual Seq(peer1)
+        pingedPeers should contain theSameElementsAs Seq(peer1)
       }
 
       describe("and oldest peer IS responding to ping") {
@@ -123,9 +123,9 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
           implicit val ping: KademliaRPC[Id] = pingOk
           thatBucket4IsFull
           // when
-          table.updateLastSeen[Id](peer4)
+          table.updateLastSeen(peer4)
           // then
-          bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3, peer1)
+          bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer3, peer1)
         }
       }
       describe("and oldest peer is NOT responding to ping") {
@@ -134,22 +134,22 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
           implicit val ping: KademliaRPC[Id] = pingFail
           thatBucket4IsFull
           // when
-          table.updateLastSeen[Id](peer4)
+          table.updateLastSeen(peer4)
           // then
-          bucketEntriesAt(DISTANCE_4) shouldEqual Seq(peer2, peer3, peer4)
+          bucketEntriesAt(DISTANCE_4) should contain theSameElementsAs Seq(peer2, peer3, peer4)
         }
       }
     }
   }
 
   private def thatBucket4IsFull(implicit ev: KademliaRPC[Id]): Unit = {
-    table.updateLastSeen[Id](peer1)
-    table.updateLastSeen[Id](peer2)
-    table.updateLastSeen[Id](peer3)
+    table.updateLastSeen(peer1)
+    table.updateLastSeen(peer2)
+    table.updateLastSeen(peer3)
   }
 
-  private def bucketEntriesAt(distance: Option[Int]): Seq[PeerNode] =
-    distance.map(d => table.table(d).map(_.node)).getOrElse(Seq.empty[PeerNode])
+  private def bucketEntriesAt(distance: Int): Seq[PeerNode] =
+    table.tableRef.get(distance).map(_.node)
 
   private val pingOk: KademliaRPC[Id]   = new KademliaRPCMock(returns = true)
   private val pingFail: KademliaRPC[Id] = new KademliaRPCMock(returns = false)

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
@@ -1,0 +1,113 @@
+package io.casperlabs.comm.discovery
+import java.util.concurrent.atomic.AtomicLong
+
+import io.casperlabs.comm.{Endpoint, NodeIdentifier, PeerNode}
+import monix.eval.Task
+import monix.execution.CancelablePromise
+import monix.execution.Scheduler.Implicits.global
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, PropSpec}
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+  private trait KademliaMock extends KademliaRPC[Task] {
+    override def lookup(id: NodeIdentifier, peer: PeerNode): Task[Seq[PeerNode]] =
+      Task.now(Seq.empty)
+    override def receive(
+        pingHandler: PeerNode => Task[Unit],
+        lookupHandler: (PeerNode, NodeIdentifier) => Task[Seq[PeerNode]]): Task[Unit] = Task.unit
+    override def shutdown(): Task[Unit]                                               = Task.unit
+  }
+
+  //1 byte width
+  private val id = NodeIdentifier("00")
+  //First bit must be equal to 1
+  private val distance   = 0
+  private val bucketSize = 20
+  // 1000 0000
+  private val min: Byte = 128.toByte
+  // 1111 1111
+  private val max: Byte = 255.toByte
+  private val maxPeersN = max - min + 1
+  private val allPotentialPeers =
+    Seq
+      .iterate(min, maxPeersN)(b => (b + 1).toByte)
+      .map(b => PeerNode(NodeIdentifier(Seq(b)), Endpoint("", 0, 0)))
+  private implicit val propCheckConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
+    minSuccessful = 500)
+
+  property("""
+      |updateLastSeen
+      |atomically adds new unique peer if bucket is not full
+      |and moves it if has seen previously""".stripMargin) {
+    forAll(
+      Gen
+        .choose(1, bucketSize)) { uniquePeersN: Int =>
+      implicit val K: KademliaMock = (_: PeerNode) => Task.now(true)
+
+      val unique     = Random.shuffle(allPotentialPeers).take(uniquePeersN)
+      val replicated = Seq.fill(10)(unique).flatten
+      val addNodesParallel = for {
+        peerTable <- PeerTable[Task](id, bucketSize)
+        _         <- Task.gatherUnordered(replicated.map(peerTable.updateLastSeen(_)))
+        bucket    <- peerTable.tableRef.get.map(_(distance).map(_.node))
+      } yield bucket
+
+      addNodesParallel.runSyncUnsafe() should contain theSameElementsAs unique
+    }
+  }
+
+  property("""
+             |updateLastSeen
+             |doesn't block read operations
+           """.stripMargin) {
+    forAll { _: Int =>
+      val never                    = CancelablePromise[Boolean]()
+      implicit val K: KademliaMock = (_: PeerNode) => Task.fromCancelablePromise(never)
+
+      val initial    = Random.shuffle(allPotentialPeers).take(bucketSize)
+      val rest       = Random.shuffle(allPotentialPeers.diff(initial))
+      val peerTable  = PeerTable[Task](id, bucketSize).runSyncUnsafe()
+      val fillBucket = Task.sequence(initial.map(peerTable.updateLastSeen(_)))
+      val hangUp     = Task.gatherUnordered(rest.map(peerTable.updateLastSeen(_)))
+
+      fillBucket.runSyncUnsafe()
+      hangUp.runAsyncAndForget
+
+      Task
+        .race(Task.sleep(1.second), peerTable.peers)
+        .runSyncUnsafe()
+        .right
+        .get should contain theSameElementsAs initial
+    }
+  }
+
+  property("""
+             |updateLastSeen
+             |atomically pings peers
+           """.stripMargin) {
+    forAll { _: Int =>
+      val pingsCounter = new AtomicLong(0)
+      implicit val K: KademliaMock = (_: PeerNode) => {
+        pingsCounter.incrementAndGet()
+        Task.now(true)
+      }
+
+      val initial        = Random.shuffle(allPotentialPeers).take(bucketSize)
+      val restReplicated = Random.shuffle(Seq.fill(10)(allPotentialPeers.diff(initial))).flatten
+
+      val addNodesParallel = for {
+        peerTable <- PeerTable[Task](id, bucketSize)
+        _         <- Task.gatherUnordered(initial.map(peerTable.updateLastSeen(_)))
+        _         <- Task.gatherUnordered(restReplicated.map(peerTable.updateLastSeen(_)))
+        peers     <- peerTable.peers
+      } yield peers
+
+      addNodesParallel.runSyncUnsafe() should contain theSameElementsAs initial
+      pingsCounter.get() shouldBe restReplicated.size
+    }
+  }
+}


### PR DESCRIPTION
## Overview
As in the title.

I didn't measure performance changes, please, say what do you think if it's needed.

I'm also not sure if `Ref` is a good choice here because [it applies changes in spin loop](https://github.com/typelevel/cats-effect/blob/master/core/shared/src/main/scala/cats/effect/concurrent/Ref.scala#L247), I assume it may be not optimal if there be too many concurrent updates.

Other possible ways are `MVar` from the `cats-effect` or our self-written `Cell` from the `shared` module.

~Not sure, but some additional tests for concurrency might have to be written as well.~ I've added concurrency testing.



Suggest starting a review from the `PeerTable.scala`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.