### PR TITLE
Extend timeout for multiple node test

### DIFF
--- a/integration-testing/TEST_FRAMEWORK.md
+++ b/integration-testing/TEST_FRAMEWORK.md
@@ -1,0 +1,84 @@
+## Test Framework
+
+The purpose of this document is to give an over view of the new test framework and how to add tests with it.
+
+## Core Objects
+
+There is confusion around the term "Node" when talking about CasperLabs objects.  The test framework has broken the
+idea of `Node` into two types.  `DockerNode` and `CasperLabsNode`.  `DockerNode` is a helper object for handling a
+`casperlabs/node` docker containers.  `CasperLabsNode` is a combination of `DockerNode`, `DockerExecutionEngine` and 
+a client for interacting with the `DockerNode`.  
+
+#### DockerConfig (docker_base.py)
+
+`DockerConfig` object is a dataclass that should hold all unique information for starting up a `CasperLabsNode`.
+
+#### DockerBase (docker_base.py)
+
+`DockerBase` handles management of a docker container.  This includes many properties that are generated based on
+values given by subclasses.  `_get_container` method is required by a subclass to stand up the docker container for
+that class.  `cleanup` method requires call during teardown.
+
+#### LoggingDockerBase (docker_base.py) from DockerBase
+
+From `DockerBase` this adds a background logging thread for a docker container.    
+
+#### DockerExecutionEngine (docker_execution_engine.py) from LoggingDockerBase
+
+Manages a `casperlabs/execution-engine` docker container.  Shares a docker volume with DockerNode container for 
+communication.
+
+#### DockerNode (docker_node.py) from LoggingDockerBase
+
+ Manages a `casperlabs/node` docker container and client to communicate with this node.  Current implementation is 
+ using a `casperlabs/client` docker container for this and we will integrate the new Python client.
+ 
+ This object creates a resources directory in `/tmp` for each `DockerNode` instance.  This holds all files used by
+ the `casperlabs/node`.
+ 
+ This object holds most methods used during interaction with the client, such as `deploy`, `propose`, `show_blocks`, etc.
+ 
+ #### CasperLabsNode (casperlabs_node.py)
+ 
+ `CasperLabsNode` holds a `DockerExecutionEngine` and `DockerNode` and creates a volume in docker for the socket 
+ communication between the two.  One `DockerConfig` is passed to both objects and must contain all data needed to 
+ stand up both `Docker*` objects.
+ 
+ #### CasperLabsNetwork (casperlabs_network.py)
+ 
+ `CasperLabsNetwork` is the one object that is needed to be stood up for a complete functioning network of nodes.
+ 
+ `CasperLabsNodes` are created and numbered from 0.  The bootstrap node is always 0.
+ 
+ `add_bootstrap` is called first for the bootstrap node-0.
+ 
+ `add_cl_node` is called for each node after.  By default, these nodes will join with the network created with the
+ bootstrap.  This may not be desired as we make more complex networks.  
+ 
+ `CasperLabsNetwork` is a contextmanager and handles clean teardown of all objects in the network.
+ 
+ Any subclass must implement `create_cl_network` to stand up the network.  Arguments can be added to control functionality.
+ 
+ Test fixtures to stand up `CasperLabsNetwork`s are created in `conftest.py`.  Here is an example of the simplest:
+ 
+    @pytest.fixture()
+    def one_node_network(docker_client_fixture):
+        with OneNodeNetwork(docker_client_fixture) as onn:
+            onn.create_cl_network()
+            yield onn
+ 
+ ### Adding tests
+ 
+ The framework uses `pytest`.  Any files with a prefix of `test_` in the `test` directory will be picked up for tests.
+ 
+ Methods in these files with `test_` prefix will be executed as tests.
+ 
+ If a `CasperLabsNetwork` class and fixture exist for the test, then you only need to call it for your test.
+ 
+     def test_my_new_test(one_node_network):
+         node = one_node_network.docker_nodes[0]
+         # At this point, network is completely stood up and node is available for methods.
+         
+     def test_my_other_new_test(three_node_network):
+         node0, node1, node2 = three_node network.docker_nodes    
+         # Three CasperLabsNodes ready for operation.

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -91,7 +91,7 @@ class CasperLabsNetwork:
     def start_cl_node(self, node_number: int) -> None:
         self.cl_nodes[node_number].execution_engine.start()
         node = self.cl_nodes[node_number].node
-        with wait_for_log_watcher(RequestedForkTipFromPeersInLogLine(node.container)):
+        with wait_for_log_watcher(RequestedForkTipFromPeersInLogLine(node.container), 60):
             node.start()
 
     def wait_for_peers(self) -> None:


### PR DESCRIPTION
## Overview
Starting up CL_Node is barely timing out during tests.  This doubles the startup time allowed to make this not happen.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [X] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
