### PR TITLE
NODE-307: DownloadManager (phase 1)

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -123,5 +123,16 @@ sealed trait GossipError extends NoStackTrace
 object GossipError {
 
   /** Download from the other party failed due to invalid chunk sizes. */
-  final case class InvalidChunks(msg: String, source: Node) extends GossipError
+  final case class InvalidChunks(msg: String, source: Node) extends Exception(msg) with GossipError
+
+  /** Tried to schedule a download for which we don't have the dependencies. */
+  final case class MissingDependencies(msg: String) extends Exception(msg) with GossipError
+  object MissingDependencies {
+    def apply(blockHash: ByteString, missing: Seq[ByteString]): MissingDependencies =
+      MissingDependencies(
+        s"Block ${Base16.encode(blockHash.toByteArray)} has missing dependencies: [${missing
+          .map(x => Base16.encode(x.toByteArray))
+          .mkString(", ")}]"
+      )
+  }
 }

--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -5,6 +5,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.catscontrib._, Catscontrib._, ski._
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.comm.protocol.routing._
+import io.casperlabs.comm.discovery.Node
 import io.grpc.{Status, StatusRuntimeException}
 import java.nio.file._
 import scala.util.control.NoStackTrace
@@ -116,4 +117,11 @@ object ServiceError {
     def block(blockHash: ByteString): ServiceException =
       apply(s"Block ${Base16.encode(blockHash.toByteArray)} could not be found.")
   }
+}
+
+sealed trait GossipError extends NoStackTrace
+object GossipError {
+
+  /** Download from the other party failed due to invalid chunk sizes. */
+  final case class InvalidChunks(msg: String, source: Node) extends GossipError
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.comm.gossiping
 
+import cats._
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.comm.discovery.Node
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -8,18 +8,13 @@ trait DownloadManager[F[_]] {
 
   /** Schedule the download of a full block from the `source` node.
     * If `relay` is `true` then gossip it afterwards, if it's valid.
-    * The returned `F[Unit]` finishes as soon as the scheduling has
-    * happened successfully, *not* when the download has completed.
-    * It is illegal to schedule an item which has dependencies that
-    * hasn't been scheduled or downloaded already; first we should
-    * sync the DAG with the `source` and add items in topological
-    * order*/
-  def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[Unit]
-
-  // TODO: We could consider adding some "watch" functionality so that the caller
-  // can await for when the download is completed. Maybe `scheduleDownload` should
-  // return an `F[Deferred[F, Unit]]`. The outer `F` would indicate the success of
-  // the scheduling and the `Deferred` would eventually complete with success or
-  // error. It would alleviate the need for some sleeps in the tests to see that
-  // nothing else happens, if we knew that the download has indeed finished.
+    * The returned `F[F[Unit]]` represents the success/failure of
+    * the scheduling itself; it fails if there's any error accessing
+    * the local backend, or if the scheduling cannot be carried out
+    * due to missing dependencies (at this point we should have synced
+    * already and the schedule should be called in topological order).
+    *
+    * The unwrapped `F[Unit]` _inside_ the `F[F[Unit]]` can be used to
+    * wait until the actual download finishes, or results in an error. */
+  def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[F[Unit]]
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -1,0 +1,12 @@
+package io.casperlabs.comm.gossiping
+
+import io.casperlabs.casper.consensus.BlockSummary
+import io.casperlabs.comm.discovery.Node
+
+/** Manage the download, validation, storing and gossiping of blocks. */
+trait DownloadManager[F[_]] {
+
+  /** Schedule the download of a full block from the `source` node.
+	  * If `relay` is `true` then gossip it afterwards, if it's valid. */
+  def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[Unit]
+}

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -7,6 +7,10 @@ import io.casperlabs.comm.discovery.Node
 trait DownloadManager[F[_]] {
 
   /** Schedule the download of a full block from the `source` node.
-	  * If `relay` is `true` then gossip it afterwards, if it's valid. */
+    * If `relay` is `true` then gossip it afterwards, if it's valid.
+    * It is illegal to schedule an item which has dependencies that
+    * hasn't been scheduled or downloaded already; first we should
+    * sync the DAG with the `source` and add items in topological
+    * order. */
   def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[Unit]
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -8,9 +8,18 @@ trait DownloadManager[F[_]] {
 
   /** Schedule the download of a full block from the `source` node.
     * If `relay` is `true` then gossip it afterwards, if it's valid.
+    * The returned `F[Unit]` finishes as soon as the scheduling has
+    * happened successfully, *not* when the download has completed.
     * It is illegal to schedule an item which has dependencies that
     * hasn't been scheduled or downloaded already; first we should
     * sync the DAG with the `source` and add items in topological
-    * order. */
+    * order*/
   def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[Unit]
+
+  // TODO: We could consider adding some "watch" functionality so that the caller
+  // can await for when the download is completed. Maybe `scheduleDownload` should
+  // return an `F[Deferred[F, Unit]]`. The outer `F` would indicate the success of
+  // the scheduling and the `Deferred` would eventually complete with success or
+  // error. It would alleviate the need for some sleeps in the tests to see that
+  // nothing else happens, if we knew that the download has indeed finished.
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
@@ -48,6 +48,8 @@ object DownloadManagerImpl {
     } {
       case (workersRef, managerLoop, _) =>
         for {
+          // TODO: Perhaps it would be nice if after cancelation the `scheduleDownload`
+          // wouldn't just block further shcedule attempts but raise an error.
           _       <- managerLoop.cancel.attempt
           workers <- workersRef.get
           _       <- workers.values.toList.map(_.cancel.attempt).sequence.void
@@ -107,7 +109,7 @@ class DownloadManagerImpl[F[_]: Sync: Concurrent](
     for {
       block <- downloadAndRestore(item.source, item.summary.blockHash)
       // TODO: Validate
-      // TODO: Storee
+      // TODO: Store
       // TODO: Gossip
       // TODO: Signal failure.
       _ <- signal.put(Signal.Downloaded(item.summary.blockHash))

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
@@ -1,0 +1,191 @@
+package io.casperlabs.comm.gossiping
+
+import cats._
+import cats.syntax._
+import cats.implicits._
+import cats.effect._
+import cats.effect.syntax._
+import cats.effect.concurrent._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.comm.discovery.Node
+import io.casperlabs.comm.GossipError
+import io.casperlabs.shared.Compression
+
+object DownloadManagerImpl {
+
+  /** Messages the DM uses inside its scheduler "queue". */
+  sealed trait Signal
+  object Signal {
+
+    /** Tell the manager to download a new block. */
+    case class Download(summary: BlockSummary, source: Node, relay: Boolean) extends Signal
+
+    /** Tell the manager that a block has been downloaded. */
+    case class Downloaded(blockHash: ByteString) extends Signal
+  }
+
+  /** Start the download manager. */
+  def apply[F[_]: Sync: Concurrent](
+      maxParallelDownloads: Int,
+      connector: Node => F[GossipService[F]],
+      validate: Block => F[Unit],
+      store: Block => F[Unit]
+  ): Resource[F, DownloadManager[F]] =
+    Resource.make {
+      for {
+        workersRef <- Ref.of(Map.empty[ByteString, Fiber[F, Unit]])
+        semaphore  <- Semaphore[F](maxParallelDownloads.toLong)
+        signal     <- MVar[F].empty[Signal]
+        manager = new DownloadManagerImpl[F](
+          workersRef,
+          semaphore,
+          signal,
+          connector
+        )
+        managerLoop <- Concurrent[F].start(manager.run)
+      } yield (workersRef, managerLoop, manager)
+    } {
+      case (workersRef, managerLoop, _) =>
+        for {
+          _       <- managerLoop.cancel.attempt
+          workers <- workersRef.get
+          _       <- workers.values.toList.map(_.cancel.attempt).sequence.void
+        } yield ()
+    } map {
+      case (_, _, manager) => manager
+    }
+}
+
+class DownloadManagerImpl[F[_]: Sync: Concurrent](
+    // Keep track of ongoing downloads so we can cancel them.
+    workersRef: Ref[F, Map[ByteString, Fiber[F, Unit]]],
+    // Limit parallel downloads.
+    semaphore: Semaphore[F],
+    // Single item control signals for the manager loop.
+    signal: MVar[F, DownloadManagerImpl.Signal],
+    // Establish gRPC connection to another node.
+    // TODO: Handle connection errors.
+    connector: Node => F[GossipService[F]]
+    // TODO: Ref to a DAG to keep track of dependencies.
+) extends DownloadManager[F] {
+
+  import DownloadManagerImpl._
+
+  override def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[Unit] =
+    signal.put {
+      Signal.Download(summary, source, relay)
+    }
+
+  /** Run the manager loop which listens to signals and starts workers when it can. */
+  def run: F[Unit] =
+    signal.take.flatMap {
+      case item: Signal.Download =>
+        // TODO: Add the source to the DAG.
+        // TODO: Check that we're not downloading it already.
+        // TODO: Check that we haven't downloaded it before.
+        // TODO: Check that all dependencies are met and we can start downloading it.
+        val start = for {
+          worker <- Concurrent[F].start(download(item))
+          _      <- workersRef.update(_ + (item.summary.blockHash -> worker))
+        } yield ()
+        // Recurse outside the flatMap to avoid stack overflow.
+        start *> run
+
+      case Signal.Downloaded(blockHash) =>
+        // Remove the worker.
+        // TODO: Check what else we can download now.
+        val finish = for {
+          _ <- workersRef.update(_ - blockHash)
+        } yield ()
+
+        finish *> run
+    }
+
+  // TODO: Just say which block hash to download, try all possible sources.
+  def download(item: Signal.Download): F[Unit] =
+    for {
+      block <- downloadAndRestore(item.source, item.summary.blockHash)
+      // TODO: Validate
+      // TODO: Storee
+      // TODO: Gossip
+      // TODO: Signal failure.
+      _ <- signal.put(Signal.Downloaded(item.summary.blockHash))
+    } yield ()
+
+  /** Download a block from the source node and decompress it. */
+  def downloadAndRestore(source: Node, blockHash: ByteString): F[Block] = {
+    // Keep track of how much we have downloaded so far and cancel the stream if it goes over the promised size.
+    case class Acc(
+        header: Option[Chunk.Header],
+        totalSizeSofar: Int,
+        chunks: List[ByteString],
+        error: Option[GossipError]
+    ) {
+      def invalid(msg: String) =
+        copy(error = Some(GossipError.InvalidChunks(msg, source)))
+
+      def append(data: ByteString) =
+        copy(totalSizeSofar = totalSizeSofar + data.size, chunks = data :: chunks)
+    }
+
+    semaphore.withPermit {
+      for {
+        stub <- connector(source)
+        req = GetBlockChunkedRequest(
+          blockHash = blockHash,
+          acceptedCompressionAlgorithms = Seq("lz4")
+        )
+
+        acc <- stub.getBlockChunked(req).foldWhileLeftL(Acc(None, 0, Nil, None)) {
+                case (acc, chunk) if acc.header.isEmpty && chunk.content.isHeader =>
+                  val header = chunk.getHeader
+                  header.compressionAlgorithm match {
+                    case "" | "lz4" =>
+                      Left(acc.copy(header = Some(header)))
+                    case other =>
+                      Right(
+                        acc.invalid(s"Block chunks compressed with unexpected algorithm: $other")
+                      )
+                  }
+
+                case (acc, chunk) if acc.header.nonEmpty && chunk.content.isHeader =>
+                  Right(acc.invalid("Block chunks contained a second header."))
+
+                case (acc, _) if acc.header.isEmpty =>
+                  Right(acc.invalid("Block chunks didn't start with a header."))
+
+                case (acc, chunk) if chunk.getData.isEmpty =>
+                  Right(acc.invalid("Block chunks contained empty data frame."))
+
+                case (acc, chunk)
+                    if acc.totalSizeSofar + chunk.getData.size > acc.header.get.contentLength =>
+                  Right(acc.invalid("Block chunks are exceeding the promised content length."))
+
+                case (acc, chunk) =>
+                  Left(acc.append(chunk.getData))
+              }
+
+        content <- acc.error map {
+                    Sync[F].raiseError(_)
+                  } getOrElse {
+                    val header  = acc.header.get
+                    val content = acc.chunks.toArray.reverse.flatMap(_.toByteArray)
+                    if (header.compressionAlgorithm.isEmpty)
+                      Sync[F].pure(content)
+                    else {
+                      Compression
+                        .decompress(content, header.originalContentLength)
+                        .fold(
+                          Sync[F].raiseError[Array[Byte]](
+                            GossipError.InvalidChunks("Could not decompress chunks.", source)
+                          )
+                        )(Sync[F].pure(_))
+                    }
+                  }
+
+        block <- Sync[F].delay(Block.parseFrom(content))
+      } yield block
+    }
+  }
+}

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
@@ -164,8 +164,11 @@ class DownloadManagerImpl[F[_]: Sync: Concurrent: Log](
         for {
           // TODO: Pick a source.
           block <- downloadAndRestore(source, summary.blockHash)
-          // TODO: Validate
-          // TODO: Store
+          _     <- backend.validateBlock(block)
+          _     <- backend.storeBlock(block)
+          // This could arguably be done by `storeBlock` but this way it's explicit,
+          // so we don't forget to talk to both kind of storages.
+          _ <- backend.storeBlockSummary(summary)
           // TODO: Gossip
         } yield ()
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
@@ -28,7 +28,7 @@ object DownloadManagerImpl {
     def storeBlockSummary(summary: BlockSummary): F[Unit]
   }
 
-  /** Messages the DM uses inside its scheduler "queue". */
+  /** Messages the Download Manager uses inside its scheduler "queue". */
   sealed trait Signal[F[_]]
   object Signal {
     case class Download[F[_]](
@@ -87,7 +87,7 @@ object DownloadManagerImpl {
     } {
       case (isShutdown, workersRef, managerLoop, _) =>
         for {
-          _       <- Log[F].info("Shutting down the DownloadManager...")
+          _       <- Log[F].info("Shutting down the Download Manager...")
           _       <- isShutdown.set(true)
           _       <- managerLoop.cancel.attempt
           workers <- workersRef.get
@@ -98,10 +98,10 @@ object DownloadManagerImpl {
     }
 
   /** All dependencies that need to be downloaded before a block. */
-  def dependencies(summary: BlockSummary): Seq[ByteString] =
+  private def dependencies(summary: BlockSummary): Seq[ByteString] =
     summary.getHeader.parentHashes ++ summary.getHeader.justifications.map(_.latestBlockHash)
 
-  def base16(blockHash: ByteString) =
+  private def base16(blockHash: ByteString) =
     Base16.encode(blockHash.toByteArray)
 }
 
@@ -127,7 +127,7 @@ class DownloadManagerImpl[F[_]: Sync: Concurrent: Log](
   private def ensureNotShutdown: F[Unit] =
     isShutdown.get.ifM(
       Sync[F]
-        .raiseError(new java.lang.IllegalStateException("Download manager already shut down.")),
+        .raiseError(new java.lang.IllegalStateException("Download Manager already shut down.")),
       Sync[F].unit
     )
 

--- a/comm/src/main/scala/io/casperlabs/comm/transport/GenerateCertificateIfAbsent.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/GenerateCertificateIfAbsent.scala
@@ -65,7 +65,7 @@ class GenerateCertificateIfAbsent[F[_]: Sync](implicit log: Log[F]) {
       pw =>
         Sync[F].delay(
           pw.write(certPrint.print(certHelp.generate(keyPair)))
-      )
+        )
     )
   }
 
@@ -76,7 +76,7 @@ class GenerateCertificateIfAbsent[F[_]: Sync](implicit log: Log[F]) {
       pw =>
         Sync[F].delay(
           pw.write(certPrint.printPrivateKey(keyPair.getPrivate))
-      )
+        )
     )
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -2,6 +2,7 @@ package io.casperlabs.comm.gossiping
 
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus._
+import io.casperlabs.comm.discovery.Node
 import org.scalacheck.{Arbitrary, Gen}
 import scala.collection.JavaConverters._
 
@@ -17,6 +18,15 @@ trait ArbitraryConsensus {
 
   val genHash = genBytes(20)
   val genKey  = genBytes(32)
+
+  implicit val arbNode: Arbitrary[Node] = Arbitrary {
+    for {
+      id   <- genHash
+      host <- Gen.listOfN(4, Gen.choose(0, 255)).map(xs => xs.mkString("."))
+    } yield {
+      Node(id, host, 40400, 40404)
+    }
+  }
 
   implicit val arbSignature: Arbitrary[Signature] = Arbitrary {
     for {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -1,0 +1,51 @@
+package io.casperlabs.comm.gossiping
+
+import org.scalatest._
+
+class DownloadManagerSpec extends WordSpecLike {
+
+  "DownloadManager" when {
+    "scheduled to download a section of the DAG" should {
+      "download blocks in topoligical order" in (pending)
+      "download siblings in parallel" in (pending)
+      "eventually download the full DAG" in (pending)
+      "not exceed the limit on parallelism" in (pending)
+    }
+    "scheduled to download a block with missing dependencies" should {
+      "raise an error" in (pending)
+    }
+    "scheduled to download a block which already exists" should {
+      "skip the download" in (pending)
+    }
+    "scheduled to download a block which is already downloading" should {
+      "skip the download" in (pending)
+    }
+    "released as a resource" should {
+      "cancel outstanding downloads" in (pending)
+      "reject further schedules" in (pending)
+    }
+    "fails to download a block for any reason" should {
+      "carry on downloading other blocks from other nodes" in (pending)
+      "try to download the block from a different source" in (pending)
+    }
+    "downloaded a valid block" should {
+      "validate the block" in (pending)
+      "store the block" in (pending)
+      "store the block summary" in (pending)
+      "gossip to other nodes" in (pending)
+    }
+    "cannot validate a block" should {
+      "not download the dependant blocks" in (pending)
+      "not store the block" in (pending)
+    }
+    "cannot connect to a node" should {
+      "try again if the same block from the same source is scheduled again" in (pending)
+      "try again later with exponential backoff" in (pending)
+    }
+    "receiving chunks" should {
+      "check that they start with the header" in (pending)
+      "check that the total size doesn't exceed promises" in (pending)
+      "check that the excpected compression algorithm is used" in (pending)
+    }
+  }
+}

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -179,13 +179,9 @@ class DownloadManagerSpec
 
     "cannot connect to a node" should {
       val block = arbitrary[Block].sample.map(withoutDependencies).get
-      val remote = MockGossipService(
-        Seq(block),
-        rechunker = _ => Iterant.raiseError(io.grpc.Status.UNAVAILABLE.asRuntimeException())
-      )
 
       "try again if the same block from the same source is scheduled again" in TestFixture(
-        remote = _ => remote
+        remote = _ => Task.raiseError(io.grpc.Status.UNAVAILABLE.asRuntimeException())
       ) {
         case (manager, _) =>
           def check(i: Int) = manager.scheduleDownload(summaryOf(block), source, false) map { _ =>

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -1,8 +1,19 @@
 package io.casperlabs.comm.gossiping
 
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.comm.discovery.Node
+import io.casperlabs.comm.GossipError
+import monix.eval.Task
+import monix.execution.Scheduler
 import org.scalatest._
+import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
+import scala.concurrent.duration._
 
-class DownloadManagerSpec extends WordSpecLike {
+class DownloadManagerSpec extends WordSpecLike with Matchers with ArbitraryConsensus {
+
+  import DownloadManagerSpec._
+  import Scheduler.Implicits.global
 
   "DownloadManager" when {
     "scheduled to download a section of the DAG" should {
@@ -11,9 +22,23 @@ class DownloadManagerSpec extends WordSpecLike {
       "eventually download the full DAG" in (pending)
       "not exceed the limit on parallelism" in (pending)
     }
+
     "scheduled to download a block with missing dependencies" should {
-      "raise an error" in (pending)
+      val block  = arbitrary[Block].suchThat(_.getHeader.parentHashes.nonEmpty).sample.get
+      val source = arbitrary[Node].sample.get
+      val remote = MockGossipService.fromBlocks(Seq(block))
+
+      "raise an error" in TestFixture(remote = _ => remote) { manager =>
+        manager.scheduleDownload(summaryOf(block), source, false).attempt.map {
+          case Left(GossipError.MissingDependencies(_)) =>
+          case other =>
+            fail(s"Expected scheduling to fail; got $other")
+        }
+      }
+
+      "accept it if the dependency has already been scheduled" in (pending)
     }
+
     "scheduled to download a block which already exists" should {
       "skip the download" in (pending)
     }
@@ -45,7 +70,104 @@ class DownloadManagerSpec extends WordSpecLike {
     "receiving chunks" should {
       "check that they start with the header" in (pending)
       "check that the total size doesn't exceed promises" in (pending)
-      "check that the excpected compression algorithm is used" in (pending)
+      "check that the expected compression algorithm is used" in (pending)
+    }
+
+    "cannot query the backend" should {
+      val block1 = arbitrary[Block].sample.get
+      val block2 = arbitrary[Block].sample.map(withoutDependencies).get
+      val source = arbitrary[Node].sample.get
+      val remote = MockGossipService.fromBlocks(Seq(block1, block2))
+      val local = new MockBackend {
+        override def hasBlock(blockHash: ByteString) =
+          if (blockHash == block1.blockHash || dependenciesOf(block1).contains(blockHash))
+            Task.raiseError(new RuntimeException("Oh no!"))
+          else
+            Task.pure(false)
+      }
+
+      "raise a scheduling error, but keep processing schedules" in TestFixture(local, _ => remote) {
+        manager =>
+          for {
+            attempt1 <- manager.scheduleDownload(summaryOf(block1), source, false).attempt
+            attempt2 <- manager.scheduleDownload(summaryOf(block2), source, false).attempt
+          } yield {
+            attempt1 match {
+              case Left(ex: RuntimeException) =>
+                ex.getMessage shouldBe "Oh no!"
+              case other =>
+                fail(s"Expected scheduling to fail; got $other")
+            }
+            attempt2 shouldBe Right(())
+          }
+      }
+    }
+  }
+}
+
+object DownloadManagerSpec {
+
+  def summaryOf(block: Block): BlockSummary =
+    BlockSummary()
+      .withBlockHash(block.blockHash)
+      .withHeader(block.getHeader)
+      .withSignature(block.getSignature)
+
+  def dependenciesOf(block: Block): Seq[ByteString] =
+    block.getHeader.parentHashes ++ block.getHeader.justifications.map(_.latestBlockHash)
+
+  def withoutDependencies(block: Block): Block =
+    block.withHeader(block.getHeader.copy(parentHashes = Seq.empty, justifications = Seq.empty))
+
+  object TestFixture {
+    def apply(
+        local: MockBackend = MockBackend.default,
+        remote: Node => Task[GossipService[Task]] = _ => MockGossipService.default,
+        maxParallelDownloads: Int = 1
+    )(
+        test: DownloadManager[Task] => Task[Unit]
+    )(implicit scheduler: Scheduler): Unit = {
+
+      val managerR = DownloadManagerImpl[Task](
+        maxParallelDownloads = maxParallelDownloads,
+        connectToGossip = remote(_),
+        backend = local
+      )
+
+      val runTest = managerR.use { manager =>
+        test(manager)
+      }
+
+      runTest.runSyncUnsafe(5.seconds)
+    }
+  }
+
+  trait MockBackend extends DownloadManagerImpl.Backend[Task] {
+    def hasBlock(blockHash: ByteString): Task[Boolean]       = Task.now(false)
+    def validateBlock(block: Block): Task[Unit]              = Task.unit
+    def storeBlock(block: Block): Task[Unit]                 = Task.unit
+    def storeBlockSummary(summary: BlockSummary): Task[Unit] = Task.unit
+  }
+  object MockBackend {
+    val default = new MockBackend {}
+  }
+
+  /** Test implementation of the remote GossipService to download the blocks from. */
+  object MockGossipService {
+    val default = Task.now {
+      new GossipServiceServer[Task](
+        getBlock = hash => Task.now(None),
+        getBlockSummary = hash => ???,
+        maxChunkSize = 100 * 1024
+      )
+    }
+    def fromBlocks(blocks: Seq[Block]) = Task.now {
+      val blockMap = blocks.groupBy(_.blockHash).mapValues(_.head)
+      new GossipServiceServer[Task](
+        getBlock = hash => Task.now(blockMap.get(hash)),
+        getBlockSummary = hash => ???,
+        maxChunkSize = 100 * 1024
+      )
     }
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -31,6 +31,8 @@ class GrpcGossipServiceSpec
   import GrpcGossipServiceSpec._
   import Scheduler.Implicits.global
 
+  implicit val consensusConfig = ConsensusConfig()
+
   // Test data that we can set in each test.
   val testDataRef = new AtomicReference(TestData.empty)
   // Set up the server and client once, to be shared, to make tests faster.

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -120,6 +120,7 @@ object EffectsTestInstances {
       infos = Vector.empty[String]
       warns = Vector.empty[String]
       errors = Vector.empty[String]
+      causes = Vector.empty[Throwable]
       all = Vector.empty[String]
     }
     def isTraceEnabled(implicit ev: LogSource): F[Boolean]  = false.pure[F]

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -106,10 +106,11 @@ object EffectsTestInstances {
 
   class LogStub[F[_]: Applicative] extends Log[F] {
 
-    var debugs: Vector[String] = Vector.empty[String]
-    var infos: Vector[String]  = Vector.empty[String]
-    var warns: Vector[String]  = Vector.empty[String]
-    var errors: Vector[String] = Vector.empty[String]
+    var debugs: Vector[String]    = Vector.empty[String]
+    var infos: Vector[String]     = Vector.empty[String]
+    var warns: Vector[String]     = Vector.empty[String]
+    var errors: Vector[String]    = Vector.empty[String]
+    var causes: Vector[Throwable] = Vector.empty[Throwable]
 
     // To be able to reconstruct the timeline.
     var all: Vector[String] = Vector.empty[String]
@@ -144,6 +145,7 @@ object EffectsTestInstances {
       ().pure[F]
     }
     def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = {
+      causes = causes :+ cause
       errors = errors :+ msg
       all = all :+ msg
       ().pure[F]


### PR DESCRIPTION
## Overview
Adds a `DownloadManager` class to download blocks from nodes that told us they had it. Should be called one the DAG syncing has been carried out.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.

https://casperlabs.atlassian.net/browse/NODE-307

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
I left in a TODO about adding exponential backoff; I'd do that in a future ticket, with maximum retries, etc.

Created some follow up tickets:
* https://casperlabs.atlassian.net/browse/NODE-357 for adding metrics
* https://casperlabs.atlassian.net/browse/NODE-358 for retries