### PR TITLE
NODE-340: Limit parallel block downloads

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -91,7 +91,7 @@ class GossipServiceServer[F[_]: Sync](
       .flatMap(Iterant.fromIterable(_))
 
   def getBlockChunked(request: GetBlockChunkedRequest): Iterant[F, Chunk] =
-    Iterant.resource(blockDownloadSemaphore.acquireN(1))(_ => blockDownloadSemaphore.releaseN(1)) flatMap {
+    Iterant.resource(blockDownloadSemaphore.acquire)(_ => blockDownloadSemaphore.release) flatMap {
       _ =>
         Iterant.liftF {
           getBlock(request.blockHash)

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.comm.gossiping
 
 import cats.implicits._
+import cats.effect.concurrent.Semaphore
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.comm.discovery.Node
@@ -532,13 +533,13 @@ object DownloadManagerSpec {
   /** Test implementation of the remote GossipService to download the blocks from. */
   object MockGossipService {
     // Used only as a default argument for when we aren't touching the remote service in a test.
-    val default = Task.now {
-      new GossipServiceServer[Task](
+    val default =
+      GossipServiceServer[Task](
         getBlock = _ => Task.now(None),
         getBlockSummary = _ => ???,
-        maxChunkSize = 100 * 1024
+        maxChunkSize = 100 * 1024,
+        maxParallelBlockDownloads = 100
       )
-    }
 
     def apply(
         blocks: Seq[Block] = Seq.empty,
@@ -546,16 +547,20 @@ object DownloadManagerSpec {
         rechunker: Iterant[Task, Chunk] => Iterant[Task, Chunk] = identity,
         // Pass in a `regetter` method to alter the behaviour of the `getBlock`, for example to add delays.
         regetter: Task[Option[Block]] => Task[Option[Block]] = identity
-    ) = Task.now {
-      val blockMap = toBlockMap(blocks)
-      new GossipServiceServer[Task](
-        getBlock = hash => regetter(Task.delay(blockMap.get(hash))),
-        getBlockSummary = hash => ???,
-        maxChunkSize = 100 * 1024
-      ) {
-        override def getBlockChunked(request: GetBlockChunkedRequest) =
-          rechunker(super.getBlockChunked(request))
+    ) =
+      for {
+        blockMap  <- Task.now(toBlockMap(blocks))
+        semaphore <- Semaphore[Task](100)
+      } yield {
+        new GossipServiceServer[Task](
+          getBlock = hash => regetter(Task.delay(blockMap.get(hash))),
+          getBlockSummary = hash => ???,
+          maxChunkSize = 100 * 1024,
+          blockDownloadSemaphore = semaphore
+        ) {
+          override def getBlockChunked(request: GetBlockChunkedRequest) =
+            rechunker(super.getBlockChunked(request))
+        }
       }
-    }
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -298,10 +298,14 @@ class GrpcGossipServiceSpec
                   r <- stub.getBlockChunked(req).toListL.attempt
                   _ = {
                     r.isLeft shouldBe true
-                    val ex = r.left.get.asInstanceOf[io.grpc.StatusRuntimeException]
-                    // TODO: When we add the ErrorInterceptor we can turn this into a proper status,
-                    // for example CANCELED or DEADLINE_EXCEEDED.
-                    ex.getStatus.getCode shouldBe io.grpc.Status.Code.UNKNOWN
+                    r.left.get match {
+                      case ex: io.grpc.StatusRuntimeException =>
+                        // TODO: When we add the ErrorInterceptor we can turn this into a proper status,
+                        // for example CANCELED or DEADLINE_EXCEEDED.
+                        ex.getStatus.getCode shouldBe io.grpc.Status.Code.UNKNOWN
+                      case other =>
+                        fail(s"Unexpected error: $other")
+                    }
                   }
                   // The semaphore should be free for the next query. Otherwise the test will time out.
                   _ <- stub.getBlockChunked(req).headL

--- a/shared/src/main/scala/io/casperlabs/shared/ObservableOps.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/ObservableOps.scala
@@ -1,0 +1,48 @@
+package io.casperlabs.shared
+
+import monix.execution.{Ack, Cancelable, Scheduler}
+import monix.reactive.{Observable, Observer}
+import monix.reactive.observers.{SafeSubscriber, Subscriber}
+import monix.eval.Task
+import scala.concurrent.{Future, TimeoutException}
+import scala.concurrent.duration.FiniteDuration
+
+object ObservableOps {
+  implicit class RichObservable[A](obs: Observable[A]) {
+
+    /** Cancel the stream if the consumer is taking too long to pull items. */
+    def withConsumerTimeout(timeout: FiniteDuration) =
+      new Observable[A] {
+
+        override def unsafeSubscribeFn(subscriber: Subscriber[A]): Cancelable = {
+          implicit val scheduler = subscriber.scheduler
+          // Using a SafeSubscriber so we can call onError while onNext is running.
+          val ss = SafeSubscriber(subscriber)
+          val cancel: Task[Ack] = Task
+            .delay {
+              // After the onNext is finished the subscriber will get error.
+              ss.onError(new TimeoutException(s"Stream item not consumed within $timeout."))
+              // While we can cancel the source observable rigth now.
+              Ack.Stop
+            }
+            .delayExecution(timeout)
+
+          obs.subscribe {
+            new Observer[A] {
+              override def onComplete() =
+                ss.onComplete()
+
+              override def onError(ex: Throwable) =
+                ss.onError(ex)
+
+              override def onNext(elem: A): Future[Ack] =
+                Task
+                  .race(cancel, Task.fromFuture(ss.onNext(elem)))
+                  .map(_.merge)
+                  .runToFuture
+            }
+          }
+        }
+      }
+  }
+}

--- a/shared/src/test/scala/io/casperlabs/shared/ObservableOpsSpec.scala
+++ b/shared/src/test/scala/io/casperlabs/shared/ObservableOpsSpec.scala
@@ -19,7 +19,7 @@ class ObservableOpsSpec extends WordSpec with Matchers {
         @volatile var cnt = 0
         val list = Observable
           .range(0, 100, 1)
-          .doOnNext(i => Task.delay(cnt += 1))
+          .doOnNext(_ => Task.delay(cnt += 1))
           .withConsumerTimeout(100.millis)
           .mapEval(x => Task.pure(x).delayResult(250.millis))
           .toListL

--- a/shared/src/test/scala/io/casperlabs/shared/ObservableOpsSpec.scala
+++ b/shared/src/test/scala/io/casperlabs/shared/ObservableOpsSpec.scala
@@ -1,0 +1,47 @@
+package io.casperlabs.shared
+
+import monix.eval.Task
+import monix.reactive.Observable
+import monix.execution.{ExecutionModel, Scheduler}
+import org.scalatest._
+import scala.concurrent.duration._
+import scala.concurrent.TimeoutException
+
+class ObservableOpsSpec extends WordSpec with Matchers {
+  import ObservableOps._
+
+  "withConsumerTimeout" when {
+    // Restrict the client to request 1 item at a time.
+    implicit val scheduler = Scheduler(ExecutionModel.BatchedExecution(1))
+
+    "the consumer is slow" should {
+      "cancel the stream" in {
+        @volatile var cnt = 0
+        val list = Observable
+          .range(0, 100, 1)
+          .doOnNext(i => Task.delay(cnt += 1))
+          .withConsumerTimeout(100.millis)
+          .mapEval(x => Task.pure(x).delayResult(250.millis))
+          .toListL
+          .attempt
+
+        val res = list.runSyncUnsafe(2.seconds)
+        res.isLeft shouldBe true
+        res.left.get.getMessage shouldBe "Stream item not consumed within 100 milliseconds."
+        cnt shouldBe 1
+      }
+    }
+
+    "the consumer is fast" should {
+      "not cancel the stream" in {
+        val list = Observable
+          .range(0, 100, 1)
+          .withConsumerTimeout(100.millis)
+          .toListL
+
+        val res = list.runSyncUnsafe(2.seconds)
+        res should have size 100
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Adds a semaphore to the `GossipServiceServer` so that the node can't be flooded with `getBlockChunked` requests and read too many of them into memory. Also adds a `blockChunkConsumerTimeout` setting to `GrpcGossipService` so that if the client isn't pulling the data fast enough then the server cancels the stream, to free up the semaphore and avoid somebody exhausting it then not pulling the data, just to starve others.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-340

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Initially I tried using [NettyServerBuilder.maxConnectionIdle](https://grpc.io/grpc-java/javadoc/io/grpc/netty/NettyServerBuilder.html#maxConnectionIdle-long-java.util.concurrent.TimeUnit-) but it turned out that the streaming gRPC call is considered active, it had no effect.
