### PR TITLE
NO-TICKET: Fix wrong gRPC logging setup

### DIFF
--- a/node/src/main/resources/logback.xml
+++ b/node/src/main/resources/logback.xml
@@ -15,7 +15,7 @@
 
     <logger name="org.http4s" level="warn"/>
     <logger name="io.netty" level="warn"/>
-    <logger name="io.grpc" level="warn"/>
+    <logger name="io.grpc" level="error"/>
     <logger name="org.http4s.blaze.channel.nio1.NIO1SocketServerGroup"
             level="OFF"/>
 

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -11,6 +11,7 @@ import io.casperlabs.node.effects._
 import io.casperlabs.shared._
 import monix.eval.{Task, TaskApp}
 import monix.execution.Scheduler
+import org.slf4j.bridge.SLF4JBridgeHandler
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
@@ -41,7 +42,10 @@ object Main extends TaskApp {
   }
 
   private def updateLoggingProps(conf: Configuration): Task[Unit] = Task {
-    java.util.logging.Logger.getLogger("io.grpc").setLevel(java.util.logging.Level.SEVERE)
+    //https://github.com/grpc/grpc-java/issues/1577#issuecomment-228342706
+    SLF4JBridgeHandler.removeHandlersForRootLogger()
+    SLF4JBridgeHandler.install()
+    sys.props.update("node.data.dir", conf.server.dataDir.toAbsolutePath.toString)
   }
 
   private def mainProgram(command: Configuration.Command, conf: Configuration)(


### PR DESCRIPTION
## Overview
Fixes wrong gRPC logging adjusting introduced by [this commit](https://github.com/CasperLabs/CasperLabs/commit/22b6ef87a59b34eba6f4907b1695befc748f243f#commitcomment-32973167) (thanks to @aakoshh who noticed this.)

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.