### PR TITLE
STOR-39: add history::trie_store::operations::write

### DIFF
--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -1,6 +1,6 @@
 use common::bytesrepr::ToBytes;
 use history::trie::{self, Parents, Pointer, Trie};
-use history::trie_store::{Readable, TrieStore};
+use history::trie_store::{Readable, TrieStore, Writable};
 use shared::newtypes::Blake2bHash;
 
 #[cfg(test)]
@@ -195,6 +195,79 @@ where
                     }
                 }
             }
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum WriteResult {
+    Written(Blake2bHash),
+    AlreadyExists,
+    RootNotFound,
+}
+
+pub fn write<K, V, T, S, E>(
+    txn: &mut T,
+    store: &S,
+    root: &Blake2bHash,
+    key: &K,
+    value: &V,
+) -> Result<WriteResult, E>
+where
+    K: ToBytes + Clone + Eq + std::fmt::Debug,
+    V: ToBytes + Clone + Eq,
+    T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
+    S: TrieStore<K, V>,
+    S::Error: From<T::Error>,
+    E: From<S::Error> + From<common::bytesrepr::Error>,
+{
+    match store.get(txn, root)? {
+        None => Ok(WriteResult::RootNotFound),
+        Some(current_root) => {
+            let new_leaf = Trie::Leaf {
+                key: key.to_owned(),
+                value: value.to_owned(),
+            };
+            let path: Vec<u8> = key.to_bytes()?;
+            let TrieScan { tip, parents: _ } =
+                scan::<K, V, T, S, E>(txn, store, &path, &current_root)?;
+            let new_elements: Vec<(Blake2bHash, Trie<K, V>)> = match tip {
+                // If the "tip" is the same as the new leaf, then the leaf
+                // is already in the Trie.
+                Trie::Leaf { .. } if new_leaf == tip => Vec::new(),
+                // If the "tip" is an existing leaf with the same key as the
+                // new leaf, but the existing leaf and new leaf have different
+                // values, then we are in the situation where we are "updating"
+                // an existing leaf.
+                Trie::Leaf {
+                    key: ref leaf_key,
+                    value: ref leaf_value,
+                } if key == leaf_key && value != leaf_value => unimplemented!(),
+                // If the "tip" is an existing leaf with a different key than
+                // the new leaf, then we are in a situation where the new leaf
+                // shares some common prefix with the existing leaf.
+                Trie::Leaf {
+                    key: ref leaf_key, ..
+                } if key != leaf_key => unimplemented!(),
+                /// This case is unreachable, but the compiler can't figure
+                /// that out.
+                Trie::Leaf { .. } => unreachable!(),
+                // If the "tip" is an existing node, then we can add the new
+                // leaf's hash to the node's pointer block and rehash.
+                Trie::Node { .. } => unimplemented!(),
+                // If the "tip" is an extension node, then we must modify or
+                // replace it, adding a node where necessary.
+                Trie::Extension { .. } => unimplemented!(),
+            };
+            if new_elements.is_empty() {
+                return Ok(WriteResult::AlreadyExists);
+            }
+            let mut root_hash = root.to_owned();
+            for (hash, element) in new_elements.iter() {
+                store.put(txn, hash, element)?;
+                root_hash = *hash;
+            }
+            Ok(WriteResult::Written(root_hash))
         }
     }
 }

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -229,8 +229,7 @@ where
                 value: value.to_owned(),
             };
             let path: Vec<u8> = key.to_bytes()?;
-            let TrieScan { tip, parents: _ } =
-                scan::<K, V, T, S, E>(txn, store, &path, &current_root)?;
+            let TrieScan { tip, .. } = scan::<K, V, T, S, E>(txn, store, &path, &current_root)?;
             let new_elements: Vec<(Blake2bHash, Trie<K, V>)> = match tip {
                 // If the "tip" is the same as the new leaf, then the leaf
                 // is already in the Trie.

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -249,8 +249,8 @@ where
                 Trie::Leaf {
                     key: ref leaf_key, ..
                 } if key != leaf_key => unimplemented!(),
-                /// This case is unreachable, but the compiler can't figure
-                /// that out.
+                // This case is unreachable, but the compiler can't figure
+                // that out.
                 Trie::Leaf { .. } => unreachable!(),
                 // If the "tip" is an existing node, then we can add the new
                 // leaf's hash to the node's pointer block and rehash.


### PR DESCRIPTION
## Overview
This PR adds a skeletal version of `history::trie_store::operations::write`.  Subsequent PRs will replace the unimplemented bits with implementations.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A