### PR TITLE
NO TICKET: Stop all docker containers before removing their images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -298,6 +298,7 @@ pipeline:
     <<: *sbtenv
     group: cleanup
     commands:
+      - docker ps -qa | xargs --no-run-if-empty  docker stop | xargs --no-run-if-empty docker rm
       - docker images --filter "dangling=true" -q --no-trunc | xargs --no-run-if-empty docker rmi -f
       - docker images | grep "DRONE-${DRONE_BUILD_NUMBER}" | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f
     volumes:


### PR DESCRIPTION
## Overview
Stop and remove any docker containers in the clean up phase of build

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
