### PR TITLE
NO-TICKET: execution-engine: fix PointerBlock's Debug impl

### DIFF
--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -130,12 +130,12 @@ impl ::std::fmt::Debug for PointerBlock {
     #[allow(clippy::assertions_on_constants)]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         assert!(RADIX > 1, "RADIX must be > 1");
-        write!(f, "{}(", stringify!(PointerBlock))?;
+        write!(f, "{}([", stringify!(PointerBlock))?;
         write!(f, "{:?}", self.0[0])?;
         for item in self.0[1..].iter() {
             write!(f, ", {:?}", item)?;
         }
-        write!(f, ")")
+        write!(f, "])")
     }
 }
 

--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -127,6 +127,7 @@ impl ::std::ops::IndexMut<usize> for PointerBlock {
 }
 
 impl ::std::fmt::Debug for PointerBlock {
+    #[allow(clippy::assertions_on_constants)]
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         assert!(RADIX > 1, "RADIX must be > 1");
         write!(f, "{}(", stringify!(PointerBlock))?;

--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -128,6 +128,7 @@ impl ::std::ops::IndexMut<usize> for PointerBlock {
 
 impl ::std::fmt::Debug for PointerBlock {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        assert!(RADIX > 1, "RADIX must be > 1");
         write!(f, "{}(", stringify!(PointerBlock))?;
         write!(f, "{:?}", self.0[0])?;
         for item in self.0[1..].iter() {

--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -129,8 +129,9 @@ impl ::std::ops::IndexMut<usize> for PointerBlock {
 impl ::std::fmt::Debug for PointerBlock {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "{}(", stringify!(PointerBlock))?;
-        for item in self.0[..].iter() {
-            write!(f, "{:?}", item)?;
+        write!(f, "{:?}", self.0[0])?;
+        for item in self.0[1..].iter() {
+            write!(f, ", {:?}", item)?;
         }
         write!(f, ")")
     }

--- a/execution-engine/storage/src/history/trie/tests.rs
+++ b/execution-engine/storage/src/history/trie/tests.rs
@@ -10,6 +10,12 @@ fn radix_is_256() {
 mod pointer_block {
     use crate::history::trie::*;
 
+    /// A defense against changes to [`RADIX`](history::trie::RADIX).
+    #[test]
+    fn debug_formatter_succeeds() {
+        let _ = format!("{:?}", PointerBlock::new());
+    }
+
     #[test]
     fn assignment_and_indexing() {
         let test_hash = Blake2bHash::new(b"TrieTrieAgain");

--- a/execution-engine/storage/src/history/trie/tests.rs
+++ b/execution-engine/storage/src/history/trie/tests.rs
@@ -1,3 +1,12 @@
+#[test]
+fn radix_is_256() {
+    assert_eq!(
+        super::RADIX,
+        256,
+        "Changing RADIX alone might cause things to break"
+    );
+}
+
 mod pointer_block {
     use crate::history::trie::*;
 


### PR DESCRIPTION
## Overview
This PR fixes the formatting of a `PointerBlock` when it is printed via its `Debug` impl.

### Which JIRA issue does this PR relate to? 
This is unticketed work.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
