### PR TITLE
EE-238: Include arguments for deployed code in Deploy message

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -211,13 +211,21 @@ class MultiParentCasperImpl[F[_]: Sync: ConnectionsCell: TransportLayer: Log: Ti
     } yield (blockStoreContains || bufferContains)
 
   //TODO: verify sig immediately (again, so we fail fast)
-  def deploy(d: DeployData): F[Either[Throwable, Unit]] = {
-    val req = ExecutionEngineService[F].verifyWasm(ValidateRequest(d.sessionCode, d.paymentCode))
+  def deploy(d: DeployData): F[Either[Throwable, Unit]] = (d.session, d.payment) match {
+    case (Some(session), Some(payment)) =>
+      val req = ExecutionEngineService[F].verifyWasm(ValidateRequest(session.code, payment.code))
 
-    EitherT(req)
-      .leftMap(c => new IllegalArgumentException(s"Contract verification failed: $c"))
-      .flatMapF(_ => addDeploy(d) map (_.asRight[Throwable]))
-      .value
+      EitherT(req)
+        .leftMap(c => new IllegalArgumentException(s"Contract verification failed: $c"))
+        .flatMapF(_ => addDeploy(d) map (_.asRight[Throwable]))
+        .value
+
+    case (None, _) | (_, None) =>
+      Either
+        .left[Throwable, Unit](
+          new IllegalArgumentException(s"Deploy was missing session and/or payment code.")
+        )
+        .pure[F]
   }
 
   def addDeploy(deployData: DeployData): F[Unit] =

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -487,6 +487,7 @@ object ProtoUtil {
           .withUser(ByteString.EMPTY)
           .withTimestamp(now)
           .withSession(DeployCode())
+          .withPayment(DeployCode())
           .withGasLimit(Integer.MAX_VALUE)
     )
 
@@ -504,6 +505,7 @@ object ProtoUtil {
       user = ByteString.EMPTY,
       timestamp = timestamp,
       session = Some(DeployCode().withCode(ByteString.copyFromUtf8(source))),
+      payment = Some(DeployCode()),
       gasLimit = gasLimit
     )
 
@@ -517,6 +519,7 @@ object ProtoUtil {
       user = ByteString.EMPTY,
       timestamp = timestamp,
       session = Some(DeployCode().withCode(sessionCode)),
+      payment = Some(DeployCode()),
       gasLimit = gasLimit
     )
 

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -8,7 +8,13 @@ import cats.effect.{Sync, Timer}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import guru.nidi.graphviz.engine._
-import io.casperlabs.casper.protocol.{BlockQuery, BlocksQuery, DeployData, VisualizeDagQuery}
+import io.casperlabs.casper.protocol.{
+  BlockQuery,
+  BlocksQuery,
+  DeployCode,
+  DeployData,
+  VisualizeDagQuery
+}
 import io.casperlabs.client.configuration.Streaming
 
 import scala.util.Try
@@ -123,8 +129,8 @@ object DeployRuntime {
             //TODO: allow user to specify their public key
             DeployData()
               .withTimestamp(System.currentTimeMillis())
-              .withSessionCode(session)
-              .withPaymentCode(payment)
+              .withSession(DeployCode().withCode(session))
+              .withPayment(DeployCode().withCode(payment))
               .withAddress(ByteString.copyFromUtf8(from))
               .withGasLimit(gasLimit)
               .withGasPrice(gasPrice)

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -124,8 +124,8 @@ trait ArbitraryConsensus {
         .withBody(
           Deploy
             .Body()
-            .withSessionCode(sessionCode)
-            .withPaymentCode(paymentCode)
+            .withSession(DeployCode().withCode(sessionCode))
+            .withPayment(DeployCode().withCode(paymentCode))
         )
         .withSignature(signature)
     }

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -10,6 +10,14 @@ message Signature {
     bytes sig = 2;
 }
 
+// Code (either session or payment) to be deployed to the platform.
+// Includes both binary instructions (wasm) and optionally, arguments
+// to those instructions encoded via our ABI
+message DeployCode {
+    bytes code = 1; // wasm byte code
+    bytes args = 2; // ABI-encoded arguments
+}
+
 // A smart contract invocation, singed by the account that sent it.
 message Deploy {
     // blake2b256 hash of the `header`.
@@ -36,9 +44,9 @@ message Deploy {
 
     message Body {
         // Wasm code of the smart contract to be executed.
-        bytes session_code = 1;
+        DeployCode session = 1;
         // Wasm code that transfers some tokens to the validators as payment in exchange to run the Deploy.
-        bytes payment_code = 2;
+        DeployCode payment = 2;
     }
 }
 

--- a/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
+++ b/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
@@ -47,11 +47,16 @@ message QueryStateResponse {
     string result = 1;
 }
 
+message DeployCode {
+    bytes code = 1; // wasm byte code
+    bytes args = 2; // ABI-encoded arguments
+}
+
 message DeployData {
     bytes address = 1; // length 20 bytes
     int64 timestamp = 2;
-    bytes session_code = 3;
-    bytes payment_code = 4;
+    DeployCode session = 3;
+    DeployCode payment = 4;
     int64 gas_limit = 5;
     int64 gas_price = 6;
     int64 nonce = 7;


### PR DESCRIPTION
## Overview
To catch people up on this, the idea is that being able to include arguments with the deploy let the same session code wasm binary be reused, which improves the development experience on the platform (in a dApp you would only need to write a finite number of session/payment code templates and fill in the arguments dynamically, e.g. from user input, as needed). There was a [previous PR](https://github.com/CasperLabs/CasperLabs/pull/342) to make this change in the Rust layer, now this PR pipes it up the the node level. I have a [future ticket](https://casperlabs.atlassian.net/browse/EE-237) to add support for deploy code arguments in our CLI.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-238

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
