### PR TITLE
NODE-305: Reimplement width checking

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -54,28 +54,33 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log](
   private def sync(source: Node, newBlockHashes: Set[ByteString]): F[Unit] = {
 
     //TODO: Define handling strategies
-    def handleSyncError(syncError: SyncError): F[Unit] = syncError match {
-      case SyncError.TooDeep(summaries, limit) =>
-        Log[F].warn(
-          s"Failed to sync DAG, source ${source.show}. Returned DAG is too deep, limit: $limit, exceeded hashes: ${summaries
-            .map(b16)}"
-        )
-      case SyncError.TooWide(branchingFactor, limit) =>
-        Log[F].warn(
-          s"Failed to sync DAG, source ${source.show}. Returned dag is too wide, exceeded branching factor: $branchingFactor, limit: $limit."
-        )
-      case SyncError.Unreachable(summary, requestedDepth) =>
-        Log[F].warn(
-          s"Failed to sync DAG, source ${source.show}. During streaming source returned unreachable block summary: ${b16(summary)}, requested depth: $requestedDepth"
-        )
-      case SyncError.ValidationError(summary, e) =>
-        Log[F].warn(
-          s"Failed to sync DAG, source ${source.show}. Failed to validated the block summary: ${b16(summary)}, reason: $e"
-        )
-      case SyncError.MissingDependencies(hashes) =>
-        Log[F].warn(
-          s"Failed to sync DAG, source ${source.show}. Missing dependencies: ${hashes.map(b16)}"
-        )
+    def handleSyncError(syncError: SyncError): F[Unit] = {
+      val prefix = s"Failed to sync DAG, source: ${source.show}."
+      syncError match {
+        case SyncError.TooDeep(summaries, limit) =>
+          Log[F].warn(
+            s"$prefix Returned DAG is too deep, limit: $limit, exceeded hashes: ${summaries
+              .map(b16)}"
+          )
+        case SyncError.TooWide(branchingFactor, limit) =>
+          Log[F].warn(
+            s"$prefix Returned dag seems to be exponentially wide, branching factor: $branchingFactor, limit: $limit"
+          )
+        case SyncError.Unreachable(summary, requestedDepth) =>
+          Log[F].warn(
+            s"$prefix During streaming source returned unreachable block summary: ${b16(summary)}, requested depth: $requestedDepth"
+          )
+        case SyncError.ValidationError(summary, e) =>
+          Log[F].warn(
+            s"$prefix Failed to validated the block summary: ${b16(summary)}, reason: $e"
+          )
+        case SyncError.MissingDependencies(hashes) =>
+          Log[F].warn(
+            s"$prefix Missing dependencies: ${hashes.map(b16)}"
+          )
+        case SyncError.Cycle(summary) =>
+          Log[F].warn(s"$prefix Detected cycle: ${b16(summary)}")
+      }
     }
 
     val trySync = for {

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -62,9 +62,9 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log](
             s"$prefix Returned DAG is too deep, limit: $limit, exceeded hashes: ${summaries
               .map(b16)}"
           )
-        case SyncError.TooWide(branchingFactor, limit) =>
+        case SyncError.TooWide(maxBranchingFactor, maxTotal, total) =>
           Log[F].warn(
-            s"$prefix Returned dag seems to be exponentially wide, branching factor: $branchingFactor, limit: $limit"
+            s"$prefix Returned dag seems to be exponentially wide, max branching factor: $maxBranchingFactor, max total summaries: $maxTotal, total returned: $total"
           )
         case SyncError.Unreachable(summary, requestedDepth) =>
           Log[F].warn(

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
@@ -22,8 +22,11 @@ trait Synchronizer[F[_]] {
 object Synchronizer {
   sealed trait SyncError extends Product with Serializable
   object SyncError {
-    final case class TooWide(branchingFactor: Double, limit: Double Refined GreaterEqual[W.`1.0`.T])
-        extends SyncError
+    final case class TooWide(
+        maxBranchingFactor: Double Refined GreaterEqual[W.`1.0`.T],
+        maxTotal: Int,
+        total: Int
+    ) extends SyncError
     final case class Unreachable(summary: BlockSummary, requestedDepth: Int Refined Positive)
         extends SyncError
     final case class TooDeep(hashes: Set[ByteString], limit: Int Refined Positive) extends SyncError

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -28,8 +28,10 @@ trait ArbitraryConsensus {
       dagSize: Int = 0,
       // Max depth of DAG. 0 means no limit.
       dagDepth: Int = 0,
-      // Number of parents in each generation. 0 means choose random.
+      // Number of parents in each generation.
       dagWidth: Int = 1,
+      // How much parents should have each children.
+      dagBranchingFactor: Int = 5,
       // Maximum size of code in blocks. Slow to generate.
       maxSessionCodeBytes: Int = 500 * 1024,
       maxPaymentCodeBytes: Int = 100 * 1024,
@@ -285,7 +287,13 @@ trait ArbitraryConsensus {
       } else {
         for {
           parents <- Gen
-                      .listOfN(c.dagWidth, arbitrary[BlockSummary])
+                      .listOfN(
+                        math.min(
+                          c.dagWidth,
+                          math.pow(c.dagBranchingFactor.toDouble, depth.toDouble).toInt
+                        ),
+                        arbitrary[BlockSummary]
+                      )
                       .map(
                         _.map(
                           s =>


### PR DESCRIPTION
## Overview
Continue some work on [previous PR](https://github.com/CasperLabs/CasperLabs/pull/379) regarding exponential syncing DAG width checks.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.
https://casperlabs.atlassian.net/browse/NODE-305

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.