### PR TITLE
STOR-39: test no-op writes

### DIFF
--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -751,3 +751,79 @@ mod scan {
         }
     }
 }
+
+mod write {
+    use super::*;
+
+    mod partial_tries {
+        use super::*;
+
+        #[test]
+        fn lmdb_noop_writes_to_n_leaf_partial_trie_had_expected_results() {
+            for (num_leaves, generator) in TEST_TRIE_GENERATORS.iter().enumerate() {
+                let (mut root_hash, tries) = generator().unwrap();
+                let mut context = LmdbTestContext::new(root_hash, &tries).unwrap();
+
+                for trie in &TEST_LEAVES[0..num_leaves] {
+                    if let Trie::Leaf { key, value } = trie {
+                        let write_result = context.write(*key, *value).unwrap();
+                        assert_eq!(WriteResult::AlreadyExists, write_result)
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn in_memory_noop_writes_to_n_leaf_partial_trie_had_expected_results() {
+            for (num_leaves, generator) in TEST_TRIE_GENERATORS.iter().enumerate() {
+                let (mut root_hash, tries) = generator().unwrap();
+                let mut context = InMemoryTestContext::new(root_hash, &tries).unwrap();
+
+                for trie in &TEST_LEAVES[0..num_leaves] {
+                    if let Trie::Leaf { key, value } = trie {
+                        let write_result = context.write(*key, *value).unwrap();
+                        assert_eq!(WriteResult::AlreadyExists, write_result)
+                    }
+                }
+            }
+        }
+    }
+
+    mod full_tries {
+        use super::*;
+
+        #[test]
+        fn lmdb_noop_writes_to_n_leaf_full_trie_had_expected_results() {
+            let mut context = LmdbTestContext::empty().unwrap();
+
+            for (num_leaves, generator) in TEST_TRIE_GENERATORS[1..].iter().enumerate() {
+                let (root_hash, tries) = generator().unwrap();
+                context.push(root_hash, &tries).unwrap();
+
+                for trie in &TEST_LEAVES[0..num_leaves] {
+                    if let Trie::Leaf { key, value } = trie {
+                        let write_result = context.write(*key, *value).unwrap();
+                        assert_eq!(WriteResult::AlreadyExists, write_result)
+                    }
+                }
+            }
+        }
+
+        #[test]
+        fn in_memory_noop_writes_to_n_leaf_full_trie_had_expected_results() {
+            let mut context = InMemoryTestContext::empty().unwrap();
+
+            for (num_leaves, generator) in TEST_TRIE_GENERATORS[1..].iter().enumerate() {
+                let (root_hash, tries) = generator().unwrap();
+                context.push(root_hash, &tries).unwrap();
+
+                for trie in &TEST_LEAVES[0..num_leaves] {
+                    if let Trie::Leaf { key, value } = trie {
+                        let write_result = context.write(*key, *value).unwrap();
+                        assert_eq!(WriteResult::AlreadyExists, write_result)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Overview
This PR introduces tests to verify that writing a _(key, value)_ pair to the trie is a no-op if that pair has already been written.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
