### PR TITLE
NODE-312: Use MonadThrowable for ProtoUtil.unsafeGetBlock

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -12,6 +12,7 @@ import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.casper.util.execengine.ExecEngineUtil
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.catscontrib.ski._
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.comm.CommError.ErrorHandler
 import io.casperlabs.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import io.casperlabs.comm.transport.TransportLayer
@@ -41,7 +42,7 @@ trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {
 object MultiParentCasper extends MultiParentCasperInstances {
   def apply[F[_]](implicit instance: MultiParentCasper[F]): MultiParentCasper[F] = instance
 
-  def forkChoiceTip[F[_]: MultiParentCasper: Sync: BlockStore]: F[BlockMessage] =
+  def forkChoiceTip[F[_]: MultiParentCasper: MonadThrowable: BlockStore]: F[BlockMessage] =
     for {
       dag       <- MultiParentCasper[F].blockDag
       tipHashes <- MultiParentCasper[F].estimator(dag)

--- a/casper/src/main/scala/io/casperlabs/casper/EquivocationDetector.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EquivocationDetector.scala
@@ -1,13 +1,13 @@
 package io.casperlabs.casper
 
 import cats.{Applicative, Monad}
-import cats.effect.Sync
 import cats.implicits._
 import cats.mtl.FunctorRaise
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockStore}
 import io.casperlabs.casper.EquivocationRecord.SequenceNumber
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.casper.protocol.{BlockMessage, Bond, Justification}
 import io.casperlabs.casper.util.{DoublyLinkedDag, ProtoUtil}
 import io.casperlabs.casper.util.ProtoUtil.{
@@ -108,7 +108,7 @@ object EquivocationDetector {
     } yield maybeCreatorJustification.latestBlockHash
 
   // See summary of algorithm above
-  def checkNeglectedEquivocationsWithUpdate[F[_]: Sync: BlockStore: FunctorRaise[
+  def checkNeglectedEquivocationsWithUpdate[F[_]: MonadThrowable: BlockStore: FunctorRaise[
     ?[_],
     InvalidBlock
   ]](
@@ -124,7 +124,7 @@ object EquivocationDetector {
       )
     )(FunctorRaise[F, InvalidBlock].raise[Unit](NeglectedEquivocation), Monad[F].unit)
 
-  private def isNeglectedEquivocationDetectedWithUpdate[F[_]: Sync: BlockStore](
+  private def isNeglectedEquivocationDetectedWithUpdate[F[_]: MonadThrowable: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       genesis: BlockMessage
@@ -147,7 +147,7 @@ object EquivocationDetector {
     *
     * @return Whether a neglected equivocation was discovered.
     */
-  private def updateEquivocationsTracker[F[_]: Sync: BlockStore](
+  private def updateEquivocationsTracker[F[_]: MonadThrowable: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
@@ -180,7 +180,7 @@ object EquivocationDetector {
           } else ().pure[F]
     } yield neglectedEquivocationDetected
 
-  private def getEquivocationDiscoveryStatus[F[_]: Sync: BlockStore](
+  private def getEquivocationDiscoveryStatus[F[_]: MonadThrowable: BlockStore](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       equivocationRecord: EquivocationRecord,
@@ -208,7 +208,7 @@ object EquivocationDetector {
     }
   }
 
-  private def getEquivocationDiscoveryStatusForBondedValidator[F[_]: Sync: BlockStore](
+  private def getEquivocationDiscoveryStatusForBondedValidator[F[_]: MonadThrowable: BlockStore](
       equivocationRecord: EquivocationRecord,
       latestMessages: Map[Validator, BlockHash],
       stake: Long,
@@ -233,7 +233,7 @@ object EquivocationDetector {
       Applicative[F].pure(EquivocationDetected)
     }
 
-  private def isEquivocationDetectable[F[_]: Sync: BlockStore](
+  private def isEquivocationDetectable[F[_]: MonadThrowable: BlockStore](
       latestMessages: Seq[(Validator, BlockHash)],
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
@@ -251,7 +251,7 @@ object EquivocationDetector {
         )
     }
 
-  private def isEquivocationDetectableAfterViewingBlock[F[_]: Sync: BlockStore](
+  private def isEquivocationDetectableAfterViewingBlock[F[_]: MonadThrowable: BlockStore](
       justificationBlockHash: BlockHash,
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
@@ -273,7 +273,7 @@ object EquivocationDetector {
       } yield equivocationDetected
     }
 
-  private def isEquivocationDetectableThroughChildren[F[_]: Sync: BlockStore](
+  private def isEquivocationDetectableThroughChildren[F[_]: MonadThrowable: BlockStore](
       equivocationRecord: EquivocationRecord,
       equivocationChildren: Set[BlockMessage],
       remainder: Seq[(Validator, BlockHash)],
@@ -304,7 +304,7 @@ object EquivocationDetector {
     } yield equivocationDetected
   }
 
-  private def maybeAddEquivocationChild[F[_]: Sync: BlockStore](
+  private def maybeAddEquivocationChild[F[_]: MonadThrowable: BlockStore](
       justificationBlock: BlockMessage,
       equivocatingValidator: Validator,
       equivocationBaseBlockSeqNum: SequenceNumber,

--- a/casper/src/main/scala/io/casperlabs/casper/Validate.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Validate.scala
@@ -11,6 +11,7 @@ import io.casperlabs.casper.protocol.{ApprovedBlock, BlockMessage, Bond, Justifi
 import io.casperlabs.casper.util.ProtoUtil.bonds
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.casper.util.{DagOperations, ProtoUtil}
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.hash.Blake2b256
 import io.casperlabs.crypto.signatures.Ed25519
 import io.casperlabs.ipc
@@ -192,7 +193,7 @@ object Validate {
   /*
    * TODO: Double check ordering of validity checks
    */
-  def blockSummary[F[_]: Sync: Log: Time: BlockStore: RaiseValidationError](
+  def blockSummary[F[_]: MonadThrowable: Log: Time: BlockStore: RaiseValidationError](
       block: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F],
@@ -207,7 +208,7 @@ object Validate {
     } yield ()
 
   /** Validations we can run even without an approved Genesis, i.e. on Genesis itself. */
-  def blockSummaryPreGenesis[F[_]: Sync: Log: Time: BlockStore: RaiseValidationError](
+  def blockSummaryPreGenesis[F[_]: MonadThrowable: Log: Time: BlockStore: RaiseValidationError](
       block: BlockMessage,
       dag: BlockDagRepresentation[F],
       shardId: String
@@ -252,7 +253,7 @@ object Validate {
     *
     * Agnostic of non-parent justifications
     */
-  def repeatDeploy[F[_]: Sync: Log: BlockStore: RaiseValidationError](
+  def repeatDeploy[F[_]: MonadThrowable: Log: BlockStore: RaiseValidationError](
       block: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Unit] = {
@@ -289,7 +290,7 @@ object Validate {
   }
 
   // This is not a slashable offence
-  def timestamp[F[_]: Sync: Log: Time: BlockStore: RaiseValidationError](
+  def timestamp[F[_]: MonadThrowable: Log: Time: BlockStore: RaiseValidationError](
       b: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Unit] =
@@ -324,7 +325,7 @@ object Validate {
     } yield result
 
   // Agnostic of non-parent justifications
-  def blockNumber[F[_]: Sync: Log: BlockStore: RaiseValidationError](
+  def blockNumber[F[_]: MonadThrowable: Log: BlockStore: RaiseValidationError](
       b: BlockMessage
   ): F[Unit] =
     for {
@@ -355,7 +356,7 @@ object Validate {
     * creator justification, this check will fail as expected. The exception is when
     * B's creator justification is the genesis block.
     */
-  def sequenceNumber[F[_]: Sync: Log: BlockStore: RaiseValidationError](
+  def sequenceNumber[F[_]: MonadThrowable: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       dag: BlockDagRepresentation[F]
   ): F[Unit] =
@@ -439,7 +440,7 @@ object Validate {
   /**
     * Works only with fully explicit justifications.
     */
-  def parents[F[_]: Sync: Log: BlockStore: RaiseValidationError](
+  def parents[F[_]: MonadThrowable: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       genesis: BlockMessage,
       lastFinalizedBlockHash: BlockHash,
@@ -488,7 +489,7 @@ object Validate {
   /*
    * This check must come before Validate.parents
    */
-  def justificationFollows[F[_]: Sync: Log: BlockStore: RaiseValidationError](
+  def justificationFollows[F[_]: MonadThrowable: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F]
@@ -523,7 +524,7 @@ object Validate {
    * Hence, we ignore justification regressions involving the block's sender and
    * let checkEquivocations handle it instead.
    */
-  def justificationRegressions[F[_]: Sync: Log: BlockStore: RaiseValidationError](
+  def justificationRegressions[F[_]: MonadThrowable: Log: BlockStore: RaiseValidationError](
       b: BlockMessage,
       genesis: BlockMessage,
       dag: BlockDagRepresentation[F]
@@ -549,7 +550,7 @@ object Validate {
     } yield result
   }
 
-  private def justificationRegressionsAux[F[_]: Sync: Log: BlockStore: FunctorRaise[
+  private def justificationRegressionsAux[F[_]: MonadThrowable: Log: BlockStore: FunctorRaise[
     ?[_],
     InvalidBlock
   ]](
@@ -586,7 +587,7 @@ object Validate {
           }
     } yield ()
 
-  private def isJustificationRegression[F[_]: Sync: Log: BlockStore](
+  private def isJustificationRegression[F[_]: MonadThrowable: Log: BlockStore](
       currentBlockJustificationHash: BlockHash,
       previousBlockJustificationHash: BlockHash
   ): F[Boolean] =

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -15,6 +15,7 @@ import io.casperlabs.casper._
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.catscontrib.ski._
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.hash.Blake2b512Random
 import io.casperlabs.graphz._
@@ -98,7 +99,7 @@ object BlockAPI {
   }
 
   // FIX: Not used at the moment - in RChain it's being used in method like `getListeningName*`
-  private def getMainChainFromTip[F[_]: Sync: MultiParentCasper: Log: SafetyOracle: BlockStore](
+  private def getMainChainFromTip[F[_]: MonadThrowable: MultiParentCasper: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[IndexedSeq[BlockMessage]] =
     for {
@@ -138,7 +139,7 @@ object BlockAPI {
   }
 
   // TOOD extract common code from show blocks
-  def showBlocks[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+  def showBlocks[F[_]: MonadThrowable: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[BlockInfoWithoutTuplespace]] = {
     val errorMessage =
@@ -160,7 +161,7 @@ object BlockAPI {
     )
   }
 
-  private def getFlattenedBlockInfosUntilDepth[F[_]: Sync: MultiParentCasper: Log: SafetyOracle: BlockStore](
+  private def getFlattenedBlockInfosUntilDepth[F[_]: MonadThrowable: MultiParentCasper: Log: SafetyOracle: BlockStore](
       depth: Int,
       dag: BlockDagRepresentation[F]
   ): F[List[BlockInfoWithoutTuplespace]] =
@@ -175,7 +176,7 @@ object BlockAPI {
                }
     } yield result
 
-  def showMainChain[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+  def showMainChain[F[_]: MonadThrowable: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       depth: Int
   ): F[List[BlockInfoWithoutTuplespace]] = {
     val errorMessage =
@@ -199,7 +200,7 @@ object BlockAPI {
   }
 
   // TODO: Replace with call to BlockStore
-  def findBlockWithDeploy[F[_]: Sync: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
+  def findBlockWithDeploy[F[_]: MonadThrowable: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       user: ByteString,
       timestamp: Long
   ): F[BlockQueryResponse] = {
@@ -233,7 +234,7 @@ object BlockAPI {
     )
   }
 
-  private def findBlockWithDeploy[F[_]: Sync: Log: BlockStore](
+  private def findBlockWithDeploy[F[_]: MonadThrowable: Log: BlockStore](
       blockHashes: Vector[BlockHash],
       user: ByteString,
       timestamp: Long

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -1,13 +1,12 @@
 package io.casperlabs.casper.util
 
 import cats.{Eval, Monad}
-import cats.effect.Sync
 import cats.implicits._
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockStore}
 import io.casperlabs.casper.protocol.BlockMessage
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.util.MapHelper.updatedWith
-import io.casperlabs.catscontrib.ListContrib
+import io.casperlabs.catscontrib.{ListContrib, MonadThrowable}
 import io.casperlabs.models.BlockMetadata
 import io.casperlabs.shared.StreamT
 
@@ -189,7 +188,7 @@ object DagOperations {
   //Conceptually, the GCA is the first point at which the histories of b1 and b2 diverge.
   //Based on that, we compute by finding the first block from genesis for which there
   //exists a child of that block which is an ancestor of b1 or b2 but not both.
-  def greatestCommonAncestorF[F[_]: Sync: BlockStore](
+  def greatestCommonAncestorF[F[_]: MonadThrowable: BlockStore](
       b1: BlockMessage,
       b2: BlockMessage,
       genesis: BlockMessage,

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
@@ -15,7 +15,7 @@ import io.casperlabs.casper.genesis.Genesis
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.util.execengine.ExecEngineUtil
 import io.casperlabs.catscontrib.Catscontrib._
-import io.casperlabs.catscontrib.MonadTrans
+import io.casperlabs.catscontrib.{MonadThrowable, MonadTrans}
 import io.casperlabs.comm.CommError.ErrorHandler
 import io.casperlabs.comm.discovery.{Node, NodeDiscovery}
 import io.casperlabs.comm.discovery.NodeUtils._
@@ -351,7 +351,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * In the future it will be possible to create checkpoint with new [[ApprovedBlock]].
     **/
-  class ApprovedBlockReceivedHandler[F[_]: RPConfAsk: BlockStore: Sync: ConnectionsCell: TransportLayer: Log: Metrics: Time: ErrorHandler](
+  class ApprovedBlockReceivedHandler[F[_]: RPConfAsk: BlockStore: MonadThrowable: ConnectionsCell: TransportLayer: Log: Metrics: Time: ErrorHandler](
       private val casper: MultiParentCasper[F],
       approvedBlock: ApprovedBlock,
       validatorId: Option[ValidatorIdentity]
@@ -441,7 +441,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       Log[F].info(s"No approved block available on node ${na.nodeIdentifer}")
   }
 
-  class CasperPacketHandlerImpl[F[_]: Sync: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Log: Metrics: Time: ErrorHandler: LastApprovedBlock: MultiParentCasperRef](
+  class CasperPacketHandlerImpl[F[_]: MonadThrowable: RPConfAsk: BlockStore: ConnectionsCell: TransportLayer: Log: Metrics: Time: ErrorHandler: LastApprovedBlock: MultiParentCasperRef](
       private val cphI: Ref[F, CasperPacketHandlerInternal[F]],
       validatorId: Option[ValidatorIdentity]
   ) extends CasperPacketHandler[F] {

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -9,6 +9,7 @@ import io.casperlabs.casper.api.BlockAPI
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper._
 import io.casperlabs.casper.protocol.{BlockMessage, Bond}
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.metrics.Metrics.MetricsNOP
 import io.casperlabs.p2p.EffectsTestInstances.LogStub
 import io.casperlabs.shared.{Log, Time}
@@ -81,7 +82,7 @@ class ManyValidatorsTest
       _                  <- casperRef.set(casperEffect)
       cliqueOracleEffect = SafetyOracle.cliqueOracle[Task]
       result <- BlockAPI.showBlocks[Task](Int.MaxValue)(
-                 Sync[Task],
+                 MonadThrowable[Task],
                  casperRef,
                  logEff,
                  cliqueOracleEffect,

--- a/shared/src/main/scala/io/casperlabs/catscontrib/MonadThrowable.scala
+++ b/shared/src/main/scala/io/casperlabs/catscontrib/MonadThrowable.scala
@@ -1,0 +1,21 @@
+package io.casperlabs.catscontrib
+
+import cats.MonadError
+
+// Mixed into the package object so the type alias is available under catscontrib.
+trait MonadThrowableInstances {
+
+  /** We can use this as a context bound when a method already uses `Monad`
+    * but now we need to raise an error, but we don't want to go all the
+    * way and use `Sync`. If the domain error extends `scala.util.control.NoStackTrace`
+    * then it's easy to use `attempt` to return `F[Either[DomainError, A]]`
+    * and `rethrow` to turn it back into `F[A]` if it's not something we want
+    * to deal with.
+    * It achieves the same as `F[_]: MonadError[?[_], Throwable]` with `F[_]: MonadThrowable */
+  type MonadThrowable[F[_]] = MonadError[F, Throwable]
+}
+
+object MonadThrowable {
+  // So that we can use `MonadThrowable[F].raiseError` rather than `MonadError[F, Throwable].raiseError`
+  def apply[F[_]](implicit ev: MonadError[F, Throwable]) = ev
+}

--- a/shared/src/main/scala/io/casperlabs/catscontrib/package.scala
+++ b/shared/src/main/scala/io/casperlabs/catscontrib/package.scala
@@ -4,3 +4,4 @@ package object catscontrib
     extends EitherTInstances
     with StateTInstances
     with ApplicativeError_Instances
+    with MonadThrowableInstances


### PR DESCRIPTION
## Overview
By adding `Sync` to `ProtoUtil.unsafeGetBlock` it gained more power than was strictly necessary for raising the error. `F[_]: MonadError[?[_], Throwable]` would be enough (or possibly `FunctorRaise`) but the syntax is more cumbersome. I added an `io.casperlabs.catscontrib.MonadThrowable` type alias that we can use like `F[_]: MonadThrowable`, so that it's a simple step to go from requiring `Monad` to this instead of going all the way to `Sync`. 

I used `MonadError` instead of `ApplicativeError` because I think `MonadError.rethrow(x.widen)` is a nice pattern to use with methods that return `F[Either[E <: NoStackTrace, A]`.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Came from the discussion in https://github.com/CasperLabs/CasperLabs/pull/418

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
The grey area around requiring `Sync` when it comes to `unsafeGetBlock` is that in reality it calls `FileIndexLMDBBlockStore.getBlock` and that class itself requires `Sync` because it's doing IO. The `BlockStore` trait itself doesn't. So while the `unsafeGetBlock` method itself may look innocuous it's not like it isn't doing IO at all. I think this is fine, we see by looking what capabilities the method needs for its own code; whether IO happens or not depends on the trait - if we wanted to advertise that then `Sync` would have to be on `BlockStore.get` as well, but an in-memory implementation doesn't need it, so...
