### PR TITLE
CON-120: bring back unit test for reject addBlock for the same (user,timestamp)

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -554,13 +554,9 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
       result <- nodes(1).casperEff
                  .contains(signedBlock4) shouldBeF true // Invalid blocks are still added
-      // TODO: Fix with https://rchain.atlassian.net/browse/RHOL-1048
-      // nodes(0).casperEff.contains(signedBlock4) should be(false)
-      //
-      // nodes(0).logEff.warns
-      //   .count(_ contains "found deploy by the same (user, millisecond timestamp) produced") should be(
-      //   1
-      // )
+      _ <- nodes(0).casperEff.contains(signedBlock4) shouldBeF (false)
+      _ = nodes(0).logEff.warns
+        .count(_ contains "found deploy by the same (user, millisecond timestamp) produced") shouldBe (1)
       _ <- nodes.map(_.tearDownNode()).toList.sequence
 
       _ = nodes.toList.traverse_[Effect, Assertion] { node =>


### PR DESCRIPTION
Since we have add nonce to generate unforgeable names, we will not have
the same bug with RCHAIN-1048

Signed-off-by: Abner Zheng <abnerzheng@gmail.com>

## Overview
Provide a brief description of what this PR does, and why it's needed.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/CON-120

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, this PR includes tests related to this feature.
- [X] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
