### PR TITLE
[OP-213] removing mac from ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,29 +36,6 @@ clone:
       fi
       git rev-parse HEAD
 
-  # The following steps labeled as '*-mac' are used to check and compile
-  # portions of the pipeline. This method mimics what was suggested in the
-  # below articles:
-  #    https://discourse.drone.io/t/multiple-build-machines/630/2
-  #    https://www.fwd.cloud/commit/post/drone-ios-deployments/
-  #
-  # The mac server is configured following our Developer.md suggestions
-  # for mac users. Please see the Developer.md for specifics.
-
-  git-clone-mac:
-    image: appleboy/drone-ssh
-    group: clone
-    secrets: [ ssh_key, ssh_host, ssh_username ]
-    script: |
-      set -ex
-      mkdir DRONE_BUILD_${DRONE_BUILD_NUMBER}
-      cd DRONE_BUILD_${DRONE_BUILD_NUMBER}
-      git clone -b ${DRONE_TAG:-${DRONE_BRANCH}} ${DRONE_REMOTE_URL} .
-      if [ x${DRONE_PULL_REQUEST} != x ]; then
-          git fetch origin refs/pull/${DRONE_PULL_REQUEST}/head
-          EMAIL=ci git merge --no-edit FETCH_HEAD
-      fi
-      git rev-parse HEAD
 pipeline:
 
   # pr
@@ -115,17 +92,6 @@ pipeline:
     commands:
       - cd execution-engine/
       - ~/.cargo/bin/cargo bench
-
-  run-rust-tests-mac:
-    image: appleboy/drone-ssh
-    group: test
-    secrets: [ ssh_key, ssh_host, ssh_username ]
-    command_timeout: 3600s
-    script: |
-      cd DRONE_BUILD_${DRONE_BUILD_NUMBER}
-      export PATH=$PATH:/usr/local/bin
-      cd execution-engine/
-      ~/.cargo/bin/cargo test
 
   run-unit-tests:
     <<: *sbtenv
@@ -226,41 +192,6 @@ pipeline:
     when:
       event: [ push, tag ]
 
-  package-ee-mac:
-    image: appleboy/drone-ssh
-    group: package-ee
-    secrets: [ ssh_key, ssh_host, ssh_username ]
-    command_timeout: 3600s
-    script: |
-      cd DRONE_BUILD_${DRONE_BUILD_NUMBER}
-      mkdir -p artifacts/${DRONE_BRANCH}
-      export PATH=$PATH:/usr/local/bin:~/.cargo/bin
-      echo $PATH
-      mkdir -p artifacts/${DRONE_BRANCH}
-      make cargo-package-all
-      WORKING_DIR=$(pwd) ;
-      cd execution-engine/target/release/rpmbuild/SOURCES ;
-      OS=$(uname -s | tr '[:upper:]' '[:lower:]') ;
-      ARCH=$(uname -p) ;
-      SOURCE=$(ls casperlabs-engine-grpc-server-*.tar.gz | sed "s/.tar.gz//") ;
-      TARGET=$(ls $SOURCE*.tar.gz | sed "s/.tar.gz/_"$OS"_"$ARCH".tar.gz/") ;
-      tar -xzf $SOURCE.tar.gz ;
-      tar -czf $TARGET -C $SOURCE/usr/bin/ . &&
-      cp $TARGET $WORKING_DIR/artifacts/${DRONE_BRANCH}
-    when:
-      event: [ push, tag ]
-
-  copy-mac-tar-drone-container:
-    <<: *buildenv
-    secrets: [ ssh_username, ssh_key, ssh_host ]
-    commands:
-      - mkdir -p ~/.ssh
-      - mkdir -p artifacts/
-      - umask 077 && echo "$SSH_KEY" > ~/.ssh/id_rsa
-      - rsync -avzhe "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" $SSH_USERNAME@$SSH_HOST:DRONE_BUILD_${DRONE_BUILD_NUMBER}/artifacts/${DRONE_BRANCH}/casperlabs-engine-grpc-server-*darwin*.gz artifacts/${DRONE_BRANCH}/
-    when:
-      event: [ push, tag ]
-
   rsync-artifacts:
     image: drillster/drone-rsync
     hosts: [ $REPO_HOST ]
@@ -332,18 +263,6 @@ pipeline:
       - docker images | grep "DRONE-${DRONE_BUILD_NUMBER}" | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    when:
-      status: [ failure, success ]
-
-# mac xargs doesn't have --no-run-if-empty
-  cleanup-mac:
-    image: appleboy/drone-ssh
-    group: cleanup
-    secrets: [ ssh_key, ssh_host, ssh_username ]
-    script: |
-      export PATH=$PATH:/usr/local/bin
-      docker rmi -f $(docker images -f "dangling=true" -q) || true
-      rm -rf DRONE_BUILD_${DRONE_BUILD_NUMBER}
     when:
       status: [ failure, success ]
 


### PR DESCRIPTION
## Overview
Provide a brief description of what this PR does, and why it's needed.
Deprecates sections of CI previously run on Mac.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.
https://casperlabs.atlassian.net/browse/OP-213

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
