### PR TITLE
OP-131: Stop auto creation of  validators in peers

### DIFF
--- a/integration-testing/casperlabsnode_testing/casperlabsnode.py
+++ b/integration-testing/casperlabsnode_testing/casperlabsnode.py
@@ -436,12 +436,13 @@ def make_bootstrap_node(
         network_name=network,
     )
     container_command_options = {
-        "--casper-validator-private-key": key_pair.private_key,
-        "--casper-has-faucet": "",
         "--server-host": name,
+        "--tls-certificate": "/root/.casperlabs/bootstrap/node.certificate.pem",
+        "--tls-key": "/root/.casperlabs/bootstrap/node.key.pem",
+        "--casper-validator-private-key": key_pair.private_key,
+        "--casper-validator-public-key": key_pair.public_key,
+        "--grpc-socket": grpc_socket_file,
         "--metrics-prometheus": "",
-        "--server-data-dir=/root/.casperlabs": "",
-        "--grpc-socket": grpc_socket_file
     }
     if cli_options is not None:
         container_command_options.update(cli_options)
@@ -525,6 +526,9 @@ def make_peer(
     name = make_peer_name(network, name)
     bootstrap_address = bootstrap.get_casperlabsnode_address()
 
+    genesis_folder = "/tmp/resources/genesis"
+    bootstrap_folder = "/tmp/resources/bootstrap_certificate"
+
     container_command_options = {
         "--server-bootstrap": bootstrap_address,
         "--casper-validator-private-key": key_pair.private_key,
@@ -533,6 +537,16 @@ def make_peer(
         "--grpc-socket": grpc_socket_file
     }
 
+    volumes = {
+        bootstrap_folder: {
+            "bind": casperlabsnode_bootstrap_folder,
+            "mode": "rw"
+        },
+        genesis_folder: {
+            "bind": casperlabsnode_genesis_folder,
+            "mode": "rw"
+        }
+    }
     container = make_node(
         docker_client=docker_client,
         name=name,
@@ -541,7 +555,7 @@ def make_peer(
         container_command='run',
         container_command_options=container_command_options,
         command_timeout=command_timeout,
-        extra_volumes={},
+        extra_volumes=volumes,
         mem_limit=mem_limit if not None else '4G',
     )
     return container


### PR DESCRIPTION
## Overview
If a node does not find bonds.txt file in it's bootstrap folder, it will automatically creates validators.  In the process of exchanging blocks, peers of same network check for existence of public keys. Node will crash  if a public key does not exist.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.

https://casperlabs.atlassian.net/browse/OP-131

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
