### PR TITLE
NO-TICKET: update DbReader to StateReader<K, V>

### DIFF
--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -183,7 +183,7 @@ impl<'a> RuntimeContext<'a> {
     }
 }
 
-pub struct Runtime<'a, R: StateReader> {
+pub struct Runtime<'a, R: StateReader<Key, Value>> {
     args: Vec<Vec<u8>>,
     memory: MemoryRef,
     state: &'a mut TrackingCopy<R>,
@@ -212,7 +212,7 @@ pub fn rename_export_to_call(module: &mut Module, name: String) {
     main_export.push_str("call");
 }
 
-impl<'a, R: StateReader> Runtime<'a, R>
+impl<'a, R: StateReader<Key, Value>> Runtime<'a, R>
 where
     R::Error: Into<Error>,
 {
@@ -686,7 +686,7 @@ const HAS_UREF_FUNC_INDEX: usize = 14;
 const ADD_UREF_FUNC_INDEX: usize = 15;
 const STORE_FN_INDEX: usize = 16;
 
-impl<'a, R: StateReader> Externals for Runtime<'a, R>
+impl<'a, R: StateReader<Key, Value>> Externals for Runtime<'a, R>
 where
     R::Error: Into<Error>,
 {
@@ -1014,7 +1014,7 @@ fn instance_and_memory(parity_module: Module) -> Result<(ModuleRef, MemoryRef), 
     Ok((instance, memory))
 }
 
-fn sub_call<R: StateReader>(
+fn sub_call<R: StateReader<Key, Value>>(
     parity_module: Module,
     args: Vec<Vec<u8>>,
     refs: &mut BTreeMap<String, Key>,
@@ -1106,7 +1106,7 @@ macro_rules! on_fail_charge {
 
 pub trait Executor<A> {
     #[allow(clippy::too_many_arguments)]
-    fn exec<R: StateReader>(
+    fn exec<R: StateReader<Key, Value>>(
         &self,
         parity_module: A,
         args: &[u8],
@@ -1123,7 +1123,7 @@ pub trait Executor<A> {
 pub struct WasmiExecutor;
 
 impl Executor<Module> for WasmiExecutor {
-    fn exec<R: StateReader>(
+    fn exec<R: StateReader<Key, Value>>(
         &self,
         parity_module: Module,
         args: &[u8],

--- a/execution-engine/engine/src/trackingcopy.rs
+++ b/execution-engine/engine/src/trackingcopy.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use common::key::Key;
 use common::value::Value;
-use storage::gs::{DbReader, ExecutionEffect};
+use storage::gs::{StateReader, ExecutionEffect};
 use storage::op::Op;
 use storage::transform::{self, Transform, TypeMismatch};
 use utils::add;
@@ -13,7 +13,7 @@ pub enum QueryResult {
     ValueNotFound(String),
 }
 
-pub struct TrackingCopy<R: DbReader> {
+pub struct TrackingCopy<R: StateReader> {
     reader: R,
     cache: HashMap<Key, Value>,
     ops: HashMap<Key, Op>,
@@ -28,7 +28,7 @@ pub enum AddResult {
     Overflow,
 }
 
-impl<R: DbReader> TrackingCopy<R> {
+impl<R: StateReader> TrackingCopy<R> {
     pub fn new(reader: R) -> TrackingCopy<R> {
         TrackingCopy {
             reader,
@@ -42,7 +42,7 @@ impl<R: DbReader> TrackingCopy<R> {
         if let Some(value) = self.cache.get(k) {
             return Ok(Some(value.clone()));
         }
-        if let Some(value) = self.reader.get(k)? {
+        if let Some(value) = self.reader.read(k)? {
             self.cache.insert(*k, value.clone());
             Ok(Some(value))
         } else {
@@ -207,7 +207,7 @@ mod tests {
     use common::key::{AccessRights, Key};
     use common::value::{Account, Contract, Value};
     use storage::gs::inmem::InMemGS;
-    use storage::gs::DbReader;
+    use storage::gs::StateReader;
     use storage::op::Op;
     use storage::transform::Transform;
 
@@ -234,9 +234,9 @@ mod tests {
         }
     }
 
-    impl DbReader for CountingDb {
+    impl StateReader for CountingDb {
         type Error = !;
-        fn get(&self, _k: &Key) -> Result<Option<Value>, Self::Error> {
+        fn read(&self, _key: &Key) -> Result<Option<Value>, Self::Error> {
             let count = self.count.get();
             let value = match self.value {
                 Some(ref v) => v.clone(),

--- a/execution-engine/engine/src/trackingcopy.rs
+++ b/execution-engine/engine/src/trackingcopy.rs
@@ -13,7 +13,7 @@ pub enum QueryResult {
     ValueNotFound(String),
 }
 
-pub struct TrackingCopy<R: StateReader> {
+pub struct TrackingCopy<R: StateReader<Key, Value>> {
     reader: R,
     cache: HashMap<Key, Value>,
     ops: HashMap<Key, Op>,
@@ -28,7 +28,7 @@ pub enum AddResult {
     Overflow,
 }
 
-impl<R: StateReader> TrackingCopy<R> {
+impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     pub fn new(reader: R) -> TrackingCopy<R> {
         TrackingCopy {
             reader,
@@ -234,7 +234,7 @@ mod tests {
         }
     }
 
-    impl StateReader for CountingDb {
+    impl StateReader<Key, Value> for CountingDb {
         type Error = !;
         fn read(&self, _key: &Key) -> Result<Option<Value>, Self::Error> {
             let count = self.count.get();

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -168,7 +168,7 @@ impl WasmMemoryManager {
         self.memory.get(offset, len)
     }
 
-    pub fn new_uref<'a, R: StateReader>(
+    pub fn new_uref<'a, R: StateReader<Key, Value>>(
         &mut self,
         runtime: &mut Runtime<'a, R>,
         value: (u32, usize), //pointer, length tuple
@@ -254,7 +254,7 @@ fn random_uref_key<G: RngCore>(entropy_source: &mut G, rights: AccessRights) -> 
     Key::URef(key, rights)
 }
 
-fn gs_write<'a, R: StateReader>(
+fn gs_write<'a, R: StateReader<Key, Value>>(
     runtime: &mut Runtime<'a, R>,
     key: (u32, usize),
     value: (u32, usize),
@@ -267,7 +267,7 @@ where
 
 /// Reads data from the GlobalState that lives under a key
 /// that can be found in the Wasm memory under `key` (pointer, length) tuple.
-fn gs_read<'a, R: StateReader, T: FromBytes>(
+fn gs_read<'a, R: StateReader<Key, Value>, T: FromBytes>(
     memory: &mut WasmMemoryManager,
     runtime: &mut Runtime<'a, R>,
     key: (u32, usize),

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -25,7 +25,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::iter::once;
 use std::iter::IntoIterator;
 use std::rc::Rc;
-use storage::gs::{inmem::*, DbReader};
+use storage::gs::{inmem::*, StateReader};
 use storage::history::*;
 use storage::transform::Transform;
 use wasm_prep::MAX_MEM_PAGES;
@@ -168,7 +168,7 @@ impl WasmMemoryManager {
         self.memory.get(offset, len)
     }
 
-    pub fn new_uref<'a, R: DbReader>(
+    pub fn new_uref<'a, R: StateReader>(
         &mut self,
         runtime: &mut Runtime<'a, R>,
         value: (u32, usize), //pointer, length tuple
@@ -254,7 +254,7 @@ fn random_uref_key<G: RngCore>(entropy_source: &mut G, rights: AccessRights) -> 
     Key::URef(key, rights)
 }
 
-fn gs_write<'a, R: DbReader>(
+fn gs_write<'a, R: StateReader>(
     runtime: &mut Runtime<'a, R>,
     key: (u32, usize),
     value: (u32, usize),
@@ -267,7 +267,7 @@ where
 
 /// Reads data from the GlobalState that lives under a key
 /// that can be found in the Wasm memory under `key` (pointer, length) tuple.
-fn gs_read<'a, R: DbReader, T: FromBytes>(
+fn gs_read<'a, R: StateReader, T: FromBytes>(
     memory: &mut WasmMemoryManager,
     runtime: &mut Runtime<'a, R>,
     key: (u32, usize),

--- a/execution-engine/storage/src/gs/inmem.rs
+++ b/execution-engine/storage/src/gs/inmem.rs
@@ -22,7 +22,7 @@ impl<K, V> Clone for InMemGS<K, V> {
     }
 }
 
-impl StateReader for InMemGS<Key, Value> {
+impl StateReader<Key, Value> for InMemGS<Key, Value> {
     type Error = StorageError;
     fn read(&self, k: &Key) -> Result<Option<Value>, Self::Error> {
         Ok(self.0.get(k).map(Clone::clone))

--- a/execution-engine/storage/src/gs/inmem.rs
+++ b/execution-engine/storage/src/gs/inmem.rs
@@ -22,9 +22,9 @@ impl<K, V> Clone for InMemGS<K, V> {
     }
 }
 
-impl DbReader for InMemGS<Key, Value> {
+impl StateReader for InMemGS<Key, Value> {
     type Error = StorageError;
-    fn get(&self, k: &Key) -> Result<Option<Value>, Self::Error> {
+    fn read(&self, k: &Key) -> Result<Option<Value>, Self::Error> {
         Ok(self.0.get(k).map(Clone::clone))
     }
 }
@@ -174,8 +174,8 @@ mod tests {
         let empty_root_hash = [0u8; 32].into();
         let hist = prepopulated_hist();
         let tc = checkout(&hist, empty_root_hash);
-        assert_eq!(tc.get(&KEY1).unwrap().unwrap(), VALUE1);
-        assert_eq!(tc.get(&KEY2).unwrap().unwrap(), VALUE2);
+        assert_eq!(tc.read(&KEY1).unwrap().unwrap(), VALUE1);
+        assert_eq!(tc.read(&KEY2).unwrap().unwrap(), VALUE2);
     }
 
     #[test]
@@ -207,8 +207,8 @@ mod tests {
         let hash_res = commit(&mut hist, empty_root_hash, effects);
         // checkout to the new hash
         let tc_2 = checkout(&hist, hash_res);
-        assert_eq!(tc_2.get(&KEY1).unwrap().unwrap(), v1);
-        assert_eq!(tc_2.get(&KEY2).unwrap().unwrap(), v2);
+        assert_eq!(tc_2.read(&KEY1).unwrap().unwrap(), v1);
+        assert_eq!(tc_2.read(&KEY2).unwrap().unwrap(), v2);
     }
 
     #[test]
@@ -235,9 +235,9 @@ mod tests {
         let _ = commit(&mut gs, empty_root_hash, effects);
         // checkout to the empty root hash
         let tc_2 = checkout(&gs, empty_root_hash);
-        assert_eq!(tc_2.get(&KEY1).unwrap().unwrap(), VALUE1);
-        assert_eq!(tc_2.get(&KEY2).unwrap().unwrap(), VALUE2);
+        assert_eq!(tc_2.read(&KEY1).unwrap().unwrap(), VALUE1);
+        assert_eq!(tc_2.read(&KEY2).unwrap().unwrap(), VALUE2);
         // test that value inserted later are not visible in the past commits.
-        assert_eq!(tc_2.get(&key3).unwrap(), None);
+        assert_eq!(tc_2.read(&key3).unwrap(), None);
     }
 }

--- a/execution-engine/storage/src/gs/mod.rs
+++ b/execution-engine/storage/src/gs/mod.rs
@@ -10,12 +10,12 @@ pub mod inmem;
 pub struct ExecutionEffect(pub HashMap<Key, Op>, pub HashMap<Key, Transform>);
 
 /// A reader of state
-pub trait StateReader {
+pub trait StateReader<K, V> {
     /// An error which occurs when reading state
     type Error;
 
     /// Returns the state value from the corresponding key
-    fn read(&self, key: &Key) -> Result<Option<Value>, Self::Error>;
+    fn read(&self, key: &K) -> Result<Option<V>, Self::Error>;
 }
 
 pub fn mocked_account(account_addr: [u8; 20]) -> BTreeMap<Key, Value> {

--- a/execution-engine/storage/src/gs/mod.rs
+++ b/execution-engine/storage/src/gs/mod.rs
@@ -9,9 +9,13 @@ pub mod inmem;
 #[derive(Debug)]
 pub struct ExecutionEffect(pub HashMap<Key, Op>, pub HashMap<Key, Transform>);
 
-pub trait DbReader {
+/// A reader of state
+pub trait StateReader {
+    /// An error which occurs when reading state
     type Error;
-    fn get(&self, k: &Key) -> Result<Option<Value>, Self::Error>;
+
+    /// Returns the state value from the corresponding key
+    fn read(&self, key: &Key) -> Result<Option<Value>, Self::Error>;
 }
 
 pub fn mocked_account(account_addr: [u8; 20]) -> BTreeMap<Key, Value> {

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -1,4 +1,5 @@
 use common::key::Key;
+use common::value::Value;
 use gs::StateReader;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
@@ -18,7 +19,7 @@ pub enum CommitResult {
 
 pub trait History {
     type Error;
-    type Reader: StateReader<Error = Self::Error>;
+    type Reader: StateReader<Key, Value, Error = Self::Error>;
 
     /// Checkouts to the post state of a specific block.
     fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error>;

--- a/execution-engine/storage/src/history/mod.rs
+++ b/execution-engine/storage/src/history/mod.rs
@@ -1,5 +1,5 @@
 use common::key::Key;
-use gs::DbReader;
+use gs::StateReader;
 use shared::newtypes::Blake2bHash;
 use std::collections::HashMap;
 use transform::{Transform, TypeMismatch};
@@ -18,7 +18,7 @@ pub enum CommitResult {
 
 pub trait History {
     type Error;
-    type Reader: DbReader<Error = Self::Error>;
+    type Reader: StateReader<Error = Self::Error>;
 
     /// Checkouts to the post state of a specific block.
     fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error>;


### PR DESCRIPTION
## Overview
This PR renames and generalizes our current `DbReader` to `StateReader<K, V>`.  Our canonical implementations of `StateReader` will be leveraging the `TrieStore` which also is parameterized by key and value types, and I believe it is better to keep this abstraction general as well.

### Which JIRA issue does this PR relate to?
This unticketed work related to [STOR-37](https://casperlabs.atlassian.net/browse/STOR-37).

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
