### PR TITLE
NODE-374: Specify minimum block size in block chunk test

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -16,7 +16,9 @@ trait ArbitraryConsensus {
       dagSize: Int = 0,
       // Maximum size of code in blocks. Slow to generate.
       maxSessionCodeBytes: Int = 500 * 1024,
-      maxPaymentCodeBytes: Int = 100 * 1024
+      maxPaymentCodeBytes: Int = 100 * 1024,
+      minSessionCodeBytes: Int = 0,
+      minPaymentCodeBytes: Int = 0
   )
 
   def genBytes(length: Int): Gen[ByteString] =

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -67,9 +67,14 @@ class GrpcGossipServiceSpec
   )
 
   object GetBlockChunkedSpec extends WordSpecLike {
-    implicit val propCheckConfig = PropertyCheckConfiguration(minSuccessful = 3)
+    implicit val propCheckConfig = PropertyCheckConfiguration(minSuccessful = 1)
     implicit val patienceConfig  = PatienceConfig(1.second, 100.millis)
-    implicit val consensusConfig = ConsensusConfig()
+    implicit val consensusConfig = ConsensusConfig(
+      maxSessionCodeBytes = 500 * 1024,
+      minSessionCodeBytes = 400 * 1024,
+      maxPaymentCodeBytes = 300 * 1024,
+      minPaymentCodeBytes = 200 * 1024
+    )
 
     "getBlocksChunked" when {
       "no compression is supported" should {
@@ -822,7 +827,7 @@ class GrpcGossipServiceSpec
       }
 
       "called with a valid sender" when {
-        implicit val config = PropertyCheckConfiguration(minSuccessful = 100)
+        implicit val config = PropertyCheckConfiguration(minSuccessful = 5)
 
         "receives no previously unknown blocks" should {
           "return false and not download anything" in {


### PR DESCRIPTION
## Overview
On at least one occasion the test which checks that an abandoned stream is terminated early failed on Drone probably because gRPC already pre-fetched all the chunks (it was only 37 chunks). By making the test block bigger it should have less chance to do so.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
http://3.16.200.31/CasperLabs/CasperLabs/1443/10

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
