### PR TITLE
OP-206: Add generic Python gRPC interceptor for use in tests

### DIFF
--- a/client/python/CasperClient/casper_client/CasperMessage_proxy.py
+++ b/client/python/CasperClient/casper_client/CasperMessage_proxy.py
@@ -27,7 +27,7 @@ def serve(proxy_port: int, node_host: str, node_port: int):
                                         pre_callback = delay,
                                         post_callback = printer)
     CasperMessage_pb2_grpc.add_DeployServiceServicer_to_server(servicer, server)
-    server.add_insecure_port('[::]:{}'.format(proxy_port))
+    server.add_insecure_port(f'[::]:{proxy_port}')
     server.start()
     try:
         while True:

--- a/client/python/CasperClient/casper_client/CasperMessage_proxy.py
+++ b/client/python/CasperClient/casper_client/CasperMessage_proxy.py
@@ -13,12 +13,19 @@ def printer(name, request, v):
     print(name, ':', request, '=>', v)
 
 
+def delay(name, request):
+    print ('received: ', name, ':', request)
+    time.sleep(1)
+    return request
+
+
 def serve(proxy_port: int, node_host: str, node_port: int):
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
     servicer = grpc_proxy.ProxyServicer(node_host, node_port,
                                         service_stub = CasperMessage_pb2_grpc.DeployServiceStub,
                                         unary_stream_methods = ['showBlocks', 'showMainChain'],
-                                        callback = printer)
+                                        pre_callback = delay,
+                                        post_callback = printer)
     CasperMessage_pb2_grpc.add_DeployServiceServicer_to_server(servicer, server)
     server.add_insecure_port('[::]:{}'.format(proxy_port))
     server.start()

--- a/client/python/CasperClient/casper_client/CasperMessage_proxy.py
+++ b/client/python/CasperClient/casper_client/CasperMessage_proxy.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import time
+import grpc
+from concurrent import futures
+
+from .proto import CasperMessage_pb2_grpc
+
+from . import grpc_proxy
+
+def printer(name, request, v):
+    print('------------------')
+    print(name, ':', request, '=>', v)
+
+
+def serve(proxy_port: int, node_host: str, node_port: int):
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    servicer = grpc_proxy.ProxyServicer(node_host, node_port,
+                                        service_stub = CasperMessage_pb2_grpc.DeployServiceStub,
+                                        unary_stream_methods = ['showBlocks', 'showMainChain'],
+                                        callback = printer)
+    CasperMessage_pb2_grpc.add_DeployServiceServicer_to_server(servicer, server)
+    server.add_insecure_port('[::]:{}'.format(proxy_port))
+    server.start()
+    try:
+        while True:
+            time.sleep(60*60)
+    except KeyboardInterrupt:
+        server.stop(0)
+
+
+if __name__ == '__main__':
+    serve(50401, '127.0.0.1', 40401)
+

--- a/client/python/CasperClient/casper_client/casper_client.py
+++ b/client/python/CasperClient/casper_client/casper_client.py
@@ -163,7 +163,7 @@ class CasperClient:
 
         :return:    response object
         """
-        return self.node.createBlock(CasperMessage_pb2.google_dot_protobuf_dot_empty__pb2.Empty())
+        return self.node.createBlock(CasperMessage_pb2.empty__pb2.Empty())
 
     @guarded
     def visualizeDag(self, depth: int, out: str = None, show_justification_lines: bool = False, stream: str = None):

--- a/client/python/CasperClient/casper_client/grpc_proxy.py
+++ b/client/python/CasperClient/casper_client/grpc_proxy.py
@@ -18,7 +18,7 @@ class ProxyServicer:
 
 
     def __getattr__(self, name):
-        node_address = "{}:{}".format(self.node_host, self.node_port)
+        node_address = f"{self.node_host}:{self.node_port}"
 
         def f(request, context):
             with grpc.insecure_channel(node_address) as channel:

--- a/client/python/CasperClient/casper_client/grpc_proxy.py
+++ b/client/python/CasperClient/casper_client/grpc_proxy.py
@@ -1,0 +1,35 @@
+import grpc
+
+class ProxyServicer:
+
+    def __init__(self, node_host: str,
+                       node_port: int,
+                       service_stub = None,
+                       unary_stream_methods = [],
+                       callback = lambda *args: args):
+
+        self.node_host = node_host
+        self.node_port = node_port
+        self.service_stub = service_stub
+        self.unary_stream_methods = unary_stream_methods
+        self.callback = callback
+
+
+    def __getattr__(self, name):
+        node_address = "{}:{}".format(self.node_host, self.node_port)
+
+        def f(request, context):
+            with grpc.insecure_channel(node_address) as channel:
+                v = getattr(self.service_stub(channel), name)(request)
+                self.callback(name, request, v)
+                return v
+
+        def g(request, context):
+            with grpc.insecure_channel(node_address) as channel:
+                vs = [x for x in getattr(self.service_stub(channel), name)(request)]
+                self.callback(name, request, vs)
+                yield from vs
+
+        return g if name in self.unary_stream_methods else f
+        
+


### PR DESCRIPTION
## Overview
This PR adds a generic Python gRPC interceptor that can be used in our test framework to:
- gather statistics on gRPC communication between nodes,
- simulate delays, dropped requests, etc.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/OP-206

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
