### PR TITLE
STOR-39: add {InMemory,Lmdb}GlobalState::write

### DIFF
--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -4,9 +4,10 @@ use common::value::Value;
 use global_state::StateReader;
 use history::trie::operations::create_hashed_empty_trie;
 use history::trie_store::in_memory::{
-    self, InMemoryEnvironment, InMemoryReadTransaction, InMemoryTrieStore,
+    self, InMemoryEnvironment, InMemoryReadTransaction, InMemoryReadWriteTransaction,
+    InMemoryTrieStore,
 };
-use history::trie_store::operations::{read, ReadResult};
+use history::trie_store::operations::{read, write, ReadResult, WriteResult};
 use history::trie_store::{Transaction, TransactionSource, TrieStore};
 use shared::newtypes::Blake2bHash;
 use std::ops::Deref;
@@ -47,6 +48,30 @@ impl InMemoryGlobalState {
             store,
             root_hash,
         }
+    }
+
+    pub fn write(&self, key: &Key, value: &Value) -> Result<Self, in_memory::Error> {
+        let mut txn = self.environment.create_read_write_txn()?;
+        let root_hash = match write::<
+            Key,
+            Value,
+            InMemoryReadWriteTransaction,
+            InMemoryTrieStore,
+            in_memory::Error,
+        >(&mut txn, &self.store, &self.root_hash, key, value)?
+        {
+            WriteResult::Written(root_hash) => root_hash,
+            WriteResult::AlreadyExists => self.root_hash,
+            WriteResult::RootNotFound => panic!("InMemoryGlobalState has invalid root"),
+        };
+        txn.commit()?;
+        let environment = Arc::clone(&self.environment);
+        let store = Arc::clone(&self.store);
+        Ok(InMemoryGlobalState {
+            environment,
+            store,
+            root_hash,
+        })
     }
 }
 

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -5,7 +5,7 @@ use error;
 use global_state::StateReader;
 use history::trie::operations::create_hashed_empty_trie;
 use history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
-use history::trie_store::operations::{read, ReadResult};
+use history::trie_store::operations::{read, write, ReadResult, WriteResult};
 use history::trie_store::{Transaction, TransactionSource, TrieStore};
 use lmdb;
 use shared::newtypes::Blake2bHash;
@@ -47,6 +47,29 @@ impl LmdbGlobalState {
             store,
             root_hash,
         }
+    }
+
+    pub fn write(&self, key: &Key, value: &Value) -> Result<Self, error::Error> {
+        let mut txn = self.environment.create_read_write_txn()?;
+        let root_hash = match write::<Key, Value, lmdb::RwTransaction, LmdbTrieStore, error::Error>(
+            &mut txn,
+            &self.store,
+            &self.root_hash,
+            key,
+            value,
+        )? {
+            WriteResult::Written(root_hash) => root_hash,
+            WriteResult::AlreadyExists => self.root_hash,
+            WriteResult::RootNotFound => panic!("LmdbGlobalState has invalid root"),
+        };
+        txn.commit()?;
+        let environment = Arc::clone(&self.environment);
+        let store = Arc::clone(&self.store);
+        Ok(LmdbGlobalState {
+            environment,
+            store,
+            root_hash,
+        })
     }
 }
 


### PR DESCRIPTION
## Overview
This PR wires up the `{InMemory,Lmdb}GlobalState` objects introduced in #388 to the `write` function introduced in #413.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
