### PR TITLE
STOR-59: add {InMemory,Lmdb}GlobalState

### DIFF
--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -1,7 +1,6 @@
-use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::value::Value;
-use history::trie::Trie;
+use history::trie::operations::create_hashed_empty_trie;
 use history::trie_store::in_memory::{self, InMemoryEnvironment, InMemoryTrieStore};
 use history::trie_store::{Transaction, TransactionSource, TrieStore};
 use shared::newtypes::Blake2bHash;
@@ -21,13 +20,9 @@ impl InMemoryGlobalState {
         store: Arc<InMemoryTrieStore>,
     ) -> Result<Self, in_memory::Error> {
         let root_hash: Blake2bHash = {
-            let root: Trie<Key, Value> = Trie::Node {
-                pointer_block: Default::default(),
-            };
-            let root_bytes: Vec<u8> = root.to_bytes()?;
-            let root_hash = Blake2bHash::new(&root_bytes);
+            let (root_hash, root) = create_hashed_empty_trie::<Key, Value>()?;
             let mut txn = environment.create_read_write_txn()?;
-            store.put(&mut txn, &root_hash, &root).unwrap();
+            store.put(&mut txn, &root_hash, &root)?;
             txn.commit()?;
             root_hash
         };

--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -1,0 +1,54 @@
+use common::bytesrepr::ToBytes;
+use common::key::Key;
+use common::value::Value;
+use history::trie::Trie;
+use history::trie_store::in_memory::{self, InMemoryEnvironment, InMemoryTrieStore};
+use history::trie_store::{Transaction, TransactionSource, TrieStore};
+use shared::newtypes::Blake2bHash;
+use std::sync::Arc;
+
+/// Represents a "view" of global state at a particular root hash.
+pub struct InMemoryGlobalState {
+    environment: Arc<InMemoryEnvironment>,
+    store: Arc<InMemoryTrieStore>,
+    root_hash: Blake2bHash,
+}
+
+impl InMemoryGlobalState {
+    /// Creates an empty state from an existing environment and store.
+    pub fn empty(
+        environment: Arc<InMemoryEnvironment>,
+        store: Arc<InMemoryTrieStore>,
+    ) -> Result<Self, in_memory::Error> {
+        let root_hash: Blake2bHash = {
+            let root: Trie<Key, Value> = Trie::Node {
+                pointer_block: Default::default(),
+            };
+            let root_bytes: Vec<u8> = root.to_bytes()?;
+            let root_hash = Blake2bHash::new(&root_bytes);
+            let mut txn = environment.create_read_write_txn()?;
+            store.put(&mut txn, &root_hash, &root).unwrap();
+            txn.commit()?;
+            root_hash
+        };
+        Ok(InMemoryGlobalState {
+            environment,
+            store,
+            root_hash,
+        })
+    }
+
+    /// Creates a state from an existing environment, store, and root_hash.
+    /// Intended to be used for testing.
+    pub(crate) fn new(
+        environment: Arc<InMemoryEnvironment>,
+        store: Arc<InMemoryTrieStore>,
+        root_hash: Blake2bHash,
+    ) -> Self {
+        InMemoryGlobalState {
+            environment,
+            store,
+            root_hash,
+        }
+    }
+}

--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -26,11 +26,7 @@ impl InMemoryGlobalState {
             txn.commit()?;
             root_hash
         };
-        Ok(InMemoryGlobalState {
-            environment,
-            store,
-            root_hash,
-        })
+        Ok(InMemoryGlobalState::new(environment, store, root_hash))
     }
 
     /// Creates a state from an existing environment, store, and root_hash.

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -1,0 +1,55 @@
+use common::bytesrepr::ToBytes;
+use common::key::Key;
+use common::value::Value;
+use error;
+use history::trie::Trie;
+use history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
+use history::trie_store::{Transaction, TransactionSource, TrieStore};
+use shared::newtypes::Blake2bHash;
+use std::sync::Arc;
+
+/// Represents a "view" of global state at a particular root hash.
+pub struct LmdbGlobalState {
+    environment: Arc<LmdbEnvironment>,
+    store: Arc<LmdbTrieStore>,
+    root_hash: Blake2bHash,
+}
+
+impl LmdbGlobalState {
+    /// Creates an empty state from an existing environment and store.
+    pub fn empty(
+        environment: Arc<LmdbEnvironment>,
+        store: Arc<LmdbTrieStore>,
+    ) -> Result<Self, error::Error> {
+        let root_hash: Blake2bHash = {
+            let root: Trie<Key, Value> = Trie::Node {
+                pointer_block: Default::default(),
+            };
+            let root_bytes: Vec<u8> = root.to_bytes()?;
+            let root_hash = Blake2bHash::new(&root_bytes);
+            let mut txn = environment.create_read_write_txn()?;
+            store.put(&mut txn, &root_hash, &root).unwrap();
+            txn.commit()?;
+            root_hash
+        };
+        Ok(LmdbGlobalState {
+            environment,
+            store,
+            root_hash,
+        })
+    }
+
+    /// Creates a state from an existing environment, store, and root_hash.
+    /// Intended to be used for testing.
+    pub(crate) fn new(
+        environment: Arc<LmdbEnvironment>,
+        store: Arc<LmdbTrieStore>,
+        root_hash: Blake2bHash,
+    ) -> Self {
+        LmdbGlobalState {
+            environment,
+            store,
+            root_hash,
+        }
+    }
+}

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -27,11 +27,7 @@ impl LmdbGlobalState {
             txn.commit()?;
             root_hash
         };
-        Ok(LmdbGlobalState {
-            environment,
-            store,
-            root_hash,
-        })
+        Ok(LmdbGlobalState::new(environment, store, root_hash))
     }
 
     /// Creates a state from an existing environment, store, and root_hash.

--- a/execution-engine/storage/src/global_state/mod.rs
+++ b/execution-engine/storage/src/global_state/mod.rs
@@ -6,6 +6,15 @@ use std::collections::{BTreeMap, HashMap};
 
 pub mod inmem;
 
+// TODO: remove this annotation
+#[allow(dead_code)]
+pub mod lmdb;
+
+// TODO: remove this annotation
+#[allow(dead_code)]
+#[cfg(test)]
+pub(crate) mod in_memory;
+
 #[derive(Debug)]
 pub struct ExecutionEffect(pub HashMap<Key, Op>, pub HashMap<Key, Transform>);
 

--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -225,3 +225,20 @@ impl<K: FromBytes, V: FromBytes> FromBytes for Trie<K, V> {
         }
     }
 }
+
+pub(crate) mod operations {
+    use common::bytesrepr::{self, ToBytes};
+    use history::trie::Trie;
+    use shared::newtypes::Blake2bHash;
+
+    /// Creates a tuple containing an empty root hash and an empty root (a node
+    /// with an empty pointer block)
+    pub fn create_hashed_empty_trie<K: ToBytes, V: ToBytes>(
+    ) -> Result<(Blake2bHash, Trie<K, V>), bytesrepr::Error> {
+        let root: Trie<K, V> = Trie::Node {
+            pointer_block: Default::default(),
+        };
+        let root_bytes: Vec<u8> = root.to_bytes()?;
+        Ok((Blake2bHash::new(&root_bytes), root))
+    }
+}

--- a/execution-engine/storage/src/history/trie_store/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/mod.rs
@@ -9,7 +9,7 @@ use shared::newtypes::Blake2bHash;
 pub mod lmdb;
 
 #[cfg(test)]
-mod in_memory;
+pub(crate) mod in_memory;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Overview
This PR introduces `InMemoryGlobalState` and `LmdbGlobalState` objects.  The former is intended to be used in test code, the latter is intended to be used in production code.  Each object will combine the functionality of `InMemGS` and `InMemHist` - there is no need for these two separate objects with trie-based state.

### Which JIRA issue does this PR relate to?
https://casperlabs.atlassian.net/browse/STOR-59

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A