### PR TITLE
NODE-366: Fix the node CLI exit behaviour

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -11,8 +11,7 @@ import monix.execution.Scheduler
 
 object Main {
 
-  implicit val logSource: LogSource = LogSource(this.getClass)
-  implicit val log: Log[Task]       = Log.log
+  implicit val log: Log[Task] = Log.log
 
   def main(args: Array[String]): Unit = {
     implicit val scheduler: Scheduler = Scheduler.computation(

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -9,19 +9,18 @@ import io.casperlabs.node.configuration._
 import io.casperlabs.node.diagnostics.client.GrpcDiagnosticsService
 import io.casperlabs.node.effects._
 import io.casperlabs.shared._
-import monix.eval.{Task, TaskApp}
+import monix.eval.Task
 import monix.execution.Scheduler
 import org.slf4j.bridge.SLF4JBridgeHandler
 
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 
-object Main extends TaskApp {
+object Main {
 
-  private implicit lazy val logSource: LogSource = LogSource(this.getClass)
-  private implicit lazy val log: Log[Task]       = effects.log
+  implicit val log: Log[Task] = effects.log
 
-  override def run(args: List[String]): Task[ExitCode] = {
+  def main(args: Array[String]): Unit = {
     implicit val scheduler: Scheduler = Scheduler.computation(
       Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
       "node-runner",
@@ -38,7 +37,7 @@ object Main extends TaskApp {
               )
       } yield ()
 
-    exec.as(ExitCode(0))
+    exec.runSyncUnsafe()
   }
 
   private def updateLoggingProps(conf: Configuration): Task[Unit] = Task {
@@ -79,7 +78,6 @@ object Main extends TaskApp {
         case None =>
           Task.delay(System.exit(0))
       }
-
   }
 
   private def nodeProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] = {


### PR DESCRIPTION
## Overview
The node's `Main` class was [changed](https://github.com/CasperLabs/CasperLabs/commit/37f1c53cc26e4e251fe8a00e2034f4514dd9ac57) earlier to use `TaskApp`, but it wasn't thoroughly revamped to _only_ rely on the returned `ExitCode`, we still called `System.exit` in `mainProgram` an Scallop also uses this mechanism by default to [print](https://github.com/scallop/scallop/blob/develop/src/main/scala/org.rogach.scallop/ScallopConfBase.scala#L449) errors and help messages.

This doesn't seem to work well with the `TaskApp` machinery which [starts](https://github.com/typelevel/cats-effect/blob/1846813109b1e78c5bf36e6e179d7a91419e01d0/core/jvm/src/main/scala/cats/effect/internals/IOAppPlatform.scala#L24) the main in a fiber and either only calls `sys.exit` if the code is non-zero, which in our case was hardcoded to be zero, although I'm not sure our code ever reached that point. In any case calling `sys.exit` in a fiber seems to behave differently. 

I think reconfiguring `Option` to raise an exception instead of printing the help and exiting is not worth the trouble, given that we'd have to duplicate the printing logic. Not sure if we can somehow catch the exit itself to return the code to `TaskApp` to handle but it doesn't seem worth the trouble since we already have exits in `mainProgram`. Those would need refactoring too to comply with `TaskApp` expectations. In any case trying to catch errors like `exec.onError{ case ex => log.error(ex) }.as(ExitCode(0))` proved futile.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-366

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
I verified that a node that already started listening can be exited. The `IOApp` would have canceled the fiber. We shut down the servers, close the backend, but I'm not exactly sure what cancels [this loop](https://github.com/CasperLabs/CasperLabs/blob/dev/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala#L362) for example.
