### PR TITLE
EE-228: Bump FFI crate version number

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -139,7 +139,7 @@ dependencies = [
 name = "casperlabs-engine-grpc-server"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.2.0",
+ "casperlabs-contract-ffi 0.3.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "execution-engine 0.1.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -259,7 +259,7 @@ name = "execution-engine"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.2.0",
+ "casperlabs-contract-ffi 0.3.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gens 0.1.0",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -347,7 +347,7 @@ dependencies = [
 name = "gens"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.2.0",
+ "casperlabs-contract-ffi 0.3.0",
  "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",
  "storage 0.1.0",
@@ -1044,7 +1044,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.2.0",
+ "casperlabs-contract-ffi 0.3.0",
 ]
 
 [[package]]
@@ -1071,7 +1071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.2.0",
+ "casperlabs-contract-ffi 0.3.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gens 0.1.0",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1149,7 +1149,7 @@ dependencies = [
 name = "tests"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.2.0",
+ "casperlabs-contract-ffi 0.3.0",
  "gens 0.1.0",
  "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.1.0",

--- a/execution-engine/common/Cargo.toml
+++ b/execution-engine/common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "casperlabs-contract-ffi"
-version = "0.2.0"
-authors = ["Michael Birch <birchmd@casperlabs.io>"]
+version = "0.3.0"
+authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."
 license = "Apache-2.0"


### PR DESCRIPTION
## Overview
Need to bump the version number so we can publish a new version after the most recent breaking change.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-228

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
