### PR TITLE
NODE-314 Rename Kademlia services according to spec, prepare NodeDiscovery for relaying

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaService.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/KademliaService.scala
@@ -2,7 +2,7 @@ package io.casperlabs.comm.discovery
 
 import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 
-trait KademliaRPC[F[_]] {
+trait KademliaService[F[_]] {
   def ping(node: PeerNode): F[Boolean]
   def lookup(id: NodeIdentifier, peer: PeerNode): F[Option[Seq[PeerNode]]]
   def receive(
@@ -12,6 +12,6 @@ trait KademliaRPC[F[_]] {
   def shutdown(): F[Unit]
 }
 
-object KademliaRPC {
-  def apply[F[_]](implicit P: KademliaRPC[F]): KademliaRPC[F] = P
+object KademliaService {
+  def apply[F[_]](implicit P: KademliaService[F]): KademliaService[F] = P
 }

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
@@ -9,7 +9,7 @@ import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 trait NodeDiscovery[F[_]] {
   def discover: F[Unit]
   def lookup(id: NodeIdentifier): F[Option[PeerNode]]
-  def peers: F[Seq[PeerNode]]
+  def alivePeersAscendingDistance: F[List[PeerNode]]
 }
 
 object NodeDiscovery extends NodeDiscoveryInstances {
@@ -21,7 +21,7 @@ object NodeDiscovery extends NodeDiscoveryInstances {
     new NodeDiscovery[T[F, ?]] {
       def discover: T[F, Unit]                               = C.discover.liftM[T]
       def lookup(id: NodeIdentifier): T[F, Option[PeerNode]] = C.lookup(id).liftM[T]
-      def peers: T[F, Seq[PeerNode]]                         = C.peers.liftM[T]
+      def alivePeersAscendingDistance: T[F, List[PeerNode]]  = C.alivePeersAscendingDistance.liftM[T]
     }
 }
 

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -13,7 +13,7 @@ import io.casperlabs.shared._
 import monix.eval.{TaskLift, TaskLike}
 import monix.execution.Scheduler
 
-object KademliaNodeDiscovery {
+object NodeDiscoveryImpl {
   def create[F[_]: Concurrent: Log: Time: Metrics: TaskLike: TaskLift: PeerNodeAsk: Timer: Par](
       id: NodeIdentifier,
       port: Int,
@@ -23,7 +23,7 @@ object KademliaNodeDiscovery {
   )(implicit scheduler: Scheduler): Resource[F, NodeDiscovery[F]] = {
     val kademliaRpcResource = Resource.make(CachedConnections[F, KademliaConnTag].map {
       implicit cache =>
-        new GrpcKademliaRPC(port, timeout)
+        new GrpcKademliaService(port, timeout)
     })(
       kRpc =>
         Concurrent[F]
@@ -35,14 +35,14 @@ object KademliaNodeDiscovery {
     kademliaRpcResource.flatMap { implicit kRpc =>
       Resource.liftF(for {
         table <- PeerTable[F](id)
-        knd   = new KademliaNodeDiscovery[F](id, table)
+        knd   = new NodeDiscoveryImpl[F](id, table)
         _     <- init.fold(().pure[F])(knd.addNode)
       } yield knd)
     }
   }
 }
 
-private[discovery] class KademliaNodeDiscovery[F[_]: Sync: Log: Time: Metrics: KademliaRPC: Par](
+private[discovery] class NodeDiscoveryImpl[F[_]: Sync: Log: Time: Metrics: KademliaService: Par](
     id: NodeIdentifier,
     table: PeerTable[F],
     alpha: Int = 3,
@@ -71,7 +71,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Sync: Log: Time: Metrics: K
 
   def discover: F[Unit] = {
 
-    val initRPC = KademliaRPC[F].receive(pingHandler, lookupHandler)
+    val initRPC = KademliaService[F].receive(pingHandler, lookupHandler)
 
     val findNew = for {
       _ <- Time[F].sleep(9.seconds)
@@ -112,7 +112,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Sync: Log: Time: Metrics: K
         for {
           responses <- callees.parTraverse { callee =>
                         for {
-                          maybeNodes <- KademliaRPC[F].lookup(toLookup, callee)
+                          maybeNodes <- KademliaService[F].lookup(toLookup, callee)
                           _          <- maybeNodes.fold(().pure[F])(_ => addNode(callee))
                         } yield (callee, maybeNodes)
                       }
@@ -148,7 +148,7 @@ private[discovery] class KademliaNodeDiscovery[F[_]: Sync: Log: Time: Metrics: K
   override def alivePeersAscendingDistance: F[List[PeerNode]] =
     table.peersAscendingDistance.flatMap { peers =>
       peers.parFlatTraverse { peer =>
-        KademliaRPC[F].ping(peer).map(success => if (success) List(peer) else Nil)
+        KademliaService[F].ping(peer).map(success => if (success) List(peer) else Nil)
       }
     }
 }

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -77,7 +77,7 @@ final class PeerTable[F[_]: Monad](
   private[discovery] def longestCommonBitPrefix(other: NodeIdentifier): Int =
     PeerTable.longestCommonBitPrefix(local, other)
 
-  def updateLastSeen(peer: PeerNode)(implicit K: KademliaRPC[F]): F[Unit] = {
+  def updateLastSeen(peer: PeerNode)(implicit K: KademliaService[F]): F[Unit] = {
     val index = longestCommonBitPrefix(peer)
     for {
       maybeCandidate <- tableRef.modify { table =>

--- a/comm/src/main/scala/io/casperlabs/comm/rp/Connect.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/rp/Connect.scala
@@ -35,10 +35,10 @@ object Connect {
     def empty: Connections = List.empty[Connection]
     implicit class ConnectionsOps(connections: Connections) {
 
-      def addConn[F[_]: Monad: Log: Metrics](connection: Connection): F[Connections] =
+      def addConn[F[_]: Apply: Log: Metrics](connection: Connection): F[Connections] =
         addConn[F](List(connection))
 
-      def addConn[F[_]: Monad: Log: Metrics](toBeAdded: List[Connection]): F[Connections] = {
+      def addConn[F[_]: Apply: Log: Metrics](toBeAdded: List[Connection]): F[Connections] = {
         val ids = toBeAdded.map(_.id)
         val newConnections = connections.partition(peer => ids.contains(peer.id)) match {
           case (_, rest) => rest ++ toBeAdded
@@ -48,10 +48,10 @@ object Connect {
           Metrics[F].setGauge("peers", size).as(newConnections)
       }
 
-      def removeConn[F[_]: Monad: Log: Metrics](connection: Connection): F[Connections] =
+      def removeConn[F[_]: Apply: Log: Metrics](connection: Connection): F[Connections] =
         removeConn[F](List(connection))
 
-      def removeConn[F[_]: Monad: Log: Metrics](toBeRemoved: List[Connection]): F[Connections] = {
+      def removeConn[F[_]: Apply: Log: Metrics](toBeRemoved: List[Connection]): F[Connections] = {
         val ids = toBeRemoved.map(_.id)
         val newConnections = connections.partition(peer => ids.contains(peer.id)) match {
           case (_, rest) => rest
@@ -74,7 +74,7 @@ object Connect {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  def clearConnections[F[_]: Sync: Time: ConnectionsCell: RPConfAsk: TransportLayer: Log: Metrics]
+  def clearConnections[F[_]: Monad: Time: ConnectionsCell: RPConfAsk: TransportLayer: Log: Metrics]
     : F[Int] = {
 
     def sendHeartbeat(peer: PeerNode): F[(PeerNode, CommErr[Protocol])] =
@@ -115,30 +115,34 @@ object Connect {
       } yield result
     }
 
-  def findAndConnect[F[_]: Sync: Log: Time: Metrics: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
+  def findAndConnect[F[_]: Monad: Log: Time: Metrics: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
       conn: (PeerNode, FiniteDuration) => F[Unit]
   ): F[List[PeerNode]] =
     for {
-      connections      <- ConnectionsCell[F].read
-      tout             <- RPConfAsk[F].reader(_.defaultTimeout)
-      peers            <- NodeDiscovery[F].peers.map(p => (p.toSet -- connections).toList)
-      responses        <- peers.traverse(peer => ErrorHandler[F].attempt(conn(peer, tout)))
-      peersAndResonses = peers.zip(responses)
-      _ <- peersAndResonses.traverse {
-            case (peer, Left(error)) =>
-              Log[F].debug(s"Failed to connect to ${peer.toAddress}. Reason: ${error.message}")
-            case (peer, Right(_)) =>
-              Log[F].info(s"Connected to ${peer.toAddress}.")
-          }
-    } yield peersAndResonses.filter(_._2.isRight).map(_._1)
+      connections <- ConnectionsCell[F].read
+      tout        <- RPConfAsk[F].reader(_.defaultTimeout)
+      peers <- NodeDiscovery[F].alivePeersAscendingDistance
+                .map(p => (p.toSet -- connections).toList)
+      connected <- peers.traverseFilter { peer =>
+                    ErrorHandler[F].attempt(conn(peer, tout)).flatMap {
+                      case Left(error) =>
+                        Log[F]
+                          .debug(
+                            s"Failed to connect to ${peer.toAddress}. Reason: ${error.message}"
+                          ) >> none[PeerNode].pure[F]
+                      case Right(_) =>
+                        Log[F].info(s"Connected to ${peer.toAddress}.") >> peer.some.pure[F]
+                    }
+                  }
+    } yield connected
 
-  def connect[F[_]: Sync: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
+  def connect[F[_]: Monad: Log: Time: Metrics: TransportLayer: NodeDiscovery: ErrorHandler: ConnectionsCell: RPConfAsk](
       peer: PeerNode,
       timeout: FiniteDuration
   ): F[Unit] =
     (
       for {
-        address  <- Sync[F].delay(peer.toAddress)
+        address  <- Applicative[F].pure(peer.toAddress)
         _        <- Log[F].debug(s"Connecting to $address")
         _        <- Metrics[F].incrementCounter("connect")
         _        <- Log[F].debug(s"Initialize protocol handshake to $address")

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -21,7 +21,7 @@ object b {
 class DistanceSpec extends FlatSpec with Matchers {
 
   val endpoint = Endpoint("", 0, 0)
-  implicit val ping: KademliaRPC[Id] = new KademliaRPC[Id] {
+  implicit val ping: KademliaService[Id] = new KademliaService[Id] {
     def ping(node: PeerNode): Boolean                                     = true
     def lookup(id: NodeIdentifier, peer: PeerNode): Option[Seq[PeerNode]] = None
     def receive(

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -86,7 +86,7 @@ class DistanceSpec extends FlatSpec with Matchers {
 
     it should "return no peers" in {
       val table = PeerTable(kr)
-      table.peers.size should be(0)
+      table.peersAscendingDistance.size should be(0)
     }
 
     it should "return no values on lookup" in {
@@ -135,7 +135,7 @@ class DistanceSpec extends FlatSpec with Matchers {
       for (k <- oneOffs(kr)) {
         table.updateLastSeen(PeerNode(k, endpoint))
       }
-      table.peers.size should be(8 * width)
+      table.peersAscendingDistance.size should be(8 * width)
     }
 
     it should "find each added peer" in {

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/GrpcKademliaServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/GrpcKademliaServiceSpec.scala
@@ -13,7 +13,7 @@ import io.casperlabs.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler
 
-class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
+class GrpcKademliaServiceSpec extends KademliaServiceSpec[Task, GrpcEnvironment] {
 
   implicit val log: Log[Task]         = new Log.NOPLog[Task]
   implicit val scheduler: Scheduler   = Scheduler.Implicits.global
@@ -28,14 +28,17 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
       GrpcEnvironment(host, port, peer)
     }
 
-  def createKademliaRPC(env: GrpcEnvironment, timeout: FiniteDuration): Task[KademliaRPC[Task]] = {
+  def createKademliaService(
+      env: GrpcEnvironment,
+      timeout: FiniteDuration
+  ): Task[KademliaService[Task]] = {
     implicit val ask: PeerNodeAsk[Task] =
       new DefaultApplicativeAsk[Task, PeerNode] {
         val applicative: Applicative[Task] = Applicative[Task]
         def ask: Task[PeerNode]            = Task.pure(env.peer)
       }
     CachedConnections[Task, KademliaConnTag].map { implicit cache =>
-      new GrpcKademliaRPC(env.port, timeout)
+      new GrpcKademliaService(env.port, timeout)
     }
   }
 

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaServiceRuntime.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaServiceRuntime.scala
@@ -13,11 +13,11 @@ import cats.implicits._
 import io.casperlabs.comm._
 import scala.concurrent.duration._
 
-abstract class KademliaRPCRuntime[F[_]: Monad: Timer, E <: Environment] extends TestRuntime {
+abstract class KademliaServiceRuntime[F[_]: Monad: Timer, E <: Environment] extends TestRuntime {
 
   def createEnvironment(port: Int): F[E]
 
-  def createKademliaRPC(env: E, timeout: FiniteDuration): F[KademliaRPC[F]]
+  def createKademliaService(env: E, timeout: FiniteDuration): F[KademliaService[F]]
 
   def extract[A](fa: F[A]): A
 
@@ -45,27 +45,27 @@ abstract class KademliaRPCRuntime[F[_]: Monad: Timer, E <: Environment] extends 
       // Give it ample time on Drone.
       timeout: FiniteDuration = 5.seconds
   ) extends Runtime[A] {
-    def execute(kademliaRPC: KademliaRPC[F], local: PeerNode, remote: PeerNode): F[A]
+    def execute(kademlia: KademliaService[F], local: PeerNode, remote: PeerNode): F[A]
 
     def run(): TwoNodesResult =
       extract(
         twoNodesEnvironment { (e1, e2) =>
           for {
-            localRpc  <- createKademliaRPC(e1, timeout)
-            remoteRpc <- createKademliaRPC(e2, timeout)
-            local     = e1.peer
-            remote    = e2.peer
-            _ <- localRpc.receive(
+            kademliaLocal  <- createKademliaService(e1, timeout)
+            kademliaRemote <- createKademliaService(e2, timeout)
+            local          = e1.peer
+            remote         = e2.peer
+            _ <- kademliaLocal.receive(
                   Handler.pingHandler[F].handle(local),
                   Handler.lookupHandlerNil[F].handle(local)
                 )
-            _ <- remoteRpc.receive(
+            _ <- kademliaRemote.receive(
                   pingHandler.handle(remote),
                   lookupHandler.handle(remote)
                 )
-            r <- execute(localRpc, local, remote)
-            _ <- remoteRpc.shutdown()
-            _ <- localRpc.shutdown()
+            r <- execute(kademliaLocal, local, remote)
+            _ <- kademliaRemote.shutdown()
+            _ <- kademliaLocal.shutdown()
           } yield
             new TwoNodesResult {
               def localNode: PeerNode  = local
@@ -84,21 +84,21 @@ abstract class KademliaRPCRuntime[F[_]: Monad: Timer, E <: Environment] extends 
       val pingHandler: PingHandler[F] = Handler.pingHandler,
       val lookupHandler: LookupHandler[F] = Handler.lookupHandlerNil
   ) extends Runtime[A] {
-    def execute(kademliaRPC: KademliaRPC[F], local: PeerNode, remote: PeerNode): F[A]
+    def execute(kademliaService: KademliaService[F], local: PeerNode, remote: PeerNode): F[A]
 
     def run(): TwoNodesResult =
       extract(
         twoNodesEnvironment { (e1, e2) =>
           for {
-            localRpc <- createKademliaRPC(e1, timeout = 500.millis)
-            local    = e1.peer
-            remote   = e2.peer
-            _ <- localRpc.receive(
+            kademliaLocal <- createKademliaService(e1, timeout = 500.millis)
+            local         = e1.peer
+            remote        = e2.peer
+            _ <- kademliaLocal.receive(
                   Handler.pingHandler[F].handle(local),
                   Handler.lookupHandlerNil[F].handle(local)
                 )
-            r <- execute(localRpc, local, remote)
-            _ <- localRpc.shutdown()
+            r <- execute(kademliaLocal, local, remote)
+            _ <- kademliaLocal.shutdown()
           } yield
             new TwoNodesResult {
               def localNode: PeerNode  = local

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaServiceSpec.scala
@@ -10,23 +10,23 @@ import io.casperlabs.comm.{NodeIdentifier, PeerNode}
 
 import org.scalatest._
 
-abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
-    extends KademliaRPCRuntime[F, E]
+abstract class KademliaServiceSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
+    extends KademliaServiceRuntime[F, E]
     with WordSpecLike
     with Matchers {
 
-  val kademliaRpcName: String = this.getClass.getSimpleName.replace("Spec", "")
+  val kademliaServiceName: String = this.getClass.getSimpleName.replace("Spec", "")
 
-  kademliaRpcName when {
+  kademliaServiceName when {
     "pinging a remote peer" when {
       "everything is fine" should {
         "send and receive a positive response" in
           new TwoNodesRuntime[Boolean]() {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Boolean] = kademliaRPC.ping(remote)
+            ): F[Boolean] = kademlia.ping(remote)
 
             val result: TwoNodesResult = run()
 
@@ -40,13 +40,13 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
         "send twice and receive positive responses" in
           new TwoNodesRuntime[(Boolean, Boolean)]() {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
             ): F[(Boolean, Boolean)] =
               for {
-                r1 <- kademliaRPC.ping(remote)
-                r2 <- kademliaRPC.ping(remote)
+                r1 <- kademlia.ping(remote)
+                r2 <- kademlia.ping(remote)
               } yield (r1, r2)
 
             val result: TwoNodesResult = run()
@@ -69,10 +69,10 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
             timeout = 500.millis
           ) {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Boolean] = kademliaRPC.ping(remote)
+            ): F[Boolean] = kademlia.ping(remote)
 
             val result: TwoNodesResult = run()
 
@@ -88,10 +88,10 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
         "get a negative result" in
           new TwoNodesRemoteDeadRuntime[Boolean]() {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Boolean] = kademliaRPC.ping(remote)
+            ): F[Boolean] = kademlia.ping(remote)
 
             val result: TwoNodesResult = run()
 
@@ -114,10 +114,10 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
             lookupHandler = Handler.lookupHandler(Seq(otherPeer))
           ) {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Option[Seq[PeerNode]]] = kademliaRPC.lookup(id, remote)
+            ): F[Option[Seq[PeerNode]]] = kademlia.lookup(id, remote)
 
             val result: TwoNodesResult = run()
 
@@ -137,10 +137,10 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
             timeout = 500.millis
           ) {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Option[Seq[PeerNode]]] = kademliaRPC.lookup(id, remote)
+            ): F[Option[Seq[PeerNode]]] = kademlia.lookup(id, remote)
 
             val result: TwoNodesResult = run()
 
@@ -157,10 +157,10 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
         "get an None" in
           new TwoNodesRemoteDeadRuntime[Option[Seq[PeerNode]]]() {
             def execute(
-                kademliaRPC: KademliaRPC[F],
+                kademlia: KademliaService[F],
                 local: PeerNode,
                 remote: PeerNode
-            ): F[Option[Seq[PeerNode]]] = kademliaRPC.lookup(id, remote)
+            ): F[Option[Seq[PeerNode]]] = kademlia.lookup(id, remote)
 
             val result: TwoNodesResult = run()
 

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
@@ -87,7 +87,7 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
       hangUp.runAsyncAndForget
 
       Task
-        .race(Task.sleep(1.second), peerTable.peers)
+        .race(Task.sleep(1.second), peerTable.peersAscendingDistance)
         .runSyncUnsafe()
         .right
         .get should contain theSameElementsAs initial
@@ -112,7 +112,7 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
         peerTable <- PeerTable[Task](id, bucketSize)
         _         <- Task.gatherUnordered(initial.map(peerTable.updateLastSeen(_)))
         _         <- Task.gatherUnordered(restReplicated.map(peerTable.updateLastSeen(_)))
-        peers     <- peerTable.peers
+        peers     <- peerTable.peersAscendingDistance
       } yield peers
 
       addNodesParallel.runSyncUnsafe() should contain theSameElementsAs initial

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
@@ -13,7 +13,7 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
-  private trait KademliaMock extends KademliaRPC[Task] {
+  private trait KademliaMock extends KademliaService[Task] {
     override def lookup(id: NodeIdentifier, peer: PeerNode): Task[Option[Seq[PeerNode]]] =
       Task.now(None)
     override def receive(

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -39,7 +39,7 @@ object EffectsTestInstances {
     var nodes: List[PeerNode] = List.empty[PeerNode]
     def reset(): Unit =
       nodes = List.empty[PeerNode]
-    def peers: F[Seq[PeerNode]] = Sync[F].delay {
+    def alivePeersAscendingDistance: F[List[PeerNode]] = Sync[F].delay {
       nodes
     }
     def discover: F[Unit]                                          = ???

--- a/node/src/main/scala/io/casperlabs/node/StatusInfo.scala
+++ b/node/src/main/scala/io/casperlabs/node/StatusInfo.scala
@@ -20,7 +20,7 @@ object StatusInfo {
     for {
       version <- Sync[F].delay(VersionInfo.get)
       peers   <- ConnectionsCell[F].read
-      nodes   <- NodeDiscovery[F].peers
+      nodes   <- NodeDiscovery[F].alivePeersAscendingDistance
     } yield Status(version, peers.length, nodes.length)
 
   def service[F[_]: Sync: ConnectionsCell: NodeDiscovery]: HttpRoutes[F] = {

--- a/node/src/main/scala/io/casperlabs/node/diagnostics/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/diagnostics/effects/package.scala
@@ -245,7 +245,7 @@ package object effects {
         }
 
       def listDiscoveredPeers(request: Empty): Task[Peers] =
-        nodeDiscovery.peers.map { ps =>
+        nodeDiscovery.alivePeersAscendingDistance.map { ps =>
           Peers(
             ps.map(
               p => Peer(p.endpoint.host, p.endpoint.tcpPort, ByteString.copyFrom(p.id.key.toArray))

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -33,7 +33,7 @@ package object effects {
       metrics: Metrics[Task]
   ): Resource[Effect, NodeDiscovery[Task]] =
     Resource(
-      KademliaNodeDiscovery
+      NodeDiscoveryImpl
         .create[Task](id, port, timeout)(init)
         .allocated
         .map {

--- a/protobuf/io/casperlabs/comm/discovery/kademlia.proto
+++ b/protobuf/io/casperlabs/comm/discovery/kademlia.proto
@@ -3,23 +3,22 @@ package io.casperlabs.comm.discovery;
 
 import "io/casperlabs/comm/discovery/node.proto";
 
-message Ping {
-  Node   sender         = 1;
+service KademliaService {
+    rpc Ping (PingRequest) returns (PingResponse) {}
+    rpc Lookup (LookupRequest) returns (LookupResponse) {}
 }
 
-message Pong {
+message PingRequest {
+    Node sender = 1;
 }
 
-message Lookup {
-  bytes  id     = 1;
-  Node   sender = 2;
+message PingResponse {}
+
+message LookupRequest {
+    bytes id = 1;
+    Node sender = 2;
 }
 
 message LookupResponse {
     repeated Node nodes = 1;
-}
-
-service KademliaRPCService {
-  rpc SendPing (Ping) returns (Pong) {}
-  rpc SendLookup (Lookup) returns (LookupResponse) {}
 }


### PR DESCRIPTION
## Overview
Changes the `peers` method on `NodeDiscovery` to `alivePeersAscendingDistance`. It will be used in the relaying mechanism ([ticket](https://casperlabs.atlassian.net/browse/NODE-310))

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-314

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.