### PR TITLE
STOR-39: implement split extension arm of history..write

### DIFF
--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -420,7 +420,7 @@ where
         let index: usize = existing_extension_path[shared_path.len()].into();
         let pointer = maybe_hashed_child_extension
             .to_owned()
-            .map_or_else(|| pointer, |(hash, _)| Pointer::NodePointer(hash));
+            .map_or(pointer, |(hash, _)| Pointer::NodePointer(hash));
         Trie::node(&[(index, pointer)])
     };
     // Create a parent extension if necessary

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -420,7 +420,7 @@ where
         let index: usize = existing_extension_path[shared_path.len()].into();
         let pointer = maybe_hashed_child_extension
             .to_owned()
-            .map_or_else(|| Ok(pointer), |(hash, _)| Ok(Pointer::NodePointer(hash)))?;
+            .map_or_else(|| pointer, |(hash, _)| Pointer::NodePointer(hash));
         Trie::node(&[(index, pointer)])
     };
     // Create a parent extension if necessary

--- a/execution-engine/storage/src/history/trie_store/operations/mod.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/mod.rs
@@ -376,7 +376,7 @@ struct SplitResult<K, V> {
 /// and child extensions.  The node pointer contained in the existing extension
 /// is repositioned in the new node or the possible child extension.  The
 /// possible parent extension is added to parents.  Returns the new node,
-/// parents, and the the possible child extension (paired with its hashed).
+/// parents, and the the possible child extension (paired with its hash).
 /// The new node and parents can be used by [`add_node_to_parents`], and the
 /// new hashed child extension can be added to the list of new trie elements.
 fn split_extension<K, V>(
@@ -420,8 +420,7 @@ where
         let index: usize = existing_extension_path[shared_path.len()].into();
         let pointer = maybe_hashed_child_extension
             .to_owned()
-            .map(|(hash, _)| Ok(Pointer::NodePointer(hash)))
-            .unwrap_or_else(|| Ok(pointer))?;
+            .map_or_else(|| Ok(pointer), |(hash, _)| Ok(Pointer::NodePointer(hash)))?;
         Trie::node(&[(index, pointer)])
     };
     // Create a parent extension if necessary

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -967,8 +967,7 @@ mod write {
 
         #[test]
         fn lmdb_writes_to_n_leaf_empty_trie_had_expected_results() {
-            // TODO: alter bounds
-            for num_leaves in 1..2 {
+            for num_leaves in 1..=TEST_LEAVES_LENGTH {
                 let (root_hash, tries) = TEST_TRIE_GENERATORS[0]().unwrap();
                 let context = LmdbTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
@@ -985,8 +984,7 @@ mod write {
 
         #[test]
         fn in_memory_writes_to_n_leaf_empty_trie_had_expected_results() {
-            // TODO: alter bounds
-            for num_leaves in 1..2 {
+            for num_leaves in 1..=TEST_LEAVES_LENGTH {
                 let (root_hash, tries) = TEST_TRIE_GENERATORS[0]().unwrap();
                 let context = InMemoryTestContext::new(&tries).unwrap();
                 let initial_states = vec![root_hash];
@@ -1005,8 +1003,7 @@ mod write {
         fn in_memory_writes_to_n_leaf_empty_trie_had_expected_store_contents() {
             let expected_contents: HashMap<Blake2bHash, TestTrie> = {
                 let mut ret = HashMap::new();
-                // TODO: remove bounds
-                for generator in &TEST_TRIE_GENERATORS[..3] {
+                for generator in &TEST_TRIE_GENERATORS {
                     let (_, tries) = generator().unwrap();
                     for HashedTestTrie { hash, trie } in tries {
                         ret.insert(hash, trie);
@@ -1023,8 +1020,7 @@ mod write {
                     &context.environment,
                     &context.store,
                     &root_hash,
-                    // TODO: remove bounds
-                    &TEST_LEAVES[..2],
+                    &TEST_LEAVES,
                 )
                 .unwrap();
 


### PR DESCRIPTION
## Overview
This PR implements the "split extension" arm of `history::trie_store::operations::write`. This arm defines the behavior when a new key-value leaf collides with an existing extension, necessitating the need for the existing extension to be dismantled and for a new node with possible child and parent extensions to be created to contain the pointer to the new leaf.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-39

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
See diagram here:
https://github.com/CasperLabs/CasperLabs/pull/440#issuecomment-490647563

Looking at the diagram, writing `TEST_LEAVES[2..]` will exercise this code path.