### PR TITLE
NO-TICKET: execution-engine: bump proptest to 0.9.2

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -346,7 +346,7 @@ name = "gens"
 version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.2.0",
- "proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",
  "storage 0.1.0",
 ]
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "0.8.7"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -664,7 +664,9 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusty-fork 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -749,18 +751,6 @@ dependencies = [
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1110,7 +1100,7 @@ version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.2.0",
  "gens 0.1.0",
- "proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1633,7 +1623,7 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
-"checksum proptest 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)" = "926d0604475349f463fe44130aae73f2294b5309ab2ca0310b998bd334ef191f"
+"checksum proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "24f5844db2f839e97e3021980975f6ebf8691d9b9b2ca67ed3feb38dc3edb52c"
 "checksum protobuf 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24d5d73d2b88fddb8b8141f2730d950d88772c940ac4f8f3e93230b9a99d92df"
 "checksum protobuf-codegen 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc1ef231350d13cb261717a1223ac43c1e93c9b3180535920c1a9cc51f80567"
 "checksum protoc 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8b83cbfb699626e2670de2aab558c34a51bd9bd25a2d3e79b4b09d05b660e8"
@@ -1643,7 +1633,6 @@ dependencies = [
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"

--- a/execution-engine/engine/Cargo.toml
+++ b/execution-engine/engine/Cargo.toml
@@ -21,7 +21,7 @@ shared = { path = "../shared" }
 [dev-dependencies]
 matches = "0.1.8"
 gens = { path = "../gens" }
-proptest = "0.8.7"
+proptest = "0.9.2"
 
 [[bin]]
 name = "engine-standalone"

--- a/execution-engine/engine/src/lib.rs
+++ b/execution-engine/engine/src/lib.rs
@@ -24,7 +24,6 @@ mod utils;
 #[macro_use]
 extern crate matches;
 #[cfg(test)]
-#[macro_use]
 extern crate proptest;
 #[cfg(test)]
 extern crate gens;

--- a/execution-engine/gens/Cargo.toml
+++ b/execution-engine/gens/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 
 [dependencies]
-proptest = "0.8.7"
+proptest = "0.9.2"
 common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }
 shared = { path = "../shared" }
 storage = { path = "../storage" }

--- a/execution-engine/gens/src/lib.rs
+++ b/execution-engine/gens/src/lib.rs
@@ -1,5 +1,3 @@
-#[macro_use]
-extern crate proptest;
 extern crate common;
 extern crate shared;
 extern crate storage;

--- a/execution-engine/tests/Cargo.toml
+++ b/execution-engine/tests/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 [dependencies]
 common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }
 gens = { path = "../gens" }
-proptest = "0.8.7"
+proptest = "0.9.2"
 


### PR DESCRIPTION
## Overview
This PR bumps the `proptest` crate, used throughout the `execution-engine`, to version `0.9.2`.

### Which JIRA issue does this PR relate to?
This is work has not ticket.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
For more information about the elision of `#[macro_use]` and the removal of `extern crate`:
https://doc.rust-lang.org/edition-guide/rust-2018/macros/macro-changes.html
