### PR TITLE
Adding final check before failing for log_watcher and more logging.

### DIFF
--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -91,7 +91,7 @@ class CasperLabsNetwork:
     def start_cl_node(self, node_number: int) -> None:
         self.cl_nodes[node_number].execution_engine.start()
         node = self.cl_nodes[node_number].node
-        with wait_for_log_watcher(RequestedForkTipFromPeersInLogLine(node.container), 60):
+        with wait_for_log_watcher(RequestedForkTipFromPeersInLogLine(node.container)):
             node.start()
 
     def wait_for_peers(self) -> None:

--- a/integration-testing/test/cl_node/docker_base.py
+++ b/integration-testing/test/cl_node/docker_base.py
@@ -54,7 +54,7 @@ class DockerConfig:
     number: int = 0
     rand_str: Optional[str] = None
     volumes: Optional[Dict[str, Dict[str, str]]] = None
-    command_timeout: int = 60
+    command_timeout: int = 180
     mem_limit: str = '4G'
     is_bootstrap: bool = False
     bootstrap_address: Optional[str] = None

--- a/integration-testing/test/cl_node/log_watcher.py
+++ b/integration-testing/test/cl_node/log_watcher.py
@@ -27,8 +27,10 @@ class LogWatcherThread(threading.Thread):
         end_line = self.container.logs(tail=1)
         containers_log_lines_generator = self.container.logs(stream=True, follow=True)
         # Fast Forward to end, so we don't get previous false positives
+        lines_count = 0
         while end_line != next(containers_log_lines_generator):
-            pass
+            lines_count += 1
+        logging.info(f'Fast Forward Complete with {lines_count} lines skipped.  End Line: {end_line}')
         try:
             while not self.stop_event.is_set() and not self.located_event.is_set():
                 line = next(containers_log_lines_generator).decode('utf-8').rstrip()
@@ -70,7 +72,7 @@ class RequestedForkTipFromPeersInLogLine(TextInLogLine):
 
 
 @contextlib.contextmanager
-def wait_for_log_watcher(log_watcher: "LogWatcherThread", timeout_secs: float = 30) -> Any:
+def wait_for_log_watcher(log_watcher: "LogWatcherThread", timeout_secs: float = 180) -> Any:
     """
     Log watcher does not parse the entire log, so a context manager starts up detection prior to
     the command that will cause it.  This can allow detection to be complete prior to coming back from
@@ -106,11 +108,21 @@ def wait_for_log_watcher(log_watcher: "LogWatcherThread", timeout_secs: float = 
             logging.info(f'SATISFIED {log_watcher.__repr__()} with data: {log_watcher.data}')
             return
         if time.time() > stop_time:
-            # Setting stop event will tear down thread after next log line received
+
+            # While debugging issues with Log Watcher, doing final check
+            logging.info(f'LOG_WATCHER_ERROR_STATE_RECHECK')
+            c_logs = log_watcher.container.logs(tail=10).decode('utf-8').split('\n')
+            search_text = log_watcher.__class__.search_text
+            for line in c_logs:
+                if search_text in line:
+                    logging.info(f'RETRY OF {log_watcher.__class__.__name__} Successful.')
+                    stop_event.set()
+                    return
+
+            # Setting stop event will tear down thread after next log line received or container shutdown
             stop_event.set()
-            # It is likely, thread exit with StopIterator when environment tears down container
             raise Exception(f'{log_watcher.container.name} did not satisfy {log_watcher.__repr__()} '
                             f'after {timeout_secs} sec(s).')
-        time.sleep(0.05)
+        time.sleep(0.1)
 
 


### PR DESCRIPTION
## Overview
Putting debugging code and a final check to try to locate log_watcher hangs.

### Which JIRA issue does this PR relate to? If there is not a JIRA issue addressing this work, please create one now and add the link here.
Add link to corresponding JIRA issue.

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### If you are not a member of the core development team, please confirm:
- [ ] You signed the commit. Merging requires a signature. Please see the [Signing Commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits) for instructions.
- [ ] Your GitHub account is also an account with [Drone CI](http://drone.casperlabs.io/). Unit tests will not run on your PR unless you have an account with Drone. Merge requires passed unit tests.

### Notes
Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else.
