### PR TITLE
STOR-39: add history::trie_store::operations::scan

### DIFF
--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -15,6 +15,8 @@ pub const RADIX: usize = 256;
 
 const U32_SIZE: usize = size_of::<u32>();
 
+pub type Parents<K, V> = Vec<(usize, Trie<K, V>)>;
+
 /// Represents a pointer to the next object in a Merkle Trie
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Pointer {

--- a/execution-engine/storage/src/history/trie_store/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/mod.rs
@@ -11,6 +11,8 @@ pub mod lmdb;
 #[cfg(test)]
 pub(crate) mod in_memory;
 
+// TODO: remove this annotation
+#[allow(dead_code)]
 pub(crate) mod operations;
 
 #[cfg(test)]

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -1,5 +1,5 @@
 use common::bytesrepr::ToBytes;
-use history::trie::{self, Pointer, Trie};
+use history::trie::{self, Parents, Pointer, Trie};
 use history::trie_store::{Readable, TrieStore};
 use shared::newtypes::Blake2bHash;
 
@@ -97,6 +97,102 @@ where
                     }
                 } else {
                     return Ok(ReadResult::NotFound);
+                }
+            }
+        }
+    }
+}
+
+struct TrieScan<K, V> {
+    tip: Trie<K, V>,
+    parents: Parents<K, V>,
+}
+
+impl<K, V> TrieScan<K, V> {
+    fn new(tip: Trie<K, V>, parents: Parents<K, V>) -> Self {
+        TrieScan { tip, parents }
+    }
+}
+
+/// Returns a [`TrieScan`] from the given key at a given root in a given store.
+/// A scan consists of the deepest trie variant found at that key, a.k.a. the
+/// "tip", along the with the parents of that variant. Parents are ordered by
+/// their depth from the root (shallow to deep).
+fn scan<K, V, T, S, E>(
+    txn: &T,
+    store: &S,
+    key_bytes: &[u8],
+    root: &Trie<K, V>,
+) -> Result<TrieScan<K, V>, E>
+where
+    K: ToBytes + Clone,
+    V: ToBytes + Clone,
+    T: Readable<Handle = S::Handle>,
+    S: TrieStore<K, V>,
+    S::Error: From<T::Error>,
+    E: From<S::Error> + From<common::bytesrepr::Error>,
+{
+    let path = key_bytes;
+
+    let mut current = root.to_owned();
+    let mut depth: usize = 0;
+    let mut acc: Parents<K, V> = Vec::new();
+
+    loop {
+        match current {
+            leaf @ Trie::Leaf { .. } => {
+                return Ok(TrieScan::new(leaf, acc));
+            }
+            Trie::Node { pointer_block } => {
+                let index: usize = {
+                    assert!(depth < path.len(), "depth must be < {}", path.len());
+                    path[depth].into()
+                };
+                let maybe_pointer: Option<Pointer> = {
+                    assert!(index < trie::RADIX, "index must be < {}", trie::RADIX);
+                    pointer_block[index]
+                };
+                match maybe_pointer {
+                    Some(pointer) => match store.get(txn, pointer.hash())? {
+                        Some(next) => {
+                            current = next;
+                            depth += 1;
+                            acc.push((index, Trie::Node { pointer_block }))
+                        }
+                        None => {
+                            panic!(
+                                "No trie value at key: {:?} (reading from path: {:?})",
+                                pointer.hash(),
+                                path
+                            );
+                        }
+                    },
+                    None => return Ok(TrieScan::new(Trie::Node { pointer_block }, acc)),
+                }
+            }
+            Trie::Extension { affix, pointer } => {
+                let sub_path = &path[depth..depth + affix.len()];
+                if sub_path == affix.as_slice() {
+                    match store.get(txn, pointer.hash())? {
+                        Some(next) => {
+                            let index: usize = {
+                                assert!(depth < path.len(), "depth must be < {}", path.len());
+                                path[depth].into()
+                            };
+                            current = next;
+                            depth += affix.len();
+                            acc.push((index, Trie::Extension { affix, pointer }))
+                        }
+                        None => {
+                            panic!(
+                                "No trie value at key: {:?} (reading from path: {:?})",
+                                pointer.hash(),
+                                path
+                            );
+                        }
+                    }
+                } else {
+                    return Ok(TrieScan::new(Trie::Extension { affix, pointer }, acc));
                 }
             }
         }

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -557,3 +557,158 @@ mod read {
         }
     }
 }
+
+mod scan {
+    use super::*;
+    use error;
+    use history::trie_store::in_memory;
+    use history::trie_store::operations::{scan, TrieScan};
+    use shared::newtypes::Blake2bHash;
+
+    fn check_scan<'a, R, S, E>(
+        environment: &'a R,
+        store: &S,
+        root_hash: &Blake2bHash,
+        key: &[u8],
+    ) -> Result<(), E>
+    where
+        R: TransactionSource<'a, Handle = S::Handle>,
+        S: TrieStore<TestKey, TestValue>,
+        S::Error: From<R::Error>,
+        E: From<R::Error> + From<S::Error> + From<common::bytesrepr::Error>,
+    {
+        let txn: R::ReadTransaction = environment.create_read_txn()?;
+
+        match store.get(&txn, &root_hash)? {
+            None => panic!("check_scan received an invalid root hash"),
+            Some(root) => {
+                let TrieScan {
+                    mut tip,
+                    mut parents,
+                } = scan::<TestKey, TestValue, R::ReadTransaction, S, E>(&txn, store, key, &root)?;
+
+                loop {
+                    match parents.pop() {
+                        Some((index, parent)) => {
+                            let expected_tip_hash = {
+                                let tip_bytes = tip.to_bytes().unwrap();
+                                Blake2bHash::new(&tip_bytes)
+                            };
+                            match parent {
+                                Trie::Leaf { .. } => {
+                                    panic!("parents should not contain any leaves")
+                                }
+                                Trie::Node { pointer_block } => {
+                                    let pointer_tip_hash =
+                                        pointer_block[index].map(|ptr| ptr.hash().to_owned());
+                                    assert_eq!(Some(expected_tip_hash), pointer_tip_hash);
+                                    tip = Trie::Node { pointer_block };
+                                }
+                                Trie::Extension { affix, pointer } => {
+                                    let pointer_tip_hash = pointer.hash().to_owned();
+                                    assert_eq!(expected_tip_hash, pointer_tip_hash);
+                                    tip = Trie::Extension { affix, pointer };
+                                }
+                            }
+                        }
+                        None => {
+                            assert_eq!(root, tip);
+                            txn.commit()?;
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    mod partial_tries {
+        use super::*;
+
+        #[test]
+        fn lmdb_scans_from_n_leaf_partial_trie_had_expected_results() {
+            for generator in &TEST_TRIE_GENERATORS {
+                let (root_hash, tries) = generator().unwrap();
+                let context = LmdbTestContext::new(root_hash, &tries).unwrap();
+                for leaf in TEST_LEAVES.iter() {
+                    let leaf_bytes = leaf.to_bytes().unwrap();
+                    check_scan::<LmdbEnvironment, LmdbTrieStore, error::Error>(
+                        &context.environment,
+                        &context.store,
+                        &root_hash,
+                        &leaf_bytes,
+                    )
+                    .unwrap()
+                }
+            }
+        }
+
+        #[test]
+        fn in_memory_scans_from_n_leaf_partial_trie_had_expected_results() {
+            for generator in &TEST_TRIE_GENERATORS {
+                let (root_hash, tries) = generator().unwrap();
+                let context = InMemoryTestContext::new(root_hash, &tries).unwrap();
+                for leaf in TEST_LEAVES.iter() {
+                    let leaf_bytes = leaf.to_bytes().unwrap();
+                    check_scan::<InMemoryEnvironment, InMemoryTrieStore, in_memory::Error>(
+                        &context.environment,
+                        &context.store,
+                        &root_hash,
+                        &leaf_bytes,
+                    )
+                    .unwrap()
+                }
+            }
+        }
+    }
+
+    mod full_tries {
+        use super::*;
+
+        #[test]
+        fn lmdb_scans_from_n_leaf_full_trie_had_expected_results() {
+            let mut context = LmdbTestContext::empty().unwrap();
+
+            for (state_index, generator) in TEST_TRIE_GENERATORS[1..].iter().enumerate() {
+                let (root_hash, tries) = generator().unwrap();
+                context.push(root_hash, &tries).unwrap();
+
+                for state in &context.states[0..state_index] {
+                    for leaf in TEST_LEAVES.iter() {
+                        let leaf_bytes = leaf.to_bytes().unwrap();
+                        check_scan::<LmdbEnvironment, LmdbTrieStore, error::Error>(
+                            &context.environment,
+                            &context.store,
+                            state,
+                            &leaf_bytes,
+                        )
+                        .unwrap()
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn in_memory_scans_from_n_leaf_full_trie_had_expected_results() {
+            let mut context = InMemoryTestContext::empty().unwrap();
+
+            for (state_index, generator) in TEST_TRIE_GENERATORS[1..].iter().enumerate() {
+                let (root_hash, tries) = generator().unwrap();
+                context.push(root_hash, &tries).unwrap();
+
+                for state in &context.states[0..state_index] {
+                    for leaf in TEST_LEAVES.iter() {
+                        let leaf_bytes = leaf.to_bytes().unwrap();
+                        check_scan::<InMemoryEnvironment, InMemoryTrieStore, in_memory::Error>(
+                            &context.environment,
+                            &context.store,
+                            state,
+                            &leaf_bytes,
+                        )
+                        .unwrap()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -581,39 +581,31 @@ mod scan {
         let root = store
             .get(&txn, &root_hash)?
             .expect("check_scan received an invalid root hash");
-        let TrieScan {
-            mut tip,
-            mut parents,
-        } = scan::<TestKey, TestValue, R::ReadTransaction, S, E>(&txn, store, key, &root)?;
+        let TrieScan { mut tip, parents } =
+            scan::<TestKey, TestValue, R::ReadTransaction, S, E>(&txn, store, key, &root)?;
 
-        loop {
-            match parents.pop() {
-                Some((index, parent)) => {
-                    let expected_tip_hash = {
-                        let tip_bytes = tip.to_bytes().unwrap();
-                        Blake2bHash::new(&tip_bytes)
-                    };
-                    match parent {
-                        Trie::Leaf { .. } => panic!("parents should not contain any leaves"),
-                        Trie::Node { pointer_block } => {
-                            let pointer_tip_hash = pointer_block[index].map(|ptr| *ptr.hash());
-                            assert_eq!(Some(expected_tip_hash), pointer_tip_hash);
-                            tip = Trie::Node { pointer_block };
-                        }
-                        Trie::Extension { affix, pointer } => {
-                            let pointer_tip_hash = pointer.hash().to_owned();
-                            assert_eq!(expected_tip_hash, pointer_tip_hash);
-                            tip = Trie::Extension { affix, pointer };
-                        }
-                    }
+        for (index, parent) in parents.into_iter().rev() {
+            let expected_tip_hash = {
+                let tip_bytes = tip.to_bytes().unwrap();
+                Blake2bHash::new(&tip_bytes)
+            };
+            match parent {
+                Trie::Leaf { .. } => panic!("parents should not contain any leaves"),
+                Trie::Node { pointer_block } => {
+                    let pointer_tip_hash = pointer_block[index].map(|ptr| *ptr.hash());
+                    assert_eq!(Some(expected_tip_hash), pointer_tip_hash);
+                    tip = Trie::Node { pointer_block };
                 }
-                None => {
-                    assert_eq!(root, tip);
-                    txn.commit()?;
-                    return Ok(());
+                Trie::Extension { affix, pointer } => {
+                    let pointer_tip_hash = pointer.hash().to_owned();
+                    assert_eq!(expected_tip_hash, pointer_tip_hash);
+                    tip = Trie::Extension { affix, pointer };
                 }
             }
         }
+        assert_eq!(root, tip);
+        txn.commit()?;
+        Ok(())
     }
 
     mod partial_tries {


### PR DESCRIPTION
## Overview
This PR adds a `scan` function to return the deepest thing found at given key in the trie, along with its parents.   This is a prerequisite for writing to the trie. 

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
