### PR TITLE
STOR-39: implement reparent leaf arm of history..write

### DIFF
--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -15,6 +15,7 @@ pub const RADIX: usize = 256;
 
 const U32_SIZE: usize = size_of::<u32>();
 
+/// A parent is represented as a pair of a child index and a node or extension.
 pub type Parents<K, V> = Vec<(usize, Trie<K, V>)>;
 
 /// Represents a pointer to the next object in a Merkle Trie

--- a/execution-engine/storage/src/history/trie_store/in_memory.rs
+++ b/execution-engine/storage/src/history/trie_store/in_memory.rs
@@ -235,6 +235,23 @@ impl InMemoryEnvironment {
     pub fn new() -> Self {
         Default::default()
     }
+
+    pub fn dump<K, V>(&self) -> Result<HashMap<Blake2bHash, Trie<K, V>>, in_memory::Error>
+    where
+        K: FromBytes,
+        V: FromBytes,
+    {
+        self.data
+            .lock()?
+            .iter()
+            .map(|(hash_bytes, trie_bytes)| {
+                let hash: Blake2bHash = deserialize(hash_bytes)?;
+                let trie: Trie<K, V> = deserialize(trie_bytes)?;
+                Ok((hash, trie))
+            })
+            .collect::<Result<HashMap<Blake2bHash, Trie<K, V>>, bytesrepr::Error>>()
+            .map_err(Into::into)
+    }
 }
 
 impl<'a> TransactionSource<'a> for InMemoryEnvironment {

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -321,12 +321,13 @@ where
 fn reparent_leaf<K, V>(
     new_leaf_path: &[u8],
     existing_leaf_path: &[u8],
-    mut parents: Parents<K, V>,
+    parents: Parents<K, V>,
 ) -> Result<(Trie<K, V>, Parents<K, V>), bytesrepr::Error>
 where
     K: ToBytes,
     V: ToBytes,
 {
+    let mut parents = parents;
     let (child_index, parent) = parents.pop().expect("parents should not be empty");
     match parent {
         Trie::Node { pointer_block } => {
@@ -395,7 +396,7 @@ where
                 value: value.to_owned(),
             };
             let path: Vec<u8> = key.to_bytes()?;
-            let TrieScan { tip, mut parents } =
+            let TrieScan { tip, parents } =
                 scan::<K, V, T, S, E>(txn, store, &path, &current_root)?;
             let new_elements: Vec<(Blake2bHash, Trie<K, V>)> = match tip {
                 // If the "tip" is the same as the new leaf, then the leaf

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -862,11 +862,7 @@ mod write {
                 let mut context = LmdbTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
 
-                writes_to_n_leaf_empty_trie_had_expected_results::<
-                    LmdbEnvironment,
-                    LmdbTrieStore,
-                    error::Error,
-                >(
+                writes_to_n_leaf_empty_trie_had_expected_results::<_, _, error::Error>(
                     &context.environment,
                     &context.store,
                     &initial_states,
@@ -883,11 +879,7 @@ mod write {
                 let mut context = InMemoryTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
 
-                writes_to_n_leaf_empty_trie_had_expected_results::<
-                    InMemoryEnvironment,
-                    InMemoryTrieStore,
-                    in_memory::Error,
-                >(
+                writes_to_n_leaf_empty_trie_had_expected_results::<_, _, in_memory::Error>(
                     &context.environment,
                     &context.store,
                     &initial_states,
@@ -905,11 +897,7 @@ mod write {
                 let context = LmdbTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
 
-                writes_to_n_leaf_empty_trie_had_expected_results::<
-                    LmdbEnvironment,
-                    LmdbTrieStore,
-                    error::Error,
-                >(
+                writes_to_n_leaf_empty_trie_had_expected_results::<_, _, error::Error>(
                     &context.environment,
                     &context.store,
                     &initial_states,
@@ -927,11 +915,7 @@ mod write {
                 let context = InMemoryTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
 
-                writes_to_n_leaf_empty_trie_had_expected_results::<
-                    InMemoryEnvironment,
-                    InMemoryTrieStore,
-                    in_memory::Error,
-                >(
+                writes_to_n_leaf_empty_trie_had_expected_results::<_, _, in_memory::Error>(
                     &context.environment,
                     &context.store,
                     &initial_states,


### PR DESCRIPTION
## Overview
This PR implements the "reparent" arm of `history::trie_store::operations::write`. The "reparent" arm defines the behavior when a new key-value leaf collides with an existing leaf that has a different key, necessitating the need for the existing leaf to be reparented in a new node (incl. a possible extension node for its parent).  The new leaf is then attached to this new node.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
This case is exemplified by adding `TEST_LEAVES[1]` to a trie containing only `TEST_LEAVES[0]`.  It is also seen when adding `TEST_LEAVES[3]` to a trie containing only `TEST_LEAVES[0..2]`

See diagram:
https://www.lucidchart.com/publicSegments/view/64949b5c-e07d-4641-b479-b62ab7baf377