### PR TITLE
NODE-338: gRPC AuthInterceptor

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/auth/Principal.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/auth/Principal.scala
@@ -1,0 +1,12 @@
+package io.casperlabs.comm.auth
+
+import com.google.protobuf.ByteString
+
+/** The identitity which is currently acting on the system. */
+sealed trait Principal
+
+object Principal {
+
+  /** The remote party had an SSL certificate. */
+  case class Peer(id: ByteString) extends Principal
+}

--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -117,6 +117,8 @@ object ServiceError {
     def block(blockHash: ByteString): ServiceException =
       apply(s"Block ${Base16.encode(blockHash.toByteArray)} could not be found.")
   }
+
+  object InvalidArgument extends StatusError(Status.INVALID_ARGUMENT)
 }
 
 sealed trait GossipError extends NoStackTrace

--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -119,6 +119,7 @@ object ServiceError {
   }
 
   object InvalidArgument extends StatusError(Status.INVALID_ARGUMENT)
+  object Unauthenticated extends StatusError(Status.UNAUTHENTICATED)
 }
 
 sealed trait GossipError extends NoStackTrace

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -6,9 +6,7 @@ import cats.effect._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.shared.Compression
-import io.casperlabs.comm.ServiceError.{NotFound, Unauthenticated}
-import io.casperlabs.comm.grpc.ContextKeys
-import io.casperlabs.comm.auth.Principal
+import io.casperlabs.comm.ServiceError.NotFound
 import monix.tail.Iterant
 import scala.collection.immutable.Queue
 import scala.math.Ordering
@@ -21,26 +19,7 @@ class GossipServiceServer[F[_]: Sync](
 ) extends GossipService[F] {
   import GossipServiceServer._
 
-  def currentPrincipal = Option(ContextKeys.Principal.get)
-
-  def newBlocks(request: NewBlocksRequest): F[NewBlocksResponse] =
-    // Verify that the sender holds the same node identity as the public key
-    // in the client SSL certificate. Alternatively we could drop the sender
-    // altogether and use Kademlia to lookup the Node with that ID the first
-    // time we see it.
-    (request.sender, currentPrincipal) match {
-      case (None, _) =>
-        Sync[F].raiseError(Unauthenticated("Sender cannot be empty."))
-
-      case (_, None) =>
-        Sync[F].raiseError(Unauthenticated("Cannot verify sender identity."))
-
-      case (Some(sender), Some(Principal.Peer(id))) if sender.id != id =>
-        Sync[F].raiseError(Unauthenticated("Sender doesn't match public key."))
-
-      case (Some(sender), _) =>
-        ???
-    }
+  def newBlocks(request: NewBlocksRequest): F[NewBlocksResponse] = ???
 
   def streamAncestorBlockSummaries(
       request: StreamAncestorBlockSummariesRequest

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -6,7 +6,7 @@ import cats.effect._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.shared.Compression
-import io.casperlabs.comm.ServiceError.NotFound
+import io.casperlabs.comm.ServiceError.{InvalidArgument, NotFound}
 import monix.tail.Iterant
 import scala.collection.immutable.Queue
 import scala.math.Ordering
@@ -19,7 +19,13 @@ class GossipServiceServer[F[_]: Sync](
 ) extends GossipService[F] {
   import GossipServiceServer._
 
-  def newBlocks(request: NewBlocksRequest): F[NewBlocksResponse] = ???
+  def newBlocks(request: NewBlocksRequest): F[NewBlocksResponse] =
+    request.sender match {
+      case None =>
+        Sync[F].raiseError(InvalidArgument("Sender cannot be empty."))
+      case _ =>
+        ???
+    }
 
   def streamAncestorBlockSummaries(
       request: StreamAncestorBlockSummariesRequest

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/AuthInterceptor.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/AuthInterceptor.scala
@@ -1,0 +1,69 @@
+package io.casperlabs.comm.grpc
+
+import cats.Id
+import com.google.protobuf.ByteString
+import io.casperlabs.comm.auth.Principal
+import io.casperlabs.comm.ServiceError.Unauthenticated
+import io.casperlabs.crypto.util.CertificateHelper
+import io.casperlabs.shared.{Log, LogSource}
+import io.grpc.{
+  Context,
+  Contexts,
+  Grpc,
+  Metadata,
+  ServerCall,
+  ServerCallHandler,
+  ServerInterceptor,
+  Status
+}
+import javax.net.ssl.SSLSession
+import scala.util.Try
+
+/** Put the remote peer identity into the gRPC Context. */
+class AuthInterceptor() extends ServerInterceptor {
+
+  // Based on https://github.com/saturnism/grpc-java-by-example/tree/master/metadata-context-example/src/main/java/com/example/grpc/server
+
+  implicit val logSource = LogSource(this.getClass)
+  implicit val logId     = Log.logId
+
+  def NoopListener[A] = new ServerCall.Listener[A] {}
+
+  override def interceptCall[A, B](
+      call: ServerCall[A, B],
+      headers: Metadata,
+      next: ServerCallHandler[A, B]
+  ): ServerCall.Listener[A] = {
+
+    val sslSessionOpt: Option[SSLSession] = Option(
+      call.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)
+    )
+
+    val ctx: Either[io.grpc.StatusRuntimeException, Context] =
+      for {
+        session <- sslSessionOpt orReject "No TLS session."
+        cert <- Try(session.getPeerCertificates).toOption
+                 .flatMap(_.headOption) orReject "No client certificate."
+        id <- CertificateHelper.publicAddress(cert.getPublicKey) orReject "Certificate validation failed."
+      } yield {
+        val p = Principal.Peer(id = ByteString.copyFrom(id))
+        Context.current.withValue(ContextKeys.Principal, p: Principal)
+      }
+
+    ctx.fold(
+      ex => {
+        Log[Id].warn(
+          s"Rejecting gRPC call with ${ex.getStatus.getCode}: ${ex.getStatus.getDescription}"
+        )
+        call.close(ex.getStatus, headers)
+        NoopListener
+      },
+      ctx => Contexts.interceptCall(ctx, call, headers, next)
+    )
+  }
+
+  implicit class RejectOps[T](x: Option[T]) {
+    def orReject(msg: String): Either[io.grpc.StatusRuntimeException, T] =
+      x.map(Right(_)).getOrElse(Left(Unauthenticated(msg)))
+  }
+}

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/AuthInterceptor.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/AuthInterceptor.scala
@@ -52,8 +52,11 @@ class AuthInterceptor() extends ServerInterceptor {
 
     ctx.fold(
       ex => {
+        val method = call.getMethodDescriptor.getFullMethodName
+        val source = Option(call.getAttributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR))
+          .fold("unknown address")(_.toString)
         Log[Id].warn(
-          s"Rejecting gRPC call with ${ex.getStatus.getCode}: ${ex.getStatus.getDescription}"
+          s"Rejecting gRPC call from $source to $method with ${ex.getStatus.getCode}: ${ex.getStatus.getDescription}"
         )
         call.close(ex.getStatus, headers)
         NoopListener

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/ContextKeys.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/ContextKeys.scala
@@ -1,0 +1,9 @@
+package io.casperlabs.comm.grpc
+
+import io.grpc.Context
+import io.casperlabs.comm.auth.Principal
+
+object ContextKeys {
+  val Principal: Context.Key[Principal] =
+    Context.key("auth.principal")
+}

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/GrpcServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/GrpcServer.scala
@@ -26,7 +26,6 @@ object GrpcServer {
           .executor(scheduler)
 
         sslContext.foreach(builder.sslContext(_))
-
         boundService.foreach(builder.addService(_))
         interceptors.foreach(builder.intercept(_))
 

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/GrpcServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/GrpcServer.scala
@@ -2,15 +2,21 @@ package io.casperlabs.comm.grpc
 
 import cats.implicits._
 import cats.effect._
-import io.grpc.{Server, ServerServiceDefinition}
+import io.grpc.{Server, ServerInterceptor, ServerServiceDefinition}
 import io.grpc.netty.NettyServerBuilder
+import io.netty.handler.ssl.SslContext
 import monix.execution.Scheduler
 
 object GrpcServer {
   type ServiceBinder[F[_]] = Scheduler => F[ServerServiceDefinition]
 
   /** Start a gRPC server resource with multiple services listening on a common port. */
-  def apply[F[_]: Sync](port: Int, services: List[ServiceBinder[F]])(
+  def apply[F[_]: Sync](
+      port: Int,
+      services: List[ServiceBinder[F]],
+      interceptors: List[ServerInterceptor] = Nil,
+      sslContext: Option[SslContext] = None
+  )(
       implicit scheduler: Scheduler
   ): Resource[F, Server] =
     Resource.make(
@@ -18,7 +24,12 @@ object GrpcServer {
         val builder = NettyServerBuilder
           .forPort(port)
           .executor(scheduler)
+
+        sslContext.foreach(builder.sslContext(_))
+
         boundService.foreach(builder.addService(_))
+        interceptors.foreach(builder.intercept(_))
+
         builder.build.start
       }
     )(

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/GrpcServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/GrpcServer.scala
@@ -1,4 +1,4 @@
-package io.casperlabs.comm
+package io.casperlabs.comm.grpc
 
 import cats.implicits._
 import cats.effect._

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/SslContexts.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/SslContexts.scala
@@ -1,0 +1,41 @@
+package io.casperlabs.comm.grpc
+
+import io.casperlabs.comm.transport.HostnameTrustManagerFactory
+import io.grpc.netty.GrpcSslContexts
+import io.netty.handler.ssl.{ClientAuth, SslContext, SslContextBuilder}
+import java.io.ByteArrayInputStream
+
+object SslContexts {
+  // For mutual TLS.
+  def forClient(cert: String, privateKey: String): SslContext = {
+    val cis = new ByteArrayInputStream(cert.getBytes())
+    val kis = new ByteArrayInputStream(privateKey.getBytes())
+
+    GrpcSslContexts.forClient
+      .trustManager(HostnameTrustManagerFactory.Instance)
+      .keyManager(cis, kis)
+      .build
+  }
+
+  // For server-only TLS.
+  def forClientUnauthenticated: SslContext =
+    GrpcSslContexts.forClient
+      .trustManager(HostnameTrustManagerFactory.Instance)
+      .build
+
+  // For mutual or server-only TLS, based on the `clientAuth` setting.
+  def forServer(
+      cert: String,
+      privateKey: String,
+      clientAuth: ClientAuth
+  ): SslContext = {
+    val cis = new ByteArrayInputStream(cert.getBytes())
+    val kis = new ByteArrayInputStream(privateKey.getBytes())
+
+    GrpcSslContexts
+      .configure(SslContextBuilder.forServer(cis, kis))
+      .trustManager(HostnameTrustManagerFactory.Instance)
+      .clientAuth(clientAuth)
+      .build
+  }
+}

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
@@ -18,8 +18,9 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
       Task.now(Seq.empty)
     override def receive(
         pingHandler: PeerNode => Task[Unit],
-        lookupHandler: (PeerNode, NodeIdentifier) => Task[Seq[PeerNode]]): Task[Unit] = Task.unit
-    override def shutdown(): Task[Unit]                                               = Task.unit
+        lookupHandler: (PeerNode, NodeIdentifier) => Task[Seq[PeerNode]]
+    ): Task[Unit]                       = Task.unit
+    override def shutdown(): Task[Unit] = Task.unit
   }
 
   //1 byte width
@@ -37,16 +38,19 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
       .iterate(min, maxPeersN)(b => (b + 1).toByte)
       .map(b => PeerNode(NodeIdentifier(Seq(b)), Endpoint("", 0, 0)))
   private implicit val propCheckConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(
-    minSuccessful = 500)
+    minSuccessful = 500
+  )
 
   property(
     """
       |updateLastSeen
       |atomically adds new unique peer if bucket is not full and moves it if has seen previously;
-      |there shouldn't be any ping requests, since 'uniquePeersN' <= bucketSize""".stripMargin) {
+      |there shouldn't be any ping requests, since 'uniquePeersN' <= bucketSize""".stripMargin
+  ) {
     forAll(
       Gen
-        .choose(1, bucketSize)) { uniquePeersN: Int =>
+        .choose(1, bucketSize)
+    ) { uniquePeersN: Int =>
       var pingCounter = 0
       implicit val K: KademliaMock = (_: PeerNode) => {
         Task(pingCounter += 1).map(_ => true)

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -7,7 +7,7 @@ import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.shared.Compression
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.comm.ServiceError.NotFound
-import io.casperlabs.comm.GrpcServer
+import io.casperlabs.comm.grpc.GrpcServer
 import io.casperlabs.comm.TestRuntime
 import io.grpc.netty.NettyChannelBuilder
 import java.util.concurrent.atomic.AtomicReference

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -20,7 +20,7 @@ import io.casperlabs.catscontrib.effect.implicits.{bracketEitherTThrowable, task
 import io.casperlabs.catscontrib._
 import io.casperlabs.catscontrib.ski._
 import io.casperlabs.comm.CommError.ErrorHandler
-import io.casperlabs.comm.{GrpcServer => _, _}
+import io.casperlabs.comm._
 import io.casperlabs.comm.discovery._
 import io.casperlabs.comm.rp.Connect.{ConnectionsCell, RPConfAsk, RPConfState}
 import io.casperlabs.comm.rp._


### PR DESCRIPTION
## Overview
Creates an `AuthInterceptor` that puts the remote peer identity into the gRPC context, which is then checked in the `NewBlocks` method to see that the `sender` identity is as expected.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-338

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
While working on it I realised the following things: 
* `HostnameTrustManager` checks that the server hostname matches the what's in the certificate, but it overrides it with the ID of the peers it's connecting to, so it doesn't actually check the hostname itself I think. For the client is doesn't check the hostname at all.
* `sender.hostname` can point at something bogus even if the `id` matches the public key. 
* Instead of using a `sender` field we could use the Kademlia `lookup` method to find the node based on the ID.
