### PR TITLE
EE-319: make lmdb map size configurable

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -1094,6 +1094,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog 2.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1171,6 +1172,7 @@ version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.5.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -31,7 +31,7 @@ const GLOBAL_STATE_DIR: &str = "global_state";
 // 1 GiB = 1073741824 bytes
 // page size on x86_64 linux = 4096 bytes
 // 1073741824 / 4096 = 262144
-const DEFAULT_PAGES: usize = 262144;
+const DEFAULT_PAGES: usize = 262_144;
 
 const GET_PAGES_EXPECT: &str = "Could not parse pages argument";
 const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -17,8 +17,10 @@ use dirs::home_dir;
 use engine_server::*;
 use execution_engine::engine::EngineState;
 use lmdb::DatabaseFlags;
+use shared::os::get_page_size;
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use storage::global_state::lmdb::LmdbGlobalState;
 use storage::history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
@@ -26,6 +28,12 @@ use storage::history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
 const DEFAULT_DATA_DIR_RELATIVE: &str = ".casperlabs";
 const GLOBAL_STATE_DIR: &str = "global_state";
 
+// 1 GiB = 1073741824 bytes
+// page size on x86_64 linux = 4096 bytes
+// 1073741824 / 4096 = 262144
+const DEFAULT_PAGES: usize = 262144;
+
+const GET_PAGES_EXPECT: &str = "Could not parse pages argument";
 const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";
 const CREATE_DATA_DIR_EXPECT: &str = "Could not create directory";
 const LMDB_ENVIRONMENT_EXPECT: &str = "Could not create LmdbEnvironment";
@@ -41,6 +49,14 @@ fn main() {
                 .long("data-dir")
                 .value_name("DIR")
                 .help("Sets the data directory")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("pages")
+                .short("p")
+                .long("pages")
+                .value_name("NUM")
+                .help("Sets the number of max number of pages to use for lmdb's mmap")
                 .takes_value(true),
         )
         .get_matches();
@@ -67,8 +83,17 @@ fn main() {
         ret
     };
 
+    let map_size: usize = {
+        let page_size = get_page_size().unwrap();
+        let pages = matches
+            .value_of("pages")
+            .map_or(Ok(DEFAULT_PAGES), usize::from_str)
+            .expect(GET_PAGES_EXPECT);
+        page_size * pages
+    };
+
     let environment = {
-        let ret = LmdbEnvironment::new(&data_dir).expect(LMDB_ENVIRONMENT_EXPECT);
+        let ret = LmdbEnvironment::new(&data_dir, map_size).expect(LMDB_ENVIRONMENT_EXPECT);
         Arc::new(ret)
     };
 

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
                 .short("p")
                 .long("pages")
                 .value_name("NUM")
-                .help("Sets the number of max number of pages to use for lmdb's mmap")
+                .help("Sets the max number of pages to use for lmdb's mmap")
                 .takes_value(true),
         )
         .get_matches();

--- a/execution-engine/shared/Cargo.toml
+++ b/execution-engine/shared/Cargo.toml
@@ -10,6 +10,7 @@ chrono = "0.4.6"
 common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }
 hostname = "0.1.5"
 lazy_static = "1.3.0"
+libc = "0.2.54"
 serde = { version = "1.0.90", features = ["derive"] }
 serde_json = "1.0.39"
 slog = "2.4.1"

--- a/execution-engine/shared/src/lib.rs
+++ b/execution-engine/shared/src/lib.rs
@@ -4,6 +4,7 @@ extern crate chrono;
 extern crate common;
 #[macro_use]
 extern crate lazy_static;
+extern crate libc;
 #[macro_use]
 extern crate slog;
 extern crate slog_async;
@@ -12,5 +13,6 @@ extern crate slog_term;
 
 pub mod logging;
 pub mod newtypes;
+pub mod os;
 pub mod semver;
 pub mod test_utils;

--- a/execution-engine/shared/src/os/mod.rs
+++ b/execution-engine/shared/src/os/mod.rs
@@ -1,0 +1,15 @@
+use std::io;
+
+use libc::{c_long, sysconf, _SC_PAGESIZE};
+
+/// Returns OS page size
+pub fn get_page_size() -> Result<usize, io::Error> {
+    // https://www.gnu.org/software/libc/manual/html_node/Sysconf.html
+    let value: c_long = unsafe { sysconf(_SC_PAGESIZE) };
+
+    if value < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(value as usize)
+}

--- a/execution-engine/storage/Cargo.toml
+++ b/execution-engine/storage/Cargo.toml
@@ -13,5 +13,6 @@ parking_lot = "0.7.1"
 shared = { path = "../shared" }
 
 [dev-dependencies]
+lazy_static = "1.3.0"
 proptest = "0.9.2"
 tempfile = "3"

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -145,7 +145,15 @@ mod tests {
     use super::*;
     use history::trie_store::operations::{write, WriteResult};
     use lmdb::DatabaseFlags;
+    use shared::os::get_page_size;
     use tempfile::tempdir;
+
+    lazy_static! {
+        static ref TEST_MAP_SIZE: usize = {
+            let page_size = get_page_size().unwrap();
+            page_size * 2560
+        };
+    }
 
     #[derive(Debug, Clone)]
     struct TestPair {
@@ -183,7 +191,9 @@ mod tests {
 
     fn create_test_state() -> LmdbGlobalState {
         let _temp_dir = tempdir().unwrap();
-        let environment = Arc::new(LmdbEnvironment::new(&_temp_dir.path().to_path_buf()).unwrap());
+        let environment = Arc::new(
+            LmdbEnvironment::new(&_temp_dir.path().to_path_buf(), *TEST_MAP_SIZE).unwrap(),
+        );
         let store =
             Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
         let mut ret = LmdbGlobalState::empty(environment, store).unwrap();

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -149,6 +149,9 @@ mod tests {
     use tempfile::tempdir;
 
     lazy_static! {
+        // 10 MiB = 10485760 bytes
+        // page size on x86_64 linux = 4096 bytes
+        // 10485760 / 4096 = 2560
         static ref TEST_MAP_SIZE: usize = {
             let page_size = get_page_size().unwrap();
             page_size * 2560

--- a/execution-engine/storage/src/history/trie_store/lmdb.rs
+++ b/execution-engine/storage/src/history/trie_store/lmdb.rs
@@ -40,7 +40,8 @@
 //! // LMDB-backed implementations, the environment is the source of
 //! // transactions.
 //! let tmp_dir = tempdir().unwrap();
-//! let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf()).unwrap();
+//! let map_size = 4096 * 2560;  // map size should be a multiple of OS page size
+//! let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), map_size).unwrap();
 //! let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
 //!
 //! // First let's create a read-write transaction, persist the values, but
@@ -168,8 +169,8 @@ pub struct LmdbEnvironment {
 }
 
 impl LmdbEnvironment {
-    pub fn new(path: &PathBuf) -> Result<Self, error::Error> {
-        let env = Environment::new().open(path)?;
+    pub fn new(path: &PathBuf, map_size: usize) -> Result<Self, error::Error> {
+        let env = Environment::new().set_map_size(map_size).open(path)?;
         let path = path.to_owned();
         Ok(LmdbEnvironment { path, env })
     }

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -11,6 +11,9 @@ use tempfile::{tempdir, TempDir};
 use {error, failure};
 
 lazy_static! {
+    // 10 MiB = 10485760 bytes
+    // page size on x86_64 linux = 4096 bytes
+    // 10485760 / 4096 = 2560
     static ref TEST_MAP_SIZE: usize = {
         let page_size = get_page_size().unwrap();
         page_size * 2560

--- a/execution-engine/storage/src/history/trie_store/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/tests.rs
@@ -6,6 +6,9 @@ use shared::newtypes::Blake2bHash;
 use shared::os::get_page_size;
 
 lazy_static! {
+    // 10 MiB = 10485760 bytes
+    // page size on x86_64 linux = 4096 bytes
+    // 10485760 / 4096 = 2560
     static ref TEST_MAP_SIZE: usize = {
         let page_size = get_page_size().unwrap();
         page_size * 2560

--- a/execution-engine/storage/src/lib.rs
+++ b/execution-engine/storage/src/lib.rs
@@ -11,6 +11,10 @@ extern crate shared;
 extern crate wasmi;
 
 #[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
+#[cfg(test)]
 extern crate proptest;
 
 extern crate core;


### PR DESCRIPTION
## Overview
This PR makes the lmdb map size configurable and sets a default map size of 1 GiB.

### Which JIRA issue does this PR relate to? 
https://casperlabs.atlassian.net/browse/EE-319

### Complete this checklist before you submit the PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs development coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, this PR includes tests related to this feature.
- [x] You assigned one person to review this PR

### Notes
N/A
