### PR TITLE
NODE-312: Moved the doppelganger check to CasperPacketHandler only.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -24,7 +24,6 @@ trait Casper[F[_], A] {
   def deploy(deployData: DeployData): F[Either[Throwable, Unit]]
   def estimator(dag: BlockDagRepresentation[F]): F[A]
   def createBlock: F[CreateBlockStatus]
-  def validatorId: Option[ValidatorIdentity]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -19,14 +19,12 @@ import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 
 trait Casper[F[_], A] {
-  def addBlock(
-      block: BlockMessage,
-      handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus]
+  def addBlock(block: BlockMessage): F[BlockStatus]
   def contains(block: BlockMessage): F[Boolean]
   def deploy(deployData: DeployData): F[Either[Throwable, Unit]]
   def estimator(dag: BlockDagRepresentation[F]): F[A]
   def createBlock: F[CreateBlockStatus]
+  def validatorId: Option[ValidatorIdentity]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {
@@ -42,8 +40,6 @@ trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {
 
 object MultiParentCasper extends MultiParentCasperInstances {
   def apply[F[_]](implicit instance: MultiParentCasper[F]): MultiParentCasper[F] = instance
-  def ignoreDoppelgangerCheck[F[_]: Applicative]: (BlockMessage, Validator) => F[Unit] =
-    kp2(().pure[F])
 
   def forkChoiceTip[F[_]: MultiParentCasper: Monad: BlockStore]: F[BlockMessage] =
     for {

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -48,7 +48,7 @@ final case class CasperState(
 class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: ExecutionEngineService](
     statelessExecutor: MultiParentCasperImpl.StatelessExecutor[F],
     broadcaster: MultiParentCasperImpl.Broadcaster[F],
-    val validatorId: Option[ValidatorIdentity],
+    validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,
     shardId: String,
     blockProcessingLock: Semaphore[F],

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -48,7 +48,7 @@ final case class CasperState(
 class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: ExecutionEngineService](
     statelessExecutor: MultiParentCasperImpl.StatelessExecutor[F],
     broadcaster: MultiParentCasperImpl.Broadcaster[F],
-    validatorId: Option[ValidatorIdentity],
+    val validatorId: Option[ValidatorIdentity],
     genesis: BlockMessage,
     shardId: String,
     blockProcessingLock: Semaphore[F],
@@ -71,8 +71,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
 
   /** Add a block if it hasn't been added yet. */
   def addBlock(
-      block: BlockMessage,
-      handleDoppelganger: (BlockMessage, Validator) => F[Unit]
+      block: BlockMessage
   ): F[BlockStatus] =
     Sync[F].bracket(blockProcessingLock.acquire)(
       _ =>
@@ -94,15 +93,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
                              )
                          )
                      } else {
-                       (validatorId match {
-                         case Some(
-                             ValidatorIdentity(publicKey, _, _)
-                             ) =>
-                           val sender =
-                             ByteString.copyFrom(publicKey)
-                           handleDoppelganger(block, sender)
-                         case None => ().pure[F]
-                       }) *> Cell[F, CasperState].modify { s =>
+                       Cell[F, CasperState].modify { s =>
                          s.copy(
                            seenBlockHashes = s.seenBlockHashes + blockHash
                          )

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -10,7 +10,6 @@ import cats.mtl.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockStore}
 import io.casperlabs.casper.Estimator.BlockHash
-import io.casperlabs.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper._
 import io.casperlabs.casper.protocol._
@@ -82,7 +81,7 @@ object BlockAPI {
                          case Created(block) =>
                            Metrics[F].incrementCounter("create-blocks-success") *>
                              casper
-                               .addBlock(block, ignoreDoppelgangerCheck[F])
+                               .addBlock(block)
                                .map(addResponse(_, block))
                        }
             } yield result

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
@@ -385,7 +385,11 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
             } else {
               for {
                 _ <- Log[F].info(s"Received ${PrettyPrinter.buildString(b)}.")
-                _ <- MultiParentCasper[F].addBlock(b, handleDoppelganger[F](peer, _, _))
+                _ <- MultiParentCasper[F].validatorId.fold(().pure[F]) {
+                      case ValidatorIdentity(publicKey, _, _) =>
+                        handleDoppelganger[F](peer, b, ByteString.copyFrom(publicKey))
+                    }
+                _ <- MultiParentCasper[F].addBlock(b)
               } yield ()
             }
       } yield ()

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -11,7 +11,6 @@ import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util._
 import io.casperlabs.casper.util.rholang._
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
-import io.casperlabs.casper.MultiParentCasper.ignoreDoppelgangerCheck
 import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.crypto.signatures.Ed25519
 import io.casperlabs.metrics.Metrics
@@ -83,11 +82,8 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
 
 private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: MultiParentCasper[F])
     extends MultiParentCasper[F] {
-
-  def addBlock(
-      b: BlockMessage,
-      handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus]                                     = underlying.addBlock(b, ignoreDoppelgangerCheck[F])
+  def validatorId                                       = underlying.validatorId
+  def addBlock(b: BlockMessage): F[BlockStatus]         = underlying.addBlock(b)
   def contains(b: BlockMessage): F[Boolean]             = underlying.contains(b)
   def deploy(d: DeployData): F[Either[Throwable, Unit]] = underlying.deploy(d)
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -82,7 +82,6 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
 
 private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: MultiParentCasper[F])
     extends MultiParentCasper[F] {
-  def validatorId                                       = underlying.validatorId
   def addBlock(b: BlockMessage): F[BlockStatus]         = underlying.addBlock(b)
   def contains(b: BlockMessage): F[Boolean]             = underlying.contains(b)
   def deploy(d: DeployData): F[Either[Throwable, Unit]] = underlying.deploy(d)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -106,9 +106,13 @@ class HashSetCasperTestNode[F[_]](
 
   implicit val multiparentCasperRef = MultiParentCasperRef.unsafe[F](Some(casperEff))
 
-  val handlerInternal = new ApprovedBlockReceivedHandler(casperEff, approvedBlock)
+  val handlerInternal =
+    new ApprovedBlockReceivedHandler(casperEff, approvedBlock, Some(validatorId))
   val casperPacketHandler =
-    new CasperPacketHandlerImpl[F](Ref.unsafe[F, CasperPacketHandlerInternal[F]](handlerInternal))
+    new CasperPacketHandlerImpl[F](
+      Ref.unsafe[F, CasperPacketHandlerInternal[F]](handlerInternal),
+      Some(validatorId)
+    )
   implicit val packetHandlerEff = PacketHandler.pf[F](
     casperPacketHandler.handle
   )

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -6,7 +6,7 @@ import cats.implicits._
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.protocol.{BlockMessage, DeployData}
-import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper}
+import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper, ValidatorIdentity}
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.storage.BlockMsgWithTransform
 
@@ -19,10 +19,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
 
   def store: Map[BlockHash, BlockMsgWithTransform] = blockStore.toMap
 
-  def addBlock(
-      b: BlockMessage,
-      handleDoppelganger: (BlockMessage, Validator) => F[Unit]
-  ): F[BlockStatus] =
+  def addBlock(b: BlockMessage): F[BlockStatus] =
     for {
       _ <- Sync[F].delay(
             blockStore
@@ -35,6 +32,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     estimatorFunc.pure[F]
   def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]
+  def validatorId: Option[ValidatorIdentity]                          = None
   def blockDag: F[BlockDagRepresentation[F]]                          = BlockDagStorage[F].getRepresentation
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
   def lastFinalizedBlock: F[BlockMessage]                             = BlockMessage().pure[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -32,7 +32,6 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
     estimatorFunc.pure[F]
   def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]
-  def validatorId: Option[ValidatorIdentity]                          = None
   def blockDag: F[BlockDagRepresentation[F]]                          = BlockDagStorage[F].getRepresentation
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
   def lastFinalizedBlock: F[BlockMessage]                             = BlockMessage().pure[F]

--- a/casper/src/test/scala/io/casperlabs/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -121,7 +121,7 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
           Ref.unsafe[Task, CasperPacketHandlerInternal[Task]](
             new GenesisValidatorHandler(validatorId, shardId, bap)
           )
-        val packetHandler     = new CasperPacketHandlerImpl[Task](ref)
+        val packetHandler     = new CasperPacketHandlerImpl[Task](ref, Some(validatorId))
         val expectedCandidate = ApprovedBlockCandidate(Some(genesis), requiredSigs)
 
         val unapprovedBlock  = BlockApproverProtocolTest.createUnapproved(requiredSigs, genesis)
@@ -153,7 +153,7 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
           Ref.unsafe[Task, CasperPacketHandlerInternal[Task]](
             new GenesisValidatorHandler(validatorId, shardId, bap)
           )
-        val packetHandler = new CasperPacketHandlerImpl[Task](ref)
+        val packetHandler = new CasperPacketHandlerImpl[Task](ref, Some(validatorId))
 
         val approvedBlockRequest = ApprovedBlockRequest("test")
         val packet1              = Packet(transport.ApprovedBlockRequest.id, approvedBlockRequest.toByteString)
@@ -211,7 +211,7 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
           )
           standaloneCasper    = new StandaloneCasperHandler[Task](abp)
           refCasper           <- Ref.of[Task, CasperPacketHandlerInternal[Task]](standaloneCasper)
-          casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper)
+          casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper, Some(validatorId))
           c1                  = abp.run().forkAndForget.runToFuture
           c2 = StandaloneCasperHandler
             .approveBlockInterval(
@@ -287,7 +287,7 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
 
         val test = for {
           refCasper           <- Ref.of[Task, CasperPacketHandlerInternal[Task]](bootstrapCasper)
-          casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper)
+          casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper, Some(validatorId))
           _                   <- casperPacketHandler.handle(local).apply(approvedPacket)
           casperO             <- MultiParentCasperRef[Task].get
           _                   = assert(casperO.isDefined)
@@ -341,9 +341,9 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
       implicit val casper = NoOpsCasperEffect[Task]().unsafeRunSync
 
       val refCasper = Ref.unsafe[Task, CasperPacketHandlerInternal[Task]](
-        new ApprovedBlockReceivedHandler[Task](casper, approvedBlock)
+        new ApprovedBlockReceivedHandler[Task](casper, approvedBlock, Some(validatorId))
       )
-      val casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper)
+      val casperPacketHandler = new CasperPacketHandlerImpl[Task](refCasper, Some(validatorId))
 
       transportLayer.setResponses(_ => p => Right(p))
 


### PR DESCRIPTION
## Overview
Removes the `handleDoppelganger` lambda from `MultiParentCasper.addBlock` so the tests are not full of the `ignoreDoppelganger[F]` boilerplate. The only place it wasn't ignoring it was the `CasperMessageHandler` where it was expected that if the node created the block and now that block is being pushed to it by another one then the node should already have it. Since the existence check is already there this extra logging can be as well.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
No separate ticket, it's just came up during refactoring the tests for the new gossiping.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
