### PR TITLE
EE-281: Review early versions of various blockchain configuration parameters.

### DIFF
--- a/execution-engine/wasm-prep/src/lib.rs
+++ b/execution-engine/wasm-prep/src/lib.rs
@@ -7,9 +7,7 @@ use pwasm_utils::{externalize_mem, inject_gas_counter, rules};
 use std::error::Error;
 use vm::wasm_costs::WasmCosts;
 
-#[allow(dead_code)]
-//NOTE(for reference): size of Wasm memory page; 64 kibibytes
-const MEM_PAGE_SIZE: u32 = 65536;
+//NOTE: size of Wasm memory page is 64 KiB
 const MEM_PAGES: u32 = 64;
 
 #[derive(Debug)]

--- a/execution-engine/wasm-prep/src/lib.rs
+++ b/execution-engine/wasm-prep/src/lib.rs
@@ -7,7 +7,10 @@ use pwasm_utils::{externalize_mem, inject_gas_counter, rules};
 use std::error::Error;
 use vm::wasm_costs::WasmCosts;
 
-const MEM_PAGES: u32 = 128;
+#[allow(dead_code)]
+//NOTE(for reference): size of Wasm memory page; 64 kibibytes
+const MEM_PAGE_SIZE: u32 = 65536;
+const MEM_PAGES: u32 = 64;
 
 #[derive(Debug)]
 pub enum PreprocessingError {


### PR DESCRIPTION
## Overview
During our work on PoC we used various configuration parameters which were taken from Parity's Ethereum client. EE-281 was created to review these values once again.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
https://casperlabs.atlassian.net/browse/EE-281

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://3.16.200.31/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
I've decreased maximum number of Wasm memory pages from 128 to 64. I've found that Parity uses 16 but all the contracts we have currently, compile to 17 as lower limit. 16 memory pages (1 MB) is a default value that `rustc` reserves for stack. I learned that we might be getting 17 because of some static data, which occupies less than 64KiB, and hence the increase. 17 though wasn't enough as contracts grow stack. I found that 20 was a minimal value that works with all the contracts we currently have. As 20 seemed like an odd number I went with 64 for the time being. We will be likely revisiting this again, when we learn more about nature of contracts deployed, Wasm and Wasm VM.