### PR TITLE
NODE-337: ErrorInterceptor to log errors and optionally change the code.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -120,8 +120,9 @@ object ServiceError {
       apply(s"Block ${Base16.encode(blockHash.toByteArray)} could not be found.")
   }
 
-  object InvalidArgument extends StatusError(Status.INVALID_ARGUMENT)
-  object Unauthenticated extends StatusError(Status.UNAUTHENTICATED)
+  object InvalidArgument  extends StatusError(Status.INVALID_ARGUMENT)
+  object Unauthenticated  extends StatusError(Status.UNAUTHENTICATED)
+  object DeadlineExceeded extends StatusError(Status.DEADLINE_EXCEEDED)
 }
 
 sealed trait GossipError extends NoStackTrace

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/AuthInterceptor.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/AuthInterceptor.scala
@@ -5,7 +5,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.comm.auth.Principal
 import io.casperlabs.comm.ServiceError.Unauthenticated
 import io.casperlabs.crypto.util.CertificateHelper
-import io.casperlabs.shared.{Log, LogSource}
+import io.casperlabs.shared.Log
 import io.grpc.{
   Context,
   Contexts,
@@ -20,12 +20,9 @@ import javax.net.ssl.SSLSession
 import scala.util.Try
 
 /** Put the remote peer identity into the gRPC Context. */
-class AuthInterceptor() extends ServerInterceptor {
+class AuthInterceptor()(implicit log: Log[Id]) extends ServerInterceptor {
 
   // Based on https://github.com/saturnism/grpc-java-by-example/tree/master/metadata-context-example/src/main/java/com/example/grpc/server
-
-  implicit val logSource = LogSource(this.getClass)
-  implicit val logId     = Log.logId
 
   def NoopListener[A] = new ServerCall.Listener[A] {}
 

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/ErrorInterceptor.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/ErrorInterceptor.scala
@@ -1,0 +1,72 @@
+package io.casperlabs.comm.grpc
+
+import cats.Id
+import io.casperlabs.shared.Log
+import io.grpc.{Grpc, Metadata, ServerCall, ServerCallHandler, ServerInterceptor, Status}
+
+/** Turn exceptions into one of the standard gRPC status codes:
+  * https://github.com/grpc/grpc/blob/master/doc/statuscodes.md */
+class ErrorInterceptor(f: PartialFunction[Throwable, Status.Code])(implicit log: Log[Id])
+    extends ServerInterceptor {
+
+  // See https://github.com/saturnism/grpc-java-by-example/tree/master/error-handling-example
+
+  class Forwarder[A, B](call: ServerCall[A, B]) extends ForwardingServerCall(call) {
+    override def close(status: Status, trailers: Metadata) = {
+      // Turn unknown errors with exceptions into Statuses.
+      val s =
+        if (status.getCode == Status.Code.UNKNOWN &&
+            status.getDescription == null &&
+            status.getCause != null) {
+          val e = status.getCause
+          f.lift(e)
+            .map(Status.fromCode(_))
+            .getOrElse(Status.INTERNAL)
+            .withDescription(e.getMessage)
+        } else status
+
+      logAndClose(s, trailers)
+    }
+
+    def logAndClose(status: Status, trailers: Metadata) = {
+      val desc   = Option(status.getDescription).getOrElse("")
+      val cause  = Option(status.getCause).map(_.getMessage).getOrElse("")
+      val method = call.getMethodDescriptor.getFullMethodName
+      val source = Option(call.getAttributes.get(Grpc.TRANSPORT_ATTR_REMOTE_ADDR))
+        .fold("unknown address")(_.toString)
+
+      // Log internal errors with stack trace. Otherwise just warn, treat them as domain errors.
+      if (status.getCode == Status.Code.INTERNAL) {
+        Log[Id].error(
+          s"Closing gRPC call from $source to $method with ${status.getCode}: $desc",
+          status.getCause
+        )
+      } else if (!status.isOk)
+        Log[Id].warn(
+          s"Closing gRPC call from $source to $method with ${status.getCode}: $desc $cause"
+        )
+
+      super.close(status, trailers)
+    }
+  }
+
+  override def interceptCall[A, B](
+      call: ServerCall[A, B],
+      headers: Metadata,
+      next: ServerCallHandler[A, B]
+  ): ServerCall.Listener[A] =
+    next.startCall(new Forwarder(call), headers)
+}
+
+object ErrorInterceptor {
+
+  /** Provide a mapping from various domain errors to gRPC status codes. */
+  def apply(f: PartialFunction[Throwable, Status.Code])(implicit log: Log[Id]) =
+    new ErrorInterceptor(f)
+
+  def default(implicit log: Log[Id]) = apply {
+    // Don't match anything, let them be turned into internal errors,
+    // unless they are already StatusRuntimeExceptions.
+    case _ if false => Status.Code.UNKNOWN
+  }
+}

--- a/comm/src/main/scala/io/casperlabs/comm/grpc/ForwardingServerCall.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/grpc/ForwardingServerCall.scala
@@ -1,0 +1,40 @@
+package io.casperlabs.comm.grpc
+
+import io.grpc.{Metadata, ServerCall, Status}
+
+// Similar to io.grpc.ForwardingServerCall but rolled into one.
+class ForwardingServerCall[A, B](delegate: ServerCall[A, B]) extends ServerCall[A, B] {
+
+  override def sendMessage(message: B) =
+    delegate.sendMessage(message)
+
+  override def request(numMessages: Int) =
+    delegate.request(numMessages)
+
+  override def sendHeaders(headers: Metadata) =
+    delegate.sendHeaders(headers)
+
+  override def isReady() =
+    delegate.isReady
+
+  override def close(status: Status, trailers: Metadata) =
+    delegate.close(status, trailers)
+
+  override def isCancelled() =
+    delegate.isCancelled
+
+  override def setMessageCompression(enabled: Boolean) =
+    delegate.setMessageCompression(enabled)
+
+  override def setCompression(compressor: String) =
+    delegate.setCompression(compressor)
+
+  override def getAttributes() =
+    delegate.getAttributes
+
+  override def getAuthority() =
+    delegate.getAuthority
+
+  override def getMethodDescriptor() =
+    delegate.getMethodDescriptor
+}

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.comm.gossiping
 
+import cats.Id
 import cats.implicits._
 import cats.effect._
 import com.google.protobuf.ByteString
@@ -9,7 +10,7 @@ import io.casperlabs.crypto.util.{CertificateHelper, CertificatePrinter}
 import io.casperlabs.comm.ServiceError.{NotFound, Unauthenticated}
 import io.casperlabs.comm.TestRuntime
 import io.casperlabs.comm.discovery.Node
-import io.casperlabs.comm.grpc.{AuthInterceptor, GrpcServer, SslContexts}
+import io.casperlabs.comm.grpc.{AuthInterceptor, ErrorInterceptor, GrpcServer, SslContexts}
 import io.casperlabs.shared.{Compression, Log}
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
 import io.netty.handler.ssl.{ClientAuth, SslContext}
@@ -311,9 +312,7 @@ class GrpcGossipServiceSpec
                     r.isLeft shouldBe true
                     r.left.get match {
                       case ex: io.grpc.StatusRuntimeException =>
-                        // TODO: When we add the ErrorInterceptor we can turn this into a proper status,
-                        // for example CANCELED or DEADLINE_EXCEEDED.
-                        ex.getStatus.getCode shouldBe io.grpc.Status.Code.UNKNOWN
+                        ex.getStatus.getCode shouldBe io.grpc.Status.Code.DEADLINE_EXCEEDED
                       case other =>
                         fail(s"Unexpected error: $other")
                     }
@@ -362,7 +361,7 @@ class GrpcGossipServiceSpec
                     r1.isLeft shouldBe true
                     r1.left.get match {
                       case ex: io.grpc.StatusRuntimeException =>
-                        ex.getStatus.getCode shouldBe io.grpc.Status.Code.UNKNOWN
+                        ex.getStatus.getCode shouldBe io.grpc.Status.Code.INTERNAL
                       case ex =>
                         fail(s"Unexpected error: $ex")
                     }
@@ -1058,9 +1057,10 @@ object GrpcGossipServiceSpec extends TestRuntime {
         oi: ObservableIterant[Task],
         scheduler: Scheduler
     ): Resource[Task, GossipingGrpcMonix.GossipServiceStub] = {
-      val port         = getFreePort
-      val serverCert   = TestCert.generate
-      implicit val log = new Log.NOPLog[Task]
+      val port             = getFreePort
+      val serverCert       = TestCert.generate
+      implicit val logTask = new Log.NOPLog[Task]
+      implicit val logId   = new Log.NOPLog[Id]
 
       val serverR = GrpcServer[Task](
         port,
@@ -1080,7 +1080,8 @@ object GrpcGossipServiceSpec extends TestRuntime {
         ),
         interceptors = List(
           // For now the AuthInterceptor rejects calls without a certificate.
-          Option(new AuthInterceptor()).filter(_ => clientAuth == ClientAuth.REQUIRE)
+          Option(new AuthInterceptor()).filter(_ => clientAuth == ClientAuth.REQUIRE),
+          Some(ErrorInterceptor.default)
         ).flatten,
         // If the server is using SSL then we can't connect to it using `.usePlaintext`
         // on the client channel, it would get UNAVAILABLE.


### PR DESCRIPTION
## Overview
Adds an `ErrorInterceptor` that:
* turns UNKNOWN gRPC errors into INTERNAL ones
* logs the source and the method

Mapped the slow consumer timeout to a `DEADLINE_EXCEEDED` error but it turns out there is no `casue` to look at in the interceptor for some reason. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-337

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
