### PR TITLE
NODE-310: Relaying blocks

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
@@ -279,7 +279,7 @@ class DownloadManagerImpl[F[_]: Sync: Concurrent: Log](
         // This could arguably be done by `storeBlock` but this way it's explicit,
         // so we don't forget to talk to both kind of storages.
         _ <- backend.storeBlockSummary(summary)
-        _ <- if (relay) relaying.relay(summary) else ().pure[F]
+        _ <- if (relay) relaying.relay(List(summary.blockHash)) else ().pure[F]
         _ <- success
       } yield ()
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManagerImpl.scala
@@ -62,7 +62,8 @@ object DownloadManagerImpl {
   def apply[F[_]: Concurrent: Log](
       maxParallelDownloads: Int,
       connectToGossip: Node => F[GossipService[F]],
-      backend: Backend[F]
+      backend: Backend[F],
+      relaying: Relaying[F]
   ): Resource[F, DownloadManager[F]] =
     Resource.make {
       for {
@@ -78,7 +79,8 @@ object DownloadManagerImpl {
           semaphore,
           signal,
           connectToGossip,
-          backend
+          backend,
+          relaying
         )
         managerLoop <- Concurrent[F].start(manager.run)
       } yield (isShutdown, workersRef, managerLoop, manager)
@@ -115,7 +117,8 @@ class DownloadManagerImpl[F[_]: Sync: Concurrent: Log](
     signal: MVar[F, DownloadManagerImpl.Signal[F]],
     // Establish gRPC connection to another node.
     connectToGossip: Node => F[GossipService[F]],
-    backend: DownloadManagerImpl.Backend[F]
+    backend: DownloadManagerImpl.Backend[F],
+    relaying: Relaying[F]
 ) extends DownloadManager[F] {
 
   import DownloadManagerImpl._
@@ -276,7 +279,7 @@ class DownloadManagerImpl[F[_]: Sync: Concurrent: Log](
         // This could arguably be done by `storeBlock` but this way it's explicit,
         // so we don't forget to talk to both kind of storages.
         _ <- backend.storeBlockSummary(summary)
-        // TODO: Gossip
+        _ <- if (relay) relaying.relay(summary) else ().pure[F]
         _ <- success
       } yield ()
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
@@ -1,0 +1,64 @@
+package io.casperlabs.comm.gossiping
+
+import cats.effect._
+import cats.implicits._
+import cats.temp.par._
+import io.casperlabs.casper.consensus.BlockSummary
+import io.casperlabs.comm.NodeAsk
+import io.casperlabs.comm.discovery.{Node, NodeDiscovery}
+import simulacrum.typeclass
+
+import scala.util.Random
+
+@typeclass
+trait Relaying[F[_]] {
+  def relay(summary: BlockSummary): F[Unit]
+}
+
+/**
+  * https://techspec.casperlabs.io/technical-details/global-state/communications#picking-nodes-for-gossip
+  */
+class RelayingImpl[F[_]: Sync: Par: NodeAsk](
+    nd: NodeDiscovery[F],
+    connectToGossip: Node => F[GossipService[F]],
+    relayFactor: Int,
+    relaySaturation: Int
+) extends Relaying[F] {
+  private val maxToTry =
+    try {
+      (relayFactor * 100) / (100 - relaySaturation)
+    } catch {
+      case e: ArithmeticException if e.getMessage.contains("/ by zero") => Int.MaxValue
+    }
+
+  override def relay(summary: BlockSummary): F[Unit] = {
+    def loop(peers: List[Node], contacted: Int): F[Unit] = {
+      val parallelism = math.min(relayFactor, maxToTry - contacted)
+      if (parallelism > 0 && peers.nonEmpty) {
+        val (recipients, rest) = Random.shuffle(peers).splitAt(parallelism)
+        for {
+          results <- recipients.parTraverse(relay(_, summary))
+          _ <- if (results.exists(!_))
+                loop(rest, contacted + recipients.size)
+              else
+                ().pure[F]
+        } yield ()
+      } else {
+        ().pure[F]
+      }
+    }
+
+    for {
+      peers <- nd.alivePeersAscendingDistance
+      _     <- loop(peers, 0)
+    } yield ()
+  }
+
+  private def relay(peer: Node, summary: BlockSummary): F[Boolean] =
+    (for {
+      service <- connectToGossip(peer)
+      local   <- NodeAsk[F].ask
+      response <- service.newBlocks(
+                   NewBlocksRequest(sender = local.some, blockHashes = List(summary.blockHash)))
+    } yield response.isNew).handleError(_ => false)
+}

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
@@ -76,10 +76,10 @@ class RelayingImpl[F[_]: Sync: Par: Log: NodeAsk](
         s"${peer.show} accepted block for downloading ${toStr(hash)}"
       else
         s"${peer.show} rejected block ${toStr(hash)}"
-      _ <- Log[F].trace(msg)
+      _ <- Log[F].debug(msg)
     } yield response.isNew).handleErrorWith { e =>
       for {
-        _ <- Log[F].trace(s"Request failed ${peer.show}, $e")
+        _ <- Log[F].debug(s"NewBlocks request failed ${peer.show}, $e")
       } yield false
     }
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
@@ -3,20 +3,23 @@ package io.casperlabs.comm.gossiping
 import cats.effect._
 import cats.implicits._
 import cats.temp.par._
-import io.casperlabs.casper.consensus.BlockSummary
+import com.google.protobuf.ByteString
 import io.casperlabs.comm.NodeAsk
+import io.casperlabs.comm.discovery.NodeUtils._
 import io.casperlabs.comm.discovery.{Node, NodeDiscovery}
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.shared.Log
 import simulacrum.typeclass
 
 import scala.util.Random
 
 @typeclass
 trait Relaying[F[_]] {
-  def relay(summary: BlockSummary): F[Unit]
+  def relay(hashes: List[ByteString]): F[Unit]
 }
 
 object RelayingImpl {
-  def apply[F[_]: Sync: Par: NodeAsk](
+  def apply[F[_]: Sync: Par: Log: NodeAsk](
       nd: NodeDiscovery[F],
       connectToGossip: Node => F[GossipService[F]],
       relayFactor: Int,
@@ -34,22 +37,22 @@ object RelayingImpl {
 /**
   * https://techspec.casperlabs.io/technical-details/global-state/communications#picking-nodes-for-gossip
   */
-class RelayingImpl[F[_]: Sync: Par: NodeAsk](
+class RelayingImpl[F[_]: Sync: Par: Log: NodeAsk](
     nd: NodeDiscovery[F],
     connectToGossip: Node => F[GossipService[F]],
     relayFactor: Int,
     maxToTry: Int
 ) extends Relaying[F] {
 
-  override def relay(summary: BlockSummary): F[Unit] = {
-    def loop(peers: List[Node], contacted: Int): F[Unit] = {
+  override def relay(hashes: List[ByteString]): F[Unit] = {
+    def loop(hash: ByteString, peers: List[Node], contacted: Int): F[Unit] = {
       val parallelism = math.min(relayFactor, maxToTry - contacted)
       if (parallelism > 0 && peers.nonEmpty) {
         val (recipients, rest) = Random.shuffle(peers).splitAt(parallelism)
         for {
-          results <- recipients.parTraverse(relay(_, summary))
+          results <- recipients.parTraverse(relay(_, hash))
           _ <- if (results.exists(!_))
-                loop(rest, contacted + recipients.size)
+                loop(hash, rest, contacted + recipients.size)
               else
                 ().pure[F]
         } yield ()
@@ -60,15 +63,25 @@ class RelayingImpl[F[_]: Sync: Par: NodeAsk](
 
     for {
       peers <- nd.alivePeersAscendingDistance
-      _     <- loop(peers, 0)
+      _     <- hashes.parTraverse(hash => loop(hash, peers, 0))
     } yield ()
   }
 
-  private def relay(peer: Node, summary: BlockSummary): F[Boolean] =
+  private def relay(peer: Node, hash: ByteString): F[Boolean] =
     (for {
-      service <- connectToGossip(peer)
-      local   <- NodeAsk[F].ask
-      response <- service.newBlocks(
-                   NewBlocksRequest(sender = local.some, blockHashes = List(summary.blockHash)))
-    } yield response.isNew).handleError(_ => false)
+      service  <- connectToGossip(peer)
+      local    <- NodeAsk[F].ask
+      response <- service.newBlocks(NewBlocksRequest(sender = local.some, blockHashes = List(hash)))
+      msg = if (response.isNew)
+        s"${peer.show} accepted block for downloading ${toStr(hash)}"
+      else
+        s"${peer.show} rejected block ${toStr(hash)}"
+      _ <- Log[F].trace(msg)
+    } yield response.isNew).handleErrorWith { e =>
+      for {
+        _ <- Log[F].trace(s"Request failed ${peer.show}, $e")
+      } yield false
+    }
+
+  private def toStr(hash: ByteString): String = Base16.encode(hash.toByteArray)
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
@@ -22,10 +22,10 @@ object RelayingImpl {
       relayFactor: Int,
       relaySaturation: Int
   ): Relaying[F] = {
-    val maxToTry = try {
+    val maxToTry = if (relaySaturation == 100) {
+      Int.MaxValue
+    } else {
       (relayFactor * 100) / (100 - relaySaturation)
-    } catch {
-      case e: ArithmeticException if e.getMessage.contains("/ by zero") => Int.MaxValue
     }
     new RelayingImpl[F](nd, connectToGossip, relayFactor, maxToTry)
   }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -26,6 +26,16 @@ trait ArbitraryConsensus {
       ByteString.copyFrom(bytes.toArray)
     }
 
+  // A generators .sample.get can sometimes return None, but these examples have no reason to not generate a result,
+  // so defend against that and retry if it does happen.
+  def sample[T](g: Gen[T]): T = {
+    def loop(i: Int): T = {
+      assert(i > 0, "Should be able to generate a sample.")
+      g.sample.fold(loop(i - 1))(identity)
+    }
+    loop(10)
+  }
+
   val genHash = genBytes(20)
   val genKey  = genBytes(32)
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -152,7 +152,7 @@ class DownloadManagerSpec
             ws <- scheduleAll(manager)
             _  <- awaitAll(ws)
           } yield {
-            relaying.relayed should contain theSameElementsAs relayed.map(summaryOf)
+            relaying.relayed should contain theSameElementsAs relayed.map(_.blockHash)
           }
       }
     }
@@ -539,10 +539,10 @@ object DownloadManagerSpec {
   }
 
   class MockRelaying extends Relaying[Task] {
-    @volatile var relayed = Vector.empty[BlockSummary]
+    @volatile var relayed = Vector.empty[ByteString]
 
-    override def relay(summary: BlockSummary): Task[Unit] = Task.delay {
-      synchronized { relayed = relayed :+ summary }
+    override def relay(hashes: List[ByteString]): Task[Unit] = Task.delay {
+      synchronized { relayed = relayed ++ hashes }
     }
   }
   object MockRelaying {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -1,0 +1,142 @@
+package io.casperlabs.comm.gossiping
+
+import cats.Applicative
+import cats.mtl.DefaultApplicativeAsk
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.comm.NodeAsk
+import io.casperlabs.comm.discovery.NodeUtils._
+import io.casperlabs.comm.discovery.{Node, NodeDiscovery, NodeIdentifier}
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import monix.execution.atomic.AtomicInt
+import monix.tail.Iterant
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+class RelayingSpec
+    extends WordSpecLike
+    with Matchers
+    with BeforeAndAfterEach
+    with ArbitraryConsensus
+    with GeneratorDrivenPropertyChecks {
+  import RelayingSpec._
+  private implicit val consensusConfig: ConsensusConfig = ConsensusConfig()
+  private implicit val arbListNode: Arbitrary[List[Node]] = Arbitrary {
+    for {
+      n     <- Gen.choose(2, 10)
+      nodes <- Gen.listOfN(n, arbitrary[Node])
+    } yield nodes
+  }
+  private implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
+
+  override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
+    PropertyCheckConfiguration(
+      minSuccessful = 500
+    )
+
+  private val summary = summaryOf(sample(arbitrary[Block]))
+
+  "Relaying" when {
+    "scheduled to relay a block" should {
+      "try to achieve certain level of 'relay factor" in
+        forAll { peers: List[Node] =>
+          TestFixture(peers.size / 2, 0, peers, _ => false) { (relaying, asked) =>
+            for {
+              _ <- relaying.relay(summary)
+            } yield asked.get() shouldBe (peers.size / 2)
+          }
+        }
+
+      "stop trying to relay a block if already achieved specified relay saturation" in
+        forAll { peers: List[Node] =>
+          TestFixture(1, 50, peers, _ => false) { (relaying, asked) =>
+            for {
+              _ <- relaying.relay(summary)
+            } yield asked.get() shouldBe 2
+          }
+        }
+
+      "stop trying to relay a block if already gossiped to 'relay factor' number of peers" in
+        forAll { peers: List[Node] =>
+          val relayFactor = Random.nextInt(peers.size) + 1
+          TestFixture(relayFactor, 100, peers, _ => true) { (relaying, asked) =>
+            for {
+              _ <- relaying.relay(summary)
+            } yield asked.get() shouldBe relayFactor
+          }
+        }
+    }
+  }
+}
+
+object RelayingSpec {
+  private val local = Node(NodeIdentifier("0000"), "localhost", 40400, 40404)
+
+  private implicit val ask: NodeAsk[Task] = new DefaultApplicativeAsk[Task, Node] {
+    val applicative: Applicative[Task] = Applicative[Task]
+    def ask: Task[Node]                = Task.pure(local)
+  }
+
+  def summaryOf(block: Block): BlockSummary =
+    BlockSummary()
+      .withBlockHash(block.blockHash)
+      .withHeader(block.getHeader)
+      .withSignature(block.getSignature)
+
+  class GossipServiceMock extends GossipService[Task] {
+    override def newBlocks(request: NewBlocksRequest): Task[NewBlocksResponse] = ???
+
+    override def streamAncestorBlockSummaries(
+        request: StreamAncestorBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
+
+    override def streamDagTipBlockSummaries(
+        request: StreamDagTipBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
+
+    override def streamBlockSummaries(
+        request: StreamBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
+
+    /** Get a full block in chunks, optionally compressed, so that it can be transferred over the wire. */
+    override def getBlockChunked(request: GetBlockChunkedRequest): Iterant[Task, Chunk] = ???
+  }
+
+  object TestFixture {
+    def apply(relayFactor: Int, relaySaturation: Int, peers: List[Node], accept: Node => Boolean)(
+        test: (Relaying[Task], AtomicInt) => Task[Unit]): Unit = {
+      val nd = new NodeDiscovery[Task] {
+        override def discover: Task[Unit]                           = ???
+        override def lookup(id: NodeIdentifier): Task[Option[Node]] = ???
+        override def alivePeersAscendingDistance: Task[List[Node]]  = Task.now(peers)
+      }
+      val asked = AtomicInt(0)
+
+      val gossipService = (peer: Node) =>
+        Task.delay {
+          asked.increment()
+          new GossipService[Task] {
+            override def newBlocks(request: NewBlocksRequest): Task[NewBlocksResponse] =
+              Task.now(NewBlocksResponse(accept(peer)))
+
+            override def streamAncestorBlockSummaries(
+                request: StreamAncestorBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
+
+            override def streamDagTipBlockSummaries(
+                request: StreamDagTipBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
+
+            override def streamBlockSummaries(
+                request: StreamBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
+
+            /** Get a full block in chunks, optionally compressed, so that it can be transferred over the wire. */
+            override def getBlockChunked(request: GetBlockChunkedRequest): Iterant[Task, Chunk] =
+              ???
+          }
+      }
+      val relayingImpl = new RelayingImpl[Task](nd, gossipService, relayFactor, relaySaturation)
+      test(relayingImpl, asked).runSyncUnsafe(5.seconds)
+    }
+  }
+}

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -3,21 +3,25 @@ package io.casperlabs.comm.gossiping
 import cats.Applicative
 import cats.effect.Sync
 import cats.mtl.DefaultApplicativeAsk
+import cats.syntax.option._
 import cats.temp.par.Par
+import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.comm.NodeAsk
 import io.casperlabs.comm.discovery.NodeUtils._
 import io.casperlabs.comm.discovery.{Node, NodeDiscovery, NodeIdentifier}
+import io.casperlabs.p2p.EffectsTestInstances.LogStub
 import io.casperlabs.shared.Log
 import io.casperlabs.shared.Log.NOPLog
 import monix.eval.Task
+import monix.eval.instances.CatsParallelForTask
 import monix.execution.Scheduler.Implicits.global
 import monix.execution.atomic.AtomicInt
 import monix.tail.Iterant
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterEach, Inspectors, Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 import scala.util.Random
@@ -29,36 +33,34 @@ class RelayingSpec
     with ArbitraryConsensus
     with GeneratorDrivenPropertyChecks {
   import RelayingSpec._
-  private implicit val consensusConfig: ConsensusConfig = ConsensusConfig()
-  private implicit val arbListNode: Arbitrary[List[Node]] = Arbitrary {
+  private val genListNode: Gen[List[Node]] =
     for {
       n     <- Gen.choose(2, 10)
       nodes <- Gen.listOfN(n, arbitrary[Node])
     } yield nodes
-  }
+
   private implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   override implicit val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(
-      minSuccessful = 500
+      minSuccessful = 50
     )
 
-  private val hash = sample(genHash)
-
   "Relaying" when {
-    "scheduled to relay a block" should {
+    "scheduled to relay blocks" should {
       "try to achieve certain level of 'relay factor" in
-        forAll { peers: List[Node] =>
-          TestFixture(peers.size / 2, 0, peers, accept = _ => false) { (relaying, asked) =>
-            for {
-              _ <- relaying.relay(List(hash))
-            } yield asked.get() shouldBe (peers.size / 2)
+        forAll(genListNode, genHash) { (peers: List[Node], hash: ByteString) =>
+          TestFixture(peers.size / 2, 0, peers, acceptOrFailure = _ => false.some) {
+            (relaying, asked, _) =>
+              for {
+                _ <- relaying.relay(List(hash))
+              } yield asked.get() shouldBe (peers.size / 2)
           }
         }
 
       "stop trying to relay a block if already achieved specified relay saturation" in
-        forAll { peers: List[Node] =>
-          TestFixture(1, 50, peers, accept = _ => false) { (relaying, asked) =>
+        forAll(genListNode, genHash) { (peers: List[Node], hash: ByteString) =>
+          TestFixture(1, 50, peers, acceptOrFailure = _ => false.some) { (relaying, asked, _) =>
             for {
               _ <- relaying.relay(List(hash))
             } yield asked.get() shouldBe 2
@@ -66,13 +68,39 @@ class RelayingSpec
         }
 
       "stop trying to relay a block if already gossiped to 'relay factor' number of peers" in
-        forAll { peers: List[Node] =>
+        forAll(genListNode, genHash) { (peers: List[Node], hash: ByteString) =>
           val relayFactor = Random.nextInt(peers.size) + 1
-          TestFixture(relayFactor, 100, peers, accept = _ => true) { (relaying, asked) =>
-            for {
-              _ <- relaying.relay(List(hash))
-            } yield asked.get() shouldBe relayFactor
+          TestFixture(relayFactor, 100, peers, acceptOrFailure = _ => true.some) {
+            (relaying, asked, _) =>
+              for {
+                _ <- relaying.relay(List(hash))
+              } yield asked.get() shouldBe relayFactor
           }
+        }
+      "not stop gossiping if received an error" in
+        forAll(genListNode, genHash) { (peers: List[Node], hash: ByteString) =>
+          val log = new LogStub[Task]()
+
+          TestFixture(peers.size, 100, peers, acceptOrFailure = _ => none[Boolean], log) {
+            (relaying, asked, _) =>
+              for {
+                _ <- relaying.relay(List(hash))
+              } yield {
+                asked.get() shouldBe peers.size
+                log.debugs.size shouldBe peers.size
+                Inspectors.forAll(log.debugs)(msg => msg should include("NewBlocks request failed"))
+              }
+          }
+        }
+      "relay blocks in parallel" in
+        forAll(genListNode, genHash, genHash, genHash) {
+          (peers: List[Node], hash1: ByteString, hash2: ByteString, hash3) =>
+            TestFixture(peers.size, 100, peers, acceptOrFailure = _ => false.some) {
+              (relaying, _, maxConcurrentRequests) =>
+                for {
+                  _ <- relaying.relay(List(hash1, hash2, hash3))
+                } yield maxConcurrentRequests.get() should be > 1
+            }
         }
     }
   }
@@ -114,21 +142,36 @@ object RelayingSpec {
     def apply(relayFactor: Int,
               relaySaturation: Int,
               peers: List[Node],
-              accept: Node => Boolean,
-              log: Log[Task] = noOpLog)(test: (Relaying[Task], AtomicInt) => Task[Unit]): Unit = {
+              acceptOrFailure: Node => Option[Boolean],
+              log: Log[Task] = noOpLog)(
+        test: (Relaying[Task], AtomicInt, AtomicInt) => Task[Unit]): Unit = {
       val nd = new NodeDiscovery[Task] {
         override def discover: Task[Unit]                           = ???
         override def lookup(id: NodeIdentifier): Task[Option[Node]] = ???
         override def alivePeersAscendingDistance: Task[List[Node]]  = Task.now(peers)
       }
-      val asked = AtomicInt(0)
+      val asked                 = AtomicInt(0)
+      val concurrency           = AtomicInt(0)
+      val maxConcurrentRequests = AtomicInt(0)
 
       val gossipService = (peer: Node) =>
-        Task.delay {
-          asked.increment()
+        for {
+          _ <- Task.delay {
+                asked.increment()
+                concurrency.increment()
+              }
+          // We need to ensure that requests are concurrent
+          _ <- Task.sleep(10.millis)
+          _ <- Task.delay {
+                maxConcurrentRequests.transform(math.max(_, concurrency.get()))
+                concurrency.decrement()
+              }
+        } yield
           new GossipService[Task] {
             override def newBlocks(request: NewBlocksRequest): Task[NewBlocksResponse] =
-              Task.now(NewBlocksResponse(accept(peer)))
+              acceptOrFailure(peer).fold(
+                Task.raiseError[NewBlocksResponse](new RuntimeException("Boom")))(accepted =>
+                Task.now(NewBlocksResponse(accepted)))
 
             override def streamAncestorBlockSummaries(
                 request: StreamAncestorBlockSummariesRequest): Iterant[Task, BlockSummary] = ???
@@ -142,14 +185,14 @@ object RelayingSpec {
             /** Get a full block in chunks, optionally compressed, so that it can be transferred over the wire. */
             override def getBlockChunked(request: GetBlockChunkedRequest): Iterant[Task, Chunk] =
               ???
-          }
-      }
+        }
+
       val relayingImpl = RelayingImpl[Task](nd, gossipService, relayFactor, relaySaturation)(
         Sync[Task],
-        Par[Task],
+        Par.fromParallel(CatsParallelForTask),
         log,
         ask)
-      test(relayingImpl, asked).runSyncUnsafe(5.seconds)
+      test(relayingImpl, asked, maxConcurrentRequests).runSyncUnsafe(5.seconds)
     }
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -39,13 +39,13 @@ class RelayingSpec
       minSuccessful = 500
     )
 
-  private val summary = summaryOf(sample(arbitrary[Block]))
+  private val summary = sample(arbitrary[BlockSummary])
 
   "Relaying" when {
     "scheduled to relay a block" should {
       "try to achieve certain level of 'relay factor" in
         forAll { peers: List[Node] =>
-          TestFixture(peers.size / 2, 0, peers, _ => false) { (relaying, asked) =>
+          TestFixture(peers.size / 2, 0, peers, accept = _ => false) { (relaying, asked) =>
             for {
               _ <- relaying.relay(summary)
             } yield asked.get() shouldBe (peers.size / 2)
@@ -54,7 +54,7 @@ class RelayingSpec
 
       "stop trying to relay a block if already achieved specified relay saturation" in
         forAll { peers: List[Node] =>
-          TestFixture(1, 50, peers, _ => false) { (relaying, asked) =>
+          TestFixture(1, 50, peers, accept = _ => false) { (relaying, asked) =>
             for {
               _ <- relaying.relay(summary)
             } yield asked.get() shouldBe 2
@@ -64,7 +64,7 @@ class RelayingSpec
       "stop trying to relay a block if already gossiped to 'relay factor' number of peers" in
         forAll { peers: List[Node] =>
           val relayFactor = Random.nextInt(peers.size) + 1
-          TestFixture(relayFactor, 100, peers, _ => true) { (relaying, asked) =>
+          TestFixture(relayFactor, 100, peers, accept = _ => true) { (relaying, asked) =>
             for {
               _ <- relaying.relay(summary)
             } yield asked.get() shouldBe relayFactor

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -135,7 +135,7 @@ object RelayingSpec {
               ???
           }
       }
-      val relayingImpl = new RelayingImpl[Task](nd, gossipService, relayFactor, relaySaturation)
+      val relayingImpl = RelayingImpl[Task](nd, gossipService, relayFactor, relaySaturation)
       test(relayingImpl, asked).runSyncUnsafe(5.seconds)
     }
   }

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -107,11 +107,11 @@ object EffectsTestInstances {
 
   class LogStub[F[_]: Applicative] extends Log[F] {
 
-    var debugs: Vector[String]    = Vector.empty[String]
-    var infos: Vector[String]     = Vector.empty[String]
-    var warns: Vector[String]     = Vector.empty[String]
-    var errors: Vector[String]    = Vector.empty[String]
-    var causes: Vector[Throwable] = Vector.empty[Throwable]
+    @volatile var debugs: Vector[String]    = Vector.empty[String]
+    @volatile var infos: Vector[String]     = Vector.empty[String]
+    @volatile var warns: Vector[String]     = Vector.empty[String]
+    @volatile var errors: Vector[String]    = Vector.empty[String]
+    @volatile var causes: Vector[Throwable] = Vector.empty[Throwable]
 
     // To be able to reconstruct the timeline.
     var all: Vector[String] = Vector.empty[String]
@@ -126,27 +126,27 @@ object EffectsTestInstances {
     }
     def isTraceEnabled(implicit ev: LogSource): F[Boolean]  = false.pure[F]
     def trace(msg: String)(implicit ev: LogSource): F[Unit] = ().pure[F]
-    def debug(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def debug(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
       debugs = debugs :+ msg
       all = all :+ msg
       ().pure[F]
     }
-    def info(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def info(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
       infos = infos :+ msg
       all = all :+ msg
       ().pure[F]
     }
-    def warn(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def warn(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
       warns = warns :+ msg
       all = all :+ msg
       ().pure[F]
     }
-    def error(msg: String)(implicit ev: LogSource): F[Unit] = {
+    def error(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
       errors = errors :+ msg
       all = all :+ msg
       ().pure[F]
     }
-    def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = {
+    def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = synchronized {
       causes = causes :+ cause
       errors = errors :+ msg
       all = all :+ msg


### PR DESCRIPTION
## Overview
This is the most naive implementation, @aakoshh please leave your thoughts about it, we may want to make it more complex with buffering of relaying blocks somewhat similar to `DownloadManager`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-310

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.