### PR TITLE
NODE-312: Small refactorings in MultiParentCasperImpl

### DIFF
--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/BlockDagStorageTest.scala
@@ -357,7 +357,7 @@ class BlockDagFileStorageTest extends BlockDagStorageTest {
                 b =>
                   blockStore.put(b.getBlockMessage.blockHash, b) *> firstStorage.insert(
                     b.getBlockMessage
-                )
+                  )
               )
           _ <- firstStorage.close()
           _ <- Sync[Task].delay {

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/BlockDagStorageBench.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/BlockDagStorageBench.scala
@@ -34,9 +34,11 @@ abstract class BlockDagStorageBench {
 
   @Benchmark
   def insert() =
-    dagStore.insert(
-      StoreBenchSuite.blocksIter.next()._2.blockMessage.get
-    ).runSyncUnsafe()
+    dagStore
+      .insert(
+        StoreBenchSuite.blocksIter.next()._2.blockMessage.get
+      )
+      .runSyncUnsafe()
 }
 
 class FileStorageWithLmdbBlockStoreBench extends BlockDagStorageBench {

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/BlockStoreBench.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/BlockStoreBench.scala
@@ -33,9 +33,11 @@ abstract class BlockStoreBench {
 
   @Benchmark
   def put(): Unit =
-    blockStore.put(
-      StoreBenchSuite.blocksIter.next()
-    ).runSyncUnsafe()
+    blockStore
+      .put(
+        StoreBenchSuite.blocksIter.next()
+      )
+      .runSyncUnsafe()
 
   @Benchmark
   def getRandom() =

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/StoreBenchSuite.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/StoreBenchSuite.scala
@@ -8,8 +8,24 @@ import cats.Monad
 import cats.effect.Concurrent
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.BlockStore.BlockHash
-import io.casperlabs.blockstorage.{BlockDagFileStorage, BlockDagStorage, BlockStore, FileLMDBIndexBlockStore, InMemBlockStore, IndexedBlockDagStorage, LMDBBlockStore}
-import io.casperlabs.casper.protocol.{BlockMessage, Body, DeployCode, DeployData, Header, Justification, ProcessedDeploy}
+import io.casperlabs.blockstorage.{
+  BlockDagFileStorage,
+  BlockDagStorage,
+  BlockStore,
+  FileLMDBIndexBlockStore,
+  InMemBlockStore,
+  IndexedBlockDagStorage,
+  LMDBBlockStore
+}
+import io.casperlabs.casper.protocol.{
+  BlockMessage,
+  Body,
+  DeployCode,
+  DeployData,
+  Header,
+  Justification,
+  ProcessedDeploy
+}
 import io.casperlabs.ipc.Key.KeyInstance
 import io.casperlabs.ipc.Transform.TransformInstance
 import io.casperlabs.ipc.{DeployCode => _, _}
@@ -70,11 +86,13 @@ object StoreBenchSuite {
   def randomDeployData: DeployData =
     DeployData()
       .withAddress(randomHexString(32))
-      .withPayment(DeployCode()
-        .withCode(randomHexString(512))
+      .withPayment(
+        DeployCode()
+          .withCode(randomHexString(512))
       )
-      .withSession(DeployCode()
-        .withCode(randomHexString(480))
+      .withSession(
+        DeployCode()
+          .withCode(randomHexString(480))
       )
 
   def randomDeploy: ProcessedDeploy =

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -24,7 +24,7 @@ trait Casper[F[_], A] {
       handleDoppelganger: (BlockMessage, Validator) => F[Unit]
   ): F[BlockStatus]
   def contains(block: BlockMessage): F[Boolean]
-  def deploy(deployDaga: DeployData): F[Either[Throwable, Unit]]
+  def deploy(deployData: DeployData): F[Either[Throwable, Unit]]
   def estimator(dag: BlockDagRepresentation[F]): F[A]
   def createBlock: F[CreateBlockStatus]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -20,11 +20,11 @@ import io.casperlabs.smartcontracts.ExecutionEngineService
 
 trait Casper[F[_], A] {
   def addBlock(
-      b: BlockMessage,
+      block: BlockMessage,
       handleDoppelganger: (BlockMessage, Validator) => F[Unit]
   ): F[BlockStatus]
-  def contains(b: BlockMessage): F[Boolean]
-  def deploy(d: DeployData): F[Either[Throwable, Unit]]
+  def contains(block: BlockMessage): F[Boolean]
+  def deploy(deployDaga: DeployData): F[Either[Throwable, Unit]]
   def estimator(dag: BlockDagRepresentation[F]): F[A]
   def createBlock: F[CreateBlockStatus]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -353,7 +353,7 @@ class MultiParentCasperImpl[F[_]: Sync: ConnectionsCell: TransportLayer: Log: Ti
   def blockDag: F[BlockDagRepresentation[F]] =
     BlockDagStorage[F].getRepresentation
 
-  // RChain used ot return the whole database as a String for testing.
+  // RChain used to return the whole database as a String for testing.
   def storageContents(hash: StateHash): F[String] =
     """""".pure[F]
 
@@ -652,4 +652,3 @@ class MultiParentCasperImpl[F[_]: Sync: ConnectionsCell: TransportLayer: Log: Ti
           }
     } yield ()
 }
-

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -992,7 +992,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
       _     <- checkLastFinalizedBlock(nodes(0), block1)
       state <- nodes(0).casperState.read
-      _     = state.deployHistory.size should be(1)
+      _     = state.deployBuffer.size should be(1)
 
       createBlock6Result <- nodes(2).casperEff
                              .deploy(deployDatas(5)) *> nodes(2).casperEff.createBlock
@@ -1003,7 +1003,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
       _     <- checkLastFinalizedBlock(nodes(0), block2)
       state <- nodes(0).casperState.read
-      _     = state.deployHistory.size should be(1)
+      _     = state.deployBuffer.size should be(1)
 
       createBlock7Result <- nodes(0).casperEff
                              .deploy(deployDatas(6)) *> nodes(0).casperEff.createBlock
@@ -1013,7 +1013,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
       _               <- nodes(2).receive()
 
       _ <- checkLastFinalizedBlock(nodes(0), block3)
-      _ = state.deployHistory.size should be(1)
+      _ = state.deployBuffer.size should be(1)
 
       createBlock8Result <- nodes(1).casperEff
                              .deploy(deployDatas(7)) *> nodes(1).casperEff.createBlock
@@ -1024,7 +1024,7 @@ class HashSetCasperTest extends FlatSpec with Matchers {
 
       _     <- checkLastFinalizedBlock(nodes(0), block4)
       state <- nodes(0).casperState.read
-      _     = state.deployHistory.size should be(1)
+      _     = state.deployBuffer.size should be(1)
 
       _ <- nodes.map(_.tearDown()).toList.sequence
     } yield ()

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -85,7 +85,7 @@ class DownloadManagerSpec
                 Task.pure(Some(block)).delayResult(250.millis)
               case other => Task.pure(other)
             }
-        ),
+          ),
         maxParallelDownloads = consensusConfig.dagSize
       ) {
         case (manager, backend) =>
@@ -119,7 +119,7 @@ class DownloadManagerSpec
                 parallelMax.set(math.max(parallelNow.get, parallelMax.get))
                 chunk
               }
-          ),
+            ),
           backend = MockBackend(validate = _ => Task.delay(parallelNow.decrementAndGet()).void),
           maxParallelDownloads = maxParallelDownloads
         ) {
@@ -145,8 +145,10 @@ class DownloadManagerSpec
         }
       }
 
-      "relay blocks only specified to be relayed" in TestFixture(remote = _ => remote,
-                                                                 relaying = relaying) {
+      "relay blocks only specified to be relayed" in TestFixture(
+        remote = _ => remote,
+        relaying = relaying
+      ) {
         case (manager, _) =>
           for {
             ws <- scheduleAll(manager)
@@ -280,7 +282,7 @@ class DownloadManagerSpec
               )
             )
           case _ => MockGossipService(Seq(block))
-      }
+        }
 
       "try to download the block from a different source" in TestFixture(remote = remote) {
         case (manager, backend) =>

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -331,7 +331,7 @@ class ConfigurationSpec
             case (Some(a), None)    => a.some
             case (None, Some(b))    => b.some
             case (None, None)       => None
-        }
+          }
       implicit def optionPlain[A: NotSubConfig: NotOption]: Merge[Option[A]] = _ orElse _
     }
 
@@ -424,8 +424,8 @@ class ConfigurationSpec
                   List.empty
                 } else {
                   p.typeclass.flatten(path :+ p.label, p.dereference(v))
-              }
-          )
+                }
+            )
       def dispatch[T](sealedTrait: SealedTrait[Typeclass, T]): Typeclass[T] = ???
       implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
 


### PR DESCRIPTION
## Overview
Going to have to split `MultiParentCasperImpl` into some components to separate concerns. These are just small changes before I attempt more substantial ones: adding some docstrings, variable renaming, early stop if deploy pool goes empty.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
In support of https://casperlabs.atlassian.net/browse/NODE-312

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
