### PR TITLE
NODE-312: Add gossiping setup to the node runtime

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -90,8 +90,7 @@ sealed abstract class MultiParentCasperInstances {
   def fromGossipServices[F[_]: Concurrent: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: ExecutionEngineService](
       validatorId: Option[ValidatorIdentity],
       genesis: BlockMessage,
-      shardId: String
-  )(
+      shardId: String,
       relaying: gossiping.Relaying[F]
   ): F[MultiParentCasper[F]] =
     init(genesis) map {

--- a/casper/src/main/scala/io/casperlabs/casper/Validate.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Validate.scala
@@ -13,7 +13,7 @@ import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.casper.util.{DagOperations, ProtoUtil}
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.hash.Blake2b256
-import io.casperlabs.crypto.signatures.Ed25519
+import io.casperlabs.crypto.signatures.{Ed25519, Secp256k1}
 import io.casperlabs.ipc
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
@@ -42,11 +42,13 @@ object Validate {
 
   final case class ValidateErrorWrapper(status: InvalidBlock) extends Exception
 
-  val DRIFT                                 = 15000 // 15 seconds
-  private implicit val logSource: LogSource = LogSource(this.getClass)
+  val DRIFT                                                                    = 15000 // 15 seconds
+  private implicit val logSource: LogSource                                    = LogSource(this.getClass)
   val signatureVerifiers: Map[String, (Data, Signature, PublicKey) => Boolean] =
+    // NOTE: This is the mirror of `SignatureAlgorithms`.
     Map(
-      "ed25519" -> Ed25519.verify
+      "ed25519"   -> Ed25519.verify,
+      "secp256k1" -> Secp256k1.verify
     )
 
   def signature(d: Data, sig: protocol.Signature): Boolean =

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -360,8 +360,10 @@ object GossipServiceCasperTestNodeFactory {
               } yield tipHashes.toList
 
             override def justifications: F[List[ByteString]] =
-              // TODO: Presently there's no way to ask.
-              List.empty.pure[F]
+              for {
+                 dag    <- casper.blockDag
+                 latest <- dag.latestMessageHashes
+               } yield latest.values.toList
 
             override def validate(blockSummary: consensus.BlockSummary): F[Unit] =
               // TODO: Presently the Validation only works on full blocks.

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -361,9 +361,9 @@ object GossipServiceCasperTestNodeFactory {
 
             override def justifications: F[List[ByteString]] =
               for {
-                 dag    <- casper.blockDag
-                 latest <- dag.latestMessageHashes
-               } yield latest.values.toList
+                dag    <- casper.blockDag
+                latest <- dag.latestMessageHashes
+              } yield latest.values.toList
 
             override def validate(blockSummary: consensus.BlockSummary): F[Unit] =
               // TODO: Presently the Validation only works on full blocks.

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -1,0 +1,22 @@
+package io.casperlabsnode.casper
+
+import cats.effect._
+import io.casperlabs.shared.{Log, Time}
+import io.casperlabs.blockstorage.{BlockDagStorage, BlockStore}
+import io.casperlabs.casper.{SafetyOracle}
+import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
+import io.casperlabs.comm.discovery.NodeDiscovery
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.node.configuration.Configuration
+import io.casperlabs.smartcontracts.ExecutionEngineService
+import monix.execution.Scheduler
+
+/** Create the Casper stack using the GossipService. */
+package object gossiping {
+  def apply[F[_]: Log: Metrics: Time: SafetyOracle: BlockStore: BlockDagStorage: NodeDiscovery: MultiParentCasperRef: ExecutionEngineService](
+      port: Int,
+      conf: Configuration,
+      grpcScheduler: Scheduler
+  )(implicit scheduler: Scheduler): Resource[F, Unit] =
+    ???
+}

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -1,11 +1,22 @@
 package io.casperlabsnode.casper
 
+import cats._
 import cats.effect._
-import io.casperlabs.shared.{Log, Time}
+import cats.implicits._
+import cats.data.OptionT
+import cats.temp.par.Par
+import com.google.protobuf.ByteString
+import io.casperlabs.shared.{Cell, Log, Time}
 import io.casperlabs.blockstorage.{BlockDagStorage, BlockStore}
-import io.casperlabs.casper.{SafetyOracle}
+import io.casperlabs.casper._
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
+import io.casperlabs.casper.consensus
+import io.casperlabs.casper.LegacyConversions
+import io.casperlabs.catscontrib.MonadThrowable
+import io.casperlabs.comm.NodeAsk
+import io.casperlabs.comm.ServiceError.{Unavailable}
 import io.casperlabs.comm.discovery.NodeDiscovery
+import io.casperlabs.comm.gossiping._
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.node.configuration.Configuration
 import io.casperlabs.smartcontracts.ExecutionEngineService
@@ -13,10 +24,108 @@ import monix.execution.Scheduler
 
 /** Create the Casper stack using the GossipService. */
 package object gossiping {
-  def apply[F[_]: Log: Metrics: Time: SafetyOracle: BlockStore: BlockDagStorage: NodeDiscovery: MultiParentCasperRef: ExecutionEngineService](
+  def apply[F[_]: Par: Concurrent: Log: Metrics: Time: Timer: SafetyOracle: BlockStore: BlockDagStorage: NodeDiscovery: NodeAsk: MultiParentCasperRef: ExecutionEngineService](
       port: Int,
       conf: Configuration,
       grpcScheduler: Scheduler
-  )(implicit scheduler: Scheduler): Resource[F, Unit] =
-    ???
+  )(implicit scheduler: Scheduler): Resource[F, Unit] = {
+
+    val connectToGossip: GossipService.Connector[F] = ???
+
+    // TODO: Method to create MultiParentCasperImpl.StatelessExecutor with temporary CasperState
+    // to run and store the genesis block candidate.
+
+    // TODO: Create caching for connections
+    // TODO: Create GenesisApprover
+    // TODO: Create Synchrnozier
+    // TODO: Create StashingSynchronizer
+    // TODO: Create InitialSynchronization
+    // TODO: Create GossipServiceServer
+    // TODO: Start gRPC for GossipServiceServer
+
+    // TODO: Configure relaying.
+    val relaying = RelayingImpl(
+      NodeDiscovery[F],
+      connectToGossip = connectToGossip,
+      relayFactor = 2,
+      relaySaturation = 90
+    )
+
+    for {
+      downloadManager <- DownloadManagerImpl[F](
+                          // TODO: Configure parallelism.
+                          maxParallelDownloads = 10,
+                          connectToGossip = connectToGossip,
+                          backend = new DownloadManagerImpl.Backend[F] {
+                            override def hasBlock(blockHash: ByteString): F[Boolean] =
+                              isInDag(blockHash)
+
+                            override def validateBlock(block: consensus.Block): F[Unit] =
+                              validateAndAddBlock(conf.casper.shardId, block)
+
+                            override def storeBlock(block: consensus.Block): F[Unit] =
+                              // Validation has already stored it.
+                              ().pure[F]
+
+                            override def storeBlockSummary(
+                                summary: consensus.BlockSummary
+                            ): F[Unit] =
+                              // TODO: Add separate storage for summaries.
+                              ().pure[F]
+                          },
+                          relaying = relaying,
+                          // TODO: Configure retry.
+                          retriesConf = DownloadManagerImpl.RetriesConf.noRetries
+                        )
+    } yield ()
+  }
+
+  private def isInDag[F[_]: Sync: BlockDagStorage](blockHash: ByteString): F[Boolean] =
+    for {
+      dag  <- BlockDagStorage[F].getRepresentation
+      cont <- dag.contains(blockHash)
+    } yield cont
+
+  private def validateAndAddBlock[F[_]: Concurrent: Time: Log: BlockStore: BlockDagStorage: ExecutionEngineService: MultiParentCasperRef](
+      shardId: String,
+      block: consensus.Block
+  ): F[Unit] =
+    MultiParentCasperRef[F].get
+      .flatMap {
+        case Some(casper) =>
+          casper.addBlock(LegacyConversions.fromBlock(block))
+
+        case None if block.getHeader.parentHashes.isEmpty =>
+          for {
+            _        <- Log[F].info(s"Validating genesis-like block ${show(block.blockHash)}...")
+            state    <- Cell.mvarCell[F, CasperState](CasperState())
+            executor = new MultiParentCasperImpl.StatelessExecutor(shardId)
+            dag      <- BlockDagStorage[F].getRepresentation
+            result <- executor.validateAndAddBlock(None, dag, LegacyConversions.fromBlock(block))(
+                       state
+                     )
+            (status, _) = result
+          } yield status
+
+        case None =>
+          MonadThrowable[F].raiseError[BlockStatus](Unavailable("Casper is not yet available."))
+      }
+      .flatMap {
+        case Valid =>
+          Log[F].debug(s"Validated and stored block ${show(block.blockHash)}")
+
+        case AdmissibleEquivocation =>
+          Log[F].debug(
+            s"Detected AdmissibleEquivocation on block ${show(block.blockHash)}"
+          )
+
+        case other =>
+          Log[F].debug(s"Received invalid block ${show(block.blockHash)}: $other") *>
+            MonadThrowable[F].raiseError[Unit](
+              new RuntimeException(s"Non-valid status: $other")
+            )
+      }
+
+  private def show(hash: ByteString) =
+    PrettyPrinter.buildString(hash)
 }


### PR DESCRIPTION
## Overview
Similarly to what has been done in https://github.com/CasperLabs/CasperLabs/pull/431, this PR adds composition code to stand up the gossiping stack. It's not yet actually wired into the `NodeRuntime` because there will be some extra type classes that I have to make, like `ConcurrentEffect[Effect` and `Par[Effect]`, but in the next PR there shall be a command line option that can turn this on. It will be off by default, and then we can opt-in to update integration tests and fix whatever isn't working.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-312

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
