### PR TITLE
NO-TICKET: Return on 'lookup' the asked node itself if it's contained in the peer table

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -140,8 +140,11 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Sync: Log: Time: Metrics: Kadem
       }
 
     for {
-      shortlist   <- table.lookup(toLookup).map(_.take(alpha))
-      closestNode <- loop(0, Set(id), shortlist)(None)
+      shortlist <- table.lookup(toLookup).map(_.take(alpha))
+      closestNode <- shortlist.headOption
+                      .filter(_.key == toLookup.key)
+                      .fold(loop(0, Set(id), shortlist)(None))(_.some.pure[F])
+
     } yield closestNode
   }
 

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -116,18 +116,14 @@ final class PeerTable[F[_]: Monad](
                     .filter(_.node.key != candidate.node.key)
                   table.updated(index, updated)
                 }
-              }
+            }
           )
     } yield ()
   }
 
   def lookup(toLookup: NodeIdentifier): F[Seq[PeerNode]] =
     tableRef.get.map { table =>
-      sort(
-        table.flatten
-          .filterNot(_.node.key == toLookup.key),
-        toLookup
-      ).take(k).map(_.node).toList
+      sort(table.flatten.toList, toLookup).take(k).map(_.node)
     }
 
   def find(toFind: NodeIdentifier): F[Option[PeerNode]] =
@@ -152,6 +148,6 @@ final class PeerTable[F[_]: Monad](
         Ordering[BigInt].compare(
           PeerTable.xorDistance(target, x.node.id),
           PeerTable.xorDistance(target, y.node.id)
-        )
+      )
     )
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/DistanceSpec.scala
@@ -120,16 +120,6 @@ class DistanceSpec extends FlatSpec with Matchers {
       table.lookup(NodeIdentifier(b.rand(width))).size should be(scala.math.min(table.k, 8 * width))
     }
 
-    it should "not return sought peer on lookup" in {
-      val table = PeerTable(kr)
-      for (k <- oneOffs(kr)) {
-        table.updateLastSeen(PeerNode(k, endpoint))
-      }
-      val target = table.tableRef.get(table.width * 4).head
-      val resp   = table.lookup(target.node.id)
-      assert(resp.forall(_.key != target.node.key))
-    }
-
     it should s"return ${8 * width} peers when sequenced" in {
       val table = PeerTable(kr)
       for (k <- oneOffs(kr)) {


### PR DESCRIPTION
## Overview
As in the title, according to the [discussion](https://github.com/CasperLabs/CasperLabs/pull/314#discussion_r270855749)

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.