### PR TITLE
NO-TICKET: Added a note about gossiping errors

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
@@ -20,6 +20,11 @@ trait Synchronizer[F[_]] {
 }
 
 object Synchronizer {
+  //TODO: Reconsider according to the consensus
+  // We can't just stop importing at a certain depth threshold,
+  // because then an attacker could probably create blocks in such a way that
+  // half the honest nodes would import them and half of them would reject them?
+  // Logic may be changed depending on the consensus algorithm.
   sealed trait SyncError extends Product with Serializable
   object SyncError {
     final case class TooWide(


### PR DESCRIPTION
## Overview
@afck Pointed to possible problems if we have strict depth or width thresholds for blocks gossiping.
Added a note about it to the code for not forgetting it in the future.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
No ticket

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
