### PR TITLE
Op 118 git status after compile

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -77,8 +77,8 @@ pipeline:
     <<: *buildenv
     commands: |
       git status | grep modified
-      echo $?
-      if [ $? = 0 ]; then exit 1; fi
+      echo "$?"
+      if [ "$?" = 0 ]; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ pipeline:
     <<: *buildenv
     commands:
       - git status | grep modified 
-      - if [ $? = 1 ]; then exit 1; fi
+      - if [ $? = 0 ]; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,7 @@ pipeline:
   git-status-post-scala-compile:
     <<: *buildenv
     commands: |
-      STATUS_CHECK=`git status | grep modified`
+      STATUS_CHECK=$(git status)
       echo $STATUS_CHECK
       if [[ $STATUS_CHECK == *"modified"* ]]; then exit 1; fi
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -73,18 +73,18 @@ pipeline:
     commands:
       - sbt compile test:compile doc
 
+  git-status-post-scala-compile:
+    <<: *buildenv
+    commands:
+      - git status | grep modified 
+      - if [ $? = 1 ]; then exit 1; fi
+
   compile-rust:
     <<: *buildenv
     commands:
       - cd execution-engine/
       - ~/.cargo/bin/cargo update
       - ~/.cargo/bin/cargo build
-
-  git-status:
-    <<: *buildenv
-    commands:
-      - git status | grep modified 
-      - if [ $? = 0 ]; then exit 1; fi
 
   run-rust-lints:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ pipeline:
     <<: *buildenv
     commands: |
       STATUS_CHECK=$(git status)
-      if echo $STATUS_CHECK | grep -q "modified" ; then echo "$STATUS_CHECK; exit 1; fi
+      if echo $STATUS_CHECK | grep -q "modified" ; then echo "$STATUS_CHECK"; exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ pipeline:
     <<: *buildenv
     commands: |
       STATUS_CHECK=$(git status)
-      if echo $STATUS_CHECK | grep -q "dev" ; then exit 1; fi
+      if echo $STATUS_CHECK | grep -q "modified" ; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,8 +77,8 @@ pipeline:
     <<: *buildenv
     commands: |
       git status | grep modified
-      echo "$?"
-      if [ "$?" = 0 ]; then exit 1; fi
+      echo ${?}
+      if [ ${?} = 0 ]; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -75,10 +75,10 @@ pipeline:
 
   git-status-post-scala-compile:
     <<: *buildenv
-    commands:
-      - git status | grep modified
-      - echo $?
-      - if [ $? = 0 ]; then exit 1; fi
+    commands: |
+      git status | grep modified
+      echo $?
+      if [ $? = 0 ]; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -80,6 +80,13 @@ pipeline:
       - ~/.cargo/bin/cargo update
       - ~/.cargo/bin/cargo build
 
+  git-status:
+    <<: *buildenv
+    commands:
+      - >-
+      git status | grep modified ;
+      if [ $? = 0 ]; then exit 1; fi
+
   run-rust-lints:
     <<: *buildenv
     group: test

--- a/.drone.yml
+++ b/.drone.yml
@@ -83,9 +83,8 @@ pipeline:
   git-status:
     <<: *buildenv
     commands:
-      - >-
-      git status | grep modified ;
-      if [ $? = 0 ]; then exit 1; fi
+      - git status | grep modified 
+      - if [ $? = 0 ]; then exit 1; fi
 
   run-rust-lints:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,7 +77,7 @@ pipeline:
     <<: *buildenv
     commands: |
       STATUS_CHECK=$(git status)
-      if echo $STATUS_CHECK | grep -q "modified" ; then exit 1; fi
+      if echo $STATUS_CHECK | grep -q "modified" ; then echo "$STATUS_CHECK; exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -78,7 +78,7 @@ pipeline:
     commands: |
       STATUS_CHECK=$(git status)
       echo $STATUS_CHECK
-      if [[ $STATUS_CHECK == *"modified"* ]]; then exit 1; fi
+      if echo $STATUS_CHECK | grep -q "modified" ; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -77,8 +77,7 @@ pipeline:
     <<: *buildenv
     commands: |
       STATUS_CHECK=$(git status)
-      echo $STATUS_CHECK
-      if echo $STATUS_CHECK | grep -q "modified" ; then exit 1; fi
+      if echo $STATUS_CHECK | grep -q "dev" ; then exit 1; fi
 
   compile-rust:
     <<: *buildenv

--- a/.drone.yml
+++ b/.drone.yml
@@ -76,7 +76,8 @@ pipeline:
   git-status-post-scala-compile:
     <<: *buildenv
     commands:
-      - git status | grep modified 
+      - git status | grep modified
+      - echo $?
       - if [ $? = 0 ]; then exit 1; fi
 
   compile-rust:

--- a/.drone.yml
+++ b/.drone.yml
@@ -76,9 +76,9 @@ pipeline:
   git-status-post-scala-compile:
     <<: *buildenv
     commands: |
-      git status | grep modified
-      echo ${?}
-      if [ ${?} = 0 ]; then exit 1; fi
+      STATUS_CHECK=`git status | grep modified`
+      echo $STATUS_CHECK
+      if [[ $STATUS_CHECK == *"modified"* ]]; then exit 1; fi
 
   compile-rust:
     <<: *buildenv


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.
This adds a git status check after the scala compile step. It is needed because the scala autoformatter may change files after compiling.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.
https://casperlabs.atlassian.net/browse/OP-118

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
