### PR TITLE
Copy rng state from sub_call runtime back to current_runtime to prevent repeated urefs

### DIFF
--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -912,6 +912,8 @@ where
     };
 
     let result = instance.invoke_export("call", &[], &mut runtime);
+    // Update rng after running, so it is remembered in the main runtime (prevents repeating URefs)
+    current_runtime.rng = runtime.rng;
 
     match result {
         Ok(_) => Ok(runtime.result),

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -39,6 +39,7 @@ pub enum Error {
     ParityWasm(ParityWasmError),
     GasLimit,
     Ret(Vec<Key>),
+    Rng(rand::Error),
     Unreachable,
 }
 
@@ -892,6 +893,7 @@ where
 {
     let (instance, memory) = instance_and_memory(parity_module.clone())?;
     let known_urefs = refs.values().cloned().chain(extra_urefs).collect();
+    let rng = ChaChaRng::from_rng(&mut current_runtime.rng).map_err(Error::Rng)?;
     let mut runtime = Runtime {
         args,
         memory,
@@ -908,12 +910,10 @@ where
             account: current_runtime.context.account,
             base_key: key,
         },
-        rng: current_runtime.rng.clone(),
+        rng,
     };
 
     let result = instance.invoke_export("call", &[], &mut runtime);
-    // Update rng after running, so it is remembered in the main runtime (prevents repeating URefs)
-    current_runtime.rng = runtime.rng;
 
     match result {
         Ok(_) => Ok(runtime.result),


### PR DESCRIPTION
## Overview
Without this fix the same `URef`s are generated if multiple contracts are called in the same session code.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-218
We should make some unit tests too in a future PR: https://casperlabs.atlassian.net/browse/EE-213

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
