### PR TITLE
EE-207: Add tests for accessing keys in various access patterns.

### DIFF
--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -158,8 +158,9 @@ impl Key {
         match self {
             Key::URef(.., access_right) => *access_right >= AccessRights::Add,
             // From within the body of a contract/account adding
-            // to its state should be possible (only allows for adding new URefs).
-            _ => true,
+            // to its state should be possible (only allows for adding new URefs)
+            // but it's guarded by the RuntimeContext (see Runtime::is_addable)
+            _ => false,
         }
     }
 }

--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -17,16 +17,16 @@ pub enum AccessRights {
 }
 
 impl AccessRights {
-    pub fn is_readable(&self) -> bool {
-        *self >= AccessRights::Read
+    pub fn is_readable(self) -> bool {
+        self >= AccessRights::Read
     }
 
-    pub fn is_writeable(&self) -> bool {
-        *self >= AccessRights::Write
+    pub fn is_writeable(self) -> bool {
+        self >= AccessRights::Write
     }
 
-    pub fn is_addable(&self) -> bool {
-        *self >= AccessRights::Add
+    pub fn is_addable(self) -> bool {
+        self >= AccessRights::Add
     }
 }
 

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -571,15 +571,12 @@ where
     }
 
     /// Tests whether addition to `key` is valid.
-    /// Addition to account key is valid iff it is being made from the contract
-    /// deployed from this account.
-    /// Addition to contract key is not valid. Contract can modify it's own internal
-    /// state using different idioms (add_uref for adding new urefs to its state).
+    /// Addition to account key is valid iff it is being made from the context of the account.
+    /// Addition to contract key is valid iff it is being made from the context of the contract.
     /// Additions to unforgeable key is valid as long as key itself is addable
     fn is_addable(&self, key: &Key) -> bool {
         match key {
-            Key::Account(_) => &self.context.base_key == key,
-            Key::Hash(_) => false,
+            Key::Account(_) | Key::Hash(_) => &self.context.base_key == key,
             Key::URef(_, rights) => rights.is_addable(),
         }
     }

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -507,6 +507,10 @@ fn store_contract_hash() {
     assert_eq!(effect, &Transform::Write(contract));
 }
 
+fn assert_invalid_access<T>(result: Result<T, wasmi::Trap>) {
+    assert_error_contains(result, "InvalidAccess")
+}
+
 fn assert_error_contains<T>(result: Result<T, wasmi::Trap>, msg: &str) {
     match result {
         Err(error) => assert!(format!("{:?}", error).contains(msg)),
@@ -765,7 +769,7 @@ fn account_key_writeable() {
     );
 
     let result = gs_write(&mut runtime, wasm_key, wasm_value);
-    assert_error_contains(result, "InvalidAccess");
+    assert_invalid_access(result);
 }
 
 // Test that is shared between two following tests for reading Account key.
@@ -818,7 +822,7 @@ fn account_key_readable_valid() {
 fn account_key_readable_invalid() {
     let init_value = Value::Int32(1);
     let read_result = test_account_key_readable(init_value, true);
-    assert_error_contains(read_result, "InvalidAccess");
+    assert_invalid_access(read_result);
 }
 
 #[test]
@@ -930,7 +934,7 @@ fn account_key_addable_invalid() {
         wasm_named_key.1 as u32,
     );
 
-    assert_error_contains(result, "InvalidAccess");
+    assert_invalid_access(result);
 }
 
 #[test]
@@ -963,7 +967,7 @@ fn contract_key_writeable() {
     );
 
     let result = gs_write(&mut runtime, wasm_key, wasm_contract);
-    assert_error_contains(result, "InvalidAccess");
+    assert_invalid_access(result);
 }
 
 #[test]
@@ -1085,7 +1089,7 @@ fn contract_key_addable_invalid() {
     let contract_key = random_contract_key(&mut rng);
     let other_contract_key = random_contract_key(&mut rng);
     let result = test_contract_key_addable(contract_key, other_contract_key);
-    assert_error_contains(result, "InvalidAccess");
+    assert_invalid_access(result);
 }
 
 // Test that is shared between two following tests for reading URef.
@@ -1144,7 +1148,7 @@ fn uref_key_readable_invalid() {
     // Tests that reading URef which is not readable fails.
     let init_value = Value::Int32(1);
     let test_result = test_uref_key_readable(init_value.clone(), AccessRights::Add);
-    assert_error_contains(test_result, "InvalidAccess")
+    assert_invalid_access(test_result);
 }
 
 // Test that is being shared between two following tests for writing to a URef.
@@ -1201,7 +1205,7 @@ fn uref_key_writeable_valid() {
 fn uref_key_writeable_invalid() {
     // Tests that writing to URef which is not writeable fails.
     let result = test_uref_key_writeable(AccessRights::Read);
-    assert_error_contains(result, "InvalidAccess")
+    assert_invalid_access(result);
 }
 
 fn test_uref_key_addable(rights: AccessRights) -> Result<(), wasmi::Trap> {
@@ -1259,5 +1263,5 @@ fn uref_key_addable_valid() {
 fn uref_key_addable_invalid() {
     // Tests that adding to URef which is not addable fails.
     let result = test_uref_key_addable(AccessRights::Read);
-    assert_error_contains(result, "InvalidAccess");
+    assert_invalid_access(result);
 }

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -380,10 +380,10 @@ fn contract_bytes_from_wat(
     mut module: Module,
     name: String,
     urefs: BTreeMap<String, Key>,
-) -> common::value::Contract {
+) -> Value {
     rename_export_to_call(&mut module, name);
     let contract_bytes = parity_wasm::serialize(module).expect("Failed to serialize Wasm module.");
-    common::value::Contract::new(contract_bytes, urefs)
+    Value::Contract(common::value::Contract::new(contract_bytes, urefs))
 }
 
 fn read_contract_hash(wasm_memory: &WasmMemoryManager, hash_ptr: u32) -> Key {
@@ -438,11 +438,8 @@ fn store_contract_hash() {
     let wasm_module = create_wasm_module();
     let urefs = urefs_map(once(("SomeKey".to_owned(), Key::Hash([1u8; 32]))));
 
-    let contract = Value::Contract(contract_bytes_from_wat(
-        wasm_module.module.clone(),
-        "add".to_owned(),
-        urefs.clone(),
-    ));
+    let contract =
+        contract_bytes_from_wat(wasm_module.module.clone(), "add".to_owned(), urefs.clone());
 
     // We need this braces so that the `tc_borrowed` gets dropped
     // and we can borrow it again when we call `effect()`.
@@ -569,11 +566,11 @@ fn store_contract_hash_legal_urefs() {
                 .chain(once(("PublicHash".to_owned(), Key::Hash([1u8; 32])))),
         );
 
-        let contract = Value::Contract(contract_bytes_from_wat(
+        let contract = contract_bytes_from_wat(
             wasm_module.module.clone(),
             wasm_module.func_name.clone(),
             urefs.clone(),
-        ));
+        );
 
         let store_result = test_fixture
             .memory
@@ -640,11 +637,11 @@ fn store_contract_uref_known_key() {
 
         let wasm_contract_uref = wasm_write(&mut test_fixture.memory, contract_uref);
 
-        let contract = Value::Contract(contract_bytes_from_wat(
+        let contract = contract_bytes_from_wat(
             wasm_module.module.clone(),
             wasm_module.func_name.clone(),
             urefs.clone(),
-        ));
+        );
 
         let wasm_contract = wasm_write(&mut test_fixture.memory, contract.clone());
 
@@ -698,11 +695,11 @@ fn store_contract_uref_forged_key() {
 
     let wasm_contract_uref = wasm_write(&mut test_fixture.memory, forged_contract_uref);
 
-    let contract = Value::Contract(contract_bytes_from_wat(
+    let contract = contract_bytes_from_wat(
         wasm_module.module.clone(),
         wasm_module.func_name.clone(),
         urefs.clone(),
-    ));
+    );
 
     let wasm_contract = wasm_write(&mut test_fixture.memory, contract.clone());
 

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -32,8 +32,8 @@ use wasmi::memory_units::Pages;
 use wasmi::{MemoryInstance, MemoryRef};
 
 struct MockEnv {
-    pub key: Key,
-    pub account: value::Account,
+    pub base_key: Key,
+    pub deploy_account: value::Account,
     pub uref_lookup: BTreeMap<String, Key>,
     pub known_urefs: HashSet<Key>,
     pub gas_limit: u64,
@@ -42,18 +42,18 @@ struct MockEnv {
 
 impl MockEnv {
     pub fn new(
-        key: Key,
+        base_key: Key,
         uref_lookup: BTreeMap<String, Key>,
         known_urefs: HashSet<Key>,
-        account: value::Account,
+        deploy_account: value::Account,
         gas_limit: u64,
     ) -> Self {
         let memory = MemoryInstance::alloc(Pages(17), Some(Pages(MAX_MEM_PAGES as usize)))
             .expect("Mocked memory should be able to be created.");
 
         MockEnv {
-            key,
-            account,
+            base_key,
+            deploy_account,
             uref_lookup,
             known_urefs,
             gas_limit,
@@ -72,8 +72,8 @@ impl MockEnv {
         let context = mock_context(
             &mut self.uref_lookup,
             &mut self.known_urefs,
-            &self.account,
-            self.key,
+            &self.deploy_account,
+            self.base_key,
         );
         Runtime::new(
             self.memory.clone(),

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -437,12 +437,16 @@ fn store_contract_hash() {
     assert_eq!(effect, &Transform::Write(contract));
 }
 
+fn assert_error_contains(result: Result<(), wasmi::Trap>, msg: &str) {
+    match result {
+        Err(error) => assert!(format!("{:?}", error).contains(msg)),
+        Ok(_) => panic!("Error. Test should fail but it didn't."),
+    }
+}
+
 // Runtime will panic with ForgedReference exception.
 fn assert_panic_forged_keys(result: Result<(), wasmi::Trap>) {
-    match result {
-        Err(error) => assert!(format!("{:?}", error).contains("ForgedReference")),
-        Ok(_) => panic!("Error. Test should fail."),
-    }
+    assert_error_contains(result, "ForgedReference")
 }
 
 #[test]

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -402,12 +402,11 @@ use execution_engine::execution::rename_export_to_call;
 // Renames "name" function to "call" in the passed Wasm module.
 // This is necessary because host runtime will do the same thing prior to saving it.
 fn contract_bytes_from_wat(
-    mut module: Module,
-    name: String,
+    mut test_module: TestModule,
     urefs: BTreeMap<String, Key>,
 ) -> Value {
-    rename_export_to_call(&mut module, name);
-    let contract_bytes = parity_wasm::serialize(module).expect("Failed to serialize Wasm module.");
+    rename_export_to_call(&mut test_module.module, test_module.func_name);
+    let contract_bytes = parity_wasm::serialize(test_module.module).expect("Failed to serialize Wasm module.");
     Value::Contract(common::value::Contract::new(contract_bytes, urefs))
 }
 
@@ -419,6 +418,7 @@ fn read_contract_hash(wasm_memory: &WasmMemoryManager, hash_ptr: u32) -> Key {
     Key::Hash(target)
 }
 
+#[derive(Clone)]
 struct TestModule {
     module: Module,
     func_name: String,
@@ -466,8 +466,7 @@ fn store_contract_hash() {
     let urefs = urefs_map(once(("SomeKey".to_owned(), hash)));
 
     let contract = contract_bytes_from_wat(
-        wasm_module.module.clone(),
-        wasm_module.func_name.to_owned(),
+        wasm_module.clone(),
         urefs.clone(),
     );
 
@@ -601,8 +600,7 @@ fn store_contract_hash_legal_urefs() {
         ))));
 
         let contract = contract_bytes_from_wat(
-            wasm_module.module.clone(),
-            wasm_module.func_name.clone(),
+            wasm_module.clone(),
             urefs.clone(),
         );
 
@@ -675,8 +673,7 @@ fn store_contract_uref_known_key() {
         let wasm_contract_uref = wasm_write(&mut test_fixture.memory, contract_uref);
 
         let contract = contract_bytes_from_wat(
-            wasm_module.module.clone(),
-            wasm_module.func_name.clone(),
+            wasm_module,
             urefs.clone(),
         );
 
@@ -735,8 +732,7 @@ fn store_contract_uref_forged_key() {
     let wasm_contract_uref = wasm_write(&mut test_fixture.memory, forged_contract_uref);
 
     let contract = contract_bytes_from_wat(
-        wasm_module.module.clone(),
-        wasm_module.func_name.clone(),
+        wasm_module,
         urefs.clone(),
     );
 
@@ -950,8 +946,7 @@ fn contract_key_writeable() {
     let urefs = urefs_map(std::iter::empty());
 
     let contract = contract_bytes_from_wat(
-        wasm_module.module.clone(),
-        wasm_module.func_name.to_owned(),
+        wasm_module.clone(),
         urefs.clone(),
     );
 

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -842,10 +842,12 @@ fn account_key_addable_valid() {
         random_contract_key(&mut rng),
     )));
     let account = Account::new([1u8; 32], 1, known_urefs.clone());
+    let account_key = Key::Account(test_fixture.addr);
+    let wasm_account_key = wasm_write(&mut test_fixture.memory, account_key);
     // This is the key we will want to add to an account
     let additional_key = ("PublichHash#2".to_owned(), random_contract_key(&mut rng));
-    let wasm_name = wasm_write(&mut test_fixture.memory, additional_key.0.clone());
-    let wasm_key = wasm_write(&mut test_fixture.memory, additional_key.1);
+    let named_key = Value::NamedKey(additional_key.0.clone(), additional_key.1);
+    let wasm_named_key = wasm_write(&mut test_fixture.memory, named_key.clone());
     {
         let mut tc_borrowed = test_fixture.tc.borrow_mut();
         // Write an account under current context's key
@@ -864,11 +866,11 @@ fn account_key_addable_valid() {
 
         // Add key to current context's account.
         runtime
-            .add_uref(
-                wasm_name.0,
-                wasm_name.1 as u32,
-                wasm_key.0,
-                wasm_key.1 as u32,
+            .add(
+                wasm_account_key.0,
+                wasm_account_key.1 as u32,
+                wasm_named_key.0,
+                wasm_named_key.1 as u32,
             )
             .expect("Adding new named key should work");
     }

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -487,6 +487,7 @@ fn assert_error_contains(result: Result<(), wasmi::Trap>, msg: &str) {
 
 #[test]
 fn store_contract_hash_illegal_urefs() {
+    // Tests that storing function (contract) with illegal (unknown) urefs is an error.
     // Test fixtures
     let mut test_fixture: TestFixture = Default::default();
     let wasm_module = create_wasm_module();
@@ -522,6 +523,7 @@ fn store_contract_hash_illegal_urefs() {
 
 #[test]
 fn store_contract_hash_legal_urefs() {
+    // Tests that storing function (contract) with valid (known) uref works.
     // Test fixtures
     let mut test_fixture: TestFixture = Default::default();
     let wasm_module = create_wasm_module();
@@ -602,6 +604,8 @@ fn store_contract_hash_legal_urefs() {
 
 #[test]
 fn store_contract_uref_known_key() {
+    // Tests that storing function (contract) under known and writeable uref, 
+    // with known refs, works.
     // ---- Test fixtures ----
     // URef where we will write contract
     let contract_uref = Key::URef([2u8; 32], AccessRights::ReadWrite);
@@ -660,6 +664,7 @@ fn store_contract_uref_known_key() {
 
 #[test]
 fn store_contract_uref_forged_key() {
+    // Tests that storing function (contract) under forged but writeable uref fails.
     // ---- Test fixtures ----
     // URef where we will write contract
     let forged_contract_uref = Key::URef([2u8; 32], AccessRights::ReadWrite);
@@ -710,6 +715,7 @@ fn store_contract_uref_forged_key() {
 
 #[test]
 fn account_key_writeable() {
+    // Tests that account key is not writeable.
     // Test fixtures
     let mut test_fixture: TestFixture = Default::default();
     let wasm_module = create_wasm_module();
@@ -733,6 +739,7 @@ fn account_key_writeable() {
 
 #[test]
 fn account_key_readable() {
+    // Tests that accout key is readable.
     // Test fixtures
     let mut test_fixture: TestFixture = Default::default();
     let wasm_module = create_wasm_module();
@@ -871,6 +878,8 @@ fn contract_key_writeable() {
 
 #[test]
 fn contract_key_readable() {
+    // Tests that contracts are readable. This test checks that it is possible to execute
+    // `call_contract` function which checks whether the key is readable.
     // Test fixtures
     let mut test_fixture: TestFixture = Default::default();
     let wasm_module = create_wasm_module();
@@ -913,25 +922,42 @@ fn contract_key_readable() {
 
 #[test]
 fn contract_key_addable() {
+    // Tests that contract key is not addable.
     unimplemented!()
 }
 
 #[test]
-fn uref_key_readable() {
+fn uref_key_readable_valid() {
+    // Tests that URef key is readable when access rights of the key allows for reading.
     unimplemented!()
 }
 
 #[test]
-fn uref_key_writeable() {
+fn uref_key_readable_invalid() {
+    // Tests that reading URef which is not readable fails.
+    unimplemented!()
+}
+
+#[test]
+fn uref_key_writeable_valid() {
+    // Tests that URef key is writeable when access rights of the key allows for writing.
+    unimplemented!()
+}
+
+#[test]
+fn uref_key_writeable_invalid() {
+    // Tests that writing to URef which is not writeable fails.
     unimplemented!()
 }
 
 #[test]
 fn uref_key_addable_valid() {
+    // Tests that URef key is addable when access rights of the key allows for adding.
     unimplemented!()
 }
 
 #[test]
 fn uref_key_addable_invalid() {
+    // Tests that adding to URef which is not addable fails.
     unimplemented!()
 }

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -639,8 +639,8 @@ fn store_contract_uref_known_key() {
     // Tests that storing function (contract) under known and writeable uref,
     // with known refs, works.
     // ---- Test fixtures ----
-    // URef where we will write contract
     let mut rng = rand::thread_rng();
+    // URef where we will write contract
     let contract_uref = random_uref_key(&mut rng, AccessRights::ReadWrite);
     // URef we want to store WITH the contract so that it can use it later
     let known_uref = random_uref_key(&mut rng, AccessRights::ReadWrite);
@@ -798,10 +798,12 @@ fn account_key_readable() {
         wasm_module.module.clone(),
     );
 
+    panic!("This test should fail. Accounts shouldn't probably be readable. Think it over.")
+
     // Read value
-    let res: Value = gs_read(&mut test_fixture.memory, &mut runtime, wasm_key)
-        .expect("Reading from GS should work.");
-    assert_eq!(res, value);
+    // let res: Value = gs_read(&mut test_fixture.memory, &mut runtime, wasm_key)
+    // .expect("Reading from GS should work.");
+    // assert_eq!(res, value);
 }
 
 #[test]


### PR DESCRIPTION
## Overview
This PR adds a suite of tests that exercise whether access to keys is guarded properly. We want to test that different keys (account, hash, uref) are accessed according to their properties. For example account key is not writeable, uref allows for writing only if it has proper access rights etc.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-207

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
