### PR TITLE
EE-64: Make `call_contract` accept arguments in their original form instead of array of byte arrays

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -126,7 +126,7 @@ dependencies = [
 name = "casperlabs-engine-grpc-server"
 version = "0.2.0"
 dependencies = [
- "casperlabs-contract-ffi 0.4.0",
+ "casperlabs-contract-ffi 0.5.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "execution-engine 0.1.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -246,7 +246,7 @@ name = "execution-engine"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.4.0",
+ "casperlabs-contract-ffi 0.5.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -981,7 +981,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.4.0",
+ "casperlabs-contract-ffi 0.5.0",
 ]
 
 [[package]]
@@ -1013,7 +1013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "storage"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.4.0",
+ "casperlabs-contract-ffi 0.5.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -7,7 +7,9 @@ use execution_engine::engine::{Error as EngineError, ExecutionResult, RootNotFou
 use execution_engine::execution::Error as ExecutionError;
 use ipc;
 use shared::newtypes::Blake2bHash;
-use storage::{global_state, history, history::CommitResult, op, transform, transform::TypeMismatch};
+use storage::{
+    global_state, history, history::CommitResult, op, transform, transform::TypeMismatch,
+};
 
 /// Helper method for turning instances of Value into Transform::Write.
 fn transform_write(v: common::value::Value) -> Result<transform::Transform, ParsingError> {

--- a/execution-engine/common/Cargo.toml
+++ b/execution-engine/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-contract-ffi"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."

--- a/execution-engine/common/RELEASES.md
+++ b/execution-engine/common/RELEASES.md
@@ -1,3 +1,7 @@
+Version 0.5.0 (2019-04-10)
+==========================
+* API method `call_contract` has been simplified. Instead of requiring arguments passed in the binary form it now accepts tuples up to 8 elements. It is required that for every type in the tuple there exists an instance of `ToBytes` trait.
+
 Version 0.4.0 (2019-04-03)
 ==========================
 

--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -420,7 +420,7 @@ where
     }
 }
 
-impl ToBytes for str {
+impl ToBytes for &str {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         if self.len() >= u32::max_value() as usize - U32_SIZE {
             return Err(Error::OutOfMemoryError);

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -1,0 +1,145 @@
+use crate::bytesrepr;
+use alloc::vec::Vec;
+use bytesrepr::{Error, ToBytes};
+
+pub trait ArgsParser {
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error>;
+}
+
+impl<T> ArgsParser for T
+where
+    T: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes = ToBytes::to_bytes(self)?;
+        Ok(vec![bytes])
+    }
+}
+
+impl<T1, T2> ArgsParser for (T1, T2)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        Ok(vec![bytes1, bytes2])
+    }
+}
+
+impl<T1, T2, T3> ArgsParser for (T1, T2, T3)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+    T3: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        let bytes3 = ToBytes::to_bytes(&self.2)?;
+        Ok(vec![bytes1, bytes2, bytes3])
+    }
+}
+
+impl<T1, T2, T3, T4> ArgsParser for (T1, T2, T3, T4)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+    T3: ToBytes,
+    T4: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        let bytes3 = ToBytes::to_bytes(&self.2)?;
+        let bytes4 = ToBytes::to_bytes(&self.3)?;
+        Ok(vec![bytes1, bytes2, bytes3, bytes4])
+    }
+}
+
+impl<T1, T2, T3, T4, T5> ArgsParser for (T1, T2, T3, T4, T5)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+    T3: ToBytes,
+    T4: ToBytes,
+    T5: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        let bytes3 = ToBytes::to_bytes(&self.2)?;
+        let bytes4 = ToBytes::to_bytes(&self.3)?;
+        let bytes5 = ToBytes::to_bytes(&self.4)?;
+        Ok(vec![bytes1, bytes2, bytes3, bytes4, bytes5])
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6> ArgsParser for (T1, T2, T3, T4, T5, T6)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+    T3: ToBytes,
+    T4: ToBytes,
+    T5: ToBytes,
+    T6: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        let bytes3 = ToBytes::to_bytes(&self.2)?;
+        let bytes4 = ToBytes::to_bytes(&self.3)?;
+        let bytes5 = ToBytes::to_bytes(&self.4)?;
+        let bytes6 = ToBytes::to_bytes(&self.5)?;
+        Ok(vec![bytes1, bytes2, bytes3, bytes4, bytes5, bytes6])
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7> ArgsParser for (T1, T2, T3, T4, T5, T6, T7)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+    T3: ToBytes,
+    T4: ToBytes,
+    T5: ToBytes,
+    T6: ToBytes,
+    T7: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        let bytes3 = ToBytes::to_bytes(&self.2)?;
+        let bytes4 = ToBytes::to_bytes(&self.3)?;
+        let bytes5 = ToBytes::to_bytes(&self.4)?;
+        let bytes6 = ToBytes::to_bytes(&self.5)?;
+        let bytes7 = ToBytes::to_bytes(&self.6)?;
+        Ok(vec![bytes1, bytes2, bytes3, bytes4, bytes5, bytes6, bytes7])
+    }
+}
+
+impl<T1, T2, T3, T4, T5, T6, T7, T8> ArgsParser for (T1, T2, T3, T4, T5, T6, T7, T8)
+where
+    T1: ToBytes,
+    T2: ToBytes,
+    T3: ToBytes,
+    T4: ToBytes,
+    T5: ToBytes,
+    T6: ToBytes,
+    T7: ToBytes,
+    T8: ToBytes,
+{
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        let bytes1 = ToBytes::to_bytes(&self.0)?;
+        let bytes2 = ToBytes::to_bytes(&self.1)?;
+        let bytes3 = ToBytes::to_bytes(&self.2)?;
+        let bytes4 = ToBytes::to_bytes(&self.3)?;
+        let bytes5 = ToBytes::to_bytes(&self.4)?;
+        let bytes6 = ToBytes::to_bytes(&self.5)?;
+        let bytes7 = ToBytes::to_bytes(&self.6)?;
+        let bytes8 = ToBytes::to_bytes(&self.7)?;
+        Ok(vec![
+            bytes1, bytes2, bytes3, bytes4, bytes5, bytes6, bytes7, bytes8,
+        ])
+    }
+}

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -2,7 +2,11 @@ use crate::bytesrepr;
 use alloc::vec::Vec;
 use bytesrepr::{Error, ToBytes};
 
+/// Parses `Self` into a byte representation.
+/// Implemented for tuples of various sizes.
 pub trait ArgsParser {
+    /// `parse` returns `Vec<Vec<u8>>` because we want to be able to
+    /// discriminate between elements of the tuple and retain the order.
     fn parse(&self) -> Result<Vec<Vec<u8>>, Error>;
 }
 

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -6,140 +6,33 @@ pub trait ArgsParser {
     fn parse(&self) -> Result<Vec<Vec<u8>>, Error>;
 }
 
-impl<T> ArgsParser for T
-where
-    T: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes = ToBytes::to_bytes(self)?;
-        Ok(vec![bytes])
-    }
+macro_rules! impl_argsparser_tuple {
+    ( $name:ident ) => (
+        impl<$name: ToBytes> ArgsParser for $name {
+            #[allow(non_snake_case)]
+            fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+                let ref $name = *self;
+                Ok(vec![ToBytes::to_bytes($name)?])
+            }
+        }
+    );
+    ( $($name:ident)+) => (
+        impl<$($name: ToBytes),*> ArgsParser for ($($name,)*) {
+            #[allow(non_snake_case)]
+            fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+                let ($(ref $name,)+) = *self;
+                Ok(vec![$(ToBytes::to_bytes($name)?,)+])
+            }
+        }
+    );
 }
 
-impl<T1, T2> ArgsParser for (T1, T2)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        Ok(vec![bytes1, bytes2])
-    }
-}
-
-impl<T1, T2, T3> ArgsParser for (T1, T2, T3)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-    T3: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        let bytes3 = ToBytes::to_bytes(&self.2)?;
-        Ok(vec![bytes1, bytes2, bytes3])
-    }
-}
-
-impl<T1, T2, T3, T4> ArgsParser for (T1, T2, T3, T4)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-    T3: ToBytes,
-    T4: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        let bytes3 = ToBytes::to_bytes(&self.2)?;
-        let bytes4 = ToBytes::to_bytes(&self.3)?;
-        Ok(vec![bytes1, bytes2, bytes3, bytes4])
-    }
-}
-
-impl<T1, T2, T3, T4, T5> ArgsParser for (T1, T2, T3, T4, T5)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-    T3: ToBytes,
-    T4: ToBytes,
-    T5: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        let bytes3 = ToBytes::to_bytes(&self.2)?;
-        let bytes4 = ToBytes::to_bytes(&self.3)?;
-        let bytes5 = ToBytes::to_bytes(&self.4)?;
-        Ok(vec![bytes1, bytes2, bytes3, bytes4, bytes5])
-    }
-}
-
-impl<T1, T2, T3, T4, T5, T6> ArgsParser for (T1, T2, T3, T4, T5, T6)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-    T3: ToBytes,
-    T4: ToBytes,
-    T5: ToBytes,
-    T6: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        let bytes3 = ToBytes::to_bytes(&self.2)?;
-        let bytes4 = ToBytes::to_bytes(&self.3)?;
-        let bytes5 = ToBytes::to_bytes(&self.4)?;
-        let bytes6 = ToBytes::to_bytes(&self.5)?;
-        Ok(vec![bytes1, bytes2, bytes3, bytes4, bytes5, bytes6])
-    }
-}
-
-impl<T1, T2, T3, T4, T5, T6, T7> ArgsParser for (T1, T2, T3, T4, T5, T6, T7)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-    T3: ToBytes,
-    T4: ToBytes,
-    T5: ToBytes,
-    T6: ToBytes,
-    T7: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        let bytes3 = ToBytes::to_bytes(&self.2)?;
-        let bytes4 = ToBytes::to_bytes(&self.3)?;
-        let bytes5 = ToBytes::to_bytes(&self.4)?;
-        let bytes6 = ToBytes::to_bytes(&self.5)?;
-        let bytes7 = ToBytes::to_bytes(&self.6)?;
-        Ok(vec![bytes1, bytes2, bytes3, bytes4, bytes5, bytes6, bytes7])
-    }
-}
-
-impl<T1, T2, T3, T4, T5, T6, T7, T8> ArgsParser for (T1, T2, T3, T4, T5, T6, T7, T8)
-where
-    T1: ToBytes,
-    T2: ToBytes,
-    T3: ToBytes,
-    T4: ToBytes,
-    T5: ToBytes,
-    T6: ToBytes,
-    T7: ToBytes,
-    T8: ToBytes,
-{
-    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-        let bytes1 = ToBytes::to_bytes(&self.0)?;
-        let bytes2 = ToBytes::to_bytes(&self.1)?;
-        let bytes3 = ToBytes::to_bytes(&self.2)?;
-        let bytes4 = ToBytes::to_bytes(&self.3)?;
-        let bytes5 = ToBytes::to_bytes(&self.4)?;
-        let bytes6 = ToBytes::to_bytes(&self.5)?;
-        let bytes7 = ToBytes::to_bytes(&self.6)?;
-        let bytes8 = ToBytes::to_bytes(&self.7)?;
-        Ok(vec![
-            bytes1, bytes2, bytes3, bytes4, bytes5, bytes6, bytes7, bytes8,
-        ])
-    }
-}
+impl_argsparser_tuple! { T1 }
+impl_argsparser_tuple! { T1 T2 }
+impl_argsparser_tuple! { T1 T2 T3 }
+impl_argsparser_tuple! { T1 T2 T3 T4 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 }

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -41,3 +41,10 @@ impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 }
 impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 }
 impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 }
 impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 T14 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 T14 T15 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 T14 T15 T16 }

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -41,10 +41,10 @@ impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 }
 impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 }
 impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 }
 impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 T14 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 T14 T15 }
-impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T10 T11 T12 T13 T14 T15 T16 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 }
+impl_argsparser_tuple! { T1 T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12 T13 T14 T15 T16 }

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -2,7 +2,8 @@ use crate::bytesrepr;
 use alloc::vec::Vec;
 use bytesrepr::{Error, ToBytes};
 
-/// Parses `Self` into a byte representation.
+/// Parses `Self` into a byte representation that is ABI compliant.
+/// It means that each type of the tuple have to implement `ToBytes`.
 /// Implemented for tuples of various sizes.
 pub trait ArgsParser {
     /// `parse` returns `Vec<Vec<u8>>` because we want to be able to

--- a/execution-engine/common/src/contract_api/argsparser.rs
+++ b/execution-engine/common/src/contract_api/argsparser.rs
@@ -11,7 +11,7 @@ macro_rules! impl_argsparser_tuple {
         impl<$name: ToBytes> ArgsParser for $name {
             #[allow(non_snake_case)]
             fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-                let ref $name = *self;
+                let $name = self;
                 Ok(vec![ToBytes::to_bytes($name)?])
             }
         }

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -1,6 +1,6 @@
 mod alloc_util;
-pub mod pointers;
 pub mod argsparser;
+pub mod pointers;
 
 use self::alloc_util::*;
 use self::pointers::*;

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -1,5 +1,6 @@
 mod alloc_util;
 pub mod pointers;
+pub mod argsparser;
 
 use self::alloc_util::*;
 use self::pointers::*;
@@ -10,6 +11,7 @@ use crate::value::{Contract, Value};
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
+use argsparser::ArgsParser;
 use core::convert::{TryFrom, TryInto};
 
 /// Read value under the key in the global state
@@ -200,14 +202,14 @@ pub fn ret<T: ToBytes>(t: &T, extra_urefs: &Vec<Key>) -> ! {
 /// execution. The value returned from the contract call (see `ret` above) is
 /// returned from this function.
 #[allow(clippy::ptr_arg)]
-pub fn call_contract<T: FromBytes>(
+pub fn call_contract<A: ArgsParser, T: FromBytes>(
     c_ptr: ContractPointer,
-    args: &Vec<Vec<u8>>,
+    args: &A,
     extra_urefs: &Vec<Key>,
 ) -> T {
     let contract_key: Key = c_ptr.into();
     let (key_ptr, key_size, _bytes1) = to_ptr(&contract_key);
-    let (args_ptr, args_size, _bytes2) = to_ptr(args);
+    let (args_ptr, args_size, _bytes2) = ArgsParser::parse(args).map(|args| to_ptr(&args)).unwrap();
     let (urefs_ptr, urefs_size, _bytes3) = to_ptr(extra_urefs);
     let res_size = unsafe {
         ext_ffi::call_contract(

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -8,14 +8,7 @@
     maybe_uninit
 )]
 
-// For test targets alloc is imported with `macro_use` which will
-// allow proptest utilities to work properly as they require `vec!`
-// macro to be available internally.
-#[cfg(any(test, feature = "gens"))]
 #[macro_use]
-extern crate alloc;
-
-#[cfg(not(any(test, feature = "gens")))]
 extern crate alloc;
 
 #[macro_use]

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -5,7 +5,7 @@ use self::blake2::VarBlake2b;
 use common::bytesrepr::{deserialize, Error as BytesReprError, ToBytes};
 use common::key::{AccessRights, Key};
 use common::value::{Account, Value};
-use storage::global_state::{StateReader, ExecutionEffect};
+use storage::global_state::{ExecutionEffect, StateReader};
 use storage::transform::TypeMismatch;
 use trackingcopy::{AddResult, TrackingCopy};
 use wasmi::memory_units::Pages;

--- a/execution-engine/engine/src/trackingcopy.rs
+++ b/execution-engine/engine/src/trackingcopy.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use common::key::Key;
 use common::value::Value;
-use storage::global_state::{StateReader, ExecutionEffect};
+use storage::global_state::{ExecutionEffect, StateReader};
 use storage::op::Op;
 use storage::transform::{self, Transform, TypeMismatch};
 use utils::add;


### PR DESCRIPTION
## Overview
As in the title.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-64

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
