### PR TITLE
NODE-312: Refactor casper test node

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -15,6 +15,7 @@ import io.casperlabs.catscontrib.ski._
 import io.casperlabs.comm.CommError.ErrorHandler
 import io.casperlabs.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import io.casperlabs.comm.transport.TransportLayer
+import io.casperlabs.comm.gossiping
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 
@@ -51,7 +52,7 @@ object MultiParentCasper extends MultiParentCasperInstances {
 
 sealed abstract class MultiParentCasperInstances {
 
-  def hashSetCasper[F[_]: Concurrent: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ExecutionEngineService](
+  def fromTransportLayer[F[_]: Concurrent: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ExecutionEngineService](
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,
       shardId: String
@@ -70,7 +71,37 @@ sealed abstract class MultiParentCasperInstances {
       implicit val state = casperState
       new MultiParentCasperImpl[F](
         new MultiParentCasperImpl.StatelessExecutor(shardId),
-        new MultiParentCasperImpl.Broadcaster(),
+        MultiParentCasperImpl.Broadcaster.fromTransportLayer(),
+        validatorId,
+        genesis,
+        shardId,
+        blockProcessingLock
+      )
+    }
+
+  /** Create a MultiParentCasper instance from the new RPC style gossiping. */
+  def fromGossipServices[F[_]: Concurrent: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: ExecutionEngineService](
+      validatorId: Option[ValidatorIdentity],
+      genesis: BlockMessage,
+      shardId: String
+  )(
+      relaying: gossiping.Relaying[F]
+  ): F[MultiParentCasper[F]] =
+    for {
+      // Initialize DAG storage with genesis block in case it is empty
+      _                   <- BlockDagStorage[F].insert(genesis)
+      dag                 <- BlockDagStorage[F].getRepresentation
+      _                   <- Sync[F].rethrow(ExecEngineUtil.validateBlockCheckpoint[F](genesis, dag))
+      blockProcessingLock <- Semaphore[F](1)
+      casperState <- Cell.mvarCell[F, CasperState](
+                      CasperState()
+                    )
+
+    } yield {
+      implicit val state = casperState
+      new MultiParentCasperImpl[F](
+        new MultiParentCasperImpl.StatelessExecutor(shardId),
+        MultiParentCasperImpl.Broadcaster.fromGossipServices(validatorId, relaying),
         validatorId,
         genesis,
         shardId,

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -725,7 +725,7 @@ object MultiParentCasperImpl {
             status: BlockStatus
         ): F[Unit] =
           status match {
-            //Add successful! Send block to peers, log success, try to add other blocks
+            //Add successful! Send block to peers.
             case Valid | AdmissibleEquivocation =>
               CommUtil.sendBlock[F](block)
 

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
@@ -289,7 +289,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                            blockMessage,
                            transforms
                          )
-                     casper <- MultiParentCasper.hashSetCasper[F](
+                     casper <- MultiParentCasper.fromTransportLayer[F](
                                 validatorId,
                                 blockMessage,
                                 shardId
@@ -603,7 +603,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
                        )
                    _ <- LastApprovedBlock[F].set(ApprovedBlockWithTransforms(b, transforms))
                    casper <- MultiParentCasper
-                              .hashSetCasper[F](
+                              .fromTransportLayer[F](
                                 validatorId,
                                 blockMessage,
                                 shardId

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -6,7 +6,11 @@ import cats.data.EitherT
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import io.casperlabs.casper._
-import io.casperlabs.casper.helper.HashSetCasperTestNode
+import io.casperlabs.casper.helper.{
+  HashSetCasperTestNode,
+  TransportLayerCasperTestNode,
+  TransportLayerCasperTestNodeFactory
+}, HashSetCasperTestNode.Effect
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util._
 import io.casperlabs.casper.util.rholang._
@@ -24,7 +28,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{FlatSpec, Matchers}
 
-class CreateBlockAPITest extends FlatSpec with Matchers {
+class CreateBlockAPITest extends FlatSpec with Matchers with TransportLayerCasperTestNodeFactory {
   import HashSetCasperTest._
   import HashSetCasperTestNode.Effect
 
@@ -43,7 +47,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers {
       def nanoTime: Task[Long]                        = timer.clock.monotonic(NANOSECONDS)
       def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
     }
-    val node   = HashSetCasperTestNode.standaloneEff(genesis, transforms, validatorKeys.head)
+    val node   = standaloneEff(genesis, transforms, validatorKeys.head)
     val casper = new SleepingMultiParentCasperImpl[Effect](node.casperEff)
     val deploys = List(
       "@0!(0) | for(_ <- @0){ @1!(1) }",

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -96,7 +96,7 @@ class HashSetCasperTestNode[F[_]](
 
   implicit val casperEff = new MultiParentCasperImpl[F](
     new MultiParentCasperImpl.StatelessExecutor(shardId),
-    new MultiParentCasperImpl.Broadcaster(),
+    MultiParentCasperImpl.Broadcaster.fromTransportLayer(),
     Some(validatorId),
     genesis,
     shardId,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -1,0 +1,302 @@
+package io.casperlabs.casper.helper
+
+import java.nio.file.Path
+
+import cats.data.EitherT
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Ref, Semaphore}
+import cats.implicits._
+import cats.{Applicative, ApplicativeError, Defer, Id, Monad}
+import com.google.protobuf.ByteString
+import io.casperlabs.blockstorage._
+import io.casperlabs.casper._
+import io.casperlabs.casper.helper.BlockDagStorageTestFixture.mapSize
+import io.casperlabs.casper.protocol._
+import io.casperlabs.casper.util.ProtoUtil
+import io.casperlabs.casper.util.comm.CasperPacketHandler.{
+  ApprovedBlockReceivedHandler,
+  CasperPacketHandlerImpl,
+  CasperPacketHandlerInternal
+}
+import io.casperlabs.casper.util.comm.TransportLayerTestImpl
+import io.casperlabs.casper.util.execengine.ExecEngineUtil
+import io.casperlabs.catscontrib.TaskContrib._
+import io.casperlabs.catscontrib._
+import io.casperlabs.catscontrib.effect.implicits._
+import io.casperlabs.catscontrib.ski._
+import io.casperlabs.comm.CommError.ErrorHandler
+import io.casperlabs.comm._
+import io.casperlabs.comm.discovery.Node
+import io.casperlabs.comm.protocol.routing._
+import io.casperlabs.comm.rp.Connect
+import io.casperlabs.comm.rp.Connect._
+import io.casperlabs.comm.rp.HandleMessages.handle
+import io.casperlabs.crypto.signatures.Ed25519
+import io.casperlabs.ipc
+import io.casperlabs.ipc.TransformEntry
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.p2p.EffectsTestInstances._
+import io.casperlabs.p2p.effects.PacketHandler
+import io.casperlabs.shared.PathOps.RichPath
+import io.casperlabs.shared.{Cell, Log}
+import io.casperlabs.smartcontracts.ExecutionEngineService
+import monix.eval.Task
+import monix.execution.Scheduler
+
+import scala.collection.mutable
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import scala.util.Random
+
+import HashSetCasperTestNode.Effect
+
+class TransportLayerCasperTestNode[F[_]](
+    name: String,
+    val local: Node,
+    tle: TransportLayerTestImpl[F],
+    val genesis: BlockMessage,
+    val transforms: Seq[TransformEntry],
+    sk: Array[Byte],
+    logicalTime: LogicalTime[F],
+    implicit val errorHandlerEff: ErrorHandler[F],
+    storageSize: Long,
+    val blockDagDir: Path,
+    val blockStoreDir: Path,
+    blockProcessingLock: Semaphore[F],
+    faultToleranceThreshold: Float = 0f,
+    shardId: String = "casperlabs"
+)(
+    implicit
+    concurrentF: Concurrent[F],
+    val blockStore: BlockStore[F],
+    val blockDagStorage: BlockDagStorage[F],
+    val metricEff: Metrics[F],
+    val casperState: Cell[F, CasperState]
+) extends HashSetCasperTestNode[F] {
+
+  implicit val logEff: LogStub[F] = new LogStub[F]()
+  implicit val timeEff            = logicalTime
+  implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
+  implicit val transportLayerEff  = tle
+  implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]
+  implicit val rpConfAsk          = createRPConfAsk[F](local)
+
+  val bonds = genesis.body
+    .flatMap(_.state.map(_.bonds.map(b => b.validator.toByteArray -> b.stake).toMap))
+    .getOrElse(Map.empty)
+
+  implicit val casperSmartContractsApi = HashSetCasperTestNode.simpleEEApi[F](bonds)
+
+  val defaultTimeout = FiniteDuration(1000, MILLISECONDS)
+
+  val validatorId = ValidatorIdentity(Ed25519.toPublic(sk), sk, "ed25519")
+
+  val approvedBlock = ApprovedBlock(candidate = Some(ApprovedBlockCandidate(block = Some(genesis))))
+
+  implicit val labF =
+    LastApprovedBlock.unsafe[F](Some(ApprovedBlockWithTransforms(approvedBlock, transforms)))
+  val postGenesisStateHash = ProtoUtil.postStateHash(genesis)
+
+  implicit val casperEff: MultiParentCasperImpl[F] = new MultiParentCasperImpl[F](
+    new MultiParentCasperImpl.StatelessExecutor(shardId),
+    MultiParentCasperImpl.Broadcaster.fromTransportLayer(),
+    Some(validatorId),
+    genesis,
+    shardId,
+    blockProcessingLock,
+    faultToleranceThreshold = faultToleranceThreshold
+  )
+
+  implicit val multiparentCasperRef = MultiParentCasperRef.unsafe[F](Some(casperEff))
+
+  val handlerInternal =
+    new ApprovedBlockReceivedHandler(casperEff, approvedBlock, Some(validatorId))
+  val casperPacketHandler =
+    new CasperPacketHandlerImpl[F](
+      Ref.unsafe[F, CasperPacketHandlerInternal[F]](handlerInternal),
+      Some(validatorId)
+    )
+  implicit val packetHandlerEff = PacketHandler.pf[F](
+    casperPacketHandler.handle
+  )
+
+  def initialize(): F[Unit] =
+    // pre-population removed from internals of Casper
+    blockStore.put(genesis.blockHash, genesis, Seq.empty) *>
+      blockDagStorage.getRepresentation.flatMap { dag =>
+        ExecEngineUtil
+          .validateBlockCheckpoint[F](
+            genesis,
+            dag
+          )
+          .void
+      }
+
+  def receive(): F[Unit] = tle.receive(p => handle[F](p, defaultTimeout), kp(().pure[F]))
+
+  def clearMessages(): F[Unit] =
+    transportLayerEff.clear(local)
+
+  def tearDown(): F[Unit] =
+    tearDownNode().map { _ =>
+      blockStoreDir.recursivelyDelete()
+      blockDagDir.recursivelyDelete()
+    }
+
+  def tearDownNode(): F[Unit] =
+    for {
+      _ <- blockStore.close()
+      _ <- blockDagStorage.close()
+    } yield ()
+}
+
+trait TransportLayerCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
+
+  type TestNode[F[_]] = TransportLayerCasperTestNode[F]
+
+  import HashSetCasperTestNode.peerNode
+
+  def standaloneF[F[_]](
+      genesis: BlockMessage,
+      transforms: Seq[TransformEntry],
+      sk: Array[Byte],
+      storageSize: Long = 1024L * 1024 * 10,
+      faultToleranceThreshold: Float = 0f
+  )(
+      implicit
+      errorHandler: ErrorHandler[F],
+      concurrentF: Concurrent[F]
+  ): F[TransportLayerCasperTestNode[F]] = {
+    val name     = "standalone"
+    val identity = peerNode(name, 40400)
+    val tle =
+      new TransportLayerTestImpl[F](identity, Map.empty[Node, Ref[F, mutable.Queue[Protocol]]])
+    val logicalTime: LogicalTime[F] = new LogicalTime[F]
+    implicit val log                = new Log.NOPLog[F]()
+    implicit val metricEff          = new Metrics.MetricsNOP[F]
+
+    val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
+    val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
+    val env           = Context.env(blockStoreDir, mapSize)
+    for {
+      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
+      blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
+                          BlockDagFileStorage.Config(blockDagDir),
+                          genesis
+                        )(Concurrent[F], Log[F], blockStore, metricEff)
+      blockProcessingLock <- Semaphore[F](1)
+      casperState         <- Cell.mvarCell[F, CasperState](CasperState())
+      node = new TransportLayerCasperTestNode[F](
+        name,
+        identity,
+        tle,
+        genesis,
+        transforms,
+        sk,
+        logicalTime,
+        errorHandler,
+        storageSize,
+        blockDagDir,
+        blockStoreDir,
+        blockProcessingLock,
+        faultToleranceThreshold
+      )(
+        concurrentF,
+        blockStore,
+        blockDagStorage,
+        metricEff,
+        casperState
+      )
+      result <- node.initialize.map(_ => node)
+    } yield result
+  }
+
+  def networkF[F[_]](
+      sks: IndexedSeq[Array[Byte]],
+      genesis: BlockMessage,
+      transforms: Seq[TransformEntry],
+      storageSize: Long = 1024L * 1024 * 10,
+      faultToleranceThreshold: Float = 0f
+  )(
+      implicit errorHandler: ErrorHandler[F],
+      concurrentF: Concurrent[F]
+  ): F[IndexedSeq[TransportLayerCasperTestNode[F]]] = {
+    val n     = sks.length
+    val names = (1 to n).map(i => s"node-$i")
+    val peers = names.map(peerNode(_, 40400))
+    val msgQueues = peers
+      .map(_ -> new mutable.Queue[Protocol]())
+      .toMap
+      .mapValues(Ref.unsafe[F, mutable.Queue[Protocol]])
+    val logicalTime: LogicalTime[F] = new LogicalTime[F]
+
+    val nodesF =
+      names
+        .zip(peers)
+        .zip(sks)
+        .toList
+        .traverse {
+          case ((n, p), sk) =>
+            val tle                = new TransportLayerTestImpl[F](p, msgQueues)
+            implicit val log       = new Log.NOPLog[F]()
+            implicit val metricEff = new Metrics.MetricsNOP[F]
+
+            val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
+            val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
+            val env           = Context.env(blockStoreDir, mapSize)
+            for {
+              blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
+              blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
+                                  BlockDagFileStorage.Config(blockDagDir),
+                                  genesis
+                                )(Concurrent[F], Log[F], blockStore, metricEff)
+              semaphore <- Semaphore[F](1)
+              casperState <- Cell.mvarCell[F, CasperState](
+                              CasperState()
+                            )
+              node = new TransportLayerCasperTestNode[F](
+                n,
+                p,
+                tle,
+                genesis,
+                transforms,
+                sk,
+                logicalTime,
+                errorHandler,
+                storageSize,
+                blockDagDir,
+                blockStoreDir,
+                semaphore,
+                faultToleranceThreshold
+              )(
+                concurrentF,
+                blockStore,
+                blockDagStorage,
+                metricEff,
+                casperState
+              )
+            } yield node
+        }
+        .map(_.toVector)
+
+    import Connections._
+    //make sure all nodes know about each other
+    for {
+      nodes <- nodesF
+      pairs = for {
+        n <- nodes
+        m <- nodes
+        if n.local != m.local
+      } yield (n, m)
+      _ <- nodes.traverse(_.initialize).void
+      _ <- pairs.foldLeft(().pure[F]) {
+            case (f, (n, m)) =>
+              f.flatMap(
+                _ =>
+                  n.connectionsCell.flatModify(
+                    _.addConn[F](m.local)(Monad[F], n.logEff, n.metricEff)
+                  )
+              )
+          }
+    } yield nodes
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/util/comm/ApproveBlockProtocolTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/comm/ApproveBlockProtocolTest.scala
@@ -3,7 +3,11 @@ package io.casperlabs.casper.util.comm
 import cats.effect.concurrent.Ref
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.LastApprovedBlock.LastApprovedBlock
-import io.casperlabs.casper.helper.HashSetCasperTestNode
+import io.casperlabs.casper.helper.{
+  HashSetCasperTestNode,
+  TransportLayerCasperTestNode,
+  TransportLayerCasperTestNodeFactory
+}
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util.TestTime
 import io.casperlabs.casper.util.comm.ApproveBlockProtocolTest.TestFixture
@@ -291,7 +295,7 @@ class ApproveBlockProtocolTest extends FlatSpec with Matchers {
   }
 }
 
-object ApproveBlockProtocolTest {
+object ApproveBlockProtocolTest extends TransportLayerCasperTestNodeFactory {
   def approval(
       c: ApprovedBlockCandidate,
       validatorSk: Array[Byte],
@@ -345,7 +349,7 @@ object ApproveBlockProtocolTest {
     val sigs                                             = Ref.unsafe[Task, Set[Signature]](Set.empty)
     val startTime                                        = System.currentTimeMillis()
 
-    val node = HashSetCasperTestNode.standaloneEff(genesis, transforms, sk)
+    val node = standaloneEff(genesis, transforms, sk)
     val protocol = ApproveBlockProtocol
       .unsafe[Task](
         genesis,

--- a/casper/src/test/scala/io/casperlabs/casper/util/comm/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/comm/BlockApproverProtocolTest.scala
@@ -2,7 +2,11 @@ package io.casperlabs.casper.util.comm
 
 import io.casperlabs.casper.HashSetCasperTest
 import io.casperlabs.casper.genesis.contracts._
-import io.casperlabs.casper.helper.HashSetCasperTestNode
+import io.casperlabs.casper.helper.{
+  HashSetCasperTestNode,
+  TransportLayerCasperTestNode,
+  TransportLayerCasperTestNodeFactory
+}
 import io.casperlabs.casper.helper.HashSetCasperTestNode.Effect
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.scalatestcontrib._
@@ -68,7 +72,7 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
   }
 }
 
-object BlockApproverProtocolTest {
+object BlockApproverProtocolTest extends TransportLayerCasperTestNodeFactory {
   def createUnapproved(requiredSigs: Int, block: BlockMessage): UnapprovedBlock =
     UnapprovedBlock(Some(ApprovedBlockCandidate(Some(block), requiredSigs)), 0L, 0L)
 
@@ -80,7 +84,7 @@ object BlockApproverProtocolTest {
       wallets: Seq[PreWallet],
       sk: Array[Byte],
       bonds: Map[Array[Byte], Long]
-  ): Effect[(BlockApproverProtocol, HashSetCasperTestNode[Effect])] = {
+  ): Effect[(BlockApproverProtocol, TransportLayerCasperTestNode[Effect])] = {
 
     val deployTimestamp = 1L
     val validators      = bonds.map(b => ProofOfStakeValidator(b._1, b._2)).toSeq
@@ -94,7 +98,7 @@ object BlockApproverProtocolTest {
       deployTimestamp
     )
     for {
-      nodes <- HashSetCasperTestNode.networkEff(Vector(sk), genesis, transforms)
+      nodes <- networkEff(Vector(sk), genesis, transforms)
       node  = nodes.head
     } yield
       new BlockApproverProtocol(


### PR DESCRIPTION
## Overview
We thought if possible we should keep both the `TransportLayer` and the new gossiping as an option, for comparisons. This PR refactors `HashSetCasperTest` and `HashSetCasperTestNode` to allow the tests to run against different setups. Doesn't add the new stuff yet.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-312

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
