### PR TITLE
NODE-334: Fix test node dockerfile.

### DIFF
--- a/docker/test-node.Dockerfile
+++ b/docker/test-node.Dockerfile
@@ -2,4 +2,5 @@ FROM casperlabs/node:latest
 
 # Using iproute2 for network simulation with `tc`.
 # iptables can also be used to block individual ports.
-RUN apt-get update && apt-get install -yq iproute2 iptables curl sed nmap
+# Double update due to: Could not open file /var/lib/apt/lists/deb.debian.org_debian_dists_stretch-backports_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
+RUN (apt-get update || apt-get update) && apt-get install -yq iproute2 iptables curl sed nmap


### PR DESCRIPTION
## Overview
I can't build the test node docker image for some strange reason. `apt-get update` can't find a file, but if I run it twice, it works.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
This is unrelated to the problem but facilitates https://casperlabs.atlassian.net/browse/NODE-334

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
