### PR TITLE
STOR-39: use u8 instead of usize in Parents

### DIFF
--- a/execution-engine/storage/src/history/trie/mod.rs
+++ b/execution-engine/storage/src/history/trie/mod.rs
@@ -16,7 +16,7 @@ pub const RADIX: usize = 256;
 const U32_SIZE: usize = size_of::<u32>();
 
 /// A parent is represented as a pair of a child index and a node or extension.
-pub type Parents<K, V> = Vec<(usize, Trie<K, V>)>;
+pub type Parents<K, V> = Vec<(u8, Trie<K, V>)>;
 
 /// Represents a pointer to the next object in a Merkle Trie
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -144,11 +144,12 @@ where
                 return Ok(TrieScan::new(leaf, acc));
             }
             Trie::Node { pointer_block } => {
-                let index: usize = {
+                let index = {
                     assert!(depth < path.len(), "depth must be < {}", path.len());
-                    path[depth].into()
+                    path[depth]
                 };
                 let maybe_pointer: Option<Pointer> = {
+                    let index: usize = index.into();
                     assert!(index < trie::RADIX, "index must be < {}", trie::RADIX);
                     pointer_block[index]
                 };
@@ -178,9 +179,9 @@ where
                 }
                 match store.get(txn, pointer.hash())? {
                     Some(next) => {
-                        let index: usize = {
+                        let index = {
                             assert!(depth < path.len(), "depth must be < {}", path.len());
-                            path[depth].into()
+                            path[depth]
                         };
                         current = next;
                         depth += affix.len();
@@ -227,7 +228,7 @@ where
                         Trie::Node { .. } => Pointer::NodePointer(tip_hash),
                         Trie::Extension { .. } => Pointer::NodePointer(tip_hash),
                     };
-                    pointer_block[index] = Some(pointer);
+                    pointer_block[index.into()] = Some(pointer);
                     Trie::Node { pointer_block }
                 };
                 tip_hash = {
@@ -260,15 +261,13 @@ fn common_prefix<A: Eq + Clone>(ls: &[A], rs: &[A]) -> Vec<A> {
         .collect()
 }
 
-fn get_parents_path<K, V>(parents: &[(usize, Trie<K, V>)]) -> Vec<u8> {
+fn get_parents_path<K, V>(parents: &[(u8, Trie<K, V>)]) -> Vec<u8> {
     let mut ret = Vec::new();
     for (index, element) in parents.iter() {
         if let Trie::Extension { affix, .. } = element {
             ret.extend(affix);
         } else {
-            // TODO: don't downcast
-            assert!(*index < std::u8::MAX as usize);
-            ret.push(index.to_owned() as u8);
+            ret.push(index.to_owned());
         }
     }
     ret
@@ -304,13 +303,13 @@ where
         path_to_node.len()
     };
     // Index path by current depth;
-    let index: usize = {
+    let index = {
         assert!(
             depth < path_to_leaf.len(),
             "depth must be < {}",
             path_to_leaf.len()
         );
-        path_to_leaf[depth].into()
+        path_to_leaf[depth]
     };
     // Add node to parents, along with index to modify
     parents.push((index, new_parent_node));
@@ -345,7 +344,7 @@ where
     let new_node = {
         let index: usize = existing_leaf_path[shared_path.len()].into();
         let existing_leaf_pointer =
-            pointer_block[child_index].expect("parent has lost the existing leaf");
+            pointer_block[child_index.into()].expect("parent has lost the existing leaf");
         Trie::node(&[(index, existing_leaf_pointer)])
     };
     // Re-add the parent node to parents

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -659,7 +659,7 @@ mod scan {
             match parent {
                 Trie::Leaf { .. } => panic!("parents should not contain any leaves"),
                 Trie::Node { pointer_block } => {
-                    let pointer_tip_hash = pointer_block[index].map(|ptr| *ptr.hash());
+                    let pointer_tip_hash = pointer_block[index.into()].map(|ptr| *ptr.hash());
                     assert_eq!(Some(expected_tip_hash), pointer_tip_hash);
                     tip = Trie::Node { pointer_block };
                 }


### PR DESCRIPTION
## Overview
This PR redefines `Parents` to:
```rust
pub type Parents<K, V> = Vec<(u8, Trie<K, V>)>;
```
Using a `u8` instead of a `usize` allows all casts to use `Into::into` and prevents us from needing to downcast a `usize` to `u8`.

This change was prompted by [a question](https://github.com/CasperLabs/CasperLabs/pull/434#discussion_r281948712) from @afck.

### Which JIRA issue does this PR relate to?
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
