### PR TITLE
NODE-374:Trying to figure out why one of the NewBlock tests is flaky.

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -3,7 +3,7 @@ package io.casperlabs.comm.gossiping
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus._
 import io.casperlabs.comm.discovery.Node
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Gen, Shrink}
 import scala.collection.JavaConverters._
 
 object ArbitraryConsensus extends ArbitraryConsensus
@@ -209,4 +209,9 @@ trait ArbitraryConsensus {
       blocks    <- Gen.sequence(summaries.map(genBlockFromSummary))
     } yield blocks.asScala.toVector
 
+  // It doesn't make sense to shrink DAGs because the default shrink
+  // will most likely get rid of parents, and make any derived selections
+  // invalid too.
+  implicit val noShrinkBlockDag: Shrink[Vector[Block]]               = Shrink(_ => Stream.empty)
+  implicit val noShrinkBlockSummaryDag: Shrink[Vector[BlockSummary]] = Shrink(_ => Stream.empty)
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -29,6 +29,7 @@ class GrpcGossipServiceSpec
     with Eventually
     with Matchers
     with BeforeAndAfterAll
+    with SequentialNestedSuiteExecution
     with ArbitraryConsensus {
 
   import GrpcGossipServiceSpec._
@@ -470,7 +471,6 @@ class GrpcGossipServiceSpec
     // and there's an error, ScalaCheck can shrink down the input to where it becomes nonsensical.
     // For example if we select N targets from the DAG it can narrow down the data to where the DAG
     // has 0 items but there are non-zero targets.
-    // Later I added implicit noop Shrinks to DAG vectors so this could be avoided that way as well.
     case class TestCase[T](dag: Vector[BlockSummary], data: T) {
       lazy val summaries = TestData(summaries = dag).summaries
     }
@@ -850,15 +850,22 @@ class GrpcGossipServiceSpec
 
         "receives new blocks" should {
           "download the new ones" in {
+            case class TestCase(
+                dag: Vector[Block],
+                node: Node,
+                knownCount: Int,
+                newCount: Int
+            )
+
             val genTestCase = for {
-              dag        <- genBlockDag
-              node       <- arbitrary[Node].map(_.withId(stubCert.keyHash))
-              knownCount <- Gen.choose(1, dag.size / 2)
-              newCount   <- Gen.choose(1, dag.size - knownCount)
-            } yield (dag, node, knownCount, newCount)
+              dag  <- genBlockDag
+              node <- arbitrary[Node].map(_.withId(stubCert.keyHash))
+              k    <- Gen.choose(1, dag.size / 2)
+              n    <- Gen.choose(1, k)
+            } yield TestCase(dag, node, k, n)
 
             forAll(genTestCase) {
-              case (dag, node, k, n) =>
+              case TestCase(dag, node, k, n) =>
                 val knownBlocks   = dag.take(k)
                 val unknownBlocks = dag.drop(k)
                 val newBlocks     = unknownBlocks.takeRight(n)

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -825,14 +825,16 @@ class GrpcGossipServiceSpec
 
         "receives no previously unknown blocks" should {
           "return false and not download anything" in {
+            case class TestCase(dag: Vector[Block], node: Node, newCount: Int)
+
             val genTestCase = for {
               dag  <- genBlockDag
               node <- arbitrary[Node].map(_.withId(stubCert.keyHash))
               n    <- Gen.choose(0, dag.size)
-            } yield (dag, node, n)
+            } yield TestCase(dag, node, n)
 
             forAll(genTestCase) {
-              case (dag, node, n) =>
+              case TestCase(dag, node, n) =>
                 runTestUnsafe(TestData(blocks = dag)) {
                   val req = NewBlocksRequest()
                     .withSender(node)


### PR DESCRIPTION
## Overview
This test randomly fails on Drone for some reason. ScalaCheck shrinks the input and then it becomes even less meaningful, it might mask the original error. I couldn't reproduce the issue, but let's see if this helps.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-374

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
