### PR TITLE
NODE-411 : Remove docker containers, volumes, and networks after receiving KeyBoard Interrupt signal.

### DIFF
--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -193,3 +193,12 @@ def three_node_network(docker_client_fixture):
     with ThreeNodeNetwork(docker_client_fixture) as tnn:
         tnn.create_cl_network()
         yield tnn
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_keyboard_interrupt(excinfo):
+    docker_client = docker_py.from_env()
+    docker_client.containers.prune()
+    docker_client.volumes.prune()
+    docker_client.networks.prune()
+    pytest.exit("Keyboard Interrupt occurred, So stopping the execution of tests.")


### PR DESCRIPTION
## Overview
Remove docker containers, networks and volumes after receiving KeyBoardInterrupt Signal. This removes any zombie containers lingering on the dev machine. 

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.

https://casperlabs.atlassian.net/browse/NODE-411

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [x] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [x] Your GitHub account is also an account with [Drone CI](http://drone.casperlabs.io/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
