### PR TITLE
NODE-396: Stashing synchronizer

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
@@ -1,0 +1,93 @@
+package io.casperlabs.comm.gossiping
+import cats.effect.{Concurrent, Sync}
+import cats.effect.implicits._
+import cats.effect.concurrent.{Deferred, Ref, Semaphore}
+import cats.implicits._
+import cats.temp.par._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.BlockSummary
+import io.casperlabs.comm.discovery.Node
+import io.casperlabs.comm.gossiping.StashingSynchronizer.Request
+import io.casperlabs.shared.Cell
+
+class StashingSynchronizer[F[_]: Concurrent: Par](
+    underlying: Synchronizer[F],
+    stashedRequestsRef: Ref[F, Map[Node, List[Request[F]]]],
+    // Prevents concurrent scheduling during processing of kept requests in 'run'
+    semaphoresCell: Cell[F, Map[Node, Semaphore[F]]],
+    transitionedRef: Ref[F, Boolean]
+) extends Synchronizer[F] {
+
+  override def syncDag(source: Node, targetBlockHashes: Set[ByteString]): F[Vector[BlockSummary]] =
+    for {
+      _ <- semaphoresCell.flatModify { semaphores =>
+            if (semaphores.contains(source)) {
+              semaphores.pure[F]
+            } else {
+              Semaphore[F](1).map { semaphore =>
+                semaphores.updated(source, semaphore)
+              }
+            }
+          }
+      semaphores   <- semaphoresCell.read
+      transitioned <- transitionedRef.get
+      dag <- if (transitioned) {
+              semaphores(source).withPermit(underlying.syncDag(source, targetBlockHashes))
+            } else {
+              for {
+                deferred <- Deferred[F, Vector[BlockSummary]]
+                _ <- stashedRequestsRef.update { stashedRequests =>
+                      val previous = stashedRequests.getOrElse(source, List.empty)
+                      val merged   = Request(targetBlockHashes, deferred) :: previous
+                      stashedRequests.updated(source, merged)
+                    }
+                res <- deferred.get
+              } yield res
+            }
+    } yield dag
+
+  def run: F[Unit] =
+    for {
+      _               <- transitionedRef.set(true)
+      stashedRequests <- stashedRequestsRef.get
+      _ <- stashedRequests.toList.parTraverse {
+            case (source, requests) =>
+              requests.reverse.traverse {
+                case Request(hashes, deferred) =>
+                  for {
+                    semaphores <- semaphoresCell.read
+                    _ <- semaphores(source).withPermit(
+                          underlying.syncDag(source, hashes) >>= deferred.complete
+                        )
+                  } yield ()
+              }.void
+          }.void
+    } yield ()
+}
+
+object StashingSynchronizer {
+  final case class Request[F[_]](
+      targetBlockHashes: Set[ByteString],
+      deferred: Deferred[F, Vector[BlockSummary]]
+  )
+
+  def wrap[F[_]: Concurrent: Par](
+      underlying: Synchronizer[F],
+      awaitApproved: F[Unit]
+  ): F[Synchronizer[F]] =
+    for {
+      stashedRequestsRef <- Ref
+                             .of[F, Map[Node, List[Request[F]]]](Map.empty)
+      semaphoresCell  <- Cell.mvarCell[F, Map[Node, Semaphore[F]]](Map.empty)
+      transitionedRef <- Ref.of[F, Boolean](false)
+      s <- Sync[F].delay(
+            new StashingSynchronizer[F](
+              underlying,
+              stashedRequestsRef,
+              semaphoresCell,
+              transitionedRef
+            )
+          )
+      _ <- (awaitApproved >> s.run).start
+    } yield s
+}

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
@@ -1,75 +1,49 @@
 package io.casperlabs.comm.gossiping
-import cats.effect.{Concurrent, Sync}
+import cats.effect.concurrent.{Deferred, Ref}
 import cats.effect.implicits._
-import cats.effect.concurrent.{Deferred, Ref, Semaphore}
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.temp.par._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.comm.discovery.Node
-import io.casperlabs.comm.gossiping.StashingSynchronizer.Request
-import io.casperlabs.shared.Cell
 
 class StashingSynchronizer[F[_]: Concurrent: Par](
     underlying: Synchronizer[F],
-    stashedRequestsRef: Ref[F, Map[Node, List[Request[F]]]],
-    // Prevents concurrent scheduling during processing of kept requests in 'run'
-    semaphoresCell: Cell[F, Map[Node, Semaphore[F]]],
+    stashedRequestsRef: Ref[F, Map[Node, (Deferred[F, Vector[BlockSummary]], Set[ByteString])]],
     transitionedRef: Ref[F, Boolean]
 ) extends Synchronizer[F] {
 
   override def syncDag(source: Node, targetBlockHashes: Set[ByteString]): F[Vector[BlockSummary]] =
     for {
-      _ <- semaphoresCell.flatModify { semaphores =>
-            if (semaphores.contains(source)) {
-              semaphores.pure[F]
-            } else {
-              Semaphore[F](1).map { semaphore =>
-                semaphores.updated(source, semaphore)
-              }
-            }
-          }
-      semaphores   <- semaphoresCell.read
       transitioned <- transitionedRef.get
       dag <- if (transitioned) {
-              semaphores(source).withPermit(underlying.syncDag(source, targetBlockHashes))
+              underlying.syncDag(source, targetBlockHashes)
             } else {
               for {
-                deferred <- Deferred[F, Vector[BlockSummary]]
-                _ <- stashedRequestsRef.update { stashedRequests =>
-                      val previous = stashedRequests.getOrElse(source, List.empty)
-                      val merged   = Request(targetBlockHashes, deferred) :: previous
-                      stashedRequests.updated(source, merged)
-                    }
+                maybeInitialDeferred <- Deferred[F, Vector[BlockSummary]]
+                deferred <- stashedRequestsRef.modify { stashedRequests =>
+                             val (d, hashes) =
+                               stashedRequests.getOrElse(source, (maybeInitialDeferred, Set.empty))
+                             (stashedRequests.updated(source, (d, hashes ++ targetBlockHashes)), d)
+                           }
                 res <- deferred.get
               } yield res
             }
     } yield dag
 
-  def run: F[Unit] =
+  private def run: F[Unit] =
     for {
       _               <- transitionedRef.set(true)
       stashedRequests <- stashedRequestsRef.get
       _ <- stashedRequests.toList.parTraverse {
-            case (source, requests) =>
-              requests.reverse.traverse {
-                case Request(hashes, deferred) =>
-                  for {
-                    semaphores <- semaphoresCell.read
-                    _ <- semaphores(source).withPermit(
-                          underlying.syncDag(source, hashes) >>= deferred.complete
-                        )
-                  } yield ()
-              }.void
-          }.void
+            case (source, (deferred, hashes)) =>
+              underlying.syncDag(source, hashes) >>= deferred.complete
+          }
     } yield ()
 }
 
 object StashingSynchronizer {
-  final case class Request[F[_]](
-      targetBlockHashes: Set[ByteString],
-      deferred: Deferred[F, Vector[BlockSummary]]
-  )
 
   def wrap[F[_]: Concurrent: Par](
       underlying: Synchronizer[F],
@@ -77,14 +51,15 @@ object StashingSynchronizer {
   ): F[Synchronizer[F]] =
     for {
       stashedRequestsRef <- Ref
-                             .of[F, Map[Node, List[Request[F]]]](Map.empty)
-      semaphoresCell  <- Cell.mvarCell[F, Map[Node, Semaphore[F]]](Map.empty)
+                             .of[F, Map[
+                               Node,
+                               (Deferred[F, Vector[BlockSummary]], Set[ByteString])
+                             ]](Map.empty)
       transitionedRef <- Ref.of[F, Boolean](false)
       s <- Sync[F].delay(
             new StashingSynchronizer[F](
               underlying,
               stashedRequestsRef,
-              semaphoresCell,
               transitionedRef
             )
           )

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
@@ -1,10 +1,12 @@
 package io.casperlabs.comm.gossiping
 
 import cats.Applicative
+import cats.syntax.either._
 import cats.effect.concurrent.Deferred
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.comm.discovery.Node
+import io.casperlabs.comm.gossiping.Synchronizer.SyncError
 import monix.eval.Task
 import monix.execution.{ExecutionModel, Scheduler}
 import monix.execution.atomic.{Atomic, AtomicInt}
@@ -12,7 +14,7 @@ import monix.execution.schedulers.CanBlock.permit
 import monix.execution.schedulers.SchedulerService
 import org.scalacheck.{Gen, Shrink}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+import org.scalatest.{BeforeAndAfterEach, Inspectors, Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 
@@ -26,13 +28,6 @@ class StashingSynchronizerSpec
   import StashingSynchronizerSpec._
 
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
-
-  implicit val applicativeGen: Applicative[Gen] = new Applicative[Gen] {
-    override def pure[A](x: A): Gen[A] = Gen.const(x)
-
-    override def ap[A, B](ff: Gen[A => B])(fa: Gen[A]): Gen[B] =
-      fa.flatMap(a => ff.map(f => f(a)))
-  }
 
   val requestsGen: Gen[List[(Node, Set[ByteString])]] = for {
     nodes       <- Gen.listOfN(100, arbNode.arbitrary)
@@ -50,7 +45,7 @@ class StashingSynchronizerSpec
     "approved" should {
       "run stashed requests in parallel but sequentially per node" in
         forAll(requestsGen) { requests =>
-          TestFixture { (synchronizer, deferred, mock) =>
+          TestFixture() { (synchronizer, deferred, mock) =>
             for {
               fiber <- requests.parTraverse {
                         case (source, hashes) => synchronizer.syncDag(source, hashes)
@@ -72,12 +67,65 @@ class StashingSynchronizerSpec
             }
           }
         }
+      "propagate SyncError errors" in
+        forAll(requestsGen) { requests =>
+          val syncError =
+            SyncError.ValidationError(sample(arbBlockSummary.arbitrary), new RuntimeException)
+          TestFixture(error = syncError.asRight[Throwable].some) { (synchronizer, deferred, mock) =>
+            for {
+              fiber <- requests.traverse {
+                        case (source, hashes) => synchronizer.syncDag(source, hashes)
+                      }.start
+              _   <- Task.sleep(500.milliseconds)
+              _   <- Task(mock.requests.get().toList shouldBe empty)
+              _   <- deferred.complete(())
+              res <- fiber.join
+              _ <- Task {
+                    mock.requests.get().toList should contain allElementsOf requests
+                      .groupBy(_._1)
+                      .mapValues(_.map(_._2).reduce(_ ++ _))
+                      .toList
+                    Inspectors.forAll(res) { either =>
+                      either.isLeft shouldBe true
+                      either.left.get shouldBe an[SyncError.ValidationError]
+                      either.left.get shouldBe syncError
+                    }
+                  }
+            } yield ()
+          }
+        }
+      "propagate unexpected runtime errors" in
+        forAll(requestsGen) { requests =>
+          val exception = new RuntimeException("Boom!")
+          TestFixture(error = exception.asLeft[SyncError].some) { (synchronizer, deferred, mock) =>
+            for {
+              fiber <- requests.traverse {
+                        case (source, hashes) => synchronizer.syncDag(source, hashes).attempt
+                      }.start
+              _   <- Task.sleep(100.milliseconds)
+              _   <- Task(mock.requests.get().toList shouldBe empty)
+              _   <- deferred.complete(())
+              res <- fiber.join
+              _ <- Task {
+                    mock.requests.get().toList should contain allElementsOf requests
+                      .groupBy(_._1)
+                      .mapValues(_.map(_._2).reduce(_ ++ _))
+                      .toList
+                    Inspectors.forAll(res) { either =>
+                      either.isLeft shouldBe true
+                      either.left.get shouldBe an[RuntimeException]
+                      either.left.get shouldBe exception
+                    }
+                  }
+            } yield ()
+          }
+        }
     }
   }
 }
 
 object StashingSynchronizerSpec {
-  class MockSynchronizer extends Synchronizer[Task] {
+  class MockSynchronizer(error: Option[Either[Throwable, SyncError]]) extends Synchronizer[Task] {
     val requests =
       Atomic(Map.empty[Node, Set[ByteString]].withDefault(_ => Set.empty))
     private val utilityTotalConcurrency = AtomicInt(0)
@@ -87,8 +135,11 @@ object StashingSynchronizerSpec {
     val concurrencyPerNode =
       Atomic(Map.empty[Node, Int].withDefault(_ => 0))
 
-    def syncDag(source: Node, targetBlockHashes: Set[ByteString]): Task[Vector[BlockSummary]] =
-      Task {
+    def syncDag(
+        source: Node,
+        targetBlockHashes: Set[ByteString]
+    ): Task[Either[SyncError, Vector[BlockSummary]]] =
+      Task.defer {
         utilityTotalConcurrency.increment()
         totalConcurrency.transform(math.max(_, utilityTotalConcurrency.get()))
         utilityTotalConcurrency.decrement()
@@ -101,17 +152,20 @@ object StashingSynchronizerSpec {
         requests.transform { rs =>
           rs.updated(source, rs(source) ++ targetBlockHashes)
         }
-        Vector.empty
+        error.fold(Task.now(Vector.empty[BlockSummary].asRight[SyncError])) {
+          case Left(e)  => Task.raiseError[Either[SyncError, Vector[BlockSummary]]](e)
+          case Right(e) => Task.now(e.asLeft[Vector[BlockSummary]])
+        }
       }
   }
 
   object TestFixture {
-    def apply(
+    def apply(error: Option[Either[Throwable, SyncError]] = None)(
         test: (Synchronizer[Task], Deferred[Task, Unit], MockSynchronizer) => Task[Unit]
     ): Unit = {
       val run = for {
         deferred <- Deferred[Task, Unit]
-        mock     <- Task(new MockSynchronizer)
+        mock     <- Task(new MockSynchronizer(error))
         stashed  <- StashingSynchronizer.wrap(mock, deferred.get)
         _        <- test(stashed, deferred, mock)
       } yield ()

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
@@ -1,0 +1,126 @@
+package io.casperlabs.comm.gossiping
+
+import cats.Applicative
+import cats.effect.concurrent.Deferred
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.BlockSummary
+import io.casperlabs.comm.discovery.Node
+import monix.eval.Task
+import monix.execution.{ExecutionModel, Scheduler}
+import monix.execution.atomic.{Atomic, AtomicInt}
+import monix.execution.schedulers.CanBlock.permit
+import monix.execution.schedulers.SchedulerService
+import org.scalacheck.{Gen, Shrink}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+
+class StashingSynchronizerSpec
+    extends WordSpecLike
+    with Matchers
+    with BeforeAndAfterEach
+    with ArbitraryConsensus
+    with GeneratorDrivenPropertyChecks {
+  import cats.implicits._
+  import StashingSynchronizerSpec._
+
+  implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
+
+  implicit val applicativeGen: Applicative[Gen] = new Applicative[Gen] {
+    override def pure[A](x: A): Gen[A] = Gen.const(x)
+
+    override def ap[A, B](ff: Gen[A => B])(fa: Gen[A]): Gen[B] =
+      fa.flatMap(a => ff.map(f => f(a)))
+  }
+
+  val requestsGen: Gen[List[(Node, Set[ByteString])]] = for {
+    nodes       <- Gen.listOfN(100, arbNode.arbitrary)
+    blockHashes <- Gen.listOfN(100, genHash)
+    hashesPerNode <- nodes.traverse(
+                      n =>
+                        for {
+                          k      <- Gen.choose(1, blockHashes.size)
+                          hashes <- Gen.pick(k, blockHashes)
+                        } yield (n, hashes.toSet)
+                    )
+  } yield hashesPerNode
+
+  "StashingSynchronizer" when {
+    "approved" should {
+      "run stashed requests in parallel but sequentially per node" in
+        forAll(requestsGen) { requests =>
+          TestFixture { (synchronizer, deferred, mock) =>
+            for {
+              fiber <- requests.parTraverse {
+                        case (source, hashes) => synchronizer.syncDag(source, hashes)
+                      }.start
+              _ <- Task.sleep(500.milliseconds)
+              _ <- Task(mock.requests.get().toList shouldBe empty)
+              _ <- deferred.complete(())
+              _ <- fiber.join
+              _ <- Task {
+                    mock.requests.get().toList should contain allElementsOf requests
+                      .groupBy(_._1)
+                      .mapValues(_.map(_._2).reduce(_ ++ _))
+                      .toList
+                  }
+            } yield {
+              mock.concurrencyPerNode.get().values.max shouldBe 1
+              //Doesn't pass in CI because it doesn't have much cores
+              //mock.totalConcurrency.get() should be > 1
+            }
+          }
+        }
+    }
+  }
+}
+
+object StashingSynchronizerSpec {
+  class MockSynchronizer extends Synchronizer[Task] {
+    val requests =
+      Atomic(Map.empty[Node, Set[ByteString]].withDefault(_ => Set.empty))
+    private val utilityTotalConcurrency = AtomicInt(0)
+    private val utilityPerNodeConcurrency =
+      Atomic(Map.empty[Node, Int].withDefault(_ => 0))
+    val totalConcurrency = AtomicInt(0)
+    val concurrencyPerNode =
+      Atomic(Map.empty[Node, Int].withDefault(_ => 0))
+
+    def syncDag(source: Node, targetBlockHashes: Set[ByteString]): Task[Vector[BlockSummary]] =
+      Task {
+        utilityTotalConcurrency.increment()
+        totalConcurrency.transform(math.max(_, utilityTotalConcurrency.get()))
+        utilityTotalConcurrency.decrement()
+
+        utilityPerNodeConcurrency.transform(map => map.updated(source, map(source) + 1))
+        concurrencyPerNode.transform(
+          map => map.updated(source, math.max(map(source), utilityPerNodeConcurrency.get()(source)))
+        )
+        utilityPerNodeConcurrency.transform(map => map.updated(source, map(source) - 1))
+        requests.transform { rs =>
+          rs.updated(source, rs(source) ++ targetBlockHashes)
+        }
+        Vector.empty
+      }
+  }
+
+  object TestFixture {
+    def apply(
+        test: (Synchronizer[Task], Deferred[Task, Unit], MockSynchronizer) => Task[Unit]
+    ): Unit = {
+      val run = for {
+        deferred <- Deferred[Task, Unit]
+        mock     <- Task(new MockSynchronizer)
+        stashed  <- StashingSynchronizer.wrap(mock, deferred.get)
+        _        <- test(stashed, deferred, mock)
+      } yield ()
+      implicit val scheduler: SchedulerService =
+        Scheduler.computation(
+          parallelism = 100,
+          executionModel = ExecutionModel.AlwaysAsyncExecution
+        )
+      run.runSyncUnsafe(10.seconds)
+    }
+  }
+}


### PR DESCRIPTION
## Overview
Stashes `NewBlocksRPC` until controllable transition.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-396

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.