### PR TITLE
OP-133: Fix block count mismatch in Drone by changing height of the DAG

### DIFF
--- a/integration-testing/test/test_multiple_deploys.py
+++ b/integration-testing/test/test_multiple_deploys.py
@@ -91,26 +91,23 @@ def test_multiple_deploys_at_once(command_line_options_fixture, docker_client_fi
                         branch out and be only 4 levels deep
                         (`G<-A1, G<-B1, G<-C1, [A1,B1,C1]<-C2`, etc).
                         """
-                        # @srini I am changing the expected blocks to 3 to pass the test
-                        # case, once i find out the reason for discrepancy between Drone
-                        # and local system block count, then i will remove this comment.
-                        expected_blocks_count = 3
+                        expected_blocks_count = 8
                         wait_for_blocks_count_at_least(
                             no1,
                             expected_blocks_count,
-                            3,
+                            8,
                             context.node_startup_timeout
                         )
                         wait_for_blocks_count_at_least(
                             no2,
                             expected_blocks_count,
-                            3,
+                            8,
                             context.node_startup_timeout
                         )
                         wait_for_blocks_count_at_least(
                             no3,
                             expected_blocks_count,
-                            3,
+                            8,
                             context.node_startup_timeout
                         )
 


### PR DESCRIPTION
## Overview
There is a mismatch between number of blocks displayed  in local and drone for this test case. This PR intends to fix that.
### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please.


https://casperlabs.atlassian.net/browse/OP-133

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
