### PR TITLE
NO-TICKET: Run protoc only when ipc.proto changed.

### DIFF
--- a/execution-engine/comm/build.rs
+++ b/execution-engine/comm/build.rs
@@ -1,6 +1,7 @@
 extern crate protoc_rust_grpc;
 
 fn main() {
+    println!("cargo:rerun-if-changed=../../protobuf/io/casperlabs/ipc/ipc.proto");
     protoc_rust_grpc::run(protoc_rust_grpc::Args {
         out_dir: "src/engine_server",
         input: &["../../protobuf/io/casperlabs/ipc/ipc.proto"],


### PR DESCRIPTION
This will save tons of time when testing EE locally without docker. Right now everytime when running `cargo run` or `cargo build` it always reruns the protoc compiler slowing everything down.

## Overview
Provide a brief description of what this PR does, and why it's needed.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
