### PR TITLE
NODE-376: Fix processed deploys

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/BlockApproverProtocol.scala
@@ -157,7 +157,8 @@ object BlockApproverProtocol {
                              deploys.map(deploy2deploy)
                            )
                          ).leftMap(_.getMessage)
-      commutingEffects = ExecEngineUtil.findCommutingEffects(processedDeploys)
+      deployEffects    = ExecEngineUtil.processedDeployEffects(deploys zip processedDeploys)
+      commutingEffects = ExecEngineUtil.findCommutingEffects(deployEffects)
       transforms       = commutingEffects.unzip._1.flatMap(_.transformMap)
       postStateHash <- EitherT(
                         ExecutionEngineService[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -363,7 +363,10 @@ object HashSetCasperTestNode {
       private var bonds = initialBonds.map(p => Bond(ByteString.copyFrom(p._1), p._2)).toSeq
 
       private def getExecutionEffect(deploy: Deploy) = {
-        val key           = Key(Key.KeyInstance.Hash(KeyHash(ByteString.copyFromUtf8(deploy.toProtoString))))
+        // The real execution engine will get the keys from what the code changes, which will include
+        // changes to the account nonce for example, but not the deploy timestamp. Make sure the `key`
+        // here isn't more specific to a deploy then the real thing would be.
+        val key           = Key(Key.KeyInstance.Hash(KeyHash(deploy.sessionCode)))
         val transform     = Transform(Transform.TransformInstance.Identity(TransformIdentity()))
         val op            = Op(Op.OpInstance.Read(ReadOp()))
         val transforEntry = TransformEntry(Some(key), Some(transform))


### PR DESCRIPTION
## Overview
The `ExecEngineUtil` created a `Map` from effects to `DeployData`, however in my tests I was using the same WASM code repeatedly which resulted in all of them having the same effects, therefore the same key in the that map. The result was that the block was created with the expected number of deploys but the `ProcessedDeploy` records were pointing at the same `DeployData` instance. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-376

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
