### PR TITLE
update format of build failure in slack

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -350,5 +350,11 @@ pipeline:
     image: plugins/slack
     channel: alerts
     secrets: [ slack_webhook ]
+    template: |
+      *{{ uppercasefirst build.status }} *
+      PR: <${DRONE_COMMIT_LINK}|#{{ build.pull }} - ${DRONE_COMMIT_MESSAGE}>
+      Commit: <${DRONE_COMMIT_LINK}/commits/{{build.commit}}|{{ truncate build.commit 10 }}>
+      Author: {{ build.author }} 
+      Drone Build:  <{{ build.link }}|#{{ build.number }}>
     when:
       status: [ failure ]


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.
Changes the formatting of slack notifications for build failures. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.
https://casperlabs.atlassian.net/browse/OP-120

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
