### PR TITLE
NO-TICKET: fix wasm type signature for new_uref function

### DIFF
--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -892,7 +892,7 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 ADD_FUNC_INDEX,
             ),
             "new_uref" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 1][..], None),
+                Signature::new(&[ValueType::I32; 3][..], None),
                 NEW_FUNC_INDEX,
             ),
             "load_arg" => FuncInstance::alloc_host(


### PR DESCRIPTION
## Overview
I forgot in my [previous PR](https://github.com/CasperLabs/CasperLabs/pull/327) to change the wasm type signature, EE is broken without this.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
No ticket.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
