### PR TITLE
STOR-52: update in-memory impl to use LMDB-like transaction semantics

### DIFF
--- a/execution-engine/storage/src/history/trie_store/in_memory.rs
+++ b/execution-engine/storage/src/history/trie_store/in_memory.rs
@@ -165,23 +165,22 @@ impl Readable for InMemoryReadTransaction {
 }
 
 /// A read-write transaction for the in-memory trie store.
-#[allow(dead_code)]
 pub struct InMemoryReadWriteTransaction<'a> {
     view: BytesMap,
     store_ref: Arc<Mutex<BytesMap>>,
-    write_lock: WriteLock<'a>,
+    _write_lock: WriteLock<'a>,
 }
 
 impl<'a> InMemoryReadWriteTransaction<'a> {
     pub fn new(store: &'a InMemoryEnvironment) -> Result<InMemoryReadWriteTransaction<'a>, Error> {
-        let write_lock = store.write_mutex.lock()?;
+        let _write_lock = store.write_mutex.lock()?;
         let store_ref = store.data.clone();
         let view = {
             let view_lock = store_ref.lock()?;
             view_lock.to_owned()
         };
         Ok(InMemoryReadWriteTransaction {
-            write_lock,
+            _write_lock,
             store_ref,
             view,
         })


### PR DESCRIPTION
## Overview
This PR updates the in-memory trie store to use LMDB-like transaction semantics.  Specifically it changes the many readers _or_ single writer semantics (based on Rust's `RwLock`), to many readers _and_ single writer semantics (which is what LMDB uses).  It also expands the use of "view" copies in both types of transactions to match LMDB's MVCC semantics.  Because this is **test-only code**, I believe the overhead of the copies is justifiable.  

### Which JIRA issue does this PR relate to?
https://casperlabs.atlassian.net/browse/STOR-52

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
Thanks to @EdHastingsCasperLabs for helping me devise this patch.


