### PR TITLE
NODE-315 Cleanup peer table from non-responding peers

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/discovery/GrpcKademliaRPC.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/GrpcKademliaRPC.scala
@@ -64,7 +64,7 @@ class GrpcKademliaRPC[F[_]: Concurrent: TaskLift: Timer: TaskLike: Log: PeerNode
     cell.modify { s =>
       s.connections.get(peer).fold(s.pure[F]) { connection =>
         for {
-          _ <- Log[F].info(s"Disconnecting from peer ${peer.toAddress}")
+          _ <- Log[F].debug(s"Disconnecting from peer ${peer.toAddress}")
           _ <- Sync[F].delay(connection.shutdownNow()).attempt
         } yield s.copy(connections = s.connections - peer)
       }
@@ -123,7 +123,7 @@ class GrpcKademliaRPC[F[_]: Concurrent: TaskLift: Timer: TaskLike: Log: PeerNode
 
   private def clientChannel(peer: PeerNode): F[ManagedChannel] =
     for {
-      _ <- Log[F].info(s"Creating new channel to peer ${peer.toAddress}")
+      _ <- Log[F].debug(s"Creating new channel to peer ${peer.toAddress}")
       c <- Sync[F].delay {
             NettyChannelBuilder
               .forAddress(peer.endpoint.host, peer.endpoint.udpPort)

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaNodeDiscovery.scala
@@ -78,7 +78,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Sync: Log: Time: Metrics: K
       _ <- findMorePeers()
     } yield ()
 
-    initRPC *> findNew.forever
+    initRPC *> lookup(id) *> findNew.forever
   }
 
   private def findMorePeers(

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaNodeDiscovery.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaNodeDiscovery.scala
@@ -127,7 +127,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Sync: Log: Time: Metrics: K
             rest ::: returnedPeers.filterNot(p => newAlreadyQueried(p.id))
           ) _
           maybeNewClosestPeerNode = if (returnedPeers.nonEmpty)
-            returnedPeers.minBy(p => PeerTable.longestCommonBitPrefix(toLookup, p.id)).some
+            returnedPeers.minBy(p => PeerTable.xorDistance(toLookup, p.id)).some
           else None
           res <- (maybeNewClosestPeerNode, maybeClosestPeerNode) match {
                   case (x @ Some(_), None) => recursion(x)

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaRPC.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaRPC.scala
@@ -4,7 +4,7 @@ import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 
 trait KademliaRPC[F[_]] {
   def ping(node: PeerNode): F[Boolean]
-  def lookup(id: NodeIdentifier, peer: PeerNode): F[Seq[PeerNode]]
+  def lookup(id: NodeIdentifier, peer: PeerNode): F[Option[Seq[PeerNode]]]
   def receive(
       pingHandler: PeerNode => F[Unit],
       lookupHandler: (PeerNode, NodeIdentifier) => F[Seq[PeerNode]]

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
@@ -4,10 +4,11 @@ import cats.Monad
 import cats.data.EitherT
 import io.casperlabs.catscontrib.Catscontrib._
 import io.casperlabs.catscontrib.{MonadTrans, _}
-import io.casperlabs.comm.PeerNode
+import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 
 trait NodeDiscovery[F[_]] {
   def discover: F[Unit]
+  def lookup(id: NodeIdentifier): F[Option[PeerNode]]
   def peers: F[Seq[PeerNode]]
 }
 
@@ -18,8 +19,9 @@ object NodeDiscovery extends NodeDiscoveryInstances {
       implicit C: NodeDiscovery[F]
   ): NodeDiscovery[T[F, ?]] =
     new NodeDiscovery[T[F, ?]] {
-      def discover: T[F, Unit]       = C.discover.liftM[T]
-      def peers: T[F, Seq[PeerNode]] = C.peers.liftM[T]
+      def discover: T[F, Unit]                               = C.discover.liftM[T]
+      def lookup(id: NodeIdentifier): T[F, Option[PeerNode]] = C.lookup(id).liftM[T]
+      def peers: T[F, Seq[PeerNode]]                         = C.peers.liftM[T]
     }
 }
 

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -141,4 +141,10 @@ final class PeerTable[F[_]: Monad](
         .sortWith(_._1 < _._1)
         .map(_._2)
     )
+
+  def remove(toRemove: NodeIdentifier): F[Unit] =
+    tableRef.update { table =>
+      val index = distance(toRemove)
+      table.updated(index, table(index).filterNot(_.node.key == toRemove.key))
+    }
 }

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -58,7 +58,7 @@ object PeerTable {
   }
 
   private[discovery] def xorDistance(a: NodeIdentifier, b: NodeIdentifier): BigInt =
-    BigInt(a.key.zip(b.key).map { case (l, r) => (l ^ r).toByte }.toArray)
+    BigInt(a.key.zip(b.key).map { case (l, r) => (l ^ r).toByte }.toArray).abs
 }
 
 /** `PeerTable` implements the routing table used in the Kademlia

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -37,8 +37,7 @@ object PeerTable {
     Seq.fill(64)(1) ++
     Seq.fill(128)(0)).toArray
 
-  /** Computes Kademlia XOR distance.
-    *
+  /**
     * Returns the length of the longest common prefix in bits between
     * the two sequences `a` and `b`. As in Ethereum's implementation,
     * "closer" nodes have higher distance values.
@@ -46,7 +45,7 @@ object PeerTable {
     * @return `Some(Int)` if `a` and `b` are comparable in this table,
     * `None` otherwise.
     */
-  private[discovery] def distance(a: NodeIdentifier, b: NodeIdentifier): Int = {
+  private[discovery] def longestCommonBitPrefix(a: NodeIdentifier, b: NodeIdentifier): Int = {
     @tailrec
     def highBit(idx: Int): Int =
       if (idx == a.key.size) 8 * a.key.size
@@ -57,6 +56,9 @@ object PeerTable {
         }
     highBit(0)
   }
+
+  private[discovery] def xorDistance(a: NodeIdentifier, b: NodeIdentifier): BigInt =
+    BigInt(a.key.zip(b.key).map { case (l, r) => (l ^ r).toByte }.toArray)
 }
 
 /** `PeerTable` implements the routing table used in the Kademlia
@@ -70,11 +72,13 @@ final class PeerTable[F[_]: Monad](
 ) {
   private[discovery] val width = local.key.size // in bytes
 
-  private[discovery] def distance(other: PeerNode): Int       = PeerTable.distance(local, other.id)
-  private[discovery] def distance(other: NodeIdentifier): Int = PeerTable.distance(local, other)
+  private[discovery] def longestCommonBitPrefix(other: PeerNode): Int =
+    PeerTable.longestCommonBitPrefix(local, other.id)
+  private[discovery] def longestCommonBitPrefix(other: NodeIdentifier): Int =
+    PeerTable.longestCommonBitPrefix(local, other)
 
   def updateLastSeen(peer: PeerNode)(implicit K: KademliaRPC[F]): F[Unit] = {
-    val index = distance(peer)
+    val index = longestCommonBitPrefix(peer)
     for {
       maybeCandidate <- tableRef.modify { table =>
                          val bucket = table(index)
@@ -122,15 +126,16 @@ final class PeerTable[F[_]: Monad](
       val flattenedArray = table.flatten.filterNot(_.node.key == toLookup.key).toArray
       Sorting.quickSort(flattenedArray)(
         (x: Entry, y: Entry) =>
-          (PeerTable.distance(toLookup, x.node.id), PeerTable.distance(toLookup, y.node.id)) match {
-            case (d0, d1) => Ordering[Int].compare(d0, d1)
-          }
+          Ordering[BigInt].compare(
+            PeerTable.xorDistance(toLookup, x.node.id),
+            PeerTable.xorDistance(toLookup, y.node.id)
+          )
       )
       flattenedArray.take(k).toList.map(_.node)
     }
 
   def find(toFind: NodeIdentifier): F[Option[PeerNode]] =
-    tableRef.get.map(_(distance(toFind)).find(_.node.id == toFind).map(_.node))
+    tableRef.get.map(_(longestCommonBitPrefix(toFind)).find(_.node.id == toFind).map(_.node))
 
   def peers: F[Seq[PeerNode]] = tableRef.get.map(_.flatMap(_.map(_.node)))
 

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -147,16 +147,5 @@ class DistanceSpec extends FlatSpec with Matchers {
         table.find(k) should be(Some(PeerNode(k, endpoint)))
       }
     }
-
-    it should "remove a peer" in {
-      val table = PeerTable(kr)
-      for (k <- oneOffs(kr)) {
-        table.updateLastSeen(PeerNode(k, endpoint))
-      }
-      for (k <- oneOffs(kr)) {
-        table.remove(k)
-      }
-      table.peers.size should be(0)
-    }
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -22,8 +22,8 @@ class DistanceSpec extends FlatSpec with Matchers {
 
   val endpoint = Endpoint("", 0, 0)
   implicit val ping: KademliaRPC[Id] = new KademliaRPC[Id] {
-    def ping(node: PeerNode): Boolean                             = true
-    def lookup(id: NodeIdentifier, peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
+    def ping(node: PeerNode): Boolean                                     = true
+    def lookup(id: NodeIdentifier, peer: PeerNode): Option[Seq[PeerNode]] = None
     def receive(
         pingHandler: PeerNode => Id[Unit],
         lookupHandler: (PeerNode, NodeIdentifier) => Id[Seq[PeerNode]]
@@ -146,6 +146,17 @@ class DistanceSpec extends FlatSpec with Matchers {
       for (k <- oneOffs(kr)) {
         table.find(k) should be(Some(PeerNode(k, endpoint)))
       }
+    }
+
+    it should "remove a peer" in {
+      val table = PeerTable(kr)
+      for (k <- oneOffs(kr)) {
+        table.updateLastSeen(PeerNode(k, endpoint))
+      }
+      for (k <- oneOffs(kr)) {
+        table.remove(k)
+      }
+      table.peers.size should be(0)
     }
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -35,7 +35,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     for (i <- 1 to 64) {
       val home = PeerNode(NodeIdentifier(b.rand(i)), endpoint)
       val nt   = PeerTable(home.id)
-      nt.distance(home) should be(8 * nt.width)
+      nt.longestCommonBitPrefix(home) should be(8 * nt.width)
     }
   }
 
@@ -58,7 +58,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     def testKey(key: Seq[Byte]): Boolean = {
       val id    = NodeIdentifier(key)
       val table = PeerTable(id)
-      oneOffs(id).map(table.distance) == (0 until 8 * width)
+      oneOffs(id).map(table.longestCommonBitPrefix) == (0 until 8 * width)
     }
 
     def keyString(key: Seq[Byte]): String =
@@ -97,7 +97,7 @@ class DistanceSpec extends FlatSpec with Matchers {
     s"A table of width $width" should "add a key at most once" in {
       val table = PeerTable(kr)
       val toAdd = oneOffs(kr).head
-      val dist  = table.distance(toAdd)
+      val dist  = table.longestCommonBitPrefix(toAdd)
       for (_ <- 1 to 10) {
         table.updateLastSeen(PeerNode(toAdd, endpoint))
         table.tableRef.get(dist).size should be(1)

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCRuntime.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaRPCRuntime.scala
@@ -150,8 +150,8 @@ final class LookupHandler[F[_]: Monad: Timer](
   def handle(peer: PeerNode): (PeerNode, NodeIdentifier) => F[Seq[PeerNode]] =
     (p, a) =>
       for {
-        _ <- delay.fold(().pure[F])(implicitly[Timer[F]].sleep)
         _ <- receivedMessages.synchronized(receivedMessages += ((peer, (p, a)))).pure[F]
+        _ <- delay.fold(().pure[F])(implicitly[Timer[F]].sleep)
       } yield response
 }
 

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
@@ -159,7 +159,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       pingedPeers += peer
       returns
     }
-    def lookup(id: NodeIdentifier, peer: PeerNode): Seq[PeerNode] = Seq.empty[PeerNode]
+    def lookup(id: NodeIdentifier, peer: PeerNode): Option[Seq[PeerNode]] = None
     def receive(
         pingHandler: PeerNode => Id[Unit],
         lookupHandler: (PeerNode, NodeIdentifier) => Id[Seq[PeerNode]]

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaSpec.scala
@@ -25,10 +25,10 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
     table = PeerTable(local.id, 3)
     pingedPeers = mutable.MutableList.empty[PeerNode]
     // peer1-4 distance is 4
-    table.distance(peer1) shouldBe DISTANCE_4
-    table.distance(peer2) shouldBe DISTANCE_4
-    table.distance(peer3) shouldBe DISTANCE_4
-    table.distance(peer4) shouldBe DISTANCE_4
+    table.longestCommonBitPrefix(peer1) shouldBe DISTANCE_4
+    table.longestCommonBitPrefix(peer2) shouldBe DISTANCE_4
+    table.longestCommonBitPrefix(peer3) shouldBe DISTANCE_4
+    table.longestCommonBitPrefix(peer4) shouldBe DISTANCE_4
   }
 
   describe("A PeertTable with 1 byte addresses and k = 3") {
@@ -36,7 +36,7 @@ class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
       it("should add it to a bucket according to its distance") {
         // given
         implicit val ping: KademliaRPC[Id] = pingOk
-        table.distance(peer0) shouldBe DISTANCE_6
+        table.longestCommonBitPrefix(peer0) shouldBe DISTANCE_6
         // when
         table.updateLastSeen(peer0)
         // then

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -40,7 +40,7 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
 
   val genFullyConnectedPeers: Gen[Map[PeerNode, List[PeerNode]]] =
     for {
-      n     <- Gen.choose(4, 4)
+      n     <- Gen.choose(4, 10)
       peers <- Gen.listOfN(n, genPeerNode)
     } yield
       peers.map { peer =>

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -1,0 +1,27 @@
+package io.casperlabs.comm.discovery
+
+import io.casperlabs.comm.gossiping.ArbitraryConsensus
+import org.scalacheck.Shrink
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{Matchers, WordSpecLike}
+
+class NodeDiscoverySpec
+    extends WordSpecLike
+    with GeneratorDrivenPropertyChecks
+    with Matchers
+    with ArbitraryConsensus {
+  implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
+
+  "KademliaNodeDiscovery" when {
+    "lookup" should {
+      "converge to the closest node" in pending
+    }
+    "discover" should {
+      "skip itself during lookup" in pending
+      "stop iterative lookup when successfully called 'k' peers" in pending
+      "stop iterative lookup when no closer node returned" in pending
+      "fill the peer table with successfully responded peers" in pending
+      "perform at most 'alpha' concurrent requests" in pending
+    }
+  }
+}

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -1,27 +1,325 @@
 package io.casperlabs.comm.discovery
 
-import io.casperlabs.comm.gossiping.ArbitraryConsensus
-import org.scalacheck.Shrink
+import cats.effect.Timer
+import cats.implicits._
+import io.casperlabs.comm.discovery.NodeDiscoverySpec.TextFixture
+import io.casperlabs.comm.{Endpoint, NodeIdentifier, PeerNode}
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.metrics.Metrics.MetricsNOP
+import io.casperlabs.shared.Log.NOPLog
+import io.casperlabs.shared.{Log, Time}
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import monix.execution.atomic.{Atomic, AtomicInt}
+import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import org.scalatest.{Matchers, WordSpecLike}
 
-class NodeDiscoverySpec
-    extends WordSpecLike
-    with GeneratorDrivenPropertyChecks
-    with Matchers
-    with ArbitraryConsensus {
+import scala.concurrent.duration._
+import scala.util.Random
+
+class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks with Matchers {
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
+
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(
+      minSuccessful = 500
+    )
+
+  val genPeerNode: Gen[PeerNode] =
+    for {
+      hash <- Gen.listOfN(20, Gen.choose(0, 255)).map(_.map(_.toByte))
+      host <- Gen.listOfN(4, Gen.choose(0, 255)).map(xs => xs.mkString("."))
+    } yield PeerNode(NodeIdentifier(hash.toArray), Endpoint(host, 40400, 40404))
+
+  val genSetPeerNodes: Gen[Set[PeerNode]] =
+    for {
+      n     <- Gen.choose(3, 10)
+      peers <- Gen.listOfN(n, genPeerNode)
+    } yield peers.toSet
+
+  val genFullyConnectedPeers: Gen[Map[PeerNode, List[PeerNode]]] =
+    for {
+      n     <- Gen.choose(4, 4)
+      peers <- Gen.listOfN(n, genPeerNode)
+    } yield
+      peers.map { peer =>
+        (peer, peers.filterNot(_ == peer))
+      }.toMap
+
+  /**
+    * Target is the last element
+    * Each peer knows next one like in linked list
+    * Ordered by decreasing of XOR distance to the last element
+    * Example:
+    * 0 - lookup start from
+    * 4 - target node, 4 XOR 4 == 0
+    * 0->1 1->2 2->3 3->4
+    */
+  val genSequentiallyConnectedPeers: Gen[List[(PeerNode, PeerNode)]] =
+    for {
+      n      <- Gen.choose(4, 10)
+      peers  <- Gen.listOfN(n, genPeerNode)
+      target <- Gen.pick(1, peers).map(_.head)
+      ordered = peers
+        .sorted(
+          (x: PeerNode, y: PeerNode) =>
+            Ordering[BigInt].compare(
+              PeerTable.xorDistance(x.id, target.id),
+              PeerTable.xorDistance(y.id, target.id)
+            )
+        )
+        .reverse
+    } yield ordered.zip(ordered.tail)
+
+  def totalN(peers: Map[PeerNode, List[PeerNode]]): Int =
+    peers.toList.flatMap { case (k, vs) => k :: vs }.toSet.size
+
+  def totalN(peers: List[(PeerNode, PeerNode)]): Int =
+    peers.flatMap { case (l, r) => List(l, r) }.toSet.size
 
   "KademliaNodeDiscovery" when {
     "lookup" should {
-      "converge to the closest node" in pending
+      "converge to the closest node if all peers are interconnected" in
+        forAll(genFullyConnectedPeers) { peers: Map[PeerNode, List[PeerNode]] =>
+          val target = peers.keys.toList(Random.nextInt(peers.size))
+          TextFixture.prefilledTable(target.id, peers, totalN(peers)) { (kademlia, nd, alpha) =>
+            for {
+              response <- nd.lookup(target.id)
+            } yield {
+              //Each lookup request returns all peers
+              //So, second round will be the last,
+              //because no closer peer will be returned
+              kademlia.totalLookups shouldBe (alpha * 2)
+              response shouldBe Some(target)
+            }
+          }
+        }
+      "converge to the closest node if each peers knows next one and the target peer is the last" in
+        forAll(genSequentiallyConnectedPeers) { peers: List[(PeerNode, PeerNode)] =>
+          val target  = peers.last._2
+          val initial = peers.head._1
+          TextFixture.customInitial(
+            target.id,
+            peers.toMap.mapValues(List(_)),
+            Set(initial),
+            totalN(peers),
+            1
+          ) { (kademlia, nd, _) =>
+            for {
+              response <- nd.lookup(target.id)
+            } yield {
+              // 0 - initial, 4 - target
+              // lookup goes by chain until it reaches the last element
+              // last element is the closest to itself, but it will make one more request
+              // 0->1 1->2 2->3 3->4 4->(empty)
+              kademlia.totalLookups shouldBe peers.size + 1
+              response shouldBe Some(target)
+              ()
+            }
+          }
+        }
+      "fill the peer table with successfully responded peers" in
+        forAll(genFullyConnectedPeers) { peers: Map[PeerNode, List[PeerNode]] =>
+          //we need strong ordering
+          val asList               = peers.toList
+          val target               = asList.init.map(_._1).apply(Random.nextInt(asList.init.size))
+          val initialAlwaysHealthy = asList.last._1
+          //fully parallel requests, so only 1 round with everyone
+          val alpha = peers.size
+          //at least 1 peer returns all others
+          val failuresN = Random.nextInt(asList.size - 1) + 1
+          val withFailures = (0 until failuresN)
+            .foldLeft(asList) {
+              case (acc, i) => acc.updated(i, (acc(i)._1, List.empty))
+            }
+            .map {
+              case (k, vs) if vs.isEmpty => (k, None)
+              case (k, vs)               => (k, Some(vs))
+            }
+            .toMap
+          TextFixture.customInitialWithFailures(
+            target.id,
+            withFailures,
+            Set(initialAlwaysHealthy),
+            totalN(peers),
+            alpha
+          ) { (_, nd, _) =>
+            for {
+              _         <- nd.lookup(target.id)
+              fromTable <- nd.peers
+            } yield {
+              fromTable should contain theSameElementsAs withFailures.collect {
+                case (k, Some(_)) => k
+              }
+            }
+          }
+        }
+      "skip itself" in
+        forAll(genSetPeerNodes) { peers: Set[PeerNode] =>
+          val target              = peers.head
+          val itself              = PeerNode(NodeDiscoverySpec.id, Endpoint("localhost", 40400, 40404))
+          val allPointingToItself = peers.map(p => (p, List(itself))).toMap
+          TextFixture.prefilledTable(target.id, allPointingToItself, peers.size) {
+            (kademlia, nd, _) =>
+              for {
+                response <- nd.lookup(target.id)
+              } yield {
+                response shouldBe Some(itself)
+                kademlia.lookupsBy(itself) shouldBe 0
+              }
+          }
+        }
+      "stop lookup when successfully called 'k' peers" in
+        forAll(genSequentiallyConnectedPeers) { peers: List[(PeerNode, PeerNode)] =>
+          val target  = peers.last._2
+          val initial = peers.head._1
+          val total   = peers.size
+          val k       = Random.nextInt(total) + 1
+          TextFixture.customInitial(target.id, peers.toMap.mapValues(List(_)), Set(initial), k, 1) {
+            (kademlia, nd, _) =>
+              for {
+                response <- nd.lookup(target.id)
+              } yield {
+                kademlia.totalLookups shouldBe k
+                response shouldBe Some(peers(k - 1)._2)
+              }
+          }
+        }
+      "stop lookup when no closer node returned in round" in
+        forAll(genSequentiallyConnectedPeers) { peers: List[(PeerNode, PeerNode)] =>
+          val target          = peers.last._2
+          val indexToSwapWith = Random.nextInt(peers.size - 1)
+          // Move the closest element to middle of chain
+          // 0->1 1->2 2->3 3->4
+          // 4 - closest, swapped with 2
+          // 0->1 1->4 4->3 3->2
+          // should stop after 4->3
+          val swapped = {
+            val original                  = peers(indexToSwapWith)._2
+            val updatedLast               = (peers.last._1, original)
+            val updatedPointingToOriginal = (peers(indexToSwapWith)._1, target)
+            val updatedNext               = (target, peers(indexToSwapWith + 1)._2)
+            peers
+              .updated(indexToSwapWith, updatedPointingToOriginal)
+              .updated(indexToSwapWith + 1, updatedNext)
+              .init :+ updatedLast
+          }
+          val initial = swapped.head._1
+          TextFixture.customInitial(
+            target.id,
+            swapped.toMap.mapValues(List(_)),
+            Set(initial),
+            totalN(peers),
+            1
+          ) { (kademlia, nd, _) =>
+            for {
+              response <- nd.lookup(target.id)
+            } yield {
+              kademlia.totalLookups shouldBe indexToSwapWith + 2
+              response shouldBe Some(target)
+              ()
+            }
+          }
+        }
+      "perform at most 'alpha' concurrent requests" in forAll(genSequentiallyConnectedPeers) {
+        peers: List[(PeerNode, PeerNode)] =>
+          val target  = peers.last._2
+          val initial = peers.head._1
+          val alpha   = 2
+          TextFixture.customInitial(
+            target.id,
+            peers.toMap.mapValues(List(_)),
+            Set(initial),
+            totalN(peers),
+            alpha
+          ) { (kademlia, nd, _) =>
+            for {
+              _ <- nd.lookup(target.id)
+            } yield {
+              kademlia.concurrentRequests should be <= alpha
+            }
+          }
+      }
     }
-    "discover" should {
-      "skip itself during lookup" in pending
-      "stop iterative lookup when successfully called 'k' peers" in pending
-      "stop iterative lookup when no closer node returned" in pending
-      "fill the peer table with successfully responded peers" in pending
-      "perform at most 'alpha' concurrent requests" in pending
-    }
+  }
+}
+
+object NodeDiscoverySpec {
+
+  class KademliaMock(peers: Map[PeerNode, Option[List[PeerNode]]]) extends KademliaRPC[Task] {
+    private val lookupsByCallee                      = Atomic(Map.empty[PeerNode, Int].withDefaultValue(0))
+    private val maxConcurrentRequests                = AtomicInt(0)
+    private val concurrency                          = AtomicInt(0)
+    def totalLookups: Int                            = lookupsByCallee.get().values.sum
+    def lookupsBy(peer: PeerNode): Int               = lookupsByCallee.get()(peer)
+    def concurrentRequests: Int                      = maxConcurrentRequests.get()
+    override def ping(node: PeerNode): Task[Boolean] = Task.now(true)
+    override def lookup(id: NodeIdentifier, peer: PeerNode): Task[Option[Seq[PeerNode]]] =
+      Task {
+        concurrency.increment()
+        maxConcurrentRequests.transform(math.max(_, concurrency.get()))
+        concurrency.decrement()
+        lookupsByCallee.transform(m => m.updated(peer, m(peer) + 1))
+        peers.getOrElse(peer, None)
+      }
+    override def receive(
+        pingHandler: PeerNode => Task[Unit],
+        lookupHandler: (PeerNode, NodeIdentifier) => Task[Seq[PeerNode]]
+    ): Task[Unit]                       = ???
+    override def shutdown(): Task[Unit] = ???
+  }
+
+  implicit val logNoOp: Log[Task] = new NOPLog[Task]
+  implicit val time: Time[Task] = new Time[Task] {
+    def currentMillis: Task[Long]                   = Timer[Task].clock.realTime(MILLISECONDS)
+    def nanoTime: Task[Long]                        = Timer[Task].clock.monotonic(NANOSECONDS)
+    def sleep(duration: FiniteDuration): Task[Unit] = Timer[Task].sleep(duration)
+  }
+  implicit val metricsNOP: Metrics[Task] = new MetricsNOP[Task]
+  val id                                 = NodeIdentifier(List.fill(20)(0.toByte))
+
+  object TextFixture {
+    def customInitialWithFailures(
+        toLookup: NodeIdentifier,
+        peers: Map[PeerNode, Option[List[PeerNode]]],
+        initial: Set[PeerNode],
+        k: Int,
+        alpha: Int = 2
+    )(test: (KademliaMock, KademliaNodeDiscovery[Task], Int) => Task[Unit]): Unit =
+      PeerTable[Task](id, k)
+        .flatMap { table =>
+          implicit val K: KademliaMock = new KademliaMock(peers)
+          val fillTable = initial.toList
+            .traverse(table.updateLastSeen)
+            .void
+          fillTable
+            .map(_ => (K, new KademliaNodeDiscovery[Task](id, table, alpha, k)))
+        }
+        .flatMap { case (kademlia, nd) => test(kademlia, nd, alpha) }
+        .runSyncUnsafe(5.seconds)
+
+    def customInitial(
+        toLookup: NodeIdentifier,
+        peers: Map[PeerNode, List[PeerNode]],
+        initial: Set[PeerNode],
+        k: Int,
+        alpha: Int = 2
+    )(test: (KademliaMock, KademliaNodeDiscovery[Task], Int) => Task[Unit]): Unit =
+      customInitialWithFailures(toLookup, peers.mapValues(Option(_)), initial, k, alpha)(test)
+
+    def prefilledTable(
+        toLookup: NodeIdentifier,
+        peers: Map[PeerNode, List[PeerNode]],
+        k: Int,
+        alpha: Int = 2
+    )(test: (KademliaMock, KademliaNodeDiscovery[Task], Int) => Task[Unit]): Unit =
+      customInitial(
+        toLookup,
+        peers,
+        peers.flatMap { case (key, values) => key :: values }.filterNot(p => p.id == id).toSet,
+        k,
+        alpha
+      )(test)
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -60,7 +60,7 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
     for {
       n      <- Gen.choose(4, 10)
       peers  <- Gen.listOfN(n, genPeerNode)
-      target <- Gen.pick(1, peers).map(_.head)
+      target <- Gen.oneOf(peers)
       ordered = peers
         .sorted(
           (x: PeerNode, y: PeerNode) =>

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
@@ -14,8 +14,8 @@ import scala.util.Random
 
 class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
   private trait KademliaMock extends KademliaRPC[Task] {
-    override def lookup(id: NodeIdentifier, peer: PeerNode): Task[Seq[PeerNode]] =
-      Task.now(Seq.empty)
+    override def lookup(id: NodeIdentifier, peer: PeerNode): Task[Option[Seq[PeerNode]]] =
+      Task.now(None)
     override def receive(
         pingHandler: PeerNode => Task[Unit],
         lookupHandler: (PeerNode, NodeIdentifier) => Task[Seq[PeerNode]]

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -43,6 +43,7 @@ object EffectsTestInstances {
       nodes
     }
     def discover: F[Unit]                                          = ???
+    def lookup(id: NodeIdentifier): F[Option[PeerNode]]            = ???
     def handleCommunications: Protocol => F[CommunicationResponse] = ???
   }
 

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -41,6 +41,7 @@ object Main extends TaskApp {
   }
 
   private def updateLoggingProps(conf: Configuration): Task[Unit] = Task {
+    java.util.logging.Logger.getLogger("io.grpc").setLevel(java.util.logging.Level.SEVERE)
     sys.props.update("node.data.dir", conf.server.dataDir.toAbsolutePath.toString)
   }
 

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -42,7 +42,6 @@ object Main extends TaskApp {
 
   private def updateLoggingProps(conf: Configuration): Task[Unit] = Task {
     java.util.logging.Logger.getLogger("io.grpc").setLevel(java.util.logging.Level.SEVERE)
-    sys.props.update("node.data.dir", conf.server.dataDir.toAbsolutePath.toString)
   }
 
   private def mainProgram(command: Configuration.Command, conf: Configuration)(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val catsMtlVersion = "0.4.0"
 
   // format: off
+  val julToSlf4j             = "org.slf4j"                  % "jul-to-slf4j"                    % "1.7.25"
   val bitcoinjCore           = "org.bitcoinj"               % "bitcoinj-core"                   % "0.14.6"
   val bouncyCastle           = "org.bouncycastle"           % "bcprov-jdk15on"                  % "1.60"
   val catsCore               = "org.typelevel"              %% "cats-core"                      % catsVersion
@@ -105,7 +106,7 @@ object Dependencies {
 
   private val testing = Seq(scalactic, scalatest, scalacheck, scalacheckShapeless)
 
-  private val logging = Seq(scalaLogging, logbackClassic, janino)
+  private val logging = Seq(scalaLogging, logbackClassic, janino, julToSlf4j)
 
   private val circeDependencies: Seq[ModuleID] =
     Seq(circeCore, circeGeneric, circeGenericExtras, circeParser, circeLiteral)

--- a/shared/src/main/scala/io/casperlabs/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/io/casperlabs/catscontrib/taskOps.scala
@@ -22,8 +22,8 @@ object TaskContrib {
         after: FiniteDuration,
         backup: F[B]
     )(implicit C: Concurrent[F], T: Timer[F]): F[B] =
-      C.race(fa, T.sleep(after)).flatMap {
-        case Left(a) =>
+      C.racePair(fa, T.sleep(after)).flatMap {
+        case Left((a, _)) =>
           Concurrent[F].pure(a)
         case Right(_) =>
           backup


### PR DESCRIPTION
## Overview
Previously, if a peer goes offline then it's removed from the peer table only when the corresponding bucket becomes full. Prior to that, a node will endlessly try sending a `lookup` message to it producing a lot of errors into the log.
Now, if a node doesn't respond on a `lookup` request then it's automatically deleted from the corresponding bucket in the peer table.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-315

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.