### PR TITLE
NO-TICKET: Decrease load in StashingSynchronizerSpec to produce less timeout errors

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
@@ -30,8 +30,8 @@ class StashingSynchronizerSpec
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   val requestsGen: Gen[List[(Node, Set[ByteString])]] = for {
-    nodes       <- Gen.listOfN(100, arbNode.arbitrary)
-    blockHashes <- Gen.listOfN(100, genHash)
+    nodes       <- Gen.listOfN(10, arbNode.arbitrary)
+    blockHashes <- Gen.listOfN(10, genHash)
     hashesPerNode <- nodes.traverse(
                       n =>
                         for {
@@ -50,7 +50,7 @@ class StashingSynchronizerSpec
               fiber <- requests.parTraverse {
                         case (source, hashes) => synchronizer.syncDag(source, hashes)
                       }.start
-              _ <- Task.sleep(500.milliseconds)
+              _ <- Task.sleep(30.milliseconds)
               _ <- Task(mock.requests.get().toList shouldBe empty)
               _ <- deferred.complete(())
               _ <- fiber.join
@@ -76,7 +76,7 @@ class StashingSynchronizerSpec
               fiber <- requests.traverse {
                         case (source, hashes) => synchronizer.syncDag(source, hashes)
                       }.start
-              _   <- Task.sleep(500.milliseconds)
+              _   <- Task.sleep(30.milliseconds)
               _   <- Task(mock.requests.get().toList shouldBe empty)
               _   <- deferred.complete(())
               res <- fiber.join
@@ -102,7 +102,7 @@ class StashingSynchronizerSpec
               fiber <- requests.traverse {
                         case (source, hashes) => synchronizer.syncDag(source, hashes).attempt
                       }.start
-              _   <- Task.sleep(100.milliseconds)
+              _   <- Task.sleep(30.milliseconds)
               _   <- Task(mock.requests.get().toList shouldBe empty)
               _   <- deferred.complete(())
               res <- fiber.join


### PR DESCRIPTION
## Overview
[Drone sometimes fails with this test](http://3.16.200.31/CasperLabs/CasperLabs/2267/11). Reduced sleeping time and amount of load in property tests.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
No ticket

### Complete this checklist before you submit the PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [ ] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.