### PR TITLE
Correcting issues with simultaneous testing on drone.

### DIFF
--- a/integration-testing/test/cl_node/docker_base.py
+++ b/integration-testing/test/cl_node/docker_base.py
@@ -124,7 +124,7 @@ class DockerBase:
 
     @property
     def host_mount_dir(self) -> str:
-        return f'/tmp/resources_{self.docker_tag}_{self.config.number}'
+        return f'/tmp/resources_{self.docker_tag}_{self.config.number}_{self.config.rand_str}'
 
     @property
     def bonds_file(self) -> str:

--- a/integration-testing/test/cl_node/docker_node.py
+++ b/integration-testing/test/cl_node/docker_node.py
@@ -88,7 +88,9 @@ class DockerNode(LoggingDockerBase):
             auto_remove=False,
             detach=True,
             mem_limit=self.config.mem_limit,
-            ports={f'{self.GRPC_PORT}/tcp': self.config.grpc_port},  # Exposing grpc for Python Client
+            # If multiple tests are running in drone, local ports are duplicated.  Need a solution to this
+            # Prior to implementing the python client.
+            # ports={f'{self.GRPC_PORT}/tcp': self.config.grpc_port},  # Exposing grpc for Python Client
             network=self.network,
             volumes=self.volumes,
             command=commands,


### PR DESCRIPTION
## Overview
Network ports opened and files created we unique with one instance per host, but not when run in parallel on drone.  This corrects that issue.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
