### PR TITLE
[EE-155] Enable the usage of FileLMDBIndexBlockStore and BlockDagFileStorage in Node.

### DIFF
--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockDagFileStorage.scala
@@ -364,7 +364,7 @@ class BlockDagFileStorage[F[_]: Concurrent: Log: BlockStore: RaiseIOError] priva
             }
           }
       _ <- updateLatestMessagesFile(
-            (newValidators + block.sender).toList,
+            newValidatorsWithSender.toList,
             block.blockHash
           )
       _ <- updateDataLookupFile(blockMetadata)

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/FileLMDBIndexBlockStore.scala
@@ -20,6 +20,7 @@ import io.casperlabs.blockstorage.util.fileIO._
 import io.casperlabs.blockstorage.util.fileIO.IOError
 import io.casperlabs.casper.protocol.BlockMessage
 import io.casperlabs.catscontrib.MonadStateOps._
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared.ByteStringOps._
 import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockMsgWithTransform
@@ -282,7 +283,7 @@ object FileLMDBIndexBlockStore {
       }
     } yield result
 
-  def create[F[_]: Concurrent: Log](
+  def create[F[_]: Concurrent: Log: Metrics](
       env: Env[ByteBuffer],
       blockStoreDataDir: Path
   ): F[StorageErr[BlockStore[F]]] =

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/util/fileIO/package.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/util/fileIO/package.scala
@@ -62,8 +62,8 @@ package object fileIO {
   def isRegularFile[F[_]: Sync: RaiseIOError](path: Path): F[Boolean] =
     handleIo(Files.isRegularFile(path), UnexpectedIOError.apply)
 
-  def makeDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[Boolean] =
-    handleIo(dirPath.toFile.mkdir(), UnexpectedIOError.apply)
+  def makeDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[Path] =
+    handleIo(Files.createDirectories(dirPath), UnexpectedIOError.apply)
 
   def listInDirectory[F[_]: Sync: RaiseIOError](dirPath: Path): F[List[Path]] =
     for {

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
@@ -120,6 +120,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
 
   private def createBlockStore(blockStoreDataDir: Path): Task[BlockStore[Task]] = {
     implicit val log = new Log.NOPLog[Task]()
+    implicit val met = new MetricsNOP[Task]
     val env          = Context.env(blockStoreDataDir, 100L * 1024L * 1024L * 4096L)
     FileLMDBIndexBlockStore.create[Task](env, blockStoreDataDir).map(_.right.get)
   }

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
@@ -4,6 +4,7 @@ import java.nio.file.StandardOpenOption
 
 import cats.effect.Sync
 import cats.implicits._
+import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.BlockDagRepresentation.Validator
 import io.casperlabs.blockstorage.BlockStore.BlockHash
 import io.casperlabs.blockstorage.util.byteOps._
@@ -189,7 +190,11 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
     val (list, latestMessageHashes, latestMessages, topoSort, topoSortTail) = lookupResult
     val realLatestMessages = blockElements.foldLeft(Map.empty[Validator, BlockMetadata]) {
       case (lm, b) =>
-        lm.updated(b.sender, BlockMetadata.fromBlock(b))
+        // Ignore empty sender for genesis block
+        if (b.sender != ByteString.EMPTY)
+          lm.updated(b.sender, BlockMetadata.fromBlock(b))
+        else
+          lm
     }
     list.zip(blockElements).foreach {
       case ((blockMetadata, latestMessageHash, latestMessage, children, contains), b) =>
@@ -205,8 +210,8 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           )
         contains shouldBe true
     }
-    latestMessageHashes shouldBe blockElements.map(b => b.sender -> b.blockHash).toMap
-    latestMessages shouldBe blockElements.map(b => b.sender      -> BlockMetadata.fromBlock(b)).toMap
+    latestMessageHashes shouldBe realLatestMessages.mapValues(_.blockHash)
+    latestMessages shouldBe realLatestMessages
 
     def normalize(topoSort: Vector[Vector[BlockHash]]): Vector[Vector[BlockHash]] =
       if (topoSort.size == 1 && topoSort.head.isEmpty)
@@ -230,6 +235,28 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
           result        <- lookupElements(blockElements, secondStorage)
           _             <- secondStorage.close()
         } yield testLookupElementsResult(result, blockElements.flatMap(_.blockMessage))
+      }
+    }
+  }
+
+  it should "be able to restore latest messages with genesis with empty sender field" in {
+    forAll(blockElementsWithParentsGen, minSize(0), sizeRange(10)) { blockElements =>
+      val blockElementsWithGenesis = blockElements match {
+        case x :: xs =>
+          val genesis = x.update(_.blockMessage.sender := ByteString.EMPTY)
+          genesis :: xs
+        case Nil =>
+          Nil
+      }
+      withDagStorageLocation { (dagDataDir, blockStore) =>
+        for {
+          firstStorage  <- createAtDefaultLocation(dagDataDir)(blockStore)
+          _             <- blockElementsWithGenesis.traverse_(b => firstStorage.insert(b.getBlockMessage))
+          _             <- firstStorage.close()
+          secondStorage <- createAtDefaultLocation(dagDataDir)(blockStore)
+          result        <- lookupElements(blockElementsWithGenesis, secondStorage)
+          _             <- secondStorage.close()
+        } yield testLookupElementsResult(result, blockElementsWithGenesis.flatMap(_.blockMessage))
       }
     }
   }

--- a/integration-testing/test/test_persistent_dag_store.py
+++ b/integration-testing/test/test_persistent_dag_store.py
@@ -42,5 +42,5 @@ def test_persistent_dag_store(command_line_options_fixture, docker_client_fixtur
             wait_for_streamed_packet(network.bootstrap, network.peers[0].name, context.node_startup_timeout)
             wait_for_finalised_hash(network.bootstrap, hash_string, context.node_startup_timeout * 3)
             wait_for_finalised_hash(network.peers[0], '', context.node_startup_timeout * 3)
-            number_of_blocks = 3
+            number_of_blocks = 1
             wait_for_metrics_and_assert_blocks_avaialable(network.peers[0], context.node_startup_timeout * 3, number_of_blocks)

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -10,7 +10,14 @@ import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import io.casperlabs.blockstorage.BlockStore.BlockHash
-import io.casperlabs.blockstorage.{BlockStore, InMemBlockDagStorage, InMemBlockStore}
+import io.casperlabs.blockstorage.{
+  BlockDagFileStorage,
+  BlockStore,
+  Context,
+  FileLMDBIndexBlockStore,
+  InMemBlockDagStorage,
+  InMemBlockStore
+}
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper._
 import io.casperlabs.casper.util.comm.CasperPacketHandler
@@ -38,6 +45,9 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.http4s.server.blaze._
 import com.olegpy.meow.effects._
+import io.casperlabs.blockstorage.util.fileIO
+import io.casperlabs.blockstorage.util.fileIO.IOError
+import io.casperlabs.blockstorage.util.fileIO.IOError.RaiseIOError
 import io.casperlabs.storage.BlockMsgWithTransform
 
 import scala.concurrent.duration._
@@ -55,7 +65,8 @@ class NodeRuntime private[node] (
 
   private val initPeer = if (conf.casper.standalone) None else Some(conf.server.bootstrap)
 
-  private implicit val logSource: LogSource = LogSource(this.getClass)
+  private implicit val logSource: LogSource       = LogSource(this.getClass)
+  implicit val raiseIOError: RaiseIOError[Effect] = IOError.raiseIOErrorThroughSync[Effect]
 
   implicit def eitherTrpConfAsk(implicit ev: RPConfAsk[Task]): RPConfAsk[Effect] =
     new EitherTApplicativeAsk[Task, RPConf, CommError]
@@ -64,6 +75,8 @@ class NodeRuntime private[node] (
 
   private val port           = conf.server.port
   private val kademliaPort   = conf.server.kademliaPort
+  private val blockstorePath = conf.server.dataDir.resolve("blockstore")
+  private val dagStoragePath = conf.server.dataDir.resolve("dagstorage")
   private val defaultTimeout = FiniteDuration(conf.server.defaultTimeout.toLong, MILLISECONDS) // TODO remove
 
   case class Servers(
@@ -129,23 +142,25 @@ class NodeRuntime private[node] (
         conf.server.chunkSize,
         commTmpFolder
       )(grpcScheduler, log, metrics, tcpConnections)
-      // TODO: This change is temporary until itegulov's BlockStore implementation is in
-      blockMap <- Ref.of[Effect, Map[BlockHash, BlockMsgWithTransform]](
-                   Map.empty[BlockHash, BlockMsgWithTransform]
-                 )
-      metricsT = Metrics.eitherT[CommError, Task](Monad[Task], metrics)
-      blockStore = InMemBlockStore.create[Effect](
-        syncEffect,
-        blockMap,
-        metricsT
-      )
-      blockDagStorage <- InMemBlockDagStorage.create[Effect](
+      _             <- fileIO.makeDirectory[Effect](conf.server.dataDir)
+      _             <- fileIO.makeDirectory[Effect](blockstorePath)
+      _             <- fileIO.makeDirectory[Effect](dagStoragePath)
+      metricsT      = Metrics.eitherT[CommError, Task](Monad[Task], metrics)
+      blockstoreEnv = Context.env(blockstorePath, 100L * 1024L * 1024L * 4096L)
+      blockStore <- FileLMDBIndexBlockStore
+                     .create[Effect](blockstoreEnv, blockstorePath)(
+                       Concurrent[Effect],
+                       Log.eitherTLog(Monad[Task], log),
+                       metricsT
+                     )
+                     .map(_.right.get)
+      dagConfig = BlockDagFileStorage.Config(dagStoragePath)
+      blockDagStorage <- BlockDagFileStorage.create[Effect](dagConfig)(
                           Concurrent[Effect],
                           Log.eitherTLog(Monad[Task], log),
                           blockStore,
                           metricsT
                         )
-      _      <- blockStore.clear() // TODO: Replace with a proper casper init when it's available
       oracle = SafetyOracle.cliqueOracle[Effect](Monad[Effect], Log.eitherTLog(Monad[Task], log))
       casperPacketHandler <- CasperPacketHandler
                               .of[Effect](

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -66,7 +66,6 @@ class NodeRuntime private[node] (
 
   private val initPeer = if (conf.casper.standalone) None else Some(conf.server.bootstrap)
 
-  private implicit val logSource: LogSource       = LogSource(this.getClass)
   implicit val raiseIOError: RaiseIOError[Effect] = IOError.raiseIOErrorThroughSync[Effect]
 
   implicit def eitherTrpConfAsk(implicit ev: RPConfAsk[Task]): RPConfAsk[Effect] =


### PR DESCRIPTION
## Overview
This PR enables the usage of FileLMDBIndexBlockStore and BlockDagFileStorage in Node to make sure they are persistent. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-155

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
