### PR TITLE
NODE-495: Add Jack's REST annotations to CasperMessage.proto

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -194,9 +194,12 @@ lazy val models = (project in file("models"))
     // TODO: As we refactor the interfaces this project should only depend on consensus
     // related models, ones that get stored, passed to client. The client for example
     // shouldn't transitively depend on node-to-node and node-to-EE interfaces.
-    PB.protoSources in Compile := Seq(protobufDirectory),
+    PB.protoSources in Compile := Seq(
+      protobufDirectory
+    ),
     includeFilter in PB.generate := new SimpleFileFilter(
       protobufSubDirectoryFilter(
+        "google/api",
         "io/casperlabs/casper/consensus",
         "io/casperlabs/casper/protocol" // TODO: Eventually remove.
       )),

--- a/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
+++ b/protobuf/io/casperlabs/casper/protocol/CasperMessage.proto
@@ -3,6 +3,9 @@ package io.casperlabs.casper.protocol;
 
 import "google/protobuf/empty.proto";
 
+// REST annotations
+import "google/api/annotations.proto";
+
 // If you are building for other languages "scalapb.proto"
 // can be manually obtained here:
 // https://raw.githubusercontent.com/scalapb/ScalaPB/master/protobuf/scalapb/scalapb.proto
@@ -18,22 +21,63 @@ option (scalapb.options) = {
 // --------- DeployService  --------
 service DeployService {
     rpc DoDeploy (DeployData) returns (DeployServiceResponse) {
+        option (google.api.http) = {
+            put: "/deploy"
+            body: "*"
+        };
     }
+
     rpc createBlock (google.protobuf.Empty) returns (DeployServiceResponse) {
+        option (google.api.http) = {
+            post: "/block"
+            body: "*"
+        };
     }
+
     rpc showBlock (BlockQuery) returns (BlockQueryResponse) {
+        option (google.api.http) = {
+            put: "/show/block"
+            body: "*"
+        };
     }
+
     // Get dag
     rpc visualizeDag(VisualizeDagQuery) returns (VisualizeBlocksResponse) {
+        option (google.api.http) = {
+            put: "/show/dag"
+            body: "*"
+        };
     }
+
     rpc showMainChain (BlocksQuery) returns (stream BlockInfoWithoutTuplespace) {
+        option (google.api.http) = {
+            put: "/show/chain"
+            body: "*"
+        };
     }
+
     rpc showBlocks (BlocksQuery) returns (stream BlockInfoWithoutTuplespace) {
+        option (google.api.http) = {
+            put: "/show/blocks"
+            body: "*"
+        };
     }
+
     rpc findBlockWithDeploy (FindDeployInBlockQuery) returns (BlockQueryResponse) {
+        option (google.api.http) = {
+            put: "/find"
+            body: "*"
+        };
     }
-    rpc queryState (QueryStateRequest) returns (QueryStateResponse) {}
+
+    rpc queryState (QueryStateRequest) returns (QueryStateResponse) {
+        option (google.api.http) = {
+            put: "/query"
+            body: "*"
+        };
+    }
 }
+
 
 message QueryStateRequest {
     string block_hash = 1; //base-16 encoding of block hash


### PR DESCRIPTION
## Overview
For the demo @gumtu has configured Envoy to do REST conversion on top of `CasperMessage.proto`. This PR adds those annotations to the file we keep in this repository so they are visible.

Later I'll have to add REST annotations to the services which supersede the `DeployService` annotated here.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/NODE-495

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Future iterations on these services should follow the [Google API Guide](https://cloud.google.com/apis/design/standard_methods) but I think these mappings are already in place for the demo.
