### PR TITLE
NODE-358: Download manager retries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,8 @@ lazy val comm = (project in file("comm"))
       catsCore,
       catsMtl,
       monix,
-      guava
+      guava,
+      refinement
     ),
     PB.protoSources in Compile := Seq(protobufDirectory),
     includeFilter in PB.generate := new SimpleFileFilter(

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -428,7 +428,10 @@ class DownloadManagerSpec
                     log.warns should have size 3
                     log.warns.last should include("attempt: 3")
                     log.causes should have size 1
-                    log.causes.head shouldBe an[io.grpc.StatusRuntimeException]
+                    log.causes.head shouldBe an[DownloadManagerImpl.RetriesFailure]
+                    log.causes.head
+                      .asInstanceOf[DownloadManagerImpl.RetriesFailure]
+                      .getCause shouldBe an[io.grpc.StatusRuntimeException]
                   }
               _ <- w.attempt
             } yield ()

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,6 +84,7 @@ object Dependencies {
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java          = "com.github.rchain"          % "secp256k1-java"                  % "0.1"
   val tomlScala              = "tech.sparse"                %% "toml-scala"                     % "0.1.1"
+  val refinement             = "eu.timepit"                 %% "refined"                        % "0.9.5"
   // format: on
 
   val overrides = Seq(
@@ -133,27 +134,27 @@ object Dependencies {
     logging ++ testing :+ kindProjector :+ macroParadise
 
   val gatlingDependencies: Seq[ModuleID] = Seq(
-      gatlingFramework,
-      gatlingGrpc,
-      gatlingHighcharts,
-      scalapbRuntime,
-      scalapbRuntimegGrpc,
-      grpcNetty
-    )
+    gatlingFramework,
+    gatlingGrpc,
+    gatlingHighcharts,
+    scalapbRuntime,
+    scalapbRuntimegGrpc,
+    grpcNetty
+  )
 
   //needed because Gatling transitively bring binary incompatible dependencies
   val gatlingOverrides: Seq[ModuleID] = Seq(
-    "com.thesamet.scalapb" %% "compilerplugin" % "0.8.2",
-    "com.thesamet.scalapb" %% "scalapb-runtime"                % "0.8.2",
-    "com.thesamet.scalapb" %% "scalapb-runtime-grpc"           % "0.8.2",
-    "io.grpc"              % "grpc-netty"                      % "1.15.1",
-    "io.netty" % "netty-buffer" % "4.1.33.Final",
-    "io.netty" % "netty-handler" % "4.1.33.Final",
-    "io.netty" % "netty-handler-proxy" % "4.1.33.Final",
-    "io.netty" % "netty-codec" % "4.1.33.Final",
-    "io.netty" % "netty-codec-http" % "4.1.33.Final",
-    "io.netty" % "netty-codec-http2" % "4.1.33.Final",
-    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2",
-    "com.google.protobuf" % "protobuf-java" % "3.6.1"
+    "com.thesamet.scalapb"       %% "compilerplugin"       % "0.8.2",
+    "com.thesamet.scalapb"       %% "scalapb-runtime"      % "0.8.2",
+    "com.thesamet.scalapb"       %% "scalapb-runtime-grpc" % "0.8.2",
+    "io.grpc"                    % "grpc-netty"            % "1.15.1",
+    "io.netty"                   % "netty-buffer"          % "4.1.33.Final",
+    "io.netty"                   % "netty-handler"         % "4.1.33.Final",
+    "io.netty"                   % "netty-handler-proxy"   % "4.1.33.Final",
+    "io.netty"                   % "netty-codec"           % "4.1.33.Final",
+    "io.netty"                   % "netty-codec-http"      % "4.1.33.Final",
+    "io.netty"                   % "netty-codec-http2"     % "4.1.33.Final",
+    "com.typesafe.scala-logging" %% "scala-logging"        % "3.9.2",
+    "com.google.protobuf"        % "protobuf-java"         % "3.6.1"
   )
 }


### PR DESCRIPTION
## Overview
Implements exponential backoff retries in `DownloadManagerImpl`.
Unfortunately, I wasn't able to make the test work with the Monix' `TestScheduler`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-358

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.