### PR TITLE
EE-236: Include ABI-encoded arguments in ipc Deploy message

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -10,7 +10,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.genesis.contracts._
 import io.casperlabs.casper.protocol
 import io.casperlabs.casper.protocol._
-import io.casperlabs.casper.util.ProtoUtil.{blockHeader, unsignedBlockProto}
+import io.casperlabs.casper.util.ProtoUtil.{blockHeader, deployDataToEEDeploy, unsignedBlockProto}
 import io.casperlabs.casper.util.Sorting
 import io.casperlabs.casper.util.execengine.ExecEngineUtil
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
@@ -61,7 +61,7 @@ object Genesis {
     for {
       processedDeploys <- MonadError[F, Throwable].rethrow(
                            ExecutionEngineService[F]
-                             .exec(startHash, blessedTerms.map(ExecEngineUtil.deploy2deploy))
+                             .exec(startHash, blessedTerms.map(deployDataToEEDeploy))
                          )
       deployEffects = ExecEngineUtil.processedDeployEffects(blessedTerms zip processedDeploys)
 

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -13,7 +13,7 @@ import io.casperlabs.casper.util.implicits._
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.catscontrib.ski.id
 import io.casperlabs.crypto.hash.Blake2b256
-import io.casperlabs.ipc.{Deploy => EEDeploy}
+import io.casperlabs.ipc.{Deploy => EEDeploy, DeployCode}
 import io.casperlabs.models.BlockMetadata
 import io.casperlabs.shared.{Log, Time}
 
@@ -526,8 +526,8 @@ object ProtoUtil {
   def deployDataToEEDeploy(dd: DeployData): EEDeploy = EEDeploy(
     address = dd.address,
     timestamp = dd.timestamp,
-    sessionCode = dd.sessionCode,
-    paymentCode = dd.paymentCode,
+    session = Some(DeployCode().withCode(dd.sessionCode)),
+    payment = Some(DeployCode().withCode(dd.paymentCode)),
     gasLimit = dd.gasLimit,
     gasPrice = dd.gasPrice,
     nonce = dd.nonce

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/BlockApproverProtocol.scala
@@ -9,8 +9,8 @@ import io.casperlabs.casper.{protocol, ValidatorIdentity}
 import io.casperlabs.casper.genesis.Genesis
 import io.casperlabs.casper.genesis.contracts._
 import io.casperlabs.casper.protocol._
+import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.casper.util.execengine.ExecEngineUtil
-import io.casperlabs.casper.util.execengine.ExecEngineUtil.deploy2deploy
 import io.casperlabs.casper.util.rholang.ProcessedDeployUtil
 import io.casperlabs.catscontrib.Catscontrib._
 import io.casperlabs.comm.CommError.ErrorHandler
@@ -155,7 +155,7 @@ object BlockApproverProtocol {
       processedDeploys <- EitherT(
                            ExecutionEngineService[F].exec(
                              ExecutionEngineService[F].emptyStateHash,
-                             deploys.map(deploy2deploy)
+                             deploys.map(ProtoUtil.deployDataToEEDeploy)
                            )
                          ).leftMap(_.getMessage)
       deployEffects    = ExecEngineUtil.processedDeployEffects(deploys zip processedDeploys)

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -26,31 +26,6 @@ case class DeploysCheckpoint(
 object ExecEngineUtil {
   type StateHash = ByteString
 
-  def deploy2deploy(d: DeployData): Deploy =
-    d match {
-      case DeployData(
-          addr,
-          time,
-          sCode,
-          pCode,
-          gasLimit,
-          gasPrice,
-          nonce,
-          _,
-          _,
-          _
-          ) =>
-        Deploy(
-          addr,
-          time,
-          sCode,
-          pCode,
-          gasLimit,
-          gasPrice,
-          nonce
-        )
-    }
-
   implicit def functorRaiseInvalidBlock[F[_]: Sync] = Validate.raiseValidateErrorThroughSync[F]
 
   def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: ExecutionEngineService](
@@ -112,7 +87,7 @@ object ExecEngineUtil {
   ): F[(StateHash, Seq[DeployResult])] =
     for {
       prestate <- computePrestate[F](parents.toList, dag)
-      ds       = deploys.map(deploy2deploy)
+      ds       = deploys.map(ProtoUtil.deployDataToEEDeploy)
       result   <- MonadError[F, Throwable].rethrow(ExecutionEngineService[F].exec(prestate, ds))
     } yield (prestate, result)
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -365,7 +365,7 @@ object HashSetCasperTestNode {
         // The real execution engine will get the keys from what the code changes, which will include
         // changes to the account nonce for example, but not the deploy timestamp. Make sure the `key`
         // here isn't more specific to a deploy then the real thing would be.
-        val key           = Key(Key.KeyInstance.Hash(KeyHash(deploy.sessionCode)))
+        val key           = Key(Key.KeyInstance.Hash(KeyHash(deploy.session.fold(ByteString.EMPTY)(_.code))))
         val transform     = Transform(Transform.TransformInstance.Identity(TransformIdentity()))
         val op            = Op(Op.OpInstance.Read(ReadOp()))
         val transforEntry = TransformEntry(Some(key), Some(transform))

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -191,7 +191,9 @@ where
     deploys
         .iter()
         .map(|deploy| {
-            let module_bytes = &deploy.session_code;
+            let session_contract = deploy.get_session();
+            let module_bytes = &session_contract.code;
+            let args = &session_contract.args;
             let address: [u8; 20] = {
                 let mut tmp = [0u8; 20];
                 tmp.copy_from_slice(&deploy.address);
@@ -203,6 +205,7 @@ where
             engine_state
                 .run_deploy(
                     module_bytes,
+                    args,
                     address,
                     timestamp,
                     nonce,

--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -129,6 +129,7 @@ where
     pub fn run_deploy<A, P: Preprocessor<A>, E: Executor<A>>(
         &self,
         module_bytes: &[u8],
+        args: &[u8],
         address: [u8; 20],
         timestamp: u64,
         nonce: u64,
@@ -144,7 +145,9 @@ where
                 Ok(checkout_result) => match checkout_result {
                     None => Err(RootNotFound(prestate_hash)),
                     Some(mut tc) => {
-                        match executor.exec(module, address, timestamp, nonce, gas_limit, &mut tc) {
+                        match executor
+                            .exec(module, args, address, timestamp, nonce, gas_limit, &mut tc)
+                        {
                             (Ok(ee), cost) => Ok(ExecutionResult::success(ee, cost)),
                             (Err(error), cost) => Ok(ExecutionResult::failure(error.into(), cost)),
                         }

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -222,6 +222,7 @@ where
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
+        args: Vec<Vec<u8>>,
         memory: MemoryRef,
         state: &'a mut TrackingCopy<R>,
         module: Module,
@@ -232,7 +233,7 @@ where
     ) -> Self {
         let rng = create_rng(&account_addr, timestamp, nonce);
         Runtime {
-            args: Vec::new(),
+            args,
             memory,
             state,
             module,
@@ -1067,6 +1068,7 @@ pub trait Executor<A> {
     fn exec<R: DbReader>(
         &self,
         parity_module: A,
+        args: &[u8],
         account_addr: [u8; 20],
         timestamp: u64,
         nonce: u64,
@@ -1083,6 +1085,7 @@ impl Executor<Module> for WasmiExecutor {
     fn exec<R: DbReader>(
         &self,
         parity_module: Module,
+        args: &[u8],
         account_addr: [u8; 20],
         timestamp: u64,
         nonce: u64,
@@ -1110,7 +1113,14 @@ impl Executor<Module> for WasmiExecutor {
             base_key: acct_key,
             gas_limit,
         };
+        let arguments: Vec<Vec<u8>> = if args.is_empty() {
+            Vec::new()
+        } else {
+            // TODO: Do we need to charge in proportion to the length of `args`?
+            on_fail_charge!(deserialize(args), 0)
+        };
         let mut runtime = Runtime::new(
+            arguments,
             memory,
             tc,
             parity_module,

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -1065,6 +1065,7 @@ macro_rules! on_fail_charge {
 }
 
 pub trait Executor<A> {
+    #[allow(clippy::too_many_arguments)]
     fn exec<R: DbReader>(
         &self,
         parity_module: A,

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -1116,7 +1116,8 @@ impl Executor<Module> for WasmiExecutor {
         let arguments: Vec<Vec<u8>> = if args.is_empty() {
             Vec::new()
         } else {
-            // TODO: Do we need to charge in proportion to the length of `args`?
+            // TODO: figure out how this works with the cost model
+            // https://casperlabs.atlassian.net/browse/EE-239
             on_fail_charge!(deserialize(args), 0)
         };
         let mut runtime = Runtime::new(

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -107,6 +107,7 @@ fn main() {
         println!("Pre state hash: {:?}", state_hash);
         let result = engine_state.run_deploy(
             &wasm_bytes.bytes,
+            &[], // TODO: consume args from CLI
             account_addr,
             timestamp,
             nonce,

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -73,6 +73,7 @@ impl MockEnv {
             self.key,
         );
         Runtime::new(
+            Vec::new(),
             self.memory.clone(),
             tc,
             module,

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -2,11 +2,16 @@ syntax = "proto3";
 
 package io.casperlabs.ipc;
 
+message DeployCode {
+  bytes code = 1; // wasm byte code
+  bytes args = 2; // ABI-encoded arguments
+}
+
 message Deploy {
     bytes address = 1; // length 20 bytes
     uint64 timestamp = 2;
-    bytes session_code = 3;
-    bytes payment_code = 4;
+    DeployCode session = 3;
+    DeployCode payment = 4;
     uint64 gas_limit = 5;
     uint64 gas_price = 6;
     uint64 nonce = 7;


### PR DESCRIPTION
## Overview
Supporting arguments in deployed code allows reusing compiled session code, which improves the developer experience on the platform.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-236

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
