### PR TITLE
STOR-39: clean up write_leaves

### DIFF
--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -728,9 +728,11 @@ mod write {
                 let write_result = write::<TestKey, TestValue, R::ReadWriteTransaction, S, E>(
                     &mut txn, store, &root_hash, key, value,
                 )?;
-                root_hash = match write_result {
-                    WriteResult::Written(root_hash) => root_hash,
-                    WriteResult::AlreadyExists => root_hash,
+                match write_result {
+                    WriteResult::Written(hash) => {
+                        root_hash = hash;
+                    }
+                    WriteResult::AlreadyExists => (),
                     WriteResult::RootNotFound => panic!("write_leaves given an invalid root"),
                 };
                 results.push(write_result);


### PR DESCRIPTION
## Overview
This PR cleans up the `write_leaves` function in the `operations` tests.  The change was suggested by @afck in a post-merge [review comment](https://github.com/CasperLabs/CasperLabs/pull/425/files/edd4a91766d44f19dfdf2ee909498943c42118d7#r281218208).

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A