### PR TITLE
OP-158 Correcting CI fix to run locally

### DIFF
--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -e
-mkdir /tmp/DRONE-${DRONE_BUILD_NUMBER}
-cp -r resources /tmp/DRONE-${DRONE_BUILD_NUMBER}
+
 pipenv run py.test -v "$@"

--- a/integration-testing/test/cl_node/casperlabsnode.py
+++ b/integration-testing/test/cl_node/casperlabsnode.py
@@ -30,7 +30,7 @@ TAG = os.environ.get("DRONE_BUILD_NUMBER", None)
 if TAG is None:
     TAG = "test"
 else:
-    TAG = "DRONE-" + TAG
+    TAG = f"DRONE-{TAG}"
 
 DEFAULT_NODE_IMAGE = f"casperlabs/node:{TAG}"
 DEFAULT_ENGINE_IMAGE = f"casperlabs/execution-engine:{TAG}"
@@ -46,9 +46,10 @@ GRPC_SOCKET_FILE = f"{CL_SOCKETS_DIR}/.casper-node.sock"
 EXECUTION_ENGINE_COMMAND = ".casperlabs/sockets/.casper-node.sock"
 CONTRACT_NAME = "helloname.wasm"
 
-HOST_MOUNT_DIR = f"/tmp/{TAG}/resources"
-HOST_GENESIS_DIR = HOST_MOUNT_DIR + "/genesis"
-HOST_BOOTSTRAP_DIR = HOST_MOUNT_DIR + "/bootstrap_certificate"
+HOST_MOUNT_DIR = f"/tmp/resources_{TAG}"
+HOST_GENESIS_DIR = f"{HOST_MOUNT_DIR}/genesis"
+HOST_BOOTSTRAP_DIR = f"{HOST_MOUNT_DIR}/bootstrap_certificate"
+
 
 class InterruptedException(Exception):
     pass
@@ -312,8 +313,7 @@ def make_node(
 ) -> Node:
     assert isinstance(name, str)
     assert '_' not in name, 'Underscore is not allowed in host name'
-    deploy_dir = make_tempdir(prefix=f"{TAG}/resources/")
-    # end slash is necessary to create in format /tmp/DRONE-${DRONE_BUILD_NUMBER}/resources/xxxxxxxx
+    deploy_dir = make_tempdir(prefix=f"{HOST_MOUNT_DIR}/")
 
     command = make_container_command(container_command, container_command_options, is_bootstrap)
 

--- a/integration-testing/test/test_network_topology.py
+++ b/integration-testing/test/test_network_topology.py
@@ -10,6 +10,7 @@ from .cl_node.casperlabsnode import (
     create_peer_nodes,
     docker_network_with_started_bootstrap,
     extract_block_hash_from_propose_output,
+    HOST_MOUNT_DIR,
 )
 from .cl_node.common import Network, TestingContext
 from .cl_node.wait import (
@@ -74,7 +75,7 @@ def test_metrics_api_socket(command_line_options_fixture, docker_client_fixture)
 
 
 def deploy_block(node, _contract_name):
-    local_contract_file_path = os.path.join('resources', _contract_name)
+    local_contract_file_path = os.path.join(HOST_MOUNT_DIR, _contract_name)
     shutil.copyfile(local_contract_file_path, f"{node.local_deploy_dir}/{_contract_name}")
     deploy_output = node.deploy()
     assert deploy_output.strip() == "Success!"


### PR DESCRIPTION
## Overview
Cleaned fix for simultaneous CI problem for integrated testing to run locally.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/OP-158

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Pulled all setup code into Python from `run_tests.sh` so that we can more easily debug any cases in Python.  The required a global setup fixture that we will probably continue to add to as it makes sense.
