### PR TITLE
NODE-305: Width check threshold based on block count.

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/SynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/SynchronizerSpec.scala
@@ -97,7 +97,7 @@ class SynchronizerSpec
         genDoubleGreaterEqualOf1(3)
       ) { (dag, n) =>
         log.reset()
-        TestFixture(dag)(maxBranchingFactor = n, startingDepthToCheckBranchingFactor = 0) {
+        TestFixture(dag)(maxBranchingFactor = n, minBlockCountToCheckBranchingFactor = 0) {
           (synchronizer, _, _) =>
             synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
               dagOrError.isLeft shouldBe true
@@ -179,14 +179,14 @@ class SynchronizerSpec
       }
     }
     "asked to sync DAG" should {
-      "ignore branching factor checks until specified depth-threshold is reached" in forAll(
+      "ignore branching factor checks until specified count-threshold is reached" in forAll(
         genPartialDagFromTips(
           ConsensusConfig(dagDepth = 3, dagBranchingFactor = 3, dagWidth = Int.MaxValue)
         ),
         genDoubleGreaterEqualOf1(2)
       ) { (dag, n) =>
         log.reset()
-        TestFixture(dag)(maxBranchingFactor = n, startingDepthToCheckBranchingFactor = Int.MaxValue) {
+        TestFixture(dag)(maxBranchingFactor = n, minBlockCountToCheckBranchingFactor = Int.MaxValue) {
           (synchronizer, _, _) =>
             synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
               dagOrError.isRight shouldBe true
@@ -336,7 +336,7 @@ object SynchronizerSpec {
         maxPossibleDepth: Int Refined Positive = Int.MaxValue,
         maxBranchingFactor: Double Refined GreaterEqual[W.`1.0`.T] = Double.MaxValue,
         maxDepthAncestorsRequest: Int Refined Positive = Int.MaxValue,
-        startingDepthToCheckBranchingFactor: Int Refined NonNegative = Int.MaxValue,
+        minBlockCountToCheckBranchingFactor: Int Refined NonNegative = Int.MaxValue,
         validate: BlockSummary => Task[Unit] = _ => Task.unit,
         notInDag: ByteString => Task[Boolean] = _ => Task.now(false),
         error: Option[RuntimeException] = None,
@@ -350,7 +350,7 @@ object SynchronizerSpec {
         connectToGossip = _ => MockGossipService(requestsCounter, error, knownHashes, dags: _*),
         backend = MockBackend(tips, justifications, notInDag, validate),
         maxPossibleDepth = maxPossibleDepth,
-        startingDepthToCheckBranchingFactor = startingDepthToCheckBranchingFactor,
+        minBlockCountToCheckBranchingFactor = minBlockCountToCheckBranchingFactor,
         maxBranchingFactor = maxBranchingFactor,
         maxDepthAncestorsRequest = maxDepthAncestorsRequest
       )


### PR DESCRIPTION
## Overview
The `Synchronizer` currently starts checking for exponential branching at a certain depth but it's easy to provide unlimited number of parents for the target block at depth 1. Changed it so it's based on block count.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-305

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
