### PR TITLE
EE-215: Allow for storing contracts under hashes.

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -271,6 +271,7 @@ dependencies = [
  "shared 0.1.0",
  "storage 0.1.0",
  "vm 0.1.0",
+ "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-prep 0.1.0",
  "wasmi 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -107,7 +107,7 @@ fn fn_bytes_by_name(name: &str) -> Vec<u8> {
     }
 }
 
-// TODO: fn_by_name should, fn_bytes_by_name and ext_ffi::serialize_function should be removed.
+// TODO: fn_by_name, fn_bytes_by_name and ext_ffi::serialize_function should be removed.
 // Functions shouldn't be serialized and returned back to the contract because they're never used there.
 // Host should read the function pointer (and correct number of bytes) and persist it on the host side.
 

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -134,6 +134,12 @@ pub fn store_function(name: &str, known_urefs: BTreeMap<String, Key>) -> Contrac
     ContractPointer::Hash(fn_hash)
 }
 
+/// Finds function by the name and stores it at the unforgable name.
+pub fn store_function_at(name: &str, known_urefs: BTreeMap<String, Key>, uref: UPointer<Contract>) {
+    let contract = fn_by_name(name, known_urefs);
+    write(uref, contract);
+}
+
 /// Return the i-th argument passed to the host for the current module
 /// invokation. Note that this is only relevent to contracts stored on-chain
 /// since a contract deployed directly is not invoked with any arguments.

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -107,6 +107,10 @@ fn fn_bytes_by_name(name: &str) -> Vec<u8> {
     }
 }
 
+// TODO: fn_by_name should, fn_bytes_by_name and ext_ffi::serialize_function should be removed.
+// Functions shouldn't be serialized and returned back to the contract because they're never used there.
+// Host should read the function pointer (and correct number of bytes) and persist it on the host side.
+
 /// Returns the serialized bytes of a function which is exported in the current module.
 /// Note that the function is wrapped up in a new module and re-exported under the name
 /// "call". `fn_bytes_by_name` is meant to be used when storing a contract on-chain at
@@ -120,18 +124,14 @@ pub fn fn_by_name(name: &str, known_urefs: BTreeMap<String, Key>) -> Contract {
 /// computes gets the address from the host to produce a key where the contract is then
 /// stored in the global state. This key is returned.
 pub fn store_function(name: &str, known_urefs: BTreeMap<String, Key>) -> ContractPointer {
-    let bytes = fn_bytes_by_name(name);
-    let fn_hash = {
-        let mut tmp = [0u8; 32];
-        unsafe {
-            ext_ffi::function_address(tmp.as_mut_ptr());
-        }
-        tmp
-    };
-    let key = Key::Hash(fn_hash);
-    let value = Value::Contract(Contract::new(bytes, known_urefs));
-    write_untyped(&key, &value);
-    ContractPointer::Hash(fn_hash)
+    let (fn_ptr, fn_size, _bytes1) = str_ref_to_ptr(name);
+    let (urefs_ptr, urefs_size, _bytes2) = to_ptr(&known_urefs);
+    let mut tmp = [0u8; 32];
+    let tmp_ptr = tmp.as_mut_ptr();
+    unsafe {
+        ext_ffi::store_function(fn_ptr, fn_size, urefs_ptr, urefs_size, tmp_ptr);
+    }
+    ContractPointer::Hash(tmp)
 }
 
 /// Finds function by the name and stores it at the unforgable name.

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -35,7 +35,13 @@ mod ext_ffi {
         pub fn new_uref(key_ptr: *mut u8);
         pub fn serialize_function(name_ptr: *const u8, name_size: usize) -> usize;
         pub fn get_function(dest_ptr: *mut u8); //can only be called after `serialize_function`
-        pub fn function_address(dest_ptr: *mut u8);
+        pub fn store_function(
+            value_ptr: *const u8,
+            value_size: usize,
+            extra_urefs_ptr: *const u8,
+            extra_urefs_size: usize,
+            hash_ptr: *const u8,
+        );
         pub fn load_arg(i: u32) -> usize;
         pub fn get_arg(dest: *mut u8); //can only be called after `load_arg`
         pub fn ret(

--- a/execution-engine/engine/Cargo.toml
+++ b/execution-engine/engine/Cargo.toml
@@ -22,6 +22,7 @@ shared = { path = "../shared" }
 matches = "0.1.8"
 gens = { path = "../gens" }
 proptest = "0.9.2"
+wabt = "0.7.4"
 
 [[bin]]
 name = "engine-standalone"

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -162,6 +162,9 @@ pub struct Runtime<'a, R: DbReader> {
     rng: ChaChaRng,
 }
 
+/// Rename function called `name` in the `module` to `call`.
+/// wasmi's entrypoint for a contracts is a function called `call`,
+/// so we have to rename function before storing it in the GlobalState.
 pub fn rename_export_to_call(module: &mut Module, name: String) {
     let main_export = module
         .export_section_mut()
@@ -426,6 +429,13 @@ where
         Ok(self.host_buf.len())
     }
 
+    /// Tries to store a function, located in the Wasm memory, into the GlobalState
+    /// and writes back a function's hash at `hash_ptr` in the Wasm memory.
+    /// 
+    /// `name_ptr` and `name_size` tell the host where to look for a function's name.
+    /// Once it knows the name it can search for this exported function in the Wasm module.
+    /// Note that functions that contract wants to store have to be marked with `export` keyword.
+    /// `urefs_ptr` and `urefs_size` describe when the additional unforgable references can be found.
     pub fn store_function(
         &mut self,
         name_ptr: u32,

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -451,7 +451,7 @@ where
         self.function_address(new_hash, hash_ptr)
     }
 
-    pub fn new_function_address(&mut self) -> [u8; 32] {
+    fn new_function_address(&mut self) -> [u8; 32] {
         let mut pre_hash_bytes = Vec::with_capacity(44); //32 byte pk + 8 byte nonce + 4 byte ID
         pre_hash_bytes.extend_from_slice(self.context.account.pub_key());
         pre_hash_bytes.append(&mut self.context.account.nonce().to_bytes());
@@ -466,7 +466,7 @@ where
         hash_bytes
     }
 
-    pub fn function_address(&mut self, hash_bytes: [u8; 32], dest_ptr: u32) -> Result<(), Trap> {
+    fn function_address(&mut self, hash_bytes: [u8; 32], dest_ptr: u32) -> Result<(), Trap> {
         self.memory
             .set(dest_ptr, &hash_bytes)
             .map_err(|e| Error::Interpreter(e).into())
@@ -582,11 +582,10 @@ const RET_FUNC_INDEX: usize = 9;
 const GET_CALL_RESULT_FUNC_INDEX: usize = 10;
 const CALL_CONTRACT_FUNC_INDEX: usize = 11;
 const GET_UREF_FUNC_INDEX: usize = 12;
-const FUNCTION_ADDRESS_FUNC_INDEX: usize = 13;
-const GAS_FUNC_INDEX: usize = 14;
-const HAS_UREF_FUNC_INDEX: usize = 15;
-const ADD_UREF_FUNC_INDEX: usize = 16;
-const STORE_FN_INDEX: usize = 17;
+const GAS_FUNC_INDEX: usize = 13;
+const HAS_UREF_FUNC_INDEX: usize = 14;
+const ADD_UREF_FUNC_INDEX: usize = 15;
+const STORE_FN_INDEX: usize = 16;
 
 impl<'a, R: DbReader> Externals for Runtime<'a, R>
 where
@@ -738,13 +737,6 @@ where
                 Ok(None)
             }
 
-            FUNCTION_ADDRESS_FUNC_INDEX => {
-                let dest_ptr = Args::parse(args)?;
-                let hash = self.new_function_address();
-                self.function_address(hash, dest_ptr)?;
-                Ok(None)
-            }
-
             GAS_FUNC_INDEX => {
                 let gas: u32 = Args::parse(args)?;
                 self.gas(u64::from(gas))?;
@@ -863,10 +855,6 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
             "add_uref" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 ADD_UREF_FUNC_INDEX,
-            ),
-            "function_address" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 1][..], None),
-                FUNCTION_ADDRESS_FUNC_INDEX,
             ),
             "gas" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 1][..], None),

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -431,7 +431,7 @@ where
 
     /// Tries to store a function, located in the Wasm memory, into the GlobalState
     /// and writes back a function's hash at `hash_ptr` in the Wasm memory.
-    /// 
+    ///
     /// `name_ptr` and `name_size` tell the host where to look for a function's name.
     /// Once it knows the name it can search for this exported function in the Wasm module.
     /// Note that functions that contract wants to store have to be marked with `export` keyword.

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -300,7 +300,7 @@ where
         }
     }
 
-    // Load the uref known by the given name into the wasm memory
+    // Load the uref known by the given name into the Wasm memory
     pub fn get_uref(&mut self, name_ptr: u32, name_size: u32, dest_ptr: u32) -> Result<(), Trap> {
         let name = self.string_from_mem(name_ptr, name_size)?;
         let uref = self
@@ -346,7 +346,7 @@ where
 
     // Return a some bytes from the memory and terminate the current `sub_call`.
     // Note that the return type is `Trap`, indicating that this function will
-    // always kill the current wasm instance.
+    // always kill the current Wasm instance.
     pub fn ret(
         &mut self,
         value_ptr: u32,
@@ -597,23 +597,23 @@ where
     ) -> Result<Option<RuntimeValue>, Trap> {
         match index {
             READ_FUNC_INDEX => {
-                // args(0) = pointer to key in wasm memory
-                // args(1) = size of key in wasm memory
+                // args(0) = pointer to key in Wasm memory
+                // args(1) = size of key in Wasm memory
                 let (key_ptr, key_size) = Args::parse(args)?;
                 let size = self.read_value(key_ptr, key_size)?;
                 Ok(Some(RuntimeValue::I32(size as i32)))
             }
 
             SER_FN_FUNC_INDEX => {
-                // args(0) = pointer to name in wasm memory
-                // args(1) = size of name in wasm memory
+                // args(0) = pointer to name in Wasm memory
+                // args(1) = size of name in Wasm memory
                 let (name_ptr, name_size) = Args::parse(args)?;
                 let size = self.serialize_function(name_ptr, name_size)?;
                 Ok(Some(RuntimeValue::I32(size as i32)))
             }
 
             WRITE_FUNC_INDEX => {
-                // args(0) = pointer to key in wasm memory
+                // args(0) = pointer to key in Wasm memory
                 // args(1) = size of key
                 // args(2) = pointer to value
                 // args(3) = size of value
@@ -623,7 +623,7 @@ where
             }
 
             ADD_FUNC_INDEX => {
-                // args(0) = pointer to key in wasm memory
+                // args(0) = pointer to key in Wasm memory
                 // args(1) = size of key
                 // args(2) = pointer to value
                 // args(3) = size of value
@@ -633,21 +633,21 @@ where
             }
 
             NEW_FUNC_INDEX => {
-                // args(0) = pointer to key destination in wasm memory
+                // args(0) = pointer to key destination in Wasm memory
                 let key_ptr = Args::parse(args)?;
                 self.new_uref(key_ptr)?;
                 Ok(None)
             }
 
             GET_READ_FUNC_INDEX => {
-                // args(0) = pointer to destination in wasm memory
+                // args(0) = pointer to destination in Wasm memory
                 let dest_ptr = Args::parse(args)?;
                 self.set_mem_from_buf(dest_ptr)?;
                 Ok(None)
             }
 
             GET_FN_FUNC_INDEX => {
-                // args(0) = pointer to destination in wasm memory
+                // args(0) = pointer to destination in Wasm memory
                 let dest_ptr = Args::parse(args)?;
                 self.set_mem_from_buf(dest_ptr)?;
                 Ok(None)
@@ -661,7 +661,7 @@ where
             }
 
             GET_ARG_FUNC_INDEX => {
-                // args(0) = pointer to destination in wasm memory
+                // args(0) = pointer to destination in Wasm memory
                 let dest_ptr = Args::parse(args)?;
                 self.set_mem_from_buf(dest_ptr)?;
                 Ok(None)
@@ -685,7 +685,7 @@ where
             CALL_CONTRACT_FUNC_INDEX => {
                 // args(0) = pointer to key where contract is at in global state
                 // args(1) = size of key
-                // args(2) = pointer to function arguments in wasm memory
+                // args(2) = pointer to function arguments in Wasm memory
                 // args(3) = size of arguments
                 // args(4) = pointer to extra supplied urefs
                 // args(5) = size of extra urefs
@@ -704,23 +704,23 @@ where
             }
 
             GET_CALL_RESULT_FUNC_INDEX => {
-                // args(0) = pointer to destination in wasm memory
+                // args(0) = pointer to destination in Wasm memory
                 let dest_ptr = Args::parse(args)?;
                 self.set_mem_from_buf(dest_ptr)?;
                 Ok(None)
             }
 
             GET_UREF_FUNC_INDEX => {
-                // args(0) = pointer to uref name in wasm memory
+                // args(0) = pointer to uref name in Wasm memory
                 // args(1) = size of uref name
-                // args(2) = pointer to destination in wasm memory
+                // args(2) = pointer to destination in Wasm memory
                 let (name_ptr, name_size, dest_ptr) = Args::parse(args)?;
                 self.get_uref(name_ptr, name_size, dest_ptr)?;
                 Ok(None)
             }
 
             HAS_UREF_FUNC_INDEX => {
-                // args(0) = pointer to uref name in wasm memory
+                // args(0) = pointer to uref name in Wasm memory
                 // args(1) = size of uref name
                 let (name_ptr, name_size) = Args::parse(args)?;
                 let result = self.has_uref(name_ptr, name_size)?;
@@ -728,9 +728,9 @@ where
             }
 
             ADD_UREF_FUNC_INDEX => {
-                // args(0) = pointer to uref name in wasm memory
+                // args(0) = pointer to uref name in Wasm memory
                 // args(1) = size of uref name
-                // args(2) = pointer to destination in wasm memory
+                // args(2) = pointer to destination in Wasm memory
                 let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
                 self.add_uref(name_ptr, name_size, key_ptr, key_size)?;
                 Ok(None)
@@ -743,12 +743,12 @@ where
             }
 
             STORE_FN_INDEX => {
-                // args(0) = pointer to function name in wasm memory
+                // args(0) = pointer to function name in Wasm memory
                 // args(1) = size of the name
                 // args(2) = pointer to additional unforgable names
-                //           to be save with the function body
+                //           to be saved with the function body
                 // args(3) = size of the additional unforgable names
-                // args(4) = pointer to a wasm memory where we will save
+                // args(4) = pointer to a Wasm memory where we will save
                 //           hash of the new function
                 let (name_ptr, name_size, urefs_ptr, urefs_size, hash_ptr) = Args::parse(args)?;
                 self.store_function(name_ptr, name_size, urefs_ptr, urefs_size, hash_ptr)?;

--- a/execution-engine/engine/src/lib.rs
+++ b/execution-engine/engine/src/lib.rs
@@ -24,6 +24,6 @@ mod utils;
 #[macro_use]
 extern crate matches;
 #[cfg(test)]
-extern crate proptest;
-#[cfg(test)]
 extern crate gens;
+#[cfg(test)]
+extern crate proptest;

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -87,7 +87,10 @@ impl WasmMemoryManager {
     }
 
     pub fn write<T: ToBytes>(&mut self, t: T) -> Result<(u32, usize), wasmi::Error> {
-        let bytes = t.to_bytes();
+        self.write_raw(t.to_bytes())
+    }
+
+    pub fn write_raw(&mut self, bytes: Vec<u8>) -> Result<(u32, usize), wasmi::Error> {
         let ptr = self.offset as u32;
 
         match self.memory.set(ptr, &bytes) {
@@ -99,6 +102,10 @@ impl WasmMemoryManager {
 
             Err(e) => Err(e),
         }
+    }
+
+    pub fn read_raw(&self, offset: u32, target: &mut [u8]) -> Result<(), wasmi::Error> {
+        self.memory.get_into(offset, target)
     }
 
     pub fn new_uref<'a, R: DbReader>(

--- a/execution-engine/wasm-prep/src/lib.rs
+++ b/execution-engine/wasm-prep/src/lib.rs
@@ -15,7 +15,6 @@ const ALLOWED_IMPORTS: &[&str] = &[
     "add",
     "new_uref",
     "serialize_function",
-    "function_address",
     "store_function",
     "get_function",
     "load_arg",

--- a/execution-engine/wasm-prep/src/lib.rs
+++ b/execution-engine/wasm-prep/src/lib.rs
@@ -16,6 +16,7 @@ const ALLOWED_IMPORTS: &[&str] = &[
     "new_uref",
     "serialize_function",
     "function_address",
+    "store_function",
     "get_function",
     "load_arg",
     "get_arg",


### PR DESCRIPTION
## Overview
Allows for storing the contract under auto-generated hash. It also adds tests for when a developer wants to store unforgable references together with the contract.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-215

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
During the work on the bug, I had to refactor the `store_function` which now makes fewer calls to the host and safes one serialization and one deserialization of the function. Mentioned refactor also unlocked the work in EE-96 (storing functions under unforgable names). The tests for that will follow shortly. It's just a coincidence that bug fix cleared another ticket. Tests are not here because I didn't want to clutter the PR with stuff that is irrelevant.