### PR TITLE
STOR-39: implement update arm of history::trie_store::operations::write

### DIFF
--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -32,6 +32,13 @@ impl Pointer {
         }
     }
 
+    pub fn update(&self, hash: Blake2bHash) -> Self {
+        match self {
+            Pointer::LeafPointer(_) => Pointer::LeafPointer(hash),
+            Pointer::NodePointer(_) => Pointer::NodePointer(hash),
+        }
+    }
+
     fn tag(&self) -> u32 {
         match self {
             Pointer::LeafPointer(_) => 0,

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -1,4 +1,4 @@
-use common::bytesrepr::ToBytes;
+use common::bytesrepr::{self, ToBytes};
 use history::trie::{self, Parents, Pointer, Trie};
 use history::trie_store::{Readable, TrieStore, Writable};
 use shared::newtypes::Blake2bHash;
@@ -200,14 +200,13 @@ where
 }
 
 #[allow(clippy::type_complexity)]
-fn rehash<K, V, E>(
+fn rehash<K, V>(
     mut tip: Trie<K, V>,
     parents: Parents<K, V>,
-) -> Result<Vec<(Blake2bHash, Trie<K, V>)>, E>
+) -> Result<Vec<(Blake2bHash, Trie<K, V>)>, bytesrepr::Error>
 where
     K: ToBytes + Clone,
     V: ToBytes + Clone,
-    E: From<common::bytesrepr::Error>,
 {
     let mut ret: Vec<(Blake2bHash, Trie<K, V>)> = Vec::new();
     let mut tip_hash = {
@@ -296,9 +295,7 @@ where
                 Trie::Leaf {
                     key: ref leaf_key,
                     value: ref leaf_value,
-                } if key == leaf_key && value != leaf_value => {
-                    rehash::<K, V, E>(new_leaf, parents)?
-                }
+                } if key == leaf_key && value != leaf_value => rehash(new_leaf, parents)?,
                 // If the "tip" is an existing leaf with a different key than
                 // the new leaf, then we are in a situation where the new leaf
                 // shares some common prefix with the existing leaf.


### PR DESCRIPTION
## Overview
This PR implements the "update" arm of `history::trie_store::operations::write`.  The "update" arm defines the behavior when a new value is written to an existing leaf.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
