### PR TITLE
NODE-355: Fix docker network startup

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -39,13 +39,13 @@ __Note__ Successfully building from source requires attending to all of the prer
   ```
 
   rust:
-  
+
   Install packages needed for installing and building Rust.
   ```console
   dev@dev:~$ sudo apt install build-essential cmake curl -y
   ```
 
-  Install Rust  
+  Install Rust
   ```console
   dev@dev:~$ curl https://sh.rustup.rs -sSf | sh
   ...
@@ -318,16 +318,6 @@ If make fails, contract can be manually built:
 
 For ease of use node assumes a default directory that is `~/.casperlabs/` First you have to create a hidden directory.
 
-#### Run the node
-
-In the root of the node (where build.sbt lives).
-
-If you're doing it for the first time you don't have private and public keys. The node can generate that for you: `./node/target/universal/stage/bin/casperlabs-node run -s`. It will create a genesis folder in `~/.casperlabs` directory. Genesis will contain `bonds.txt` file with the list of public keys and a files containing private key for each public key from `bonds.txt`. Choose one public key from `bonds.txt` file and corresponding private key (content) from `~/.casperlabs/genesis/<public_key>.sk`.
-
-```
-./node/target/universal/stage/bin/casperlabs-node run --casper-validator-private-key <private key from <public_key>.sk file> --casper-validator-public-key <public_key> -s
-```
-
 #### Run the Execution Engine
 
 In the root of th EE (`execution-engine/comm/`), run:
@@ -337,6 +327,16 @@ cargo run --bin casperlabs-engine-grpc-server ~/.casperlabs/.casper-node.sock
 ```
 
 .caspernode.sock is default socket file used for IPC communication.
+
+#### Run the node
+
+In the root of the node (where build.sbt lives).
+
+If you're doing it for the first time you don't have private and public keys. The node can generate that for you: `./node/target/universal/stage/bin/casperlabs-node run -s`. It will create a genesis folder in `~/.casperlabs` directory. Genesis will contain `bonds.txt` file with the list of public keys and a files containing private key for each public key from `bonds.txt`. Choose one public key from `bonds.txt` file and corresponding private key (content) from `~/.casperlabs/genesis/<public_key>.sk`.
+
+```
+./node/target/universal/stage/bin/casperlabs-node run --casper-validator-private-key <private key from <public_key>.sk file> --casper-validator-public-key <public_key> -s
+```
 
 ### Deploying data
 
@@ -374,7 +374,7 @@ It's also possible subscribing to DAG changes and view them in the realtime
 
 The outputs will be saved into the files `test_0.png`, `test_1.png`, etc.
 
-For more information and possible output image formats check the help message 
+For more information and possible output image formats check the help message
 
 ```
 ./client/target/universal/stage/bin/casperlabs-client vdag --help

--- a/VALIDATOR.md
+++ b/VALIDATOR.md
@@ -39,7 +39,7 @@ OpenJDK 64-Bit Server VM (build 11.0.1+13-Ubuntu-3ubuntu116.04ppa1, mixed mode, 
 
 The node consists of an API component running in Java and an execution engine running the WASM code of the deploys. They have to be started separately at the moment and configured to talk to each other.
 
-*NOTE: Users will need to update \[VERSION\] with the version the want. See: 
+*NOTE: Users will need to update \[VERSION\] with the version the want. See:
 
 ```sh
 curl -sO http://repo.casperlabs.io/casperlabs/repo/master/casperlabs-node_[VERSION]_all.deb
@@ -51,6 +51,19 @@ sudo dpkg -i casperlabs-engine-grpc-server_[VERSION]_amd64.deb
 After these steps you should be able to run `casperlabs-node --help` and `casperlabs-engine-grpc-server --help`.
 
 
+### Starting the execution engine
+
+The execution engine runs as a separate process and isn't open to the network, it communicates with the node through a UNIX file socket. If you're using Windows it will have to run under Windows Subsystem for Linux (WSL).
+
+The node will want to connect to this socket, so it's best to start the engine up front.
+
+```console
+$ mkdir casperlabs-node-data
+$ casperlabs-engine-grpc-server casperlabs-node-data/.caspernode.sock
+Server is listening on socket: casperlabs-node-data/.caspernode.sock
+```
+
+
 ### Setting up keys
 
 As a validator you'll need a public and private key to sign blocks, and an SSL certificate to provide secure communication with other nodes on the network. You can run the node once to generate these up front.
@@ -58,8 +71,11 @@ As a validator you'll need a public and private key to sign blocks, and an SSL c
 You'll need to create a directory to hold data. By default this is expected to be at `~/.casperlabs`, but you can provide another location with the `--server-data-dir` option.
 
 ```console
-$ mkdir casperlabs-node-data
-$ casperlabs-node run -s --server-data-dir casperlabs-node-data --casper-num-validators 1
+$ casperlabs-node run -s \
+    --server-data-dir casperlabs-node-data \
+    --grpc-socket casperlabs-node-data/.caspernode.sock \
+    --casper-num-validators 1
+
 10:40:19.729 [main] INFO  io.casperlabs.node.Main$ - CasperLabs node (030bb96133ef9a9c31133ab3371937c2388bf5b9)
 10:40:19.736 [main] INFO  io.casperlabs.node.NodeEnvironment$ - Using data dir: /home/aakoshh/projects/casperlabs-node-data
 10:40:19.748 [main] INFO  i.c.c.t.GenerateCertificateIfAbsent - No certificate found at path /home/aakoshh/projects/casperlabs-node-data/node.certificate.pem
@@ -110,15 +126,6 @@ The node will listen on multiple ports; the following are the default values, yo
 * `--server-port 40400`: Intra node communication port for consensus.
 * `--server-kademila-port 40404`: Intra node communication port for node discovery.
 
-
-### Starting the execution engine
-
-The execution engine runs as a separate process and isn't open to the network, it communicates with the node through a UNIX file socket. If you're using Windows it will have to run under Windows Subsystem for Linux (WSL).
-
-```console
-$ casperlabs-engine-grpc-server casperlabs-node-data/.caspernode.sock
-Server is listening on socket: casperlabs-node-data/.caspernode.sock
-```
 
 
 ### Starting the node

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -101,19 +101,29 @@ slow:
 
 # Generate keys and bonds.
 .casperlabs:
-	@# Start a node to generate keys.
 	mkdir -p .bootstrap
+	@# The node needs the execution engine to listen on the socket, otherwise it quits before
+	@# it prints the node ID in the logs. In the future (NODE-235 and NODE-237) we'll have
+	@# dedicated CLI entry point to generate keys.
+	docker run --rm -d \
+		--name make-genesis-ee \
+		-v ${PWD}/.bootstrap:/root/.casperlabs \
+		casperlabs/execution-engine:$(CL_VERSION) \
+		/root/.casperlabs/.caspernode.sock
+	@# Start a node to generate keys.
 	docker run --rm -d \
 		--name make-genesis \
 		-v ${PWD}/.bootstrap:/root/.casperlabs \
 		casperlabs/node:$(CL_VERSION) \
 		run -s \
-		--casper-num-validators $(CL_CASPER_NUM_VALIDATORS)
+		--casper-num-validators $(CL_CASPER_NUM_VALIDATORS) \
+		--grpc-socket /root/.casperlabs/.caspernode.sock
 
 	@# Wait until the node is running, so we know it generated the files. Capture the Node ID fromt the logs.
-	NODE_ID=`(docker logs -f make-genesis &) | grep -m 1 "Listening for traffic" | awk -F'[//|@]' '{print $$3}'` && \
+	NODE_ID=`(docker logs -f make-genesis &) | grep -m 1 "Listening for traffic" | awk -F'[//|@]' '{print $$3}' | grep -e .` && \
 	echo $$NODE_ID > .bootstrap/node-id
-	docker stop make-genesis
+
+	docker stop make-genesis make-genesis-ee
 
 	@# Copy files to where we can mount them separately from.
 	mkdir -p .casperlabs/bootstrap

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineConf.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineConf.scala
@@ -27,6 +27,8 @@ class ExecutionEngineConf[F[_]: Sync: Log: TaskLift](
   val eventLoopGroup =
     if (Epoll.isAvailable) new EpollEventLoopGroup() else new KQueueEventLoopGroup()
 
+  // If we point the socket at a non-existing file, or one where the EE isn't listening,
+  // it's not going to fail here, only later when we try to make a call.
   val channelF = Sync[F].delay(
     NettyChannelBuilder
       .forAddress(new DomainSocketAddress(addr.toFile))


### PR DESCRIPTION
## Overview
The Node once again fails if the Execution Engine isn't listening on the socket. Probably earlier it didn't try to talk to it, but now it does. I fixed the `docker/Makefile` to start a `casperlabs-execution-engine` container too. Ideally in the future we'd have simple CLI entries for it but that would take longer to develop. Tickets exist, just need to prioritise them.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-355

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
