### PR TITLE
NO TICKET: Move lints up the pipeline before rust tests so that build fails fast

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,6 +80,15 @@ pipeline:
       - ~/.cargo/bin/cargo update
       - ~/.cargo/bin/cargo build
 
+  run-rust-lints:
+    <<: *buildenv
+    group: test
+    commands:
+      - cd execution-engine
+      - ~/.cargo/bin/rustup toolchain install $(cat rust-toolchain)
+      - ~/.cargo/bin/rustup component add --toolchain=$(cat rust-toolchain) clippy
+      - ~/.cargo/bin/cargo clippy --all-targets --all -- -D warnings -A renamed_and_removed_lints
+
   run-rust-tests:
     <<: *buildenv
     group: test
@@ -97,15 +106,6 @@ pipeline:
       export PATH=$PATH:/usr/local/bin
       cd execution-engine/
       ~/.cargo/bin/cargo test
-
-  run-rust-lints:
-    <<: *buildenv
-    group: test
-    commands:
-      - cd execution-engine
-      - ~/.cargo/bin/rustup toolchain install $(cat rust-toolchain)
-      - ~/.cargo/bin/rustup component add --toolchain=$(cat rust-toolchain) clippy
-      - ~/.cargo/bin/cargo clippy --all-targets --all -- -D warnings -A renamed_and_removed_lints
 
   run-unit-tests:
     <<: *sbtenv


### PR DESCRIPTION
## Overview
Move lints up the pipeline before rust tests so that build fails fast. A build pipeline should follow these steps. 

**"Compile" -> "Lint" -> "Tests"**

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.