### PR TITLE
NODE-422: Automatic block proposal

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
@@ -1,0 +1,79 @@
+package io.casperlabs.casper
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent._
+import io.casperlabs.casper.protocol.DeployData
+import io.casperlabs.casper.api.BlockAPI
+import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
+import io.casperlabs.shared.Time
+import io.casperlabs.shared.Log
+import io.casperlabs.metrics.Metrics
+import scala.concurrent.duration._
+import scala.util.control.NonFatal
+
+/** Propose a block automatically whenever a timespan has elapsed or
+  * we have more than a certain number of deploys in the buffer. */
+class AutoProposer[F[_]: Concurrent: Time: Timer: Log: Metrics: MultiParentCasperRef](
+    checkInterval: FiniteDuration,
+    maxInterval: FiniteDuration,
+    maxCount: Int,
+    blockApiLock: Semaphore[F]
+) {
+
+  private val maxElapsedMillis = maxInterval.toMillis
+  private val noDeploys        = Set.empty[DeployData]
+
+  private def run(): F[Unit] = {
+    def loop(prevDeploys: Set[DeployData], lastProposeMillis: Long): F[Unit] = {
+
+      val snapshot = for {
+        currentMillis <- Time[F].currentMillis
+        casper        <- MultiParentCasperRef[F].get
+        // NOTE: Currently the `remainingDeploys` method is private and quite inefficient
+        // (easily goes back to Genesis), but in theory we could try to detect orphans and
+        // propose again automatically.
+        deploys <- casper.fold(noDeploys.pure[F])(_.bufferedDeploys)
+      } yield (currentMillis, currentMillis - lastProposeMillis, deploys, deploys diff prevDeploys)
+
+      snapshot flatMap {
+        case (currentMillis, elapsedMillis, deploys, newDeploys)
+            if newDeploys.nonEmpty && (elapsedMillis >= maxElapsedMillis || newDeploys.size >= maxCount) =>
+          Log[F].info(
+            s"Automatically proposing block after ${elapsedMillis} ms and ${newDeploys.size} new deploys."
+          ) *>
+            BlockAPI.createBlock(blockApiLock) *>
+            loop(deploys, currentMillis)
+
+        case _ =>
+          Timer[F].sleep(checkInterval) *>
+            loop(prevDeploys, lastProposeMillis)
+      }
+    }
+
+    Time[F].currentMillis flatMap { ms =>
+      loop(noDeploys, ms) onError {
+        case NonFatal(ex) =>
+          Log[F].error(s"Error during auto-proposal of blocks.", ex)
+      }
+    }
+  }
+}
+
+object AutoProposer {
+
+  /** Start the proposal loop in the background. */
+  def apply[F[_]: Concurrent: Time: Timer: Log: Metrics: MultiParentCasperRef](
+      checkInterval: FiniteDuration,
+      maxInterval: FiniteDuration,
+      maxCount: Int,
+      blockApiLock: Semaphore[F]
+  ): Resource[F, Unit] =
+    Resource[F, Unit] {
+      val ap = new AutoProposer(checkInterval, maxInterval, maxCount, blockApiLock)
+      Concurrent[F].start(ap.run()) map { fiber =>
+        () -> fiber.cancel
+      }
+    }
+}

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -26,6 +26,7 @@ trait Casper[F[_], A] {
   def deploy(deployData: DeployData): F[Either[Throwable, Unit]]
   def estimator(dag: BlockDagRepresentation[F]): F[A]
   def createBlock: F[CreateBlockStatus]
+  def bufferedDeploys: F[Set[DeployData]]
 }
 
 trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -37,7 +37,11 @@ final case class CasperConf(
     approveGenesisInterval: FiniteDuration,
     approveGenesisDuration: FiniteDuration,
     deployTimestamp: Option[Long],
-    ignoreDeploySignature: Boolean
+    ignoreDeploySignature: Boolean,
+    autoProposeEnabled: Boolean,
+    autoProposeCheckInterval: FiniteDuration,
+    autoProposeMaxInterval: FiniteDuration,
+    autoProposeMaxCount: Int
 ) extends SubConfig
 
 object CasperConf {

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -219,6 +219,9 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
         BlockStore[F].contains(block.blockHash)
       )
 
+  override def bufferedDeploys: F[Set[DeployData]] =
+    Cell[F, CasperState].read.map(_.deployBuffer)
+
   /** Add a deploy to the buffer, if the code passes basic validation. */
   def deploy(deployData: DeployData): F[Either[Throwable, Unit]] =
     (deployData.session, deployData.payment) match {

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -97,7 +97,7 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   ) { _ => implicit casperRef =>
     val defectiveCasper = new MockMultiParentCasper[Task]() {
       override def createBlock: Task[CreateBlockStatus] =
-        throw new RuntimeException("No can do!")
+        throw new RuntimeException("Oh no!")
     }
     for {
       _      <- MultiParentCasperRef[Task].set(defectiveCasper)

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -1,0 +1,199 @@
+package io.casperlabs.casper
+
+import cats._
+import cats.effect._
+import cats.effect.concurrent._
+import cats.implicits._
+import com.google.protobuf.ByteString
+import org.scalatest._
+import org.scalacheck.Arbitrary.arbitrary
+import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
+import io.casperlabs.comm.gossiping.ArbitraryConsensus
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.shared.{Log, Time}
+import monix.eval.Task
+import monix.execution.Scheduler
+import scala.concurrent.duration._
+
+class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
+
+  import AutoProposerTest._
+
+  implicit val cc = ConsensusConfig()
+
+  def sampleDeployData = {
+    val deploy = sample(arbitrary[consensus.Deploy])
+    LegacyConversions.fromDeploy(deploy)
+  }
+
+  behavior of "AutoProposer"
+
+  val waitForCheck = Timer[Task].sleep(2 * DefaultCheckInterval)
+
+  it should "propose if more than max-count deploys are accumulated within max-interval" in TestFixture(
+    maxInterval = 5.seconds,
+    maxCount = 2
+  ) { _ => implicit casperRef =>
+    for {
+      casper <- MockMultiParentCasper[Task]
+      _      <- casper.deploy(sampleDeployData)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 0
+      _      <- casper.deploy(sampleDeployData)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 1
+    } yield ()
+  }
+
+  it should "propose if less than max-count deploys are accumulated after max-interval" in TestFixture(
+    maxInterval = 250.millis,
+    maxCount = 10
+  ) { _ => implicit casperRef =>
+    for {
+      casper <- MockMultiParentCasper[Task]
+      _      <- casper.deploy(sampleDeployData)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 0
+      _      <- Timer[Task].sleep(300.millis)
+      _      = casper.proposalCount shouldBe 1
+    } yield ()
+  }
+
+  it should "not propose if none of the thresholds are reached" in TestFixture(
+    maxInterval = 1.second,
+    maxCount = 2
+  ) { _ => implicit casperRef =>
+    for {
+      casper <- MockMultiParentCasper[Task]
+      _      <- casper.deploy(sampleDeployData)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 0
+    } yield ()
+  }
+
+  it should "not propose if there are no new deploys" in TestFixture(
+    maxInterval = 1.second,
+    maxCount = 1
+  ) { _ => implicit casperRef =>
+    for {
+      casper <- MockMultiParentCasper[Task]
+      d1     = sampleDeployData
+      _      <- casper.deploy(d1)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 1
+      _      <- casper.deploy(d1)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 1
+      d2     = sampleDeployData
+      _      <- casper.deploy(d2)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 2
+    } yield ()
+  }
+
+  it should "not stop if the proposal fails" in TestFixture(
+    maxInterval = 1.second,
+    maxCount = 1
+  ) { _ => implicit casperRef =>
+    val defectiveCasper = new MockMultiParentCasper[Task]() {
+      override def createBlock: Task[CreateBlockStatus] =
+        throw new RuntimeException("No can do!")
+    }
+    for {
+      _      <- MultiParentCasperRef[Task].set(defectiveCasper)
+      _      <- defectiveCasper.deploy(sampleDeployData)
+      _      <- waitForCheck
+      casper <- MockMultiParentCasper[Task]
+      _      <- casper.deploy(sampleDeployData)
+      _      <- waitForCheck
+      _      = casper.proposalCount shouldBe 1
+    } yield ()
+  }
+
+}
+
+object AutoProposerTest {
+  import io.casperlabs.casper.protocol._
+  import io.casperlabs.blockstorage.BlockDagRepresentation
+
+  import Scheduler.Implicits.global
+  implicit val log     = new Log.NOPLog[Task]()
+  implicit val metrics = new Metrics.MetricsNOP[Task]()
+
+  implicit val time = new Time[Task] {
+    val timer                                       = implicitly[Timer[Task]]
+    def currentMillis: Task[Long]                   = timer.clock.realTime(MILLISECONDS)
+    def nanoTime: Task[Long]                        = timer.clock.monotonic(NANOSECONDS)
+    def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
+  }
+
+  val DefaultCheckInterval = 50.millis
+
+  object TestFixture {
+    def apply(
+        checkInterval: FiniteDuration = DefaultCheckInterval,
+        maxInterval: FiniteDuration,
+        maxCount: Int
+    )(
+        f: AutoProposer[Task] => MultiParentCasperRef[Task] => Task[Unit]
+    ): Unit = {
+
+      implicit val emptyRef = MultiParentCasperRef.unsafe[Task]()
+
+      val resources = for {
+        blockApiLock <- Resource.liftF(Semaphore[Task](1))
+        proposer <- AutoProposer[Task](
+                     checkInterval = checkInterval,
+                     maxInterval = maxInterval,
+                     maxCount = maxCount,
+                     blockApiLock = blockApiLock
+                   )
+      } yield (proposer, emptyRef)
+
+      val test = resources.use {
+        case (proposer, casperRef) => f(proposer)(casperRef)
+      }
+
+      test.runSyncUnsafe(5.seconds)
+    }
+  }
+
+  object MockMultiParentCasper {
+    def apply[F[_]: Sync: MultiParentCasperRef] =
+      for {
+        c <- Sync[F].delay(new MockMultiParentCasper[F]())
+        _ <- MultiParentCasperRef[F].set(c)
+      } yield c
+  }
+
+  class MockMultiParentCasper[F[_]: Sync] extends MultiParentCasper[F] {
+
+    @volatile var deployBuffer  = Set.empty[DeployData]
+    @volatile var proposalCount = 0
+
+    override def deploy(deployData: DeployData): F[Either[Throwable, Unit]] =
+      Sync[F].delay {
+        deployBuffer = deployBuffer + deployData
+        Right(())
+      }
+
+    override def bufferedDeploys: F[Set[DeployData]] =
+      deployBuffer.pure[F]
+
+    override def createBlock: F[CreateBlockStatus] =
+      Sync[F].delay {
+        proposalCount += 1
+        ReadOnlyMode
+      }
+
+    override def addBlock(block: BlockMessage): F[BlockStatus] = ???
+
+    override def contains(block: BlockMessage): F[Boolean]                            = ???
+    override def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[ByteString]] = ???
+    override def blockDag: F[BlockDagRepresentation[F]]                               = ???
+    override def fetchDependencies: F[Unit]                                           = ???
+    override def normalizedInitialFault(weights: Map[ByteString, Long]): F[Float]     = ???
+    override def lastFinalizedBlock: F[BlockMessage]                                  = ???
+    override def storageContents(hash: ByteString): F[String]                         = ???
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -96,6 +96,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def lastFinalizedBlock: F[BlockMessage]          = underlying.lastFinalizedBlock
   def storageContents(hash: ByteString): F[String] = underlying.storageContents(hash)
   def fetchDependencies: F[Unit]                   = underlying.fetchDependencies
+  def bufferedDeploys                              = underlying.bufferedDeploys
 
   override def createBlock: F[CreateBlockStatus] =
     for {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -37,6 +37,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def lastFinalizedBlock: F[BlockMessage]                             = BlockMessage().pure[F]
   def storageContents(hash: BlockHash): F[String]                     = "".pure[F]
   def fetchDependencies: F[Unit]                                      = ().pure[F]
+  def bufferedDeploys: F[Set[DeployData]]                             = Set.empty.pure[F]
 }
 
 object NoOpsCasperEffect {

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -179,6 +179,19 @@ approve-genesis-duration = "5minutes"
 ignore-deploy-signature = true
 
 
+# Enable auto-proposal of blocks.
+auto-propose-enabled = false
+
+# Time between proposal checks.
+auto-propose-check-interval = "1second"
+
+# Time to accumulate deploys before proposing.
+auto-propose-max-interval = "5seconds"
+
+# Number of deploys to accumulate before proposing.
+auto-propose-max-count = 10
+
+
 # io.casperlabs.node.configuration.Configuration.Kamon
 [metrics]
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -156,6 +156,9 @@ class NodeRuntime private[node] (
 
         blockApiLock <- Resource.liftF(Semaphore[Effect](1))
 
+        // For now just either starting the auto-proposer or not, but ostensibly we
+        // could pass it the flag to run or not and also wire it into the ControlService
+        // so that the operator can turn it on/off on the fly.
         _ <- AutoProposer[Effect](
               checkInterval = conf.casper.autoProposeCheckInterval,
               maxInterval = conf.casper.autoProposeMaxInterval,
@@ -164,7 +167,6 @@ class NodeRuntime private[node] (
             )(
               Concurrent[Effect],
               Time.eitherTTime(Monad[Task], effects.time),
-              Timer[Effect],
               logEff,
               metricsEff,
               multiParentCasperRef

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -157,9 +157,9 @@ class NodeRuntime private[node] (
         blockApiLock <- Resource.liftF(Semaphore[Effect](1))
 
         _ <- AutoProposer[Effect](
-              checkInterval = 1.second,
-              maxInterval = 5.seconds,
-              maxCount = 5,
+              checkInterval = conf.casper.autoProposeCheckInterval,
+              maxInterval = conf.casper.autoProposeMaxInterval,
+              maxCount = conf.casper.autoProposeMaxCount,
               blockApiLock = blockApiLock
             )(
               Concurrent[Effect],
@@ -168,7 +168,7 @@ class NodeRuntime private[node] (
               logEff,
               metricsEff,
               multiParentCasperRef
-            ).whenA(false)
+            ).whenA(conf.casper.autoProposeEnabled)
 
         _ <- api.Servers
               .internalServersR(

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -156,6 +156,20 @@ class NodeRuntime private[node] (
 
         blockApiLock <- Resource.liftF(Semaphore[Effect](1))
 
+        _ <- AutoProposer[Effect](
+              checkInterval = 1.second,
+              maxInterval = 5.seconds,
+              maxCount = 5,
+              blockApiLock = blockApiLock
+            )(
+              Concurrent[Effect],
+              Time.eitherTTime(Monad[Task], effects.time),
+              Timer[Effect],
+              logEff,
+              metricsEff,
+              multiParentCasperRef
+            ).whenA(false)
+
         _ <- api.Servers
               .internalServersR(
                 conf.grpc.portInternal,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -288,6 +288,23 @@ private[configuration] final case class Options private (
     @scallop
     val casperIgnoreDeploySignature =
       gen[Flag]("Bypass deploy hash and signature validation, for debug purposes.")
+
+    @scallop
+    val casperAutoProposeEnabled =
+      gen[Flag]("Enable auto-proposal of blocks.")
+
+    @scallop
+    val casperAutoProposeCheckInterval =
+      gen[FiniteDuration]("Time between proposal checks.")
+
+    @scallop
+    val casperAutoProposeMaxInterval =
+      gen[FiniteDuration]("Time to accumulate deploys before proposing.")
+
+    @scallop
+    val casperAutoProposeMaxCount =
+      gen[Int]("Number of deploys to accumulate before proposing.")
+
     @scallop
     val serverBootstrap =
       gen[Node](

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -56,6 +56,10 @@ approve-genesis-interval = "1second"
 approve-genesis-duration = "1second"
 deploy-timestamp = 1
 ignore-deploy-signature = false
+auto-propose-enabled = false
+auto-propose-check-interval = "1second"
+auto-propose-max-interval = "1second"
+auto-propose-max-count = 1
 
 [blockstorage]
 latest-messages-log-max-size-factor = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -88,7 +88,11 @@ class ConfigurationSpec
       approveGenesisDuration = FiniteDuration(1, TimeUnit.SECONDS),
       deployTimestamp = 1L.some,
       genesisPath = Paths.get("/tmp/genesis"),
-      ignoreDeploySignature = false
+      ignoreDeploySignature = false,
+      autoProposeEnabled = false,
+      autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
+      autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),
+      autoProposeMaxCount = 1
     )
     val tls = Tls(
       certificate = Paths.get("/tmp/test"),


### PR DESCRIPTION
### Overview
Add an `AutoProposer` component to propose a block when we have received new deploys over a certain number or if they have been waiting for longer then a certain time.

You can switch it on with the `--casper-auto-propose-enabled` flag and set parameters like `--casper-auto-propose-max-count=5` and `--caser-auto-propose-max-interval=5seconds`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-422

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
