### PR TITLE
EE-256: Change internal representation of AccessRights to bit flags.

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -242,6 +242,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "execution-engine"
 version = "0.1.0"
 dependencies = [
@@ -249,6 +254,7 @@ dependencies = [
  "casperlabs-contract-ffi 0.4.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -391,6 +397,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1529,6 +1543,7 @@ dependencies = [
 "checksum crunchy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c240f247c278fa08a6d4820a6a222bfc6e0d999e51ba67be94f44c905b2161f2"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1543,6 +1558,7 @@ dependencies = [
 "checksum grpc-compiler 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f140d998d8940880e464f3fd291052618199432e91e59ae5c5075c0c8a40c"
 "checksum httpbis 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7689cfa896b2a71da4f16206af167542b75d242b6906313e53857972a92d5614"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
+"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
 name = "casperlabs-contract-ffi"
 version = "0.4.0"
 dependencies = [
+ "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -7,7 +7,9 @@ use execution_engine::engine::{Error as EngineError, ExecutionResult, RootNotFou
 use execution_engine::execution::Error as ExecutionError;
 use ipc;
 use shared::newtypes::Blake2bHash;
-use storage::{global_state, history, history::CommitResult, op, transform, transform::TypeMismatch};
+use storage::{
+    global_state, history, history::CommitResult, op, transform, transform::TypeMismatch,
+};
 
 /// Helper method for turning instances of Value into Transform::Write.
 fn transform_write(v: common::value::Value) -> Result<transform::Transform, ParsingError> {

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -291,7 +291,7 @@ impl TryFrom<&super::ipc::Key> for common::key::Key {
             // TODO: What to do about access rights here?
             Ok(common::key::Key::URef(
                 arr,
-                common::key::AccessRights::ReadWrite,
+                common::key::AccessRights::READ_ADD_WRITE,
             ))
         } else {
             parse_error(format!(

--- a/execution-engine/common/Cargo.toml
+++ b/execution-engine/common/Cargo.toml
@@ -17,6 +17,7 @@ num = { version = "0.2.0", default-features = false }
 wee_alloc = "0.4.3"
 uint = { version = "0.6.1", default-features = false, features = [] }
 proptest = { version = "0.9.2", default-features = false, optional = true }
+bitflags = "1.0.4"
 
 [dev-dependencies]
 proptest = { version = "0.9.2", default-features = false }

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -27,13 +27,14 @@ pub fn uref_map_arb(depth: usize) -> impl Strategy<Value = BTreeMap<String, Key>
 
 pub fn access_rights_arb() -> impl Strategy<Value = AccessRights> {
     prop_oneof![
-        Just(AccessRights::Eqv),
-        Just(AccessRights::Read),
-        Just(AccessRights::Add),
-        Just(AccessRights::Write),
-        Just(AccessRights::ReadAdd),
-        Just(AccessRights::ReadWrite),
-        Just(AccessRights::AddWrite),
+        Just(AccessRights::EQ),
+        Just(AccessRights::READ),
+        Just(AccessRights::ADD),
+        Just(AccessRights::WRITE),
+        Just(AccessRights::READ_ADD),
+        Just(AccessRights::READ_WRITE),
+        Just(AccessRights::ADD_WRITE),
+        Just(AccessRights::READ_ADD_WRITE),
     ]
 }
 

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -27,7 +27,6 @@ pub fn uref_map_arb(depth: usize) -> impl Strategy<Value = BTreeMap<String, Key>
 
 pub fn access_rights_arb() -> impl Strategy<Value = AccessRights> {
     prop_oneof![
-        Just(AccessRights::EQ),
         Just(AccessRights::READ),
         Just(AccessRights::ADD),
         Just(AccessRights::WRITE),

--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -4,16 +4,15 @@ use crate::contract_api::pointers::*;
 use core::ops::{BitAnd, BitOr};
 
 #[allow(clippy::derive_hash_xor_eq)]
-#[repr(C)]
+#[repr(u8)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
-
 pub enum AccessRights {
-    Eqv,
-    Read,
-    Write,
-    Add,
-    ReadAdd,
-    ReadWrite,
+    Eqv = 0b0001,
+    Read = 0b0011,
+    Write = 0x05,
+    Add = 0x07,
+    ReadAdd = 0x09,
+    ReadWrite = 0x11,
     AddWrite,
     ReadAddWrite,
 }
@@ -38,7 +37,7 @@ impl BitAnd for AccessRights {
 
 use AccessRights::*;
 impl AccessRights {
-    pub fn bitwise_repr(&self) -> u8 {
+    pub fn bitwise_repr(self) -> u8 {
         match self {
             Eqv => 0b0001,
             Read => 0b0011,

--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -6,10 +6,9 @@ use bitflags;
 bitflags! {
     #[allow(clippy::derive_hash_xor_eq)]
     pub struct AccessRights: u8 {
-        const EQ    = 0b0001;
-        const READ  = 0b0011;
-        const WRITE = 0b0101;
-        const ADD   = 0b1001;
+        const READ  = 0b001;
+        const WRITE = 0b010;
+        const ADD   = 0b100;
         const READ_ADD       = Self::READ.bits | Self::ADD.bits;
         const READ_WRITE     = Self::READ.bits | Self::WRITE.bits;
         const ADD_WRITE      = Self::ADD.bits  | Self::WRITE.bits;
@@ -197,7 +196,6 @@ mod tests {
         test_readable(AccessRights::READ_ADD_WRITE, true);
         test_readable(AccessRights::ADD, false);
         test_readable(AccessRights::ADD_WRITE, false);
-        test_readable(AccessRights::EQ, false);
         test_readable(AccessRights::WRITE, false);
     }
 
@@ -210,7 +208,6 @@ mod tests {
         test_writable(AccessRights::WRITE, true);
         test_writable(AccessRights::READ_WRITE, true);
         test_writable(AccessRights::ADD_WRITE, true);
-        test_writable(AccessRights::EQ, false);
         test_writable(AccessRights::READ, false);
         test_writable(AccessRights::ADD, false);
         test_writable(AccessRights::READ_ADD, false);
@@ -227,7 +224,6 @@ mod tests {
         test_addable(AccessRights::READ_ADD, true);
         test_addable(AccessRights::READ_WRITE, false);
         test_addable(AccessRights::ADD_WRITE, true);
-        test_addable(AccessRights::EQ, false);
         test_addable(AccessRights::READ, false);
         test_addable(AccessRights::WRITE, false);
         test_addable(AccessRights::READ_ADD_WRITE, true);

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -22,6 +22,8 @@ extern crate alloc;
 extern crate uint;
 extern crate failure;
 extern crate wee_alloc;
+#[macro_use]
+extern crate bitflags;
 
 #[cfg(any(test, feature = "gens"))]
 extern crate proptest;

--- a/execution-engine/engine/Cargo.toml
+++ b/execution-engine/engine/Cargo.toml
@@ -18,6 +18,7 @@ parking_lot = "0.7.1"
 rand = "0.6.1"
 rand_chacha = "0.1.1"
 shared = { path = "../shared" }
+itertools = "0.8.0"
 
 [dev-dependencies]
 matches = "0.1.8"

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -125,7 +125,7 @@ impl<'a> RuntimeContext<'a> {
             let entry_rights = self
                 .known_urefs
                 .entry(raw_addr)
-                .or_insert_with(|| std::iter::once(AccessRights::Eqv).collect());
+                .or_insert_with(|| std::iter::once(AccessRights::EQ).collect());
             entry_rights.insert(rights);
         }
     }
@@ -463,7 +463,7 @@ where
             Ok(self.host_buf.len())
         } else {
             Err(Error::InvalidAccess {
-                required: AccessRights::Read,
+                required: AccessRights::READ,
             })
         }
     }
@@ -547,7 +547,7 @@ where
                     Ok(())
                 } else {
                     Err(Error::InvalidAccess {
-                        required: AccessRights::Write,
+                        required: AccessRights::WRITE,
                     })
                 }
             })
@@ -606,7 +606,7 @@ where
             err_on_missing_key(key, self.state.read(key)).map_err(Into::into)
         } else {
             Err(Error::InvalidAccess {
-                required: AccessRights::Read,
+                required: AccessRights::READ,
             }
             .into())
         }
@@ -629,7 +629,7 @@ where
             }
         } else {
             Err(Error::InvalidAccess {
-                required: AccessRights::Add,
+                required: AccessRights::ADD,
             }
             .into())
         }
@@ -653,7 +653,7 @@ where
         let value = self.value_from_mem(value_ptr, value_size)?; // read initial value from memory
         let mut key = [0u8; 32];
         self.rng.fill_bytes(&mut key);
-        let key = Key::URef(key, AccessRights::ReadWrite);
+        let key = Key::URef(key, AccessRights::READ_ADD_WRITE);
         self.state.write(key, value); // write initial value to state
         self.context.insert_uref(key);
         self.memory

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -125,7 +125,7 @@ impl<'a> RuntimeContext<'a> {
             let entry_rights = self
                 .known_urefs
                 .entry(raw_addr)
-                .or_insert_with(|| std::iter::once(AccessRights::EQ).collect());
+                .or_insert_with(|| std::iter::empty().collect());
             entry_rights.insert(rights);
         }
     }

--- a/execution-engine/engine/src/lib.rs
+++ b/execution-engine/engine/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate common;
 extern crate core;
 extern crate failure;
+extern crate itertools;
 extern crate parity_wasm;
 extern crate parking_lot;
 extern crate pwasm_utils;

--- a/execution-engine/engine/src/trackingcopy.rs
+++ b/execution-engine/engine/src/trackingcopy.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use common::key::Key;
 use common::value::Value;
-use storage::global_state::{StateReader, ExecutionEffect};
+use storage::global_state::{ExecutionEffect, StateReader};
 use storage::op::Op;
 use storage::transform::{self, Transform, TypeMismatch};
 use utils::add;

--- a/execution-engine/engine/src/trackingcopy.rs
+++ b/execution-engine/engine/src/trackingcopy.rs
@@ -364,8 +364,8 @@ mod tests {
         let db = CountingDb::new_init(Value::Account(account));
         let mut tc = TrackingCopy::new(db);
         let k = Key::Hash([0u8; 32]);
-        let u1 = Key::URef([1u8; 32], AccessRights::ReadWrite);
-        let u2 = Key::URef([2u8; 32], AccessRights::ReadWrite);
+        let u1 = Key::URef([1u8; 32], AccessRights::READ_WRITE);
+        let u2 = Key::URef([2u8; 32], AccessRights::READ_WRITE);
 
         let named_key = Value::NamedKey("test".to_string(), u1);
         let other_named_key = Value::NamedKey("test2".to_string(), u2);

--- a/execution-engine/engine/tests/execution_test.rs
+++ b/execution-engine/engine/tests/execution_test.rs
@@ -384,7 +384,7 @@ fn forged_uref() {
     // create a forged uref
     let uref = wasm_write(
         &mut test_fixture.memory,
-        random_uref_key(&mut rng, AccessRights::ReadWrite),
+        random_uref_key(&mut rng, AccessRights::READ_WRITE),
     );
 
     // write arbitrary value to wasm memory to allow call to write
@@ -523,7 +523,7 @@ fn store_contract_hash_illegal_urefs() {
     let mut rng = rand::thread_rng();
     let wasm_module = create_wasm_module();
     // Create URef we don't own
-    let uref = random_uref_key(&mut rng, AccessRights::Read);
+    let uref = random_uref_key(&mut rng, AccessRights::READ);
     let urefs = urefs_map(vec![("ForgedURef".to_owned(), uref)]);
 
     let mut tc_borrowed = test_fixture.tc.borrow_mut();
@@ -637,9 +637,9 @@ fn store_contract_uref_known_key() {
     // ---- Test fixtures ----
     let mut rng = rand::thread_rng();
     // URef where we will write contract
-    let contract_uref = random_uref_key(&mut rng, AccessRights::ReadWrite);
+    let contract_uref = random_uref_key(&mut rng, AccessRights::READ_WRITE);
     // URef we want to store WITH the contract so that it can use it later
-    let known_uref = random_uref_key(&mut rng, AccessRights::ReadWrite);
+    let known_uref = random_uref_key(&mut rng, AccessRights::READ_WRITE);
     let urefs = urefs_map(vec![("KnownURef".to_owned(), known_uref)]);
     let known_urefs: HashSet<Key> = once(contract_uref).chain(once(known_uref)).collect();
     let mut test_fixture: TestFixture = {
@@ -693,9 +693,9 @@ fn store_contract_uref_forged_key() {
     // ---- Test fixtures ----
     // URef where we will write contract
     let mut rng = rand::thread_rng();
-    let forged_contract_uref = random_uref_key(&mut rng, AccessRights::ReadWrite);
+    let forged_contract_uref = random_uref_key(&mut rng, AccessRights::READ_WRITE);
     // URef we want to store WITH the contract so that it can use it later
-    let known_uref = random_uref_key(&mut rng, AccessRights::ReadWrite);
+    let known_uref = random_uref_key(&mut rng, AccessRights::READ_WRITE);
     let urefs = urefs_map(vec![("KnownURef".to_owned(), known_uref)]);
     let known_urefs: HashSet<Key> = once(known_uref).collect();
 
@@ -1123,7 +1123,7 @@ fn test_uref_key_readable(init_value: Value, rights: AccessRights) -> Result<Val
 fn uref_key_readable_valid() {
     // Tests that URef key is readable when access rights of the key allows for reading.
     let init_value = Value::Int32(1);
-    let test_result = test_uref_key_readable(init_value.clone(), AccessRights::Read)
+    let test_result = test_uref_key_readable(init_value.clone(), AccessRights::READ)
         .expect("Reading from GS should work.");
     assert_eq!(test_result, init_value);
 }
@@ -1132,7 +1132,7 @@ fn uref_key_readable_valid() {
 fn uref_key_readable_invalid() {
     // Tests that reading URef which is not readable fails.
     let init_value = Value::Int32(1);
-    let test_result = test_uref_key_readable(init_value.clone(), AccessRights::Add);
+    let test_result = test_uref_key_readable(init_value.clone(), AccessRights::ADD);
     assert_invalid_access(test_result);
 }
 
@@ -1183,13 +1183,13 @@ fn test_uref_key_writeable(rights: AccessRights) -> Result<(), wasmi::Trap> {
 #[test]
 fn uref_key_writeable_valid() {
     // Tests that URef key is writeable when access rights of the key allows for writing.
-    test_uref_key_writeable(AccessRights::Write).expect("Writing to writeable URef should work.")
+    test_uref_key_writeable(AccessRights::WRITE).expect("Writing to writeable URef should work.")
 }
 
 #[test]
 fn uref_key_writeable_invalid() {
     // Tests that writing to URef which is not writeable fails.
-    let result = test_uref_key_writeable(AccessRights::Read);
+    let result = test_uref_key_writeable(AccessRights::READ);
     assert_invalid_access(result);
 }
 
@@ -1240,13 +1240,13 @@ fn test_uref_key_addable(rights: AccessRights) -> Result<(), wasmi::Trap> {
 #[test]
 fn uref_key_addable_valid() {
     // Tests that URef key is addable when access rights of the key allows for adding.
-    test_uref_key_addable(AccessRights::Add)
+    test_uref_key_addable(AccessRights::ADD)
         .expect("Adding to URef when it is Addable should work.")
 }
 
 #[test]
 fn uref_key_addable_invalid() {
     // Tests that adding to URef which is not addable fails.
-    let result = test_uref_key_addable(AccessRights::Read);
+    let result = test_uref_key_addable(AccessRights::READ);
     assert_invalid_access(result);
 }


### PR DESCRIPTION
## Overview
As in the title.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-256

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
This is my stab at what @EdHastingsCasperLabs proposed yesterday. I couldn't find a way to encode `AccessRights` like:
```rust
pub enum AccessRights {
  Eqv  = 0b0001,
  Read = 0b0011,
  Add  = 0b0101,
  ReadAdd = Read | Add,
}
```
It worked when I defined it like:
```rust
type AccessRights = u8,

const Eqv: u8 = ...;
const Read: u8 = ...;
const Add: u8 = ...;
const ReadAdd = Read | Add;
```
but then I don't have as much control over _what_ can become an instance of `AccessRights` because the space is whole `u8` and this is wrong.

Notable changes:
1. (the good ones) Removed `PartialOrd for AccessRights` and `Ord for Key` and a whole bunch of tests for it.
2. (the bad ones) Now encoding of `AccessRights` is a bit _looser_ (u8) and `parse_bitwise` may return `None` but I don't expect it to be used outside of the controlled environment. 