### PR TITLE
NODE-413: Added Block.rank

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -181,6 +181,7 @@ trait ArbitraryConsensus {
                 validatorPublicKey = j.getHeader.validatorPublicKey
               )
             })
+            .withRank(parents.map(_.getHeader.rank).max + 1)
           block.withHeader(header)
         }
 

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -80,6 +80,8 @@ message Block {
         string chain_id = 8;
         uint32 validator_block_seq_num = 9;
         bytes validator_public_key = 10;
+        // Distance from Genesis.
+        uint32 rank = 11;
     }
 
     message Body {


### PR DESCRIPTION
## Overview
The DAG storage uses the `blockNumber` field to remember which checkpoint files contain blocks up to what distance from the Genesis. I didn't know what this field was and missed porting it from `CasperMessage.proto`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-413

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
I was wondering if this changed what's possible in `streamAncestorBlockSummaries`. With a `maxDepth` limit I opted to use Breadth First Order. With the `rank` field present we could order the blocks - but we could have effectively the same using `timestamp`. The fact that the `maxDepth` limit exists means it's always possible that from a fork-join with unequal side lengths you get to see the fork without first having seen all its descendants, because in a BFS order it's closer to the join on one side then the other. Unless the rank was used for filtering depth this doesn't change. NB the DAG visualization works by limiting the rank depth.
