### PR TITLE
STOR-39: monomorphize StateReader impls

### DIFF
--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -1,4 +1,3 @@
-use common::bytesrepr::{FromBytes, ToBytes};
 use common::key::Key;
 use common::value::Value;
 use global_state::StateReader;
@@ -50,16 +49,12 @@ impl InMemoryGlobalState {
     }
 }
 
-impl<K, V> StateReader<K, V> for InMemoryGlobalState
-where
-    K: ToBytes + FromBytes + Eq + std::fmt::Debug,
-    V: ToBytes + FromBytes,
-{
+impl StateReader<Key, Value> for InMemoryGlobalState {
     type Error = in_memory::Error;
 
-    fn read(&self, key: &K) -> Result<Option<V>, Self::Error> {
+    fn read(&self, key: &Key) -> Result<Option<Value>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
-        let ret = match read::<K, V, InMemoryReadTransaction, InMemoryTrieStore, Self::Error>(
+        let ret = match read::<Key, Value, InMemoryReadTransaction, InMemoryTrieStore, Self::Error>(
             &txn,
             self.store.deref(),
             &self.root_hash,

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -1,4 +1,3 @@
-use common::bytesrepr::{FromBytes, ToBytes};
 use common::key::Key;
 use common::value::Value;
 use error;
@@ -50,16 +49,12 @@ impl LmdbGlobalState {
     }
 }
 
-impl<K, V> StateReader<K, V> for LmdbGlobalState
-where
-    K: ToBytes + FromBytes + Eq + std::fmt::Debug,
-    V: ToBytes + FromBytes,
-{
+impl StateReader<Key, Value> for LmdbGlobalState {
     type Error = error::Error;
 
-    fn read(&self, key: &K) -> Result<Option<V>, Self::Error> {
+    fn read(&self, key: &Key) -> Result<Option<Value>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
-        let ret = match read::<K, V, lmdb::RoTransaction, LmdbTrieStore, Self::Error>(
+        let ret = match read::<Key, Value, lmdb::RoTransaction, LmdbTrieStore, Self::Error>(
             &txn,
             self.store.deref(),
             &self.root_hash,


### PR DESCRIPTION
## Overview
This PR monomorphizes our `StateReader` impls to only use our `Key` and `Value` types.  This is primarily done to be consistent with the `{InMemory,Lmdb}GlobalState::write` methods introduced in #414.

This also seems like a good idea from a POLA/POLP perspective: it makes it harder to write code that accidentally uses other `Key` and `Value` types.  The underlying implementation of `read` introduced in #403 is still generic, but these impls don't need to be.  If we decide we need that additional power later, we can reintroduce it.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
