### PR TITLE
EE-211: Add up AccessRights of the same URef.

### DIFF
--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -2,7 +2,7 @@ use super::alloc::vec::Vec;
 use super::bytesrepr::{Error, FromBytes, ToBytes, N32, U32_SIZE};
 use crate::contract_api::pointers::*;
 use core::cmp::Ordering;
-use core::ops::Add;
+use core::ops::{Add, AddAssign};
 
 #[allow(clippy::derive_hash_xor_eq)]
 #[repr(C)]
@@ -63,6 +63,12 @@ impl Add for AccessRights {
             (Add, ReadAdd) | (ReadAdd, Add) => ReadAdd,
             (Add, AddWrite) | (AddWrite, Add) => AddWrite,
         }
+    }
+}
+
+impl AddAssign for AccessRights {
+    fn add_assign(&mut self, other: AccessRights) {
+        *self = *self + other;
     }
 }
 


### PR DESCRIPTION
## Overview
Implement the addition for `AccessRights` and merge them in the `known_urefs` of the `Account`/`Contract`.

Use case:
When an account receives `URef(1, Write)`, which it saves in its `known_urefs` map, and at some point later `URef(1, Read)`, it should be the case that an account now has a reference for `URef(1, ReadWrite)`. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-211

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
