### PR TITLE
EE-212: Add AddWrite access rights variant

### DIFF
--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -13,6 +13,7 @@ pub enum AccessRights {
     Add,
     ReadAdd,
     ReadWrite,
+    AddWrite,
 }
 
 use AccessRights::*;
@@ -79,6 +80,16 @@ impl PartialOrd for AccessRights {
             (ReadWrite, Read) => Some(Ordering::Greater),
             (Write, Add) => None,
             (Add, Write) => None,
+            (Read, AddWrite) => None,
+            (Add, AddWrite) => Some(Ordering::Less),
+            (Write, AddWrite) => Some(Ordering::Less),
+            (ReadAdd, AddWrite) => None,
+            (ReadWrite, AddWrite) => None,
+            (AddWrite, Read) => None,
+            (AddWrite, Add) => Some(Ordering::Greater),
+            (AddWrite, Write) => Some(Ordering::Greater),
+            (AddWrite, ReadAdd) => None,
+            (AddWrite, ReadWrite) => None,
             (Write, ReadWrite) => Some(Ordering::Less),
             (ReadWrite, Write) => Some(Ordering::Greater),
             (Add, ReadAdd) => Some(Ordering::Less),
@@ -206,6 +217,7 @@ impl ToBytes for AccessRights {
             AccessRights::Write => 4u8.to_bytes(),
             AccessRights::ReadAdd => 5u8.to_bytes(),
             AccessRights::ReadWrite => 6u8.to_bytes(),
+            AccessRights::AddWrite => 7u8.to_bytes(),
         }
     }
 }
@@ -220,6 +232,7 @@ impl FromBytes for AccessRights {
             4 => Ok(AccessRights::Write),
             5 => Ok(AccessRights::ReadAdd),
             6 => Ok(AccessRights::ReadWrite),
+            7 => Ok(AccessRights::AddWrite),
             _ => Err(Error::FormattingError),
         };
         access_rights.map(|rights| (rights, rest))

--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -326,3 +326,72 @@ impl AsRef<[u8]> for Key {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::key::AccessRights::{self, *};
+    use crate::key::Key;
+
+    fn test_key_capabilities<F>(
+        right: AccessRights,
+        requires: AccessRights,
+        is_true: bool,
+        predicate: F,
+    ) where
+        F: Fn(Key) -> bool,
+    {
+        let key = Key::URef([0u8; 32], right);
+        assert_eq!(
+            predicate(key),
+            is_true,
+            "{:?} isn't enough to perform {:?} operation",
+            right,
+            requires
+        )
+    }
+
+    fn test_readable(right: AccessRights, is_true: bool) {
+        test_key_capabilities(right, Read, is_true, |key| key.is_readable())
+    }
+
+    #[test]
+    fn test_is_readable() {
+        test_readable(Read, true);
+        test_readable(ReadAdd, true);
+        test_readable(ReadWrite, true);
+        test_readable(Add, false);
+        test_readable(AddWrite, false);
+        test_readable(Eqv, false);
+        test_readable(Write, false);
+    }
+
+    fn test_writable(right: AccessRights, is_true: bool) {
+        test_key_capabilities(right, Write, is_true, |key| key.is_writable())
+    }
+
+    #[test]
+    fn test_is_writable() {
+        test_writable(Write, true);
+        test_writable(ReadWrite, true);
+        test_writable(AddWrite, true);
+        test_writable(Eqv, false);
+        test_writable(Read, false);
+        test_writable(Add, false);
+        test_writable(ReadAdd, false);
+    }
+
+    fn test_addable(right: AccessRights, is_true: bool) {
+        test_key_capabilities(right, Add, is_true, |key| key.is_addable())
+    }
+
+    #[test]
+    fn test_is_addable() {
+        test_addable(Add, true);
+        test_addable(ReadAdd, true);
+        test_addable(ReadWrite, true);
+        test_addable(AddWrite, true);
+        test_addable(Eqv, false);
+        test_addable(Read, false);
+        test_addable(Write, false);
+    }
+}

--- a/execution-engine/gens/src/gens.rs
+++ b/execution-engine/gens/src/gens.rs
@@ -34,7 +34,8 @@ pub fn access_rights_arb() -> impl Strategy<Value = AccessRights> {
         Just(AccessRights::Add),
         Just(AccessRights::Write),
         Just(AccessRights::ReadAdd),
-        Just(AccessRights::ReadWrite)
+        Just(AccessRights::ReadWrite),
+        Just(AccessRights::AddWrite),
     ]
 }
 

--- a/execution-engine/tests/src/partialord.rs
+++ b/execution-engine/tests/src/partialord.rs
@@ -16,6 +16,7 @@ mod tests {
         assert_eq!(read == AccessRights::Read, true);
         assert_eq!(read < AccessRights::ReadAdd, true);
         assert_eq!(read < AccessRights::ReadWrite, true);
+        assert_eq!(read != AccessRights::AddWrite, true);
         assert_eq!(read != AccessRights::Add, true);
         assert_eq!(read != AccessRights::Write, true);
     }
@@ -26,6 +27,7 @@ mod tests {
         assert_eq!(add == AccessRights::Add, true);
         assert_eq!(add < AccessRights::ReadAdd, true);
         assert_eq!(add < AccessRights::ReadWrite, true);
+        assert_eq!(add < AccessRights::AddWrite, true);
         assert_eq!(add != AccessRights::Read, true);
         assert_eq!(add != AccessRights::Write, true);
     }
@@ -35,6 +37,7 @@ mod tests {
         let write = AccessRights::Write;
         assert_eq!(write == AccessRights::Write, true);
         assert_eq!(write < AccessRights::ReadWrite, true);
+        assert_eq!(write < AccessRights::AddWrite, true);
         assert_eq!(write != AccessRights::Read, true);
         assert_eq!(write != AccessRights::Add, true);
         assert_eq!(write != AccessRights::ReadAdd, true);


### PR DESCRIPTION
## Overview
As per the title.

This PR also adds tests for `Key`'s `is_*able()` methods (`is_readable()`, `is_writable()`, `is_addable()`). 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-212

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
N/A