### PR TITLE
NODE-312: Add Casper tests based on new gossip

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EquivocationDetector.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper
 
 import cats.{Applicative, Monad}
+import cats.effect.Sync
 import cats.implicits._
 import cats.mtl.FunctorRaise
 import com.google.protobuf.ByteString
@@ -107,7 +108,7 @@ object EquivocationDetector {
     } yield maybeCreatorJustification.latestBlockHash
 
   // See summary of algorithm above
-  def checkNeglectedEquivocationsWithUpdate[F[_]: Monad: BlockStore: FunctorRaise[
+  def checkNeglectedEquivocationsWithUpdate[F[_]: Sync: BlockStore: FunctorRaise[
     ?[_],
     InvalidBlock
   ]](
@@ -123,7 +124,7 @@ object EquivocationDetector {
       )
     )(FunctorRaise[F, InvalidBlock].raise[Unit](NeglectedEquivocation), Monad[F].unit)
 
-  private def isNeglectedEquivocationDetectedWithUpdate[F[_]: Monad: BlockStore](
+  private def isNeglectedEquivocationDetectedWithUpdate[F[_]: Sync: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       genesis: BlockMessage
@@ -146,7 +147,7 @@ object EquivocationDetector {
     *
     * @return Whether a neglected equivocation was discovered.
     */
-  private def updateEquivocationsTracker[F[_]: Monad: BlockStore](
+  private def updateEquivocationsTracker[F[_]: Sync: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
@@ -179,7 +180,7 @@ object EquivocationDetector {
           } else ().pure[F]
     } yield neglectedEquivocationDetected
 
-  private def getEquivocationDiscoveryStatus[F[_]: Monad: BlockStore](
+  private def getEquivocationDiscoveryStatus[F[_]: Sync: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
@@ -207,7 +208,7 @@ object EquivocationDetector {
     }
   }
 
-  private def getEquivocationDiscoveryStatusForBondedValidator[F[_]: Monad: BlockStore](
+  private def getEquivocationDiscoveryStatusForBondedValidator[F[_]: Sync: BlockStore](
       equivocationRecord: EquivocationRecord,
       latestMessages: Map[Validator, BlockHash],
       stake: Long,
@@ -232,7 +233,7 @@ object EquivocationDetector {
       Applicative[F].pure(EquivocationDetected)
     }
 
-  private def isEquivocationDetectable[F[_]: Monad: BlockStore](
+  private def isEquivocationDetectable[F[_]: Sync: BlockStore](
       latestMessages: Seq[(Validator, BlockHash)],
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
@@ -250,7 +251,7 @@ object EquivocationDetector {
         )
     }
 
-  private def isEquivocationDetectableAfterViewingBlock[F[_]: Monad: BlockStore](
+  private def isEquivocationDetectableAfterViewingBlock[F[_]: Sync: BlockStore](
       justificationBlockHash: BlockHash,
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
@@ -272,7 +273,7 @@ object EquivocationDetector {
       } yield equivocationDetected
     }
 
-  private def isEquivocationDetectableThroughChildren[F[_]: Monad: BlockStore](
+  private def isEquivocationDetectableThroughChildren[F[_]: Sync: BlockStore](
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
       remainder: Seq[(Validator, BlockHash)],
@@ -303,7 +304,7 @@ object EquivocationDetector {
     } yield equivocationDetected
   }
 
-  private def maybeAddEquivocationChild[F[_]: Monad: BlockStore](
+  private def maybeAddEquivocationChild[F[_]: Sync: BlockStore](
       justificationBlock: BlockMessage,
       equivocatingValidator: Validator,
       equivocationBaseBlockSeqNum: SequenceNumber,

--- a/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
@@ -3,8 +3,111 @@ package io.casperlabs.casper
 import io.casperlabs.casper.consensus
 import io.casperlabs.casper.protocol
 
+/** Convert between the message in CasperMessage.proto and consensus.proto while we have both.
+  * This is assuming that the storage and validation are still using the protocol.* types,
+  * and that the consensus.* ones are just used for communication, so hashes don't have to be
+  * correct on the new objects, they are purely serving as DTOs. */
 object LegacyConversions {
-  def toBlockSummary(block: protocol.BlockMessage): consensus.BlockSummary = ???
-  def toBlock(block: protocol.BlockMessage): consensus.Block               = ???
-  def fromBlock(block: consensus.Block): protocol.BlockMessage             = ???
+  def toBlockSummary(block: protocol.BlockMessage): consensus.BlockSummary =
+    consensus
+      .BlockSummary()
+      .withBlockHash(block.blockHash)
+      .withHeader(
+        consensus.Block
+          .Header()
+          .withParentHashes(block.getHeader.parentsHashList)
+          .withJustifications(block.justifications.map { x =>
+            consensus.Block
+              .Justification()
+              .withValidatorPublicKey(x.validator)
+              .withLatestBlockHash(x.latestBlockHash)
+          })
+          .withState(
+            consensus.Block
+              .GlobalState()
+              .withPreStateHash(block.getBody.getState.preStateHash)
+              .withPostStateHash(block.getBody.getState.postStateHash)
+              .withBonds(block.getBody.getState.bonds.map { x =>
+                consensus
+                  .Bond()
+                  .withValidatorPublicKey(x.validator)
+                  .withStake(x.stake)
+              })
+          )
+          .withBodyHash(block.getHeader.deploysHash)
+          .withTimestamp(block.getHeader.timestamp)
+          .withProtocolVersion(block.getHeader.protocolVersion)
+          .withDeployCount(block.getHeader.deployCount)
+          .withChainId(block.shardId)
+          .withValidatorBlockSeqNum(block.seqNum)
+          .withValidatorPublicKey(block.sender)
+          .withRank(block.getBody.getState.blockNumber.toInt)
+      )
+      .withSignature(
+        consensus
+          .Signature()
+          .withSigAlgorithm(block.sigAlgorithm)
+          .withSig(block.sig)
+      )
+
+  def toBlock(block: protocol.BlockMessage): consensus.Block = {
+    val summary = toBlockSummary(block)
+    consensus
+      .Block()
+      .withBlockHash(summary.blockHash)
+      .withHeader(summary.getHeader)
+      .withBody(
+        consensus.Block
+          .Body()
+          .withDeploys(block.getBody.deploys.map { x =>
+            consensus.Block
+              .ProcessedDeploy()
+              .withDeploy(
+                consensus
+                  .Deploy()
+                  //.withDeployHash() // Legacy doesn't have it.
+                  .withHeader(
+                    consensus.Deploy
+                      .Header()
+                      // TODO: The client isn't signing the deploy yet, but it's sending an account address.
+                      // Once we sign the deploy, we can derive the account address from it on the way back.
+                      //.withAccountPublicKey(x.getDeploy.user)
+                      .withAccountPublicKey(x.getDeploy.address)
+                      .withNonce(x.getDeploy.nonce)
+                      .withTimestamp(x.getDeploy.timestamp)
+                      //.withBodyHash() // Legacy doesn't have it.
+                      .withGasPrice(x.getDeploy.gasPrice)
+                  )
+                  .withBody(
+                    consensus.Deploy
+                      .Body()
+                      .withSession(
+                        consensus.Deploy
+                          .Code()
+                          .withCode(x.getDeploy.getSession.code)
+                          .withArgs(x.getDeploy.getSession.args)
+                      )
+                      .withPayment(
+                        consensus.Deploy
+                          .Code()
+                          .withCode(x.getDeploy.getPayment.code)
+                          .withArgs(x.getDeploy.getPayment.args)
+                      )
+                  )
+                  .withSignature(
+                    consensus
+                      .Signature()
+                      .withSigAlgorithm(x.getDeploy.sigAlgorithm)
+                      .withSig(x.getDeploy.signature)
+                  )
+              )
+              .withCost(x.cost)
+              .withIsError(x.errored)
+          //.withErrorMessage() // Legacy doesn't have it.
+          })
+      )
+      .withSignature(summary.getSignature)
+  }
+
+  def fromBlock(block: consensus.Block): protocol.BlockMessage = ???
 }

--- a/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
@@ -1,0 +1,10 @@
+package io.casperlabs.casper
+
+import io.casperlabs.casper.consensus
+import io.casperlabs.casper.protocol
+
+object LegacyConversions {
+  def toBlockSummary(block: protocol.BlockMessage): consensus.BlockSummary = ???
+  def toBlock(block: protocol.BlockMessage): consensus.Block               = ???
+  def fromBlock(block: consensus.Block): protocol.BlockMessage             = ???
+}

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -739,10 +739,14 @@ object MultiParentCasperImpl {
                 InvalidTransaction | InvalidBondsCache | InvalidRepeatDeploy | InvalidShardId |
                 InvalidBlockHash | InvalidDeployCount | InvalidPreStateHash | InvalidPostStateHash |
                 Processing =>
-              ().pure[F]
+              Log[F].warn(
+                s"Not sending notification about ${PrettyPrinter.buildString(block.blockHash)}: $status"
+              )
 
-            case BlockException(_) =>
-              ().pure[F]
+            case BlockException(ex) =>
+              Log[F].warn(
+                s"Not sending notification about ${PrettyPrinter.buildString(block.blockHash)}: $ex"
+              )
           }
 
         /** Ask all peers to send us a block. */

--- a/casper/src/main/scala/io/casperlabs/casper/Validate.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Validate.scala
@@ -192,7 +192,7 @@ object Validate {
   /*
    * TODO: Double check ordering of validity checks
    */
-  def blockSummary[F[_]: Monad: Log: Time: BlockStore: RaiseValidationError](
+  def blockSummary[F[_]: Sync: Log: Time: BlockStore: RaiseValidationError](
       block: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F],
@@ -207,7 +207,7 @@ object Validate {
     } yield ()
 
   /** Validations we can run even without an approved Genesis, i.e. on Genesis itself. */
-  def blockSummaryPreGenesis[F[_]: Monad: Log: Time: BlockStore: RaiseValidationError](
+  def blockSummaryPreGenesis[F[_]: Sync: Log: Time: BlockStore: RaiseValidationError](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       shardId: String
@@ -252,7 +252,7 @@ object Validate {
     *
     * Agnostic of non-parent justifications
     */
-  def repeatDeploy[F[_]: Monad: Log: BlockStore: RaiseValidationError](
+  def repeatDeploy[F[_]: Sync: Log: BlockStore: RaiseValidationError](
       block: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Unit] = {
@@ -289,7 +289,7 @@ object Validate {
   }
 
   // This is not a slashable offence
-  def timestamp[F[_]: Monad: Log: Time: BlockStore: RaiseValidationError](
+  def timestamp[F[_]: Sync: Log: Time: BlockStore: RaiseValidationError](
       b: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Unit] =
@@ -324,7 +324,7 @@ object Validate {
     } yield result
 
   // Agnostic of non-parent justifications
-  def blockNumber[F[_]: Monad: Log: BlockStore: RaiseValidationError](
+  def blockNumber[F[_]: Sync: Log: BlockStore: RaiseValidationError](
       b: BlockMessage
   ): F[Unit] =
     for {
@@ -355,7 +355,7 @@ object Validate {
     * creator justification, this check will fail as expected. The exception is when
     * B's creator justification is the genesis block.
     */
-  def sequenceNumber[F[_]: Monad: Log: BlockStore: RaiseValidationError](
+  def sequenceNumber[F[_]: Sync: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Unit] =
@@ -439,7 +439,7 @@ object Validate {
   /**
     * Works only with fully explicit justifications.
     */
-  def parents[F[_]: Monad: Log: BlockStore: RaiseValidationError](
+  def parents[F[_]: Sync: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       genesis: BlockMessage,
       lastFinalizedBlockHash: BlockHash,
@@ -488,7 +488,7 @@ object Validate {
   /*
    * This check must come before Validate.parents
    */
-  def justificationFollows[F[_]: Monad: Log: BlockStore: RaiseValidationError](
+  def justificationFollows[F[_]: Sync: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F]
@@ -523,7 +523,7 @@ object Validate {
    * Hence, we ignore justification regressions involving the block's sender and
    * let checkEquivocations handle it instead.
    */
-  def justificationRegressions[F[_]: Monad: Log: BlockStore: RaiseValidationError](
+  def justificationRegressions[F[_]: Sync: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F]
@@ -549,7 +549,7 @@ object Validate {
     } yield result
   }
 
-  private def justificationRegressionsAux[F[_]: Monad: Log: BlockStore: FunctorRaise[
+  private def justificationRegressionsAux[F[_]: Sync: Log: BlockStore: FunctorRaise[
     ?[_],
     InvalidBlock
   ]](
@@ -586,7 +586,7 @@ object Validate {
           }
     } yield ()
 
-  private def isJustificationRegression[F[_]: Monad: Log: BlockStore](
+  private def isJustificationRegression[F[_]: Sync: Log: BlockStore](
       currentBlockJustificationHash: BlockHash,
       previousBlockJustificationHash: BlockHash
   ): F[Boolean] =

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -98,7 +98,7 @@ object BlockAPI {
   }
 
   // FIX: Not used at the moment - in RChain it's being used in method like `getListeningName*`
-  private def getMainChainFromTip[F[_]: Monad: MultiParentCasper: Log: SafetyOracle: BlockStore](
+  private def getMainChainFromTip[F[_]: Sync: MultiParentCasper: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[IndexedSeq[BlockMessage]] =
     for {
@@ -138,7 +138,7 @@ object BlockAPI {
   }
 
   // TOOD extract common code from show blocks
-  def showBlocks[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+  def showBlocks[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[BlockInfoWithoutTuplespace]] = {
     val errorMessage =
@@ -160,7 +160,7 @@ object BlockAPI {
     )
   }
 
-  private def getFlattenedBlockInfosUntilDepth[F[_]: Monad: MultiParentCasper: Log: SafetyOracle: BlockStore](
+  private def getFlattenedBlockInfosUntilDepth[F[_]: Sync: MultiParentCasper: Log: SafetyOracle: BlockStore](
       depth: Int,
       dag: BlockDagRepresentation[F]
   ): F[List[BlockInfoWithoutTuplespace]] =
@@ -175,7 +175,7 @@ object BlockAPI {
                }
     } yield result
 
-  def showMainChain[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+  def showMainChain[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[BlockInfoWithoutTuplespace]] = {
     val errorMessage =
@@ -199,7 +199,7 @@ object BlockAPI {
   }
 
   // TODO: Replace with call to BlockStore
-  def findBlockWithDeploy[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+  def findBlockWithDeploy[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       user: ByteString,
       timestamp: Long
   ): F[BlockQueryResponse] = {
@@ -233,7 +233,7 @@ object BlockAPI {
     )
   }
 
-  private def findBlockWithDeploy[F[_]: Monad: Log: BlockStore](
+  private def findBlockWithDeploy[F[_]: Sync: Log: BlockStore](
       blockHashes: Vector[BlockHash],
       user: ByteString,
       timestamp: Long

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper.util
 
 import cats.{Eval, Monad}
+import cats.effect.Sync
 import cats.implicits._
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockStore}
 import io.casperlabs.casper.protocol.BlockMessage
@@ -188,7 +189,7 @@ object DagOperations {
   //Conceptually, the GCA is the first point at which the histories of b1 and b2 diverge.
   //Based on that, we compute by finding the first block from genesis for which there
   //exists a child of that block which is an ancestor of b1 or b2 but not both.
-  def greatestCommonAncestorF[F[_]: Monad: BlockStore](
+  def greatestCommonAncestorF[F[_]: Sync: BlockStore](
       b1: BlockMessage,
       b2: BlockMessage,
       genesis: BlockMessage,

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -77,7 +77,6 @@ object ProtoUtil {
     } yield mainChain
   }
 
-  // TODO: instead of throwing Exception use MonadError.raiseError
   def unsafeGetBlock[F[_]: Sync: BlockStore](hash: BlockHash): F[BlockMessage] =
     for {
       maybeBlock <- BlockStore[F].getBlockMessage(hash)

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -118,7 +118,7 @@ object ExecEngineUtil {
       case (_, Some((eff, cost))) => (eff, cost)
     }
 
-  def effectsForBlock[F[_]: MonadError[?[_], Throwable]: BlockStore: ExecutionEngineService](
+  def effectsForBlock[F[_]: Sync: BlockStore: ExecutionEngineService](
       block: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[(StateHash, Seq[TransformEntry])] =

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -69,7 +69,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
   //test since we cannot reset it
   behavior of "HashSetCasper"
 
-  ignore should "accept deploys" in effectTest {
+  it should "accept deploys" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
     implicit val timeEff = new LogicalTime[Effect]
@@ -84,7 +84,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "not allow multiple threads to process the same block" in {
+  it should "not allow multiple threads to process the same block" in {
     val scheduler = Scheduler.fixedPool("three-threads", 3)
     val node =
       standaloneEff(genesis, transforms, validatorKeys.head)(scheduler)
@@ -116,7 +116,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     node.tearDown().value.unsafeRunSync
   }
 
-  ignore should "create blocks based on deploys" in effectTest {
+  it should "create blocks based on deploys" in effectTest {
     val node            = standaloneEff(genesis, transforms, validatorKeys.head)
     implicit val casper = node.casperEff
 
@@ -141,7 +141,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "accept signed blocks" in effectTest {
+  it should "accept signed blocks" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
     implicit val timeEff = new LogicalTime[Effect]
@@ -160,7 +160,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "be able to create a chain of blocks from different deploys" in effectTest {
+  it should "be able to create a chain of blocks from different deploys" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
 
@@ -196,7 +196,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "allow multiple deploys in a single block" in effectTest {
+  it should "allow multiple deploys in a single block" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
 
@@ -214,7 +214,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "reject unsigned blocks" in effectTest {
+  it should "reject unsigned blocks" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
     implicit val timeEff = new LogicalTime[Effect]
@@ -235,7 +235,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "not request invalid blocks from peers" in effectTest {
+  it should "not request invalid blocks from peers" in effectTest {
     val dummyContract =
       ByteString.readFrom(getClass.getResourceAsStream("/helloname.wasm"))
 
@@ -266,7 +266,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "reject blocks not from bonded validators" in effectTest {
+  it should "reject blocks not from bonded validators" in effectTest {
     val node = standaloneEff(genesis, transforms, otherSk)
     import node._
     implicit val timeEff = new LogicalTime[Effect]
@@ -286,7 +286,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "propose blocks it adds to peers" in effectTest {
+  it should "propose blocks it adds to peers" in effectTest {
     for {
       nodes                <- networkEff(validatorKeys.take(2), genesis, transforms)
       deployData           <- ProtoUtil.basicDeployData[Effect](0)
@@ -308,7 +308,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "add a valid block from peer" in effectTest {
+  it should "add a valid block from peer" in effectTest {
     for {
       nodes                      <- networkEff(validatorKeys.take(2), genesis, transforms)
       deployData                 <- ProtoUtil.basicDeployData[Effect](1)
@@ -329,7 +329,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "handle multi-parent blocks correctly" in effectTest {
+  it should "handle multi-parent blocks correctly" in effectTest {
     for {
       nodes       <- networkEff(validatorKeys.take(2), genesis, transforms)
       deployData0 <- ProtoUtil.basicDeployData[Effect](0)
@@ -380,7 +380,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
   }
 
   //todo we need some genenis Contract to pass this test
-//  ignore should "allow bonding and distribute the joining fee" in {
+//  it should "allow bonding and distribute the joining fee" in {
 //    val nodes =
 //      HashSetCasperTestNode.network(
 //        validatorKeys :+ otherSk,
@@ -416,7 +416,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 //    val block1Status = nodes(0).casperEff.addBlock(block1)
 //    nodes.foreach(_.receive) //send to all peers
 
-  ignore should "allow bonding via the faucet" in effectTest {
+  it should "allow bonding via the faucet" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node.{casperEff, logEff}
 
@@ -457,7 +457,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "not fail if the forkchoice changes after a bonding event" in {
+  it should "not fail if the forkchoice changes after a bonding event" in {
     val localValidators = validatorKeys.take(3)
     val localBonds      = localValidators.map(Ed25519.toPublic).zip(List(10L, 30L, 5000L)).toMap
     val BlockMsgWithTransform(Some(localGenesis), localTransforms) =
@@ -539,7 +539,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "reject addBlock when there exist deploy by the same (user, millisecond timestamp) in the chain" in {
+  it should "reject addBlock when there exist deploy by the same (user, millisecond timestamp) in the chain" in {
     for {
       nodes <- networkEff(validatorKeys.take(2), genesis, transforms)
       deployDatas <- (0 to 2).toList
@@ -595,7 +595,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "ask peers for blocks it is missing" in effectTest {
+  it should "ask peers for blocks it is missing" in effectTest {
     for {
       nodes <- networkEff(validatorKeys.take(3), genesis, transforms)
       deployDatas = Vector(
@@ -674,7 +674,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
    *  f2 has in its justifications list c2. This should be handled properly.
    *
    */
-  ignore should "ask peers for blocks it is missing and add them" in effectTest {
+  it should "ask peers for blocks it is missing and add them" in effectTest {
     //TODO: figure out a way to get wasm into deploys for tests
     val deployDatasFs = Vector[() => DeployData](
       () => ProtoUtil.sourceDeploy("1", System.currentTimeMillis, Integer.MAX_VALUE),
@@ -733,7 +733,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       // this block will be propagated to all nodes and force nodes(2) to ask for missing blocks.
       br <- deploy(nodes(0), deployDatasFs(0).apply()) // block h1
-      _  = println(PrettyPrinter.buildString(br))
 
       // node(0) just created this block, so it should have it.
       _ <- nodes(0).casperEff.contains(br) shouldBeF true
@@ -751,7 +750,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "ignore adding equivocation blocks" in effectTest {
+  it should "ignore adding equivocation blocks" in effectTest {
     for {
       nodes <- networkEff(validatorKeys.take(2), genesis, transforms)
 
@@ -786,7 +785,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
   }
 
   // See [[/docs/casper/images/minimal_equivocation_neglect.png]] but cross out genesis block
-  ignore should "not ignore equivocation blocks that are required for parents of proper nodes" in effectTest {
+  it should "not ignore equivocation blocks that are required for parents of proper nodes" in effectTest {
     for {
       nodes       <- networkEff(validatorKeys.take(3), genesis, transforms)
       deployDatas <- (0 to 5).toList.traverse[Effect, DeployData](ProtoUtil.basicDeployData[Effect])
@@ -888,7 +887,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "prepare to slash a block that includes a invalid block pointer" in effectTest {
+  it should "prepare to slash a block that includes a invalid block pointer" in effectTest {
     for {
       nodes           <- networkEff(validatorKeys.take(3), genesis, transforms)
       deploys         <- (0 to 5).toList.traverse(i => ProtoUtil.basicDeploy[Effect](i))
@@ -932,7 +931,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  ignore should "handle a long chain of block requests appropriately" in effectTest {
+  it should "handle a long chain of block requests appropriately" in effectTest {
     for {
       nodes <- networkEff(
                 validatorKeys.take(2),
@@ -982,8 +981,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  // FIXME
-  ignore should "increment last finalized block as appropriate in round robin" in effectTest {
+  it should "increment last finalized block as appropriate in round robin" in effectTest {
     val stake      = 10L
     val equalBonds = validators.map(_ -> stake).toMap
     val BlockMsgWithTransform(Some(genesisWithEqualBonds), transformsWithEqualBonds) =
@@ -1082,7 +1080,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  ignore should "fail when deploying with insufficient gas" in effectTest {
+  it should "fail when deploying with insufficient gas" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
     implicit val timeEff = new LogicalTime[Effect]
@@ -1098,7 +1096,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     }
   }
 
-  ignore should "succeed if given enough gas for deploy" in effectTest {
+  it should "succeed if given enough gas for deploy" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
     implicit val timeEff = new LogicalTime[Effect]

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -628,7 +628,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _ <- nodes(2).casperEff.contains(signedBlock2) shouldBeF true
       // TransportLayer gets 1 block, 1 is missing. GossipService gets 1 hash, 2 block missing.
       _ = nodes(2).logEff.infos
-        .count(_ startsWith "Requested missing block") should be >= 1
+        .count(_ startsWith "Requested missing block") should (be >= 1 and be <= 2)
       // TransportLayer controlled by .receive calls, only node(1) responds. GossipService has unlimited retrieve, goes to node(0).
       result = (0 to 1)
         .flatMap(nodes(_).logEff.infos)
@@ -831,7 +831,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _ <- nodes(1).receive() // receives block1'; adds both block3 and block1'
 
       // node(1) should have both block2 and block3 at this point and recognize the equivocation.
-      // Because node(1) will also see that the singedBlock3 is building on top of signedBlock1Prime,
+      // Because node(1) will also see that the signedBlock3 is building on top of signedBlock1Prime,
       // it should download signedBlock1Prime as an `AdmissibleEquivocation`; otherwise if it didn't
       // have an offspring it would be an `IgnorableEquivocation` and dropped.
       _ <- nodes(1).casperEff.contains(signedBlock3) shouldBeF true

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -801,7 +801,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       // NOTE: Adding a block created (but not stored) by node(0) directly to node(1)
       // is not something you can normally achieve with gossiping.
-      _ <- nodes(1).casperEff.superAddBlock(signedBlock1)
+      _ <- nodes(1).casperEff.addBlock(signedBlock1)
       _ <- nodes(0).clearMessages() //nodes(0) misses this block
       _ <- nodes(2).clearMessages() //nodes(2) misses this block
 
@@ -922,9 +922,9 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       // )
       // _ <- nodes(0).transportLayerEff.send(nodes(1).local, signedInvalidBlockPacketMessage)
       // _ <- nodes(1).receive() // receives signedInvalidBlock; attempts to add both blocks
-      // NOTE: Instead of the above let's just add it directly to node(1); need to use `superAddBlock` becuase node(0) doesn't have this block.
+      // NOTE: Instead of the above let's just add it directly to node(1); node(0) doesn't have this block.
       _ <- nodes(1).casperEff
-            .superAddBlock(signedInvalidBlock)
+            .addBlock(signedInvalidBlock)
 
       result = nodes(1).logEff.warns.count(_ startsWith "Recording invalid block") should be(1)
       _      <- nodes.map(_.tearDown()).toList.sequence

--- a/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
@@ -1,0 +1,34 @@
+package io.casperlabs.casper
+
+import com.google.protobuf.ByteString
+import org.scalatest._
+import io.casperlabs.comm.gossiping.ArbitraryConsensus
+import org.scalatest.prop.GeneratorDrivenPropertyChecks.{forAll, PropertyCheckConfiguration}
+
+class LegacyConversionsTest extends FlatSpec with ArbitraryConsensus with Matchers {
+
+  implicit val propCheckConfig = PropertyCheckConfiguration(minSuccessful = 100)
+
+  implicit val consensusConfig =
+    ConsensusConfig(maxSessionCodeBytes = 50, maxPaymentCodeBytes = 10)
+
+  "LegacyConversions" should "convert correctly between old and new blocks" in {
+    forAll { (orig: consensus.Block) =>
+      // Some fields are not supported by the legacy one.
+      val comp = orig.withBody(
+        orig.getBody.withDeploys(orig.getBody.deploys.map { pd =>
+          pd.withDeploy(
+              pd.getDeploy
+                .withDeployHash(ByteString.EMPTY)
+                .withHeader(pd.getDeploy.getHeader.withBodyHash(ByteString.EMPTY))
+            )
+            .withErrorMessage("")
+        })
+      )
+      val conv = LegacyConversions.fromBlock(comp)
+      val back = LegacyConversions.toBlock(conv)
+      back shouldBe comp
+    }
+  }
+
+}

--- a/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
@@ -15,16 +15,22 @@ class LegacyConversionsTest extends FlatSpec with ArbitraryConsensus with Matche
   "LegacyConversions" should "convert correctly between old and new blocks" in {
     forAll { (orig: consensus.Block) =>
       // Some fields are not supported by the legacy one.
-      val comp = orig.withBody(
-        orig.getBody.withDeploys(orig.getBody.deploys.map { pd =>
-          pd.withDeploy(
-              pd.getDeploy
-                .withDeployHash(ByteString.EMPTY)
-                .withHeader(pd.getDeploy.getHeader.withBodyHash(ByteString.EMPTY))
-            )
-            .withErrorMessage("")
-        })
-      )
+      val comp =
+        orig
+          .withHeader(
+            // Body hash would have to be a valid serialization from the 2 fields in the old message.
+            orig.getHeader.withBodyHash(ByteString.EMPTY)
+          )
+          .withBody(
+            orig.getBody.withDeploys(orig.getBody.deploys.map { pd =>
+              pd.withDeploy(
+                  pd.getDeploy
+                    .withDeployHash(ByteString.EMPTY)
+                    .withHeader(pd.getDeploy.getHeader.withBodyHash(ByteString.EMPTY))
+                )
+                .withErrorMessage("")
+            })
+          )
       val conv = LegacyConversions.fromBlock(comp)
       val back = LegacyConversions.toBlock(conv)
       back shouldBe comp

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -81,7 +81,7 @@ class ManyValidatorsTest
       _                  <- casperRef.set(casperEffect)
       cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       result <- BlockAPI.showBlocks[Task](Int.MaxValue)(
-                 Monad[Task],
+                 Sync[Task],
                  casperRef,
                  logEff,
                  cliqueOracleEffect,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -218,7 +218,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
       .traverse {
         case (peer, sk) =>
           val logicalTime        = new LogicalTime[F]
-          implicit val log       = new LogStub[F](peer.host, printEnabled = true)
+          implicit val log       = new LogStub[F](peer.host, printEnabled = false)
           implicit val metricEff = new Metrics.MetricsNOP[F]
           implicit val nodeAsk   = makeNodeAsk(peer)(concurrentF)
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -217,7 +217,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
       .toList
       .traverse {
         case (peer, sk) =>
-          val logicalTime = new LogicalTime[F]
+          val logicalTime        = new LogicalTime[F]
           implicit val log       = new LogStub[F](peer.host, printEnabled = true)
           implicit val metricEff = new Metrics.MetricsNOP[F]
           implicit val nodeAsk   = makeNodeAsk(peer)(concurrentF)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -9,8 +9,12 @@ import cats.implicits._
 import cats.temp.par.Par
 import cats.mtl.DefaultApplicativeAsk
 import com.google.protobuf.ByteString
+import eu.timepit.refined._
+import eu.timepit.refined.auto._
+import eu.timepit.refined.numeric._
 import io.casperlabs.blockstorage._
 import io.casperlabs.casper._
+import io.casperlabs.casper.consensus
 import io.casperlabs.casper.helper.BlockDagStorageTestFixture.mapSize
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util.ProtoUtil
@@ -31,9 +35,10 @@ import io.casperlabs.shared.{Cell, Log, Time}
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import monix.eval.Task
 import monix.execution.Scheduler
+import monix.tail.Iterant
 
 import scala.collection.mutable
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS}
 import scala.util.Random
 
 class GossipServiceCasperTestNode[F[_]](
@@ -45,7 +50,9 @@ class GossipServiceCasperTestNode[F[_]](
     blockProcessingLock: Semaphore[F],
     faultToleranceThreshold: Float = 0f,
     shardId: String = "casperlabs",
-    relaying: Relaying[F]
+    relaying: Relaying[F],
+    gossipService: GossipServiceCasperTestNodeFactory.TestGossipService[F],
+    validatorToNode: Map[ByteString, Node]
 )(
     implicit
     concurrentF: Concurrent[F],
@@ -66,6 +73,10 @@ class GossipServiceCasperTestNode[F[_]](
 
   //val defaultTimeout = FiniteDuration(1000, MILLISECONDS)
 
+  val ownValidatorKey = validatorId match {
+    case ValidatorIdentity(key, _, _) => ByteString.copyFrom(key)
+  }
+
   implicit val casperEff: MultiParentCasperImpl[F] = new MultiParentCasperImpl[F](
     new MultiParentCasperImpl.StatelessExecutor(shardId),
     MultiParentCasperImpl.Broadcaster.fromGossipServices(Some(validatorId), relaying),
@@ -74,15 +85,27 @@ class GossipServiceCasperTestNode[F[_]](
     shardId,
     blockProcessingLock,
     faultToleranceThreshold = faultToleranceThreshold
-  )
+  ) {
+    override def addBlock(block: BlockMessage): F[BlockStatus] =
+      if (block.sender == ownValidatorKey) {
+        // The test is adding something this node created.
+        super.addBlock(block)
+      } else {
+        // The test is adding something it created in another node's name,
+        // i.e. it expects that dependencies will be requested.
+        val sender  = validatorToNode(block.sender)
+        val request = NewBlocksRequest(sender.some, List(block.blockHash))
+        gossipService.newBlocks(request).map { response =>
+          if (response.isNew) Processing else Valid
+        }
+      }
+  }
 
   /** Allow RPC calls intended for this node to be processed and enqueue responses. */
-  def receive(): F[Unit] =
-    ???
+  def receive(): F[Unit] = gossipService.receive()
 
   /** Forget RPC calls intended for this node. */
-  def clearMessages(): F[Unit] =
-    ???
+  def clearMessages(): F[Unit] = gossipService.clearMessages()
 }
 
 trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
@@ -102,7 +125,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
       implicit
       errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
-      parF: Par[F]
+      parF: Par[F],
+      timerF: Timer[F]
   ): F[GossipServiceCasperTestNode[F]] = {
     val name               = "standalone"
     val identity           = peerNode(name, 40400)
@@ -111,42 +135,41 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
     implicit val metricEff = new Metrics.MetricsNOP[F]
     implicit val nodeAsk   = makeNodeAsk(identity)(concurrentF)
 
-    val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
-    val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
-    val env           = Context.env(blockStoreDir, BlockDagStorageTestFixture.mapSize)
-    for {
-      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
-      blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
-                          BlockDagFileStorage.Config(blockDagDir),
-                          genesis
-                        )(concurrentF, log, blockStore, metricEff)
-      blockProcessingLock <- Semaphore[F](1)
-      casperState         <- Cell.mvarCell[F, CasperState](CasperState())
-      node = new GossipServiceCasperTestNode[F](
-        identity,
-        genesis,
-        sk,
-        blockDagDir,
-        blockStoreDir,
-        blockProcessingLock,
-        faultToleranceThreshold,
-        // Standalone, so nobody to relay to.
-        relaying = RelayingImpl(
-          new NoPeersNodeDiscovery[F](),
-          connectToGossip = _ => ???,
-          relayFactor = 0,
-          relaySaturation = 0
-        )
-      )(
-        concurrentF,
-        blockStore,
-        blockDagStorage,
-        logicalTime,
-        metricEff,
-        casperState
-      )
-      _ <- node.initialize
-    } yield node
+    // Standalone, so nobody to relay to.
+    val relaying = RelayingImpl(
+      new TestNodeDiscovery[F](Nil),
+      connectToGossip = _ => ???,
+      relayFactor = 0,
+      relaySaturation = 0
+    )
+
+    initStorage(genesis) flatMap {
+      case (blockDagDir, blockStoreDir, blockDagStorage, blockStore) =>
+        for {
+          blockProcessingLock <- Semaphore[F](1)
+          casperState         <- Cell.mvarCell[F, CasperState](CasperState())
+          node = new GossipServiceCasperTestNode[F](
+            identity,
+            genesis,
+            sk,
+            blockDagDir,
+            blockStoreDir,
+            blockProcessingLock,
+            faultToleranceThreshold,
+            relaying = relaying,
+            gossipService = new TestGossipService[F](),
+            validatorToNode = Map.empty // Shouldn't need it.
+          )(
+            concurrentF,
+            blockStore,
+            blockDagStorage,
+            logicalTime,
+            metricEff,
+            casperState
+          )
+          _ <- node.initialize
+        } yield node
+    }
   }
 
   def networkF[F[_]](
@@ -158,16 +181,88 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
   )(
       implicit errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
-      parF: Par[F]
-  ): F[IndexedSeq[GossipServiceCasperTestNode[F]]] =
-    ???
+      parF: Par[F],
+      timerF: Timer[F]
+  ): F[IndexedSeq[GossipServiceCasperTestNode[F]]] = {
+    val n     = sks.length
+    val names = (1 to n).map(i => s"node-$i")
+    val peers = names.map(peerNode(_, 40400))
+
+    var gossipServices = peers.map { peer =>
+      peer -> new TestGossipService[F]()
+    }.toMap
+
+    val validatorToNode = peers
+      .zip(sks)
+      .map {
+        case (node, sk) =>
+          ByteString.copyFrom(Ed25519.toPublic(sk)) -> node
+      }
+      .toMap
+
+    peers
+      .zip(sks)
+      .toList
+      .traverse {
+        case (peer, sk) =>
+          val logicalTime          = new LogicalTime[F]
+          implicit val log: Log[F] = new Log.NOPLog[F]()
+          implicit val metricEff   = new Metrics.MetricsNOP[F]
+          implicit val nodeAsk     = makeNodeAsk(peer)(concurrentF)
+
+          // Simulate the broadcast semantics.
+          val nodeDiscovery = new TestNodeDiscovery[F](peers.filterNot(_ == peer).toList)
+
+          val connectToGossip: GossipService.Connector[F] =
+            peer => gossipServices(peer).asInstanceOf[GossipService[F]].pure[F]
+
+          val relaying = RelayingImpl(
+            nodeDiscovery,
+            connectToGossip = connectToGossip,
+            relayFactor = peers.size - 1,
+            relaySaturation = 100
+          )
+
+          initStorage(genesis) flatMap {
+            case (blockDagDir, blockStoreDir, blockDagStorage, blockStore) =>
+              for {
+                semaphore <- Semaphore[F](1)
+                casperState <- Cell.mvarCell[F, CasperState](
+                                CasperState()
+                              )
+                gossipService = gossipServices(peer)
+                node = new GossipServiceCasperTestNode[F](
+                  peer,
+                  genesis,
+                  sk,
+                  blockDagDir,
+                  blockStoreDir,
+                  semaphore,
+                  faultToleranceThreshold,
+                  relaying = relaying,
+                  gossipService = gossipService,
+                  validatorToNode = validatorToNode
+                )(
+                  concurrentF,
+                  blockStore,
+                  blockDagStorage,
+                  logicalTime,
+                  metricEff,
+                  casperState
+                )
+                _ <- gossipService.init(node.casperEff, blockStore, relaying, connectToGossip)
+              } yield node
+          }
+      } map (_.toIndexedSeq)
+
+  }
 }
 
 object GossipServiceCasperTestNodeFactory {
-  class NoPeersNodeDiscovery[F[_]: Applicative] extends NodeDiscovery[F] {
+  class TestNodeDiscovery[F[_]: Applicative](peers: List[Node]) extends NodeDiscovery[F] {
     def discover: F[Unit]                           = ???
     def lookup(id: NodeIdentifier): F[Option[Node]] = ???
-    def alivePeersAscendingDistance: F[List[Node]]  = List.empty.pure[F]
+    def alivePeersAscendingDistance: F[List[Node]]  = peers.pure[F]
   }
 
   def makeNodeAsk[F[_]](node: Node)(implicit ev: Applicative[F]) =
@@ -175,4 +270,163 @@ object GossipServiceCasperTestNodeFactory {
       val applicative: Applicative[F] = ev
       def ask: F[Node]                = node.pure[F]
     }
+
+  /** Accumulate messages until receive is called by the test. */
+  class TestGossipService[F[_]: Concurrent: Timer: Par]() extends GossipService[F] {
+
+    /** Exercise the full underlying stack. It's what we are testing here, via the MultiParentCasper tests. */
+    var underlying: GossipServiceServer[F] = _
+
+    /** Casper is created a bit later then the TestGossipService instance. */
+    def init(
+        casper: MultiParentCasperImpl[F],
+        blockStore: BlockStore[F],
+        relaying: Relaying[F],
+        connectToGossip: GossipService.Connector[F]
+    )(implicit log: Log[F]): F[Unit] = {
+
+      val resources = for {
+        downloadManager <- DownloadManagerImpl[F](
+                            maxParallelDownloads = 10,
+                            connectToGossip = connectToGossip,
+                            backend = new DownloadManagerImpl.Backend[F] {
+                              override def hasBlock(blockHash: ByteString): F[Boolean] =
+                                blockStore.contains(blockHash)
+
+                              override def validateBlock(block: consensus.Block): F[Unit] =
+                                // Casper can only validate, store, but won't gossip because the Broadcaster we give it
+                                // will assume the DownloadManager will do that.
+                                casper.addBlock(LegacyConversions.fromBlock(block)) map {
+                                  case Valid =>
+                                  case other => new RuntimeException(s"Non-valid status: $other")
+                                }
+
+                              override def storeBlock(block: consensus.Block): F[Unit] =
+                                // Validation has already stored it.
+                                ().pure[F]
+
+                              override def storeBlockSummary(
+                                  summary: consensus.BlockSummary
+                              ): F[Unit] =
+                                // No means to store summaries separately yet.
+                                ().pure[F]
+                            },
+                            relaying = relaying,
+                            retriesConf = DownloadManagerImpl.RetriesConf.noRetries
+                          )
+      } yield downloadManager
+
+      resources.use {
+        case downloadManager =>
+          val synchronizer = new SynchronizerImpl[F](
+            connectToGossip = connectToGossip,
+            backend = new SynchronizerImpl.Backend[F] {
+              override def tips: F[List[ByteString]] =
+                for {
+                  dag       <- casper.blockDag
+                  tipHashes <- casper.estimator(dag)
+                } yield tipHashes.toList
+
+              override def justifications: F[List[ByteString]] =
+                // TODO: Presently there's no way to ask.
+                List.empty.pure[F]
+
+              override def validate(blockSummary: consensus.BlockSummary): F[Unit] =
+                // TODO: Presently the Validation only works on full blocks.
+                ().pure[F]
+
+              override def notInDag(blockHash: ByteString): F[Boolean] =
+                blockStore.contains(blockHash).map(!_)
+            },
+            maxPossibleDepth = Int.MaxValue,
+            minBlockCountToCheckBranchingFactor = Int.MaxValue,
+            maxBranchingFactor = 2.0,
+            maxDepthAncestorsRequest = Int.MaxValue
+          )
+
+          for {
+            server <- GossipServiceServer[F](
+                       backend = new GossipServiceServer.Backend[F] {
+                         override def hasBlock(blockHash: ByteString): F[Boolean] =
+                           blockStore.contains(blockHash)
+
+                         override def getBlockSummary(
+                             blockHash: ByteString
+                         ): F[Option[consensus.BlockSummary]] =
+                           blockStore
+                             .get(blockHash)
+                             .map(
+                               _.map(mwt => LegacyConversions.toBlockSummary(mwt.getBlockMessage))
+                             )
+
+                         override def getBlock(blockHash: ByteString): F[Option[consensus.Block]] =
+                           blockStore
+                             .get(blockHash)
+                             .map(_.map(mwt => LegacyConversions.toBlock(mwt.getBlockMessage)))
+                       },
+                       synchronizer = synchronizer,
+                       downloadManager = downloadManager,
+                       consensus = new GossipServiceServer.Consensus[F] {
+                         override def onPending(dag: Vector[consensus.BlockSummary]) =
+                           ().pure[F]
+                         override def onDownloaded(blockHash: ByteString) =
+                           // The validation already did what it had to.
+                           ().pure[F]
+                         override def listTips =
+                           ???
+                       },
+                       // Not testing the genesis ceremony.
+                       genesisApprover = new GenesisApprover[F] {
+                         override def getCandidate = ???
+                         override def addApproval(
+                             blockHash: ByteString,
+                             approval: consensus.Approval
+                         )                          = ???
+                         override def awaitApproval = ???
+                       },
+                       maxChunkSize = 1024 * 1024,
+                       maxParallelBlockDownloads = 10
+                     )
+          } yield {
+            underlying = server
+          }
+      }
+    }
+
+    /** With the TransportLayer this would mean the target node receives the full block and adds it.
+      * We have to allow `newBlocks` to return for the original block to be able to finish adding,
+      * so maybe we can return `true`, and call the underlying service later. But then we have to
+      * allow it to play out all async actions, such as downloading blocks, syncing the DAG, etc. */
+    def receive(): F[Unit] = ().pure[F]
+
+    /** With the TransportLayer this would mean the target node won't process a message.
+      * For us it could mean that it receives the `newBlocks` notification but after that
+      * we don't let it play out the async operations, for example by returning errors for
+      * all requests it started. */
+    def clearMessages(): F[Unit] = ().pure[F]
+
+    override def getBlockChunked(request: GetBlockChunkedRequest): Iterant[F, Chunk] =
+      underlying.getBlockChunked(request)
+
+    override def newBlocks(request: NewBlocksRequest): F[NewBlocksResponse] =
+      underlying.newBlocks(request)
+
+    override def streamAncestorBlockSummaries(
+        request: StreamAncestorBlockSummariesRequest
+    ): Iterant[F, consensus.BlockSummary] =
+      underlying.streamAncestorBlockSummaries(request)
+
+    // The following methods are not tested in these suites.
+
+    override def addApproval(request: AddApprovalRequest): F[Empty] = ???
+    override def getGenesisCandidate(
+        request: GetGenesisCandidateRequest
+    ): F[consensus.GenesisCandidate] = ???
+    override def streamDagTipBlockSummaries(
+        request: StreamDagTipBlockSummariesRequest
+    ): Iterant[F, consensus.BlockSummary] = ???
+    override def streamBlockSummaries(
+        request: StreamBlockSummariesRequest
+    ): Iterant[F, consensus.BlockSummary] = ???
+  }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -1,0 +1,178 @@
+package io.casperlabs.casper.helper
+
+import java.nio.file.Path
+
+import cats._
+import cats.effect._
+import cats.effect.concurrent._
+import cats.implicits._
+import cats.temp.par.Par
+import cats.mtl.DefaultApplicativeAsk
+import com.google.protobuf.ByteString
+import io.casperlabs.blockstorage._
+import io.casperlabs.casper._
+import io.casperlabs.casper.helper.BlockDagStorageTestFixture.mapSize
+import io.casperlabs.casper.protocol._
+import io.casperlabs.casper.util.ProtoUtil
+import io.casperlabs.casper.util.execengine.ExecEngineUtil
+import io.casperlabs.catscontrib.TaskContrib._
+import io.casperlabs.catscontrib._
+import io.casperlabs.catscontrib.effect.implicits._
+import io.casperlabs.comm.CommError.ErrorHandler
+import io.casperlabs.comm._
+import io.casperlabs.comm.discovery.{Node, NodeDiscovery, NodeIdentifier}
+import io.casperlabs.comm.gossiping._
+import io.casperlabs.crypto.signatures.Ed25519
+import io.casperlabs.ipc.TransformEntry
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.p2p.EffectsTestInstances._
+import io.casperlabs.shared.PathOps.RichPath
+import io.casperlabs.shared.{Cell, Log, Time}
+import io.casperlabs.smartcontracts.ExecutionEngineService
+import monix.eval.Task
+import monix.execution.Scheduler
+
+import scala.collection.mutable
+import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import scala.util.Random
+
+class GossipServiceCasperTestNode[F[_]](
+    local: Node,
+    genesis: BlockMessage,
+    sk: Array[Byte],
+    blockDagDir: Path,
+    blockStoreDir: Path,
+    blockProcessingLock: Semaphore[F],
+    faultToleranceThreshold: Float = 0f,
+    shardId: String = "casperlabs",
+    relaying: Relaying[F]
+)(
+    implicit
+    concurrentF: Concurrent[F],
+    blockStore: BlockStore[F],
+    blockDagStorage: BlockDagStorage[F],
+    timeEff: Time[F],
+    metricEff: Metrics[F],
+    casperState: Cell[F, CasperState]
+) extends HashSetCasperTestNode[F](
+      local,
+      sk,
+      genesis,
+      blockDagDir,
+      blockStoreDir
+    )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
+
+  implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]
+
+  //val defaultTimeout = FiniteDuration(1000, MILLISECONDS)
+
+  implicit val casperEff: MultiParentCasperImpl[F] = new MultiParentCasperImpl[F](
+    new MultiParentCasperImpl.StatelessExecutor(shardId),
+    MultiParentCasperImpl.Broadcaster.fromGossipServices(Some(validatorId), relaying),
+    Some(validatorId),
+    genesis,
+    shardId,
+    blockProcessingLock,
+    faultToleranceThreshold = faultToleranceThreshold
+  )
+
+  /** Allow RPC calls intended for this node to be processed and enqueue responses. */
+  def receive(): F[Unit] =
+    ???
+
+  /** Forget RPC calls intended for this node. */
+  def clearMessages(): F[Unit] =
+    ???
+}
+
+trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
+
+  type TestNode[F[_]] = GossipServiceCasperTestNode[F]
+
+  import HashSetCasperTestNode.peerNode
+  import GossipServiceCasperTestNodeFactory._
+
+  def standaloneF[F[_]](
+      genesis: BlockMessage,
+      transforms: Seq[TransformEntry],
+      sk: Array[Byte],
+      storageSize: Long = 1024L * 1024 * 10,
+      faultToleranceThreshold: Float = 0f
+  )(
+      implicit
+      errorHandler: ErrorHandler[F],
+      concurrentF: Concurrent[F],
+      parF: Par[F]
+  ): F[GossipServiceCasperTestNode[F]] = {
+    val name               = "standalone"
+    val identity           = peerNode(name, 40400)
+    val logicalTime        = new LogicalTime[F]
+    implicit val log       = new Log.NOPLog[F]()
+    implicit val metricEff = new Metrics.MetricsNOP[F]
+    implicit val nodeAsk   = makeNodeAsk(identity)(concurrentF)
+
+    val blockDagDir   = BlockDagStorageTestFixture.blockDagStorageDir
+    val blockStoreDir = BlockDagStorageTestFixture.blockStorageDir
+    val env           = Context.env(blockStoreDir, BlockDagStorageTestFixture.mapSize)
+    for {
+      blockStore <- FileLMDBIndexBlockStore.create[F](env, blockStoreDir).map(_.right.get)
+      blockDagStorage <- BlockDagFileStorage.createEmptyFromGenesis[F](
+                          BlockDagFileStorage.Config(blockDagDir),
+                          genesis
+                        )(concurrentF, log, blockStore, metricEff)
+      blockProcessingLock <- Semaphore[F](1)
+      casperState         <- Cell.mvarCell[F, CasperState](CasperState())
+      node = new GossipServiceCasperTestNode[F](
+        identity,
+        genesis,
+        sk,
+        blockDagDir,
+        blockStoreDir,
+        blockProcessingLock,
+        faultToleranceThreshold,
+        // Standalone, so nobody to relay to.
+        relaying = RelayingImpl(
+          new NoPeersNodeDiscovery[F](),
+          connectToGossip = _ => ???,
+          relayFactor = 0,
+          relaySaturation = 0
+        )
+      )(
+        concurrentF,
+        blockStore,
+        blockDagStorage,
+        logicalTime,
+        metricEff,
+        casperState
+      )
+      _ <- node.initialize
+    } yield node
+  }
+
+  def networkF[F[_]](
+      sks: IndexedSeq[Array[Byte]],
+      genesis: BlockMessage,
+      transforms: Seq[TransformEntry],
+      storageSize: Long = 1024L * 1024 * 10,
+      faultToleranceThreshold: Float = 0f
+  )(
+      implicit errorHandler: ErrorHandler[F],
+      concurrentF: Concurrent[F],
+      parF: Par[F]
+  ): F[IndexedSeq[GossipServiceCasperTestNode[F]]] =
+    ???
+}
+
+object GossipServiceCasperTestNodeFactory {
+  class NoPeersNodeDiscovery[F[_]: Applicative] extends NodeDiscovery[F] {
+    def discover: F[Unit]                           = ???
+    def lookup(id: NodeIdentifier): F[Option[Node]] = ???
+    def alivePeersAscendingDistance: F[List[Node]]  = List.empty.pure[F]
+  }
+
+  def makeNodeAsk[F[_]](node: Node)(implicit ev: Applicative[F]) =
+    new DefaultApplicativeAsk[F, Node] {
+      val applicative: Applicative[F] = ev
+      def ask: F[Node]                = node.pure[F]
+    }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -462,9 +462,9 @@ object GossipServiceCasperTestNodeFactory {
       * so maybe we can return `true`, and call the underlying service later. But then we have to
       * allow it to play out all async actions, such as downloading blocks, syncing the DAG, etc. */
     def receive(): F[Unit] = {
-      // It can be ricky to line up the semantics of the notifications between the TransportLayer
-      // and the GossipService. At least in one test the queue was longer and the node wasn't Processing
-      // the message the test was expecting it to, it was reacting to an earlier one. To circumvent
+      // It can be tricky to line up the semantics of the notifications between the TransportLayer
+      // and the GossipService. At least in one test the queue was longer and the node wasn't processing
+      // the message the test was expecting it to, it was still reacting to an earlier one. To circumvent
       // these tests failures process all enqueued messages.
       def receiveOne =
         for {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -218,8 +218,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
       .traverse {
         case (peer, sk) =>
           val logicalTime = new LogicalTime[F]
-          //implicit val log: Log[F] = new Log.NOPLog[F]()
-          implicit val log       = new LogStub[F](peer.host)
+          implicit val log       = new LogStub[F](peer.host, printEnabled = true)
           implicit val metricEff = new Metrics.MetricsNOP[F]
           implicit val nodeAsk   = makeNodeAsk(peer)(concurrentF)
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -65,7 +65,8 @@ abstract class HashSetCasperTestNode[F[_]](
     val casperState: Cell[F, CasperState]
 ) {
   implicit val logEff: LogStub[F] = new LogStub[F]()
-  implicit val casperEff: MultiParentCasperImpl[F]
+
+  implicit val casperEff: MultiParentCasperImpl[F] with HashSetCasperTestNode.AddBlockProxy[F]
 
   val validatorId = ValidatorIdentity(Ed25519.toPublic(sk), sk, "ed25519")
 
@@ -187,6 +188,17 @@ trait HashSetCasperTestNodeFactory {
 
 object HashSetCasperTestNode {
   type Effect[A] = EitherT[Task, CommError, A]
+
+  /** Currently the tests call `addBlock` directly, but with the GossipService tests
+    * we want that to happen via gossiping, if the node isn't the creator. Yet this
+    * is currently also the only method that can do validation, so there has to be a
+    * back door to run blocks created by other nodes. */
+  trait AddBlockProxy[F[_]] { self: MultiParentCasper[F] =>
+    // This should point at the original `addBlock`,
+    // allowing the tests to override it but also call the original.
+    def superAddBlock(blockMessage: BlockMessage): F[BlockStatus] =
+      addBlock(blockMessage)
+  }
 
   val appErrId = new ApplicativeError[Id, CommError] {
     def ap[A, B](ff: Id[A => B])(fa: Id[A]): Id[B] = Applicative[Id].ap[A, B](ff)(fa)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -66,7 +66,7 @@ abstract class HashSetCasperTestNode[F[_]](
 ) {
   implicit val logEff: LogStub[F]
 
-  implicit val casperEff: MultiParentCasperImpl[F] with HashSetCasperTestNode.AddBlockProxy[F]
+  implicit val casperEff: MultiParentCasperImpl[F]
 
   val validatorId = ValidatorIdentity(Ed25519.toPublic(sk), sk, "ed25519")
 
@@ -188,17 +188,6 @@ trait HashSetCasperTestNodeFactory {
 
 object HashSetCasperTestNode {
   type Effect[A] = EitherT[Task, CommError, A]
-
-  /** Currently the tests call `addBlock` directly, but with the GossipService tests
-    * we want that to happen via gossiping, if the node isn't the creator. Yet this
-    * is currently also the only method that can do validation, so there has to be a
-    * back door to run blocks created by other nodes. */
-  trait AddBlockProxy[F[_]] { self: MultiParentCasper[F] =>
-    // This should point at the original `addBlock`,
-    // allowing the tests to override it but also call the original.
-    def superAddBlock(blockMessage: BlockMessage): F[BlockStatus] =
-      addBlock(blockMessage)
-  }
 
   val appErrId = new ApplicativeError[Id, CommError] {
     def ap[A, B](ff: Id[A => B])(fa: Id[A]): Id[B] = Applicative[Id].ap[A, B](ff)(fa)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -64,7 +64,7 @@ abstract class HashSetCasperTestNode[F[_]](
     val metricEff: Metrics[F],
     val casperState: Cell[F, CasperState]
 ) {
-  implicit val logEff: LogStub[F] = new LogStub[F]()
+  implicit val logEff: LogStub[F]
 
   implicit val casperEff: MultiParentCasperImpl[F] with HashSetCasperTestNode.AddBlockProxy[F]
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -73,6 +73,7 @@ class TransportLayerCasperTestNode[F[_]](
       blockStoreDir
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
+  implicit val logEff: LogStub[F] = new LogStub[F]()
   implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
   implicit val transportLayerEff  = tle
   implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -73,7 +73,7 @@ class TransportLayerCasperTestNode[F[_]](
       blockStoreDir
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
-  implicit val logEff: LogStub[F] = new LogStub[F]()
+  implicit val logEff: LogStub[F] = new LogStub[F](local.host)
   implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
   implicit val transportLayerEff  = tle
   implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -86,7 +86,7 @@ class TransportLayerCasperTestNode[F[_]](
   implicit val labF =
     LastApprovedBlock.unsafe[F](Some(ApprovedBlockWithTransforms(approvedBlock, transforms)))
 
-  implicit val casperEff: MultiParentCasperImpl[F] with HashSetCasperTestNode.AddBlockProxy[F] =
+  implicit val casperEff: MultiParentCasperImpl[F] =
     new MultiParentCasperImpl[F](
       new MultiParentCasperImpl.StatelessExecutor(shardId),
       MultiParentCasperImpl.Broadcaster.fromTransportLayer(),
@@ -95,7 +95,7 @@ class TransportLayerCasperTestNode[F[_]](
       shardId,
       blockProcessingLock,
       faultToleranceThreshold = faultToleranceThreshold
-    ) with HashSetCasperTestNode.AddBlockProxy[F]
+    )
 
   implicit val multiparentCasperRef = MultiParentCasperRef.unsafe[F](Some(casperEff))
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -73,7 +73,7 @@ class TransportLayerCasperTestNode[F[_]](
       blockStoreDir
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
-  implicit val logEff: LogStub[F] = new LogStub[F](local.host)
+  implicit val logEff: LogStub[F] = new LogStub[F](local.host, printEnabled = true)
   implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
   implicit val transportLayerEff  = tle
   implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -73,7 +73,7 @@ class TransportLayerCasperTestNode[F[_]](
       blockStoreDir
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
-  implicit val logEff: LogStub[F] = new LogStub[F](local.host, printEnabled = true)
+  implicit val logEff: LogStub[F] = new LogStub[F](local.host, printEnabled = false)
   implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
   implicit val transportLayerEff  = tle
   implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -94,6 +94,9 @@ object DownloadManagerImpl {
       initialBackoffPeriod: FiniteDuration,
       backoffFactor: Double Refined GreaterEqual[W.`1.0`.T]
   )
+  object RetriesConf {
+    val noRetries = RetriesConf(0, Duration.Zero, 1.0)
+  }
 
   /** Start the download manager. */
   def apply[F[_]: Concurrent: Log: Timer](

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -38,9 +38,9 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log](
     // and finally notify the consensus engine.
     newBlocks(request, (node, hashes) => sync(node, hashes, skipRelaying = false).start)
 
-  /* Same as 'newBlocks' but with synchronous semantics, needed for bootstrapping */
-  protected[gossiping] def newBlocksSynchronous(request: NewBlocksRequest): F[NewBlocksResponse] =
-    newBlocks(request, (node, hashes) => sync(node, hashes, skipRelaying = true))
+  /* Same as 'newBlocks' but with synchronous semantics, needed for bootstrapping and some tests. */
+  def newBlocksSynchronous(request: NewBlocksRequest, skipRelaying: Boolean): F[NewBlocksResponse] =
+    newBlocks(request, (node, hashes) => sync(node, hashes, skipRelaying))
 
   private def newBlocks(
       request: NewBlocksRequest,

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -95,7 +95,9 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log](
     }
 
     val trySync = for {
-      _ <- Log[F].info(s"Notified about ${newBlockHashes.size} new blocks by ${source.show}.")
+      _ <- Log[F].info(
+            s"Received notification about ${newBlockHashes.size} new blocks by ${source.show}."
+          )
       dagOrError <- synchronizer.syncDag(
                      source = source,
                      targetBlockHashes = newBlockHashes

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -96,7 +96,7 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log](
 
     val trySync = for {
       _ <- Log[F].info(
-            s"Received notification about ${newBlockHashes.size} new blocks by ${source.show}."
+            s"Received notification about ${newBlockHashes.size} new blocks from ${source.show}."
           )
       dagOrError <- synchronizer.syncDag(
                      source = source,

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/InitialSynchronization.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/InitialSynchronization.scala
@@ -55,7 +55,8 @@ class InitialSynchronizationImpl[F[_]: Concurrent: Par: Log: Timer](
               NewBlocksRequest(
                 sender = node.some,
                 blockHashes = tips.map(_.blockHash)
-              )
+              ),
+              skipRelaying = true
             )
       } yield ()
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
@@ -69,7 +69,7 @@ class RelayingImpl[F[_]: Sync: Par: Log: NodeAsk](
       local    <- NodeAsk[F].ask
       response <- service.newBlocks(NewBlocksRequest(sender = local.some, blockHashes = List(hash)))
       msg = if (response.isNew)
-        s"${peer.show} accepted block for downloading ${hex(hash)}"
+        s"${peer.show} accepted block ${hex(hash)}"
       else
         s"${peer.show} rejected block ${hex(hash)}"
       _ <- Log[F].debug(msg)

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -157,8 +157,8 @@ trait ArbitraryConsensus {
         .withBody(
           Deploy
             .Body()
-            .withSession(DeployCode().withCode(sessionCode))
-            .withPayment(DeployCode().withCode(paymentCode))
+            .withSession(Deploy.Code().withCode(sessionCode))
+            .withPayment(Deploy.Code().withCode(paymentCode))
         )
         .withSignature(signature)
     }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -241,7 +241,7 @@ class DownloadManagerSpec
                     connectToGossip = _ => remote,
                     backend = backend,
                     relaying = MockRelaying.default,
-                    retriesConf = defaultNoRetriesConf
+                    retriesConf = RetriesConf.noRetries
                   ).allocated
           (manager, release) = alloc
           _                  <- manager.scheduleDownload(summaryOf(block), source, relay = false)
@@ -264,7 +264,7 @@ class DownloadManagerSpec
                     connectToGossip = _ => MockGossipService(),
                     backend = MockBackend(),
                     relaying = MockRelaying.default,
-                    retriesConf = defaultNoRetriesConf
+                    retriesConf = RetriesConf.noRetries
                   ).allocated
           (manager, release) = alloc
           _                  <- release
@@ -520,8 +520,6 @@ class DownloadManagerSpec
 
 object DownloadManagerSpec {
 
-  val defaultNoRetriesConf: RetriesConf = RetriesConf(0, 1.second, 2.0)
-
   def summaryOf(block: Block): BlockSummary =
     BlockSummary()
       .withBlockHash(block.blockHash)
@@ -545,7 +543,7 @@ object DownloadManagerSpec {
         remote: Node => Task[GossipService[Task]] = _ => MockGossipService.default,
         maxParallelDownloads: Int = 1,
         relaying: MockRelaying = MockRelaying.default,
-        retriesConf: RetriesConf = defaultNoRetriesConf,
+        retriesConf: RetriesConf = RetriesConf.noRetries,
         timeout: FiniteDuration = 5.seconds
     )(
         test: TestArgs => Task[Unit]

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -90,7 +90,9 @@ class InitialSynchronizationSpec
             ) { (initialSynchronizer, mockGossipServiceServer) =>
               for {
                 w <- initialSynchronizer.sync()
-                _ <- w.timeout(75.millis).attempt
+                // It's configured with minimum isccessful being infinite so it will try
+                // forever and fail. We just want to give it enough time to try all of them.
+                _ <- w.timeout(200.millis).attempt
               } yield {
                 val asked = mockGossipServiceServer.asked.get()
                 Inspectors.forAll(failingNodes) { node =>

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -223,8 +223,9 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
       ) {
     val asked = Atomic(Vector.empty[Node])
 
-    override protected[gossiping] def newBlocksSynchronous(
-        request: NewBlocksRequest
+    override def newBlocksSynchronous(
+        request: NewBlocksRequest,
+        skipRelaying: Boolean
     ): Task[NewBlocksResponse] = {
       asked.transform(_ :+ request.getSender)
       sync(request.getSender, request.blockHashes).map(b => NewBlocksResponse(isNew = b))

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -105,8 +105,7 @@ object EffectsTestInstances {
     def shutdown(msg: Protocol): F[Unit] = ???
   }
 
-  class LogStub[F[_]: Applicative](prefix: String = "", printEnabled: Boolean = false)
-      extends Log[F] {
+  class LogStub[F[_]: Sync](prefix: String = "", printEnabled: Boolean = false) extends Log[F] {
 
     @volatile var debugs: Vector[String]    = Vector.empty[String]
     @volatile var infos: Vector[String]     = Vector.empty[String]
@@ -127,37 +126,34 @@ object EffectsTestInstances {
     }
     def isTraceEnabled(implicit ev: LogSource): F[Boolean]  = false.pure[F]
     def trace(msg: String)(implicit ev: LogSource): F[Unit] = ().pure[F]
-    def debug(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
+    def debug(msg: String)(implicit ev: LogSource): F[Unit] = sync {
       if (printEnabled) println(s"DEBUG $prefix $msg")
       debugs = debugs :+ msg
       all = all :+ msg
-      ().pure[F]
     }
-    def info(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
+    def info(msg: String)(implicit ev: LogSource): F[Unit] = sync {
       if (printEnabled) println(s"INFO  $prefix $msg")
       infos = infos :+ msg
       all = all :+ msg
-      ().pure[F]
     }
-    def warn(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
+    def warn(msg: String)(implicit ev: LogSource): F[Unit] = sync {
       if (printEnabled) println(s"WARN  $prefix $msg")
       warns = warns :+ msg
       all = all :+ msg
-      ().pure[F]
     }
-    def error(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
+    def error(msg: String)(implicit ev: LogSource): F[Unit] = sync {
       if (printEnabled) println(s"ERROR $prefix $msg")
       errors = errors :+ msg
       all = all :+ msg
-      ().pure[F]
     }
-    def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = synchronized {
+    def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = sync {
       if (printEnabled) println(s"ERROR $prefix $msg: $cause")
       causes = causes :+ cause
       errors = errors :+ msg
       all = all :+ msg
-      ().pure[F]
     }
+
+    private def sync(thunk: => Unit): F[Unit] = Sync[F].delay(synchronized(thunk))
   }
 
 }

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -105,7 +105,9 @@ object EffectsTestInstances {
     def shutdown(msg: Protocol): F[Unit] = ???
   }
 
-  class LogStub[F[_]: Applicative] extends Log[F] {
+  class LogStub[F[_]: Applicative](prefix: String = "") extends Log[F] {
+
+    private def p(msg: String) = s"$prefix $msg"
 
     @volatile var debugs: Vector[String]    = Vector.empty[String]
     @volatile var infos: Vector[String]     = Vector.empty[String]
@@ -127,29 +129,34 @@ object EffectsTestInstances {
     def isTraceEnabled(implicit ev: LogSource): F[Boolean]  = false.pure[F]
     def trace(msg: String)(implicit ev: LogSource): F[Unit] = ().pure[F]
     def debug(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      debugs = debugs :+ msg
-      all = all :+ msg
+      println(s"DEBUG ${p(msg)}")
+      debugs = debugs :+ p(msg)
+      all = all :+ p(msg)
       ().pure[F]
     }
     def info(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      infos = infos :+ msg
-      all = all :+ msg
+      println(s"INFO  ${p(msg)}")
+      infos = infos :+ p(msg)
+      all = all :+ p(msg)
       ().pure[F]
     }
     def warn(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      warns = warns :+ msg
-      all = all :+ msg
+      println(s"WARN  ${p(msg)}")
+      warns = warns :+ p(msg)
+      all = all :+ p(msg)
       ().pure[F]
     }
     def error(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      errors = errors :+ msg
-      all = all :+ msg
+      println(s"ERROR ${p(msg)}")
+      errors = errors :+ p(msg)
+      all = all :+ p(msg)
       ().pure[F]
     }
     def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = synchronized {
+      println(s"ERROR ${p(msg)}: $cause")
       causes = causes :+ cause
-      errors = errors :+ msg
-      all = all :+ msg
+      errors = errors :+ p(msg)
+      all = all :+ p(msg)
       ().pure[F]
     }
   }

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -105,9 +105,7 @@ object EffectsTestInstances {
     def shutdown(msg: Protocol): F[Unit] = ???
   }
 
-  class LogStub[F[_]: Applicative](prefix: String = "") extends Log[F] {
-
-    private def p(msg: String) = s"$prefix $msg"
+  class LogStub[F[_]: Applicative](prefix: String = "", printEnabled: Boolean = false) extends Log[F] {
 
     @volatile var debugs: Vector[String]    = Vector.empty[String]
     @volatile var infos: Vector[String]     = Vector.empty[String]
@@ -129,34 +127,34 @@ object EffectsTestInstances {
     def isTraceEnabled(implicit ev: LogSource): F[Boolean]  = false.pure[F]
     def trace(msg: String)(implicit ev: LogSource): F[Unit] = ().pure[F]
     def debug(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      println(s"DEBUG ${p(msg)}")
-      debugs = debugs :+ p(msg)
-      all = all :+ p(msg)
+      if (printEnabled) println(s"DEBUG $prefix $msg")
+      debugs = debugs :+ msg
+      all = all :+ msg
       ().pure[F]
     }
     def info(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      println(s"INFO  ${p(msg)}")
-      infos = infos :+ p(msg)
-      all = all :+ p(msg)
+      if (printEnabled) println(s"INFO  $prefix $msg")
+      infos = infos :+ msg
+      all = all :+ msg
       ().pure[F]
     }
     def warn(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      println(s"WARN  ${p(msg)}")
-      warns = warns :+ p(msg)
-      all = all :+ p(msg)
+      if (printEnabled) println(s"WARN  $prefix $msg")
+      warns = warns :+ msg
+      all = all :+ msg
       ().pure[F]
     }
     def error(msg: String)(implicit ev: LogSource): F[Unit] = synchronized {
-      println(s"ERROR ${p(msg)}")
-      errors = errors :+ p(msg)
-      all = all :+ p(msg)
+      if (printEnabled) println(s"ERROR $prefix $msg")
+      errors = errors :+ msg
+      all = all :+ msg
       ().pure[F]
     }
     def error(msg: String, cause: scala.Throwable)(implicit ev: LogSource): F[Unit] = synchronized {
-      println(s"ERROR ${p(msg)}: $cause")
+      if (printEnabled) println(s"ERROR $prefix $msg: $cause")
       causes = causes :+ cause
-      errors = errors :+ p(msg)
-      all = all :+ p(msg)
+      errors = errors :+ msg
+      all = all :+ msg
       ().pure[F]
     }
   }

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -105,7 +105,8 @@ object EffectsTestInstances {
     def shutdown(msg: Protocol): F[Unit] = ???
   }
 
-  class LogStub[F[_]: Applicative](prefix: String = "", printEnabled: Boolean = false) extends Log[F] {
+  class LogStub[F[_]: Applicative](prefix: String = "", printEnabled: Boolean = false)
+      extends Log[F] {
 
     @volatile var debugs: Vector[String]    = Vector.empty[String]
     @volatile var infos: Vector[String]     = Vector.empty[String]

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -10,13 +10,6 @@ message Signature {
     bytes sig = 2;
 }
 
-// Code (either session or payment) to be deployed to the platform.
-// Includes both binary instructions (wasm) and optionally, arguments
-// to those instructions encoded via our ABI
-message DeployCode {
-    bytes code = 1; // wasm byte code
-    bytes args = 2; // ABI-encoded arguments
-}
 
 // A smart contract invocation, singed by the account that sent it.
 message Deploy {
@@ -44,9 +37,17 @@ message Deploy {
 
     message Body {
         // Wasm code of the smart contract to be executed.
-        DeployCode session = 1;
+        Code session = 1;
         // Wasm code that transfers some tokens to the validators as payment in exchange to run the Deploy.
-        DeployCode payment = 2;
+        Code payment = 2;
+    }
+
+    // Code (either session or payment) to be deployed to the platform.
+    // Includes both binary instructions (wasm) and optionally, arguments
+    // to those instructions encoded via our ABI
+    message Code {
+        bytes code = 1; // wasm byte code
+        bytes args = 2; // ABI-encoded arguments
     }
 }
 

--- a/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
+++ b/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
@@ -308,3 +308,9 @@ message Bond {
     int64 stake = 2;
 }
 // --------- End Core Protocol  --------
+
+// Technical message for mapping to new gossip structure.
+message BodyHashes {
+    bytes deploysHash = 1;
+    bytes stateHash = 2;
+}

--- a/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
+++ b/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
@@ -134,7 +134,7 @@ message BlockInfoWithoutTuplespace {
     string blockHash = 1;
     string blockSize = 2;
     int64 blockNumber = 3;
-    int64 protocol_version = 4;
+    int64 protocolVersion = 4;
     int32 deployCount = 5;
     string tupleSpaceHash = 6; // Same as postStateHash of BlockMessage
     int64 timestamp = 7;
@@ -149,7 +149,7 @@ message BlockInfo {
     string blockHash = 1;
     string blockSize = 2;
     int64 blockNumber = 3;
-    int64 protocol_version = 4;
+    int64 protocolVersion = 4;
     int32 deployCount = 5;
     string tupleSpaceHash = 6; // Same as postStateHash of BlockMessage
     string tupleSpaceDump = 7;
@@ -245,7 +245,7 @@ message Header {
     bytes postStateHash = 2;
     bytes deploysHash = 3;
     int64 timestamp = 5;
-    int64 protocol_version = 6;
+    int64 protocolVersion = 6;
     int32 deployCount = 7;
     bytes extraBytes = 8;
 }


### PR DESCRIPTION
## Overview
Make all the `HashSetCasperTest` tests work with both the `TransportLayer` and the `GossipService`.

The wiring is done in `GossipServiceCasperTestNodeFactory` and it serves the purpose of testing rather then be the final wiring we have to do in the node. This is so that the tests can call `node.receive()` and `node.clearMessages()` to achieve their diabolical plans. Logs were added to emulate the transport layer logs.

The real setup is going to be simpler than this, hopefully.

There are some extensions points missing from Casper that we can add later:
* Can't ask for the justifications for syncing
* Can't validate the `BlockSummary` on its own
* Can't store or retrieve just the `BlockSummary`

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-312

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
