### PR TITLE
CON-130: Change estimator to return block hashes instead of full blocks.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -104,8 +104,9 @@ object BlockAPI {
   ): F[IndexedSeq[BlockMessage]] =
     for {
       dag       <- MultiParentCasper[F].blockDag
-      estimates <- MultiParentCasper[F].estimator(dag)
-      tip       = estimates.head
+      tipHashes <- MultiParentCasper[F].estimator(dag)
+      tipHash   = tipHashes.head
+      tip       <- ProtoUtil.unsafeGetBlock[F](tipHash)
       mainChain <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[BlockMessage], depth)
     } yield mainChain
 
@@ -184,8 +185,9 @@ object BlockAPI {
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
         dag        <- MultiParentCasper[F].blockDag
-        estimates  <- MultiParentCasper[F].estimator(dag)
-        tip        = estimates.head
+        tipHashes  <- MultiParentCasper[F].estimator(dag)
+        tipHash    = tipHashes.head
+        tip        <- ProtoUtil.unsafeGetBlock[F](tipHash)
         mainChain  <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[BlockMessage], depth)
         blockInfos <- mainChain.toList.traverse(getBlockInfoWithoutTuplespace[F])
       } yield blockInfos

--- a/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
@@ -75,7 +75,7 @@ class ForkchoiceTest
                        genesis.blockHash,
                        Map.empty[Validator, BlockHash]
                      )
-      } yield forkchoice.head should be(genesis)
+      } yield forkchoice.head should be(genesis.blockHash)
   }
 
   // See https://docs.google.com/presentation/d/1znz01SF1ljriPzbMoFV0J127ryPglUYLFyhvsb-ftQk/edit?usp=sharing slide 29 for diagram
@@ -140,8 +140,8 @@ class ForkchoiceTest
                        genesis.blockHash,
                        latestBlocks
                      )
-        _      = forkchoice.head should be(b6)
-        result = forkchoice(1) should be(b8)
+        _      = forkchoice.head should be(b6.blockHash)
+        result = forkchoice(1) should be(b8.blockHash)
       } yield result
   }
 
@@ -210,8 +210,8 @@ class ForkchoiceTest
                        genesis.blockHash,
                        latestBlocks
                      )
-        _      = forkchoice.head should be(b8)
-        result = forkchoice(1) should be(b7)
+        _      = forkchoice.head should be(b8.blockHash)
+        result = forkchoice(1) should be(b7.blockHash)
       } yield result
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -138,9 +138,10 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _                    <- MultiParentCasper[Effect].addBlock(signedBlock, ignoreDoppelgangerCheck[Effect])
       _                    = logEff.warns.isEmpty should be(true)
       dag                  <- MultiParentCasper[Effect].blockDag
-      result               <- MultiParentCasper[Effect].estimator(dag) shouldBeF IndexedSeq(signedBlock)
+      estimate             <- MultiParentCasper[Effect].estimator(dag)
+      _                    = estimate shouldBe IndexedSeq(signedBlock.blockHash)
       _                    = node.tearDown()
-    } yield result
+    } yield ()
   }
 
   it should "be able to create a chain of blocks from different deploys" in effectTest {
@@ -169,7 +170,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _                     = logEff.warns shouldBe empty
       _                     = ProtoUtil.parentHashes(signedBlock2) should be(Seq(signedBlock1.blockHash))
       dag                   <- MultiParentCasper[Effect].blockDag
-      _                     <- MultiParentCasper[Effect].estimator(dag) shouldBeF IndexedSeq(signedBlock2)
+      estimate              <- MultiParentCasper[Effect].estimator(dag)
+
+      _ = estimate shouldBe IndexedSeq(signedBlock2.blockHash)
       _ = pendingUntilFixed {
         storage.contains("!(12)") should be(true)
       }

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -71,7 +71,7 @@ class ManyValidatorsTest
                            )
       newIndexedBlockDagStorage <- IndexedBlockDagStorage.create(newBlockDagStorage)
       dag                       <- newIndexedBlockDagStorage.getRepresentation
-      tips                      <- Estimator.tips[Task](dag, genesis.blockHash)(Monad[Task], blockStore)
+      tips                      <- Estimator.tips[Task](dag, genesis.blockHash)(Monad[Task])
       casperEffect <- NoOpsCasperEffect[Task](
                        HashMap.empty[BlockHash, BlockMsgWithTransform],
                        tips.toIndexedSeq

--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -392,7 +392,9 @@ class ValidateTest
 
                    _ = log.warns should have size (3)
                    result = log.warns.forall(
-                     _.contains("block parents did not match estimate based on justification")
+                     _.matches(
+                       ".* block parents .* did not match estimate .* based on justification .*"
+                     )
                    ) should be(
                      true
                    )

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -10,7 +10,7 @@ import io.casperlabs.casper.helper.HashSetCasperTestNode
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util._
 import io.casperlabs.casper.util.rholang._
-import io.casperlabs.casper.Estimator.Validator
+import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.crypto.signatures.Ed25519
@@ -90,7 +90,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   ): F[BlockStatus]                                     = underlying.addBlock(b, ignoreDoppelgangerCheck[F])
   def contains(b: BlockMessage): F[Boolean]             = underlying.contains(b)
   def deploy(d: DeployData): F[Either[Throwable, Unit]] = underlying.deploy(d)
-  def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockMessage]] =
+  def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     underlying.estimator(dag)
   def blockDag: F[BlockDagRepresentation[F]] = underlying.blockDag
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =


### PR DESCRIPTION
Signed-off-by: Abner Zheng <abnerzheng@gmail.com>

## Overview
Change estimator to return block hashes instead of full blocks since some caller doesn't need the full blocks. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
