### PR TITLE
STOR-39: update TEST_LEAVES

### DIFF
--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -9,7 +9,7 @@ use shared::newtypes::Blake2bHash;
 use tempfile::{tempdir, TempDir};
 use {error, failure};
 
-const TEST_KEY_LENGTH: usize = 4;
+const TEST_KEY_LENGTH: usize = 7;
 
 /// A short key type for tests.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -68,105 +68,121 @@ impl HashedTestTrie {
     }
 }
 
-const TEST_LEAVES_LENGTH: usize = 5;
+const TEST_LEAVES_LENGTH: usize = 6;
 
 /// Keys have been chosen deliberately and the `create_` functions below depend
 /// on these exact definitions.  Values are arbitrary.
 const TEST_LEAVES: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {
-        key: TestKey([0u8, 0, 0, 0]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"value0"),
     },
     Trie::Leaf {
-        key: TestKey([0u8, 0, 0, 255]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 1]),
         value: TestValue(*b"value1"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 1, 0]),
+        key: TestKey([0u8, 0, 0, 2, 0, 0, 0]),
         value: TestValue(*b"value2"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 1, 255]),
+        key: TestKey([0u8, 0, 0, 0, 0, 255, 0]),
         value: TestValue(*b"value3"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 2, 255]),
+        key: TestKey([0u8, 1, 0, 0, 0, 0, 0]),
         value: TestValue(*b"value4"),
+    },
+    Trie::Leaf {
+        key: TestKey([0u8, 0, 2, 0, 0, 0, 0]),
+        value: TestValue(*b"value5"),
     },
 ];
 
 const TEST_LEAVES_UPDATED: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {
-        key: TestKey([0u8, 0, 0, 0]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueA"),
     },
     Trie::Leaf {
-        key: TestKey([0u8, 0, 0, 255]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 1]),
         value: TestValue(*b"valueB"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 1, 0]),
+        key: TestKey([0u8, 0, 0, 2, 0, 0, 0]),
         value: TestValue(*b"valueC"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 1, 255]),
+        key: TestKey([0u8, 0, 0, 0, 0, 255, 0]),
         value: TestValue(*b"valueD"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 2, 255]),
+        key: TestKey([0u8, 1, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueE"),
+    },
+    Trie::Leaf {
+        key: TestKey([0u8, 0, 2, 0, 0, 0, 0]),
+        value: TestValue(*b"valueF"),
     },
 ];
 
 const TEST_LEAVES_NON_COLLIDING: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {
-        key: TestKey([0u8, 0, 0, 0]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueA"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 0, 0]),
+        key: TestKey([1u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueB"),
     },
     Trie::Leaf {
-        key: TestKey([2u8, 0, 0, 0]),
+        key: TestKey([2u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueC"),
     },
     Trie::Leaf {
-        key: TestKey([3u8, 0, 0, 0]),
+        key: TestKey([3u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueD"),
     },
     Trie::Leaf {
-        key: TestKey([4u8, 0, 0, 0]),
+        key: TestKey([4u8, 0, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueE"),
+    },
+    Trie::Leaf {
+        key: TestKey([5u8, 0, 0, 0, 0, 0, 0]),
+        value: TestValue(*b"valueF"),
     },
 ];
 
 const TEST_LEAVES_ADJACENTS: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {
-        key: TestKey([0u8, 0, 0, 1]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 2]),
         value: TestValue(*b"valueA"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 1, 1]),
+        key: TestKey([0u8, 0, 0, 0, 0, 0, 3]),
         value: TestValue(*b"valueB"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 1, 2]),
+        key: TestKey([0u8, 0, 0, 3, 0, 0, 0]),
         value: TestValue(*b"valueC"),
     },
     Trie::Leaf {
-        key: TestKey([1u8, 0, 3, 255]),
+        key: TestKey([0u8, 0, 0, 0, 0, 1, 0]),
         value: TestValue(*b"valueD"),
     },
     Trie::Leaf {
-        key: TestKey([2u8, 0, 0, 0]),
+        key: TestKey([0u8, 2, 0, 0, 0, 0, 0]),
         value: TestValue(*b"valueE"),
+    },
+    Trie::Leaf {
+        key: TestKey([0u8, 0, 3, 0, 0, 0, 0]),
+        value: TestValue(*b"valueF"),
     },
 ];
 
 type TestTrieGenerator = fn() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error>;
 
-const TEST_TRIE_GENERATORS_LENGTH: usize = 6;
+const TEST_TRIE_GENERATORS_LENGTH: usize = 7;
 
 const TEST_TRIE_GENERATORS: [TestTrieGenerator; TEST_TRIE_GENERATORS_LENGTH] = [
     create_0_leaf_trie,
@@ -175,6 +191,7 @@ const TEST_TRIE_GENERATORS: [TestTrieGenerator; TEST_TRIE_GENERATORS_LENGTH] = [
     create_3_leaf_trie,
     create_4_leaf_trie,
     create_5_leaf_trie,
+    create_6_leaf_trie,
 ];
 
 fn hash_test_tries(tries: &[TestTrie]) -> Result<Vec<HashedTestTrie>, bytesrepr::Error> {
@@ -189,11 +206,11 @@ fn create_0_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr:
 
     let root_hash: Blake2bHash = root.hash;
 
-    let non_leaves: Vec<HashedTestTrie> = vec![root];
+    let parents: Vec<HashedTestTrie> = vec![root];
 
     let tries: Vec<HashedTestTrie> = {
         let mut ret = Vec::new();
-        ret.extend(non_leaves);
+        ret.extend(parents);
         ret
     };
 
@@ -207,12 +224,12 @@ fn create_1_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr:
 
     let root_hash: Blake2bHash = root.hash;
 
-    let non_leaves: Vec<HashedTestTrie> = vec![root];
+    let parents: Vec<HashedTestTrie> = vec![root];
 
     let tries: Vec<HashedTestTrie> = {
         let mut ret = Vec::new();
         ret.extend(leaves);
-        ret.extend(non_leaves);
+        ret.extend(parents);
         ret
     };
 
@@ -222,26 +239,26 @@ fn create_1_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr:
 fn create_2_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error> {
     let leaves = hash_test_tries(&TEST_LEAVES[..2])?;
 
-    let node_1 = HashedTestTrie::new(Trie::node(&[
+    let node = HashedTestTrie::new(Trie::node(&[
         (0, Pointer::LeafPointer(leaves[0].hash)),
-        (255, Pointer::LeafPointer(leaves[1].hash)),
+        (1, Pointer::LeafPointer(leaves[1].hash)),
     ]))?;
 
-    let ext_node_1 = HashedTestTrie::new(Trie::extension(
-        vec![0u8, 0],
-        Pointer::NodePointer(node_1.hash),
+    let ext = HashedTestTrie::new(Trie::extension(
+        vec![0u8, 0, 0, 0, 0],
+        Pointer::NodePointer(node.hash),
     ))?;
 
-    let root = HashedTestTrie::new(Trie::node(&[(0, Pointer::NodePointer(ext_node_1.hash))]))?;
+    let root = HashedTestTrie::new(Trie::node(&[(0, Pointer::NodePointer(ext.hash))]))?;
 
     let root_hash = root.hash;
 
-    let non_leaves: Vec<HashedTestTrie> = vec![node_1, ext_node_1, root];
+    let parents: Vec<HashedTestTrie> = vec![root, ext, node];
 
     let tries: Vec<HashedTestTrie> = {
         let mut ret = Vec::new();
         ret.extend(leaves);
-        ret.extend(non_leaves);
+        ret.extend(parents);
         ret
     };
 
@@ -253,27 +270,34 @@ fn create_3_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr:
 
     let node_1 = HashedTestTrie::new(Trie::node(&[
         (0, Pointer::LeafPointer(leaves[0].hash)),
-        (255, Pointer::LeafPointer(leaves[1].hash)),
+        (1, Pointer::LeafPointer(leaves[1].hash)),
     ]))?;
 
-    let ext_node_1 = HashedTestTrie::new(Trie::extension(
+    let ext_1 = HashedTestTrie::new(Trie::extension(
         vec![0u8, 0],
         Pointer::NodePointer(node_1.hash),
     ))?;
 
-    let root = HashedTestTrie::new(Trie::node(&[
-        (0, Pointer::NodePointer(ext_node_1.hash)),
-        (1, Pointer::LeafPointer(leaves[2].hash)),
+    let node_2 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(ext_1.hash)),
+        (2, Pointer::LeafPointer(leaves[2].hash)),
     ]))?;
+
+    let ext_2 = HashedTestTrie::new(Trie::extension(
+        vec![0u8, 0],
+        Pointer::NodePointer(node_2.hash),
+    ))?;
+
+    let root = HashedTestTrie::new(Trie::node(&[(0, Pointer::NodePointer(ext_2.hash))]))?;
 
     let root_hash = root.hash;
 
-    let non_leaves: Vec<HashedTestTrie> = vec![node_1, ext_node_1, root];
+    let parents: Vec<HashedTestTrie> = vec![root, ext_2, node_2, ext_1, node_1];
 
     let tries: Vec<HashedTestTrie> = {
         let mut ret = Vec::new();
         ret.extend(leaves);
-        ret.extend(non_leaves);
+        ret.extend(parents);
         ret
     };
 
@@ -285,37 +309,39 @@ fn create_4_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr:
 
     let node_1 = HashedTestTrie::new(Trie::node(&[
         (0, Pointer::LeafPointer(leaves[0].hash)),
-        (255, Pointer::LeafPointer(leaves[1].hash)),
+        (1, Pointer::LeafPointer(leaves[1].hash)),
     ]))?;
 
     let node_2 = HashedTestTrie::new(Trie::node(&[
-        (0, Pointer::LeafPointer(leaves[2].hash)),
+        (0, Pointer::NodePointer(node_1.hash)),
         (255, Pointer::LeafPointer(leaves[3].hash)),
     ]))?;
 
-    let ext_node_1 = HashedTestTrie::new(Trie::extension(
-        vec![0u8, 0],
-        Pointer::NodePointer(node_1.hash),
-    ))?;
-
-    let ext_node_2 = HashedTestTrie::new(Trie::extension(
-        vec![0u8, 1],
+    let ext_1 = HashedTestTrie::new(Trie::extension(
+        vec![0u8],
         Pointer::NodePointer(node_2.hash),
     ))?;
 
-    let root = HashedTestTrie::new(Trie::node(&[
-        (0, Pointer::NodePointer(ext_node_1.hash)),
-        (1, Pointer::NodePointer(ext_node_2.hash)),
+    let node_3 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(ext_1.hash)),
+        (2, Pointer::LeafPointer(leaves[2].hash)),
     ]))?;
+
+    let ext_2 = HashedTestTrie::new(Trie::extension(
+        vec![0u8, 0],
+        Pointer::NodePointer(node_3.hash),
+    ))?;
+
+    let root = HashedTestTrie::new(Trie::node(&[(0, Pointer::NodePointer(ext_2.hash))]))?;
 
     let root_hash = root.hash;
 
-    let non_leaves: Vec<HashedTestTrie> = vec![node_1, node_2, ext_node_1, ext_node_2, root];
+    let parents: Vec<HashedTestTrie> = vec![root, ext_2, node_3, ext_1, node_2, node_1];
 
     let tries: Vec<HashedTestTrie> = {
         let mut ret = Vec::new();
         ret.extend(leaves);
-        ret.extend(non_leaves);
+        ret.extend(parents);
         ret
     };
 
@@ -323,47 +349,97 @@ fn create_4_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr:
 }
 
 fn create_5_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error> {
-    let leaves = hash_test_tries(&TEST_LEAVES)?;
+    let leaves = hash_test_tries(&TEST_LEAVES[..5])?;
 
     let node_1 = HashedTestTrie::new(Trie::node(&[
         (0, Pointer::LeafPointer(leaves[0].hash)),
-        (255, Pointer::LeafPointer(leaves[1].hash)),
+        (1, Pointer::LeafPointer(leaves[1].hash)),
     ]))?;
 
     let node_2 = HashedTestTrie::new(Trie::node(&[
-        (0, Pointer::LeafPointer(leaves[2].hash)),
+        (0, Pointer::NodePointer(node_1.hash)),
         (255, Pointer::LeafPointer(leaves[3].hash)),
     ]))?;
 
-    let node_3 = HashedTestTrie::new(Trie::node(&[
-        (1, Pointer::NodePointer(node_2.hash)),
-        (2, Pointer::LeafPointer(leaves[4].hash)),
-    ]))?;
-
-    let ext_node_1 = HashedTestTrie::new(Trie::extension(
-        vec![0u8, 0],
-        Pointer::NodePointer(node_1.hash),
+    let ext_1 = HashedTestTrie::new(Trie::extension(
+        vec![0u8],
+        Pointer::NodePointer(node_2.hash),
     ))?;
 
-    let ext_node_2 = HashedTestTrie::new(Trie::extension(
+    let node_3 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(ext_1.hash)),
+        (2, Pointer::LeafPointer(leaves[2].hash)),
+    ]))?;
+
+    let ext_2 = HashedTestTrie::new(Trie::extension(
         vec![0u8],
         Pointer::NodePointer(node_3.hash),
     ))?;
 
-    let root = HashedTestTrie::new(Trie::node(&[
-        (0, Pointer::NodePointer(ext_node_1.hash)),
-        (1, Pointer::NodePointer(ext_node_2.hash)),
+    let node_4 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(ext_2.hash)),
+        (1, Pointer::LeafPointer(leaves[4].hash)),
     ]))?;
 
-    let root_hash: Blake2bHash = root.hash;
+    let root = HashedTestTrie::new(Trie::node(&[(0, Pointer::NodePointer(node_4.hash))]))?;
 
-    let non_leaves: Vec<HashedTestTrie> =
-        vec![node_1, node_2, node_3, ext_node_1, ext_node_2, root];
+    let root_hash = root.hash;
+
+    let parents: Vec<HashedTestTrie> = vec![root, node_4, ext_2, node_3, ext_1, node_2, node_1];
 
     let tries: Vec<HashedTestTrie> = {
         let mut ret = Vec::new();
         ret.extend(leaves);
-        ret.extend(non_leaves);
+        ret.extend(parents);
+        ret
+    };
+
+    Ok((root_hash, tries))
+}
+
+fn create_6_leaf_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error> {
+    let leaves = hash_test_tries(&TEST_LEAVES)?;
+
+    let node_1 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::LeafPointer(leaves[0].hash)),
+        (1, Pointer::LeafPointer(leaves[1].hash)),
+    ]))?;
+
+    let node_2 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(node_1.hash)),
+        (255, Pointer::LeafPointer(leaves[3].hash)),
+    ]))?;
+
+    let ext = HashedTestTrie::new(Trie::extension(
+        vec![0u8],
+        Pointer::NodePointer(node_2.hash),
+    ))?;
+
+    let node_3 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(ext.hash)),
+        (2, Pointer::LeafPointer(leaves[2].hash)),
+    ]))?;
+
+    let node_4 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(node_3.hash)),
+        (2, Pointer::LeafPointer(leaves[5].hash)),
+    ]))?;
+
+    let node_5 = HashedTestTrie::new(Trie::node(&[
+        (0, Pointer::NodePointer(node_4.hash)),
+        (1, Pointer::LeafPointer(leaves[4].hash)),
+    ]))?;
+
+    let root = HashedTestTrie::new(Trie::node(&[(0, Pointer::NodePointer(node_5.hash))]))?;
+
+    let root_hash = root.hash;
+
+    let parents: Vec<HashedTestTrie> = vec![root, node_5, node_4, node_3, ext, node_2, node_1];
+
+    let tries: Vec<HashedTestTrie> = {
+        let mut ret = Vec::new();
+        ret.extend(leaves);
+        ret.extend(parents);
         ret
     };
 
@@ -892,7 +968,7 @@ mod write {
         #[test]
         fn lmdb_writes_to_n_leaf_empty_trie_had_expected_results() {
             // TODO: alter bounds
-            for num_leaves in 1..TEST_LEAVES_LENGTH {
+            for num_leaves in 1..2 {
                 let (root_hash, tries) = TEST_TRIE_GENERATORS[0]().unwrap();
                 let context = LmdbTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
@@ -910,7 +986,7 @@ mod write {
         #[test]
         fn in_memory_writes_to_n_leaf_empty_trie_had_expected_results() {
             // TODO: alter bounds
-            for num_leaves in 1..TEST_LEAVES_LENGTH {
+            for num_leaves in 1..2 {
                 let (root_hash, tries) = TEST_TRIE_GENERATORS[0]().unwrap();
                 let context = InMemoryTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
@@ -930,7 +1006,7 @@ mod write {
             let expected_contents: HashMap<Blake2bHash, TestTrie> = {
                 let mut ret = HashMap::new();
                 // TODO: remove bounds
-                for generator in &TEST_TRIE_GENERATORS[..5] {
+                for generator in &TEST_TRIE_GENERATORS[..3] {
                     let (_, tries) = generator().unwrap();
                     for HashedTestTrie { hash, trie } in tries {
                         ret.insert(hash, trie);
@@ -948,7 +1024,7 @@ mod write {
                     &context.store,
                     &root_hash,
                     // TODO: remove bounds
-                    &TEST_LEAVES[..4],
+                    &TEST_LEAVES[..2],
                 )
                 .unwrap();
 
@@ -1343,7 +1419,7 @@ mod write {
             E: From<R::Error> + From<S::Error> + From<common::bytesrepr::Error>,
         {
             let mut states = states.to_vec();
-            let num_leaves = 5;
+            let num_leaves = TEST_LEAVES_LENGTH;
 
             // Check that the expected set of leaves is in the trie at every state reference
             for (state_index, state) in states.iter().enumerate() {


### PR DESCRIPTION
## Overview
This PR updates `TEST_LEAVES` to provide more coverage to the various cases of the (as of yet unsubmitted) "modify extension" arm of `history::trie_store::operations::write`.  The "modify extension" arm is the most complex arm of this function, and it's important to me that it gets sufficiently tested.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
