### PR TITLE
OP-115 Updated to correct grpc build name and execution-engine compil…

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -285,13 +285,6 @@ Once the above prerequistes are installed for your environment, you are ready to
 
 ### How to build components
 
-#### Build proto definitions:
-
-This is required only when the `ipc.proto` file changes (but this is true when you run it for the first time).
-  1. Go to Execution Engine root directory. This is `execution-engine` directory in the node's root dir.
-  2. Go to comm project directory (`cd comm`).
-  3. Run: `cargo build --bin casperlabs-engine-grpc-server`
-
 #### Build Wasm contracts:
 Contracts are in a separate github repo: https://github.com/CasperLabs/contract-examples.
 Clone this locally.
@@ -318,7 +311,8 @@ If make fails, contract can be manually built:
 #### Building Execution Engine:
 
   1. Go to Execution Engine root directory. This is `execution-engine` directory in the node's root dir.
-  2. Run `cargo build`
+  2. Go to comm project directory (`cd comm`)
+  3. Run `cargo build`
 
 ### Running components
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -3,12 +3,14 @@
 __Note__ Successfully building from source requires attending to all of the prerequisites shown below. When users experience errors, it is typically related to failure to assure all prerequisites are met. Work is in progress to improve this experience.
 
 ### Prerequisites
+
 * [OpenJDK](https://openjdk.java.net) Java Development Kit (JDK), version 11. We recommend using the OpenJDK
 * [sbt](https://www.scala-sbt.org/download.html)
 * [rust](https://www.rust-lang.org/tools/install)
 * [protoc](https://github.com/protocolbuffers/protobuf/releases)
 
 ### CasperLabs Development Environment on Ubuntu and Debian
+
 <details>
   <summary>Click to expand!</summary>
 
@@ -37,6 +39,13 @@ __Note__ Successfully building from source requires attending to all of the prer
   ```
 
   rust:
+  
+  Install packages needed for installing and building Rust.
+  ```console
+  dev@dev:~$ sudo apt install build-essential cmake curl -y
+  ```
+
+  Install Rust  
   ```console
   dev@dev:~$ curl https://sh.rustup.rs -sSf | sh
   ...
@@ -123,7 +132,7 @@ __Note__ Successfully building from source requires attending to all of the prer
   ```console
   dev@dev:~$ brew install rustup
   ...
-  
+
   dev@dev:~$rustup-init
   Welcome to Rust!
 
@@ -266,6 +275,7 @@ __Note__ Successfully building from source requires attending to all of the prer
 </details>
 
 ### CasperLabs Development Environment on ArchLinux
+
 You can use `pacaur` or other AUR installer instead of [`trizen`](https://github.com/trizen/trizen).
 ```
 TBD
@@ -274,11 +284,13 @@ TBD
 Once the above prerequistes are installed for your environment, you are ready to build.
 
 ### How to build components
-#### Build proto defitnitions:
+
+#### Build proto definitions:
+
 This is required only when the `ipc.proto` file changes (but this is true when you run it for the first time).
   1. Go to Execution Engine root directory. This is `execution-engine` directory in the node's root dir.
   2. Go to comm project directory (`cd comm`).
-  3. Run: `cargo run --bin grpc-protoc`
+  3. Run: `cargo build --bin casperlabs-engine-grpc-server`
 
 #### Build Wasm contracts:
 Contracts are in a separate github repo: https://github.com/CasperLabs/contract-examples.
@@ -294,22 +306,26 @@ If make fails, contract can be manually built:
   4. If `cargo build --release ...`  doesn't work try `cargo +nightly build ...`
 
 #### Building node:
+
   1. Go to node's root directory (it's where `build.sbt` file is located).
   2. Run `sbt -mem 5000 node/universal:stage`
 
 #### Building node's client:
+
   1. Go to node's root directory (it's where `build.sbt` file is located).
   2. Run `sbt -mem 5000 client/universal:stage`
 
 #### Building Execution Engine:
+
   1. Go to Execution Engine root directory. This is `execution-engine` directory in the node's root dir.
-  2. Go to comm project directory (`cd comm`)
-  3. Run `cargo build`
+  2. Run `cargo build`
 
 ### Running components
+
 For ease of use node assumes a default directory that is `~/.casperlabs/` First you have to create a hidden directory.
 
 #### Run the node
+
 In the root of the node (where build.sbt lives).
 
 If you're doing it for the first time you don't have private and public keys. The node can generate that for you: `./node/target/universal/stage/bin/casperlabs-node run -s`. It will create a genesis folder in `~/.casperlabs` directory. Genesis will contain `bonds.txt` file with the list of public keys and a files containing private key for each public key from `bonds.txt`. Choose one public key from `bonds.txt` file and corresponding private key (content) from `~/.casperlabs/genesis/<public_key>.sk`.
@@ -319,6 +335,7 @@ If you're doing it for the first time you don't have private and public keys. Th
 ```
 
 #### Run the Execution Engine
+
 In the root of th EE (`execution-engine/comm/`), run:
 
 ```
@@ -328,6 +345,7 @@ cargo run --bin casperlabs-engine-grpc-server ~/.casperlabs/.casper-node.sock
 .caspernode.sock is default socket file used for IPC communication.
 
 ### Deploying data
+
 In the root of the node, run:
 
 ```
@@ -345,11 +363,13 @@ After deploying contract it's not yet executed (its effects are not applied to t
 For the demo purposes we have to propose contracts separately because second contract (`hello-name/call`) won't see the changes (in practice it won't be able to call `hello-name/define` contract) from the previous deploy.
 
 ### Visualising DAG state
+
 In the root of the node, run:
 
 ```
 ./client/target/universal/stage/bin/casperlabs-client --host 127.0.0.1 --port 40401 vdag --depth 10 --out test.png
 ```
+
 The output will be saved into the `test.png` file.
 
 It's also possible subscribing to DAG changes and view them in the realtime
@@ -361,17 +381,19 @@ It's also possible subscribing to DAG changes and view them in the realtime
 The outputs will be saved into the files `test_0.png`, `test_1.png`, etc.
 
 For more information and possible output image formats check the help message 
+
 ```
 ./client/target/universal/stage/bin/casperlabs-client vdag --help
 ```
 
-
 ## Information for developers
+
 Assure prerequisites shown above are met.
 
 ### Developer Quick-Start
 
 When working in a single project, scope all `sbt` commands to that project. The most effective way is to maintain a running `sbt` instance, invoked from the project root:
+
 ```
 dev@dev:~/CasperLabs$ sbt
 [info] Loading settings for project casperlabs-build from plugins.sbt ...
@@ -386,11 +408,15 @@ sbt:node> stage
 [info] Done packaging.
 [success] Total time: 113 s, completed Jan 22, 2019, 10:53:37 PM
 ```
+
 but single-line commands work, too:
+
 ```
 $ sbt "project node" clean compile test
 ```
+
 or
+
 ```
 $ sbt node/clean node/compile node/test
 ```
@@ -405,12 +431,15 @@ The most up-to-date code is found in the `dev` branch. This brilliant, cutting-e
 
 Please check the prerequistes on your machine if the code generation fails.
 Then build the whole project with all submodules:
+
 ```
 > sbt compile
 ```
 
 #### Packaging
+
 To publish a docker image to your local repo run:
+
 ```
 > sbt node/docker:publishLocal
 [... output snipped ...]
@@ -424,6 +453,7 @@ To publish a docker image to your local repo run:
 ```
 
 Check the local docker repo:
+
 ```
 > docker images
 REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
@@ -433,6 +463,7 @@ openjdk             8u151-jre-alpine    b1bd879ca9b3        4 months ago        
 ```
 
 To deploy a tarball run:
+
 ```
 > sbt node/universal:packageZipTarball
 ```
@@ -440,13 +471,17 @@ To deploy a tarball run:
 The tarball can be found in directory `node/target/universal/`
 
 #### Running
+
 ```
 TBD
 ```
+
 Now after you've done some local changes and want to test them, simply run the last command `tbd` again. It will kill the running app and start a new instance containing latest changes in a completely new forked JVM.
 
 ### Cross-developing for Linux (e.g. Ubuntu) on a Mac
+
 You will need a virtual machine running the appropriate version of Linux.
+
 1. Install [VirtualBox]( https://www.virtualbox.org/wiki/Downloads)
 2. Install the Linux distribution you need (e.g. [Ubuntu](http://releases.ubuntu.com/16.04/ubuntu-16.04.4-server-amd64.iso))
 3. Start VirtualBox and create a new virtual machine in the manager


### PR DESCRIPTION
## Overview
Corrected the proto definition build to use the new `casperlabs-engine-grpc-server`.
Corrected execution-engine build instructions.
Added installs required for clean Ubuntu to develop.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/OP-115

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
