### PR TITLE
STOR-82: use LmdbGlobalState in production

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -147,10 +147,12 @@ version = "0.2.0"
 dependencies = [
  "casperlabs-contract-ffi 0.5.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "execution-engine 0.1.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust-grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shared 0.2.0",

--- a/execution-engine/comm/Cargo.toml
+++ b/execution-engine/comm/Cargo.toml
@@ -17,6 +17,8 @@ storage = { path = "../storage" }
 wasm-prep = { path = "../wasm-prep" }
 common = { path = "../common", package = "casperlabs-contract-ffi" }
 wabt = "0.7.4"
+dirs = "1.0.5"
+lmdb = "0.8.0"
 
 [build-dependencies]
 protoc-rust-grpc = "0.6.1"

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -1,7 +1,9 @@
 extern crate clap;
 extern crate common;
+extern crate dirs;
 extern crate execution_engine;
 extern crate grpc;
+extern crate lmdb;
 extern crate protobuf;
 extern crate shared;
 extern crate storage;
@@ -11,13 +13,37 @@ extern crate wasm_prep;
 pub mod engine_server;
 
 use clap::{App, Arg};
+use dirs::home_dir;
 use engine_server::*;
 use execution_engine::engine::EngineState;
-use storage::global_state::in_memory::InMemoryGlobalState;
+use lmdb::DatabaseFlags;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use storage::global_state::lmdb::LmdbGlobalState;
+use storage::history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
+
+const DEFAULT_DATA_DIR_RELATIVE: &str = "./.casperlabs";
+const GLOBAL_STATE_DIR: &str = "global_state";
+
+const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";
+const CANONICALIZE_DATA_DIR_EXPECT: &str = "Could not canonicalize data directory";
+const CREATE_DATA_DIR_EXPECT: &str = "Could not create directory";
+const LMDB_ENVIRONMENT_EXPECT: &str = "Could not create LmdbEnvironment";
+const LMDB_TRIE_STORE_EXPECT: &str = "Could not create LmdbTrieStore";
+const LMDB_GLOBAL_STATE_EXPECT: &str = "Could not create LmdbGlobalState";
 
 fn main() {
     let matches = App::new("Execution engine server")
         .arg(Arg::with_name("socket").required(true).help("Socket file"))
+        .arg(
+            Arg::with_name("data-dir")
+                .short("d")
+                .long("data-dir")
+                .value_name("DIR")
+                .help("Sets the data directory")
+                .takes_value(true),
+        )
         .get_matches();
     let socket = matches
         .value_of("socket")
@@ -27,9 +53,42 @@ fn main() {
         std::fs::remove_file(socket_path).expect("Remove old socket file.");
     }
 
-    let init_state = storage::global_state::mocked_account([48u8; 20]);
-    let global_state =
-        InMemoryGlobalState::from_pairs(&init_state).expect("Could not create global state");
+    let data_dir: PathBuf = {
+        let mut ret = matches.value_of("data-dir").map_or_else(
+            || {
+                let mut dir = home_dir().expect(GET_HOME_DIR_EXPECT);
+                dir.push(DEFAULT_DATA_DIR_RELATIVE);
+                dir
+            },
+            |str| PathBuf::from(str),
+        );
+        ret = fs::canonicalize(ret).expect(CANONICALIZE_DATA_DIR_EXPECT);
+        ret.push(GLOBAL_STATE_DIR);
+        fs::create_dir_all(&ret).expect(&format!("{}: {:?}", CREATE_DATA_DIR_EXPECT, ret));
+        ret
+    };
+
+    let environment = {
+        let ret = LmdbEnvironment::new(&data_dir).expect(LMDB_ENVIRONMENT_EXPECT);
+        Arc::new(ret)
+    };
+
+    let trie_store = {
+        let ret = LmdbTrieStore::new(&environment, None, DatabaseFlags::empty())
+            .expect(LMDB_TRIE_STORE_EXPECT);
+        Arc::new(ret)
+    };
+
+    let global_state = {
+        let init_state = storage::global_state::mocked_account([48u8; 20]);
+        LmdbGlobalState::from_pairs(
+            Arc::clone(&environment),
+            Arc::clone(&trie_store),
+            &init_state,
+        )
+        .expect(LMDB_GLOBAL_STATE_EXPECT)
+    };
+
     let engine_state = EngineState::new(global_state);
     let server_builder = engine_server::new(socket, engine_state);
     let _server = server_builder.build().expect("Start server");

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -53,8 +53,8 @@ fn main() {
     }
 
     let data_dir: PathBuf = {
-        let mut ret = matches.value_of("data-dir").map_or_else(
-            || {
+        let mut ret = matches.value_of("data-dir").map_or(
+            {
                 let mut dir = home_dir().expect(GET_HOME_DIR_EXPECT);
                 dir.push(DEFAULT_DATA_DIR_RELATIVE);
                 dir

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -23,11 +23,10 @@ use std::sync::Arc;
 use storage::global_state::lmdb::LmdbGlobalState;
 use storage::history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
 
-const DEFAULT_DATA_DIR_RELATIVE: &str = "./.casperlabs";
+const DEFAULT_DATA_DIR_RELATIVE: &str = ".casperlabs";
 const GLOBAL_STATE_DIR: &str = "global_state";
 
 const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";
-const CANONICALIZE_DATA_DIR_EXPECT: &str = "Could not canonicalize data directory";
 const CREATE_DATA_DIR_EXPECT: &str = "Could not create directory";
 const LMDB_ENVIRONMENT_EXPECT: &str = "Could not create LmdbEnvironment";
 const LMDB_TRIE_STORE_EXPECT: &str = "Could not create LmdbTrieStore";
@@ -62,7 +61,6 @@ fn main() {
             },
             PathBuf::from,
         );
-        ret = fs::canonicalize(ret).expect(CANONICALIZE_DATA_DIR_EXPECT);
         ret.push(GLOBAL_STATE_DIR);
         fs::create_dir_all(&ret)
             .unwrap_or_else(|_| panic!("{}: {:?}", CREATE_DATA_DIR_EXPECT, ret));

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -60,11 +60,12 @@ fn main() {
                 dir.push(DEFAULT_DATA_DIR_RELATIVE);
                 dir
             },
-            |str| PathBuf::from(str),
+            PathBuf::from,
         );
         ret = fs::canonicalize(ret).expect(CANONICALIZE_DATA_DIR_EXPECT);
         ret.push(GLOBAL_STATE_DIR);
-        fs::create_dir_all(&ret).expect(&format!("{}: {:?}", CREATE_DATA_DIR_EXPECT, ret));
+        fs::create_dir_all(&ret)
+            .unwrap_or_else(|_| panic!("{}: {:?}", CREATE_DATA_DIR_EXPECT, ret));
         ret
     };
 


### PR DESCRIPTION
## Overview
This PR changes the execution engine to use `LmdbGlobalState`.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/STOR-82

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
