### PR TITLE
OP-245: cherry-pick EE-319 into release-v0.3 branch

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -30,7 +30,7 @@ name = "atty"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -48,7 +48,7 @@ dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -59,7 +59,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -282,7 +282,7 @@ name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -420,7 +420,7 @@ name = "hostname"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -450,7 +450,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -460,7 +460,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -499,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.50"
+version = "0.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -508,7 +508,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -518,7 +518,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -582,7 +582,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -596,7 +596,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -617,7 +617,7 @@ version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -682,7 +682,7 @@ name = "num_cpus"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -720,7 +720,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -835,7 +835,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -847,7 +847,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -902,7 +902,7 @@ name = "rand_jitter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -914,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1089,6 +1089,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "machine-ip 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1167,6 +1168,7 @@ version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.5.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1227,7 +1229,7 @@ version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1249,7 +1251,7 @@ name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1275,7 +1277,7 @@ name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1504,7 +1506,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1520,7 +1522,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1565,7 +1567,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1616,7 +1618,7 @@ name = "wait-timeout"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1643,7 +1645,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
  "memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1749,7 +1751,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
-"checksum libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)" = "aab692d7759f5cd8c859e169db98ae5b52c924add2af5fbbca11d12fefb567c1"
+"checksum libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)" = "42914d39aad277d9e176efbdad68acb1d5443ab65afe0e0e4f0d49352a950880"
 "checksum lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b0908efb5d6496aa977d96f91413da2635a902e5e31dbef0bfb88986c248539"
 "checksum lmdb-sys 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5b392838cfe8858e86fac37cf97a0e8c55cc60ba0a18365cadc33092f128ce9"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -31,7 +31,7 @@ const GLOBAL_STATE_DIR: &str = "global_state";
 // 1 GiB = 1073741824 bytes
 // page size on x86_64 linux = 4096 bytes
 // 1073741824 / 4096 = 262144
-const DEFAULT_PAGES: usize = 262144;
+const DEFAULT_PAGES: usize = 262_144;
 
 const GET_PAGES_EXPECT: &str = "Could not parse pages argument";
 const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -17,8 +17,10 @@ use dirs::home_dir;
 use engine_server::*;
 use execution_engine::engine::EngineState;
 use lmdb::DatabaseFlags;
+use shared::os::get_page_size;
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use storage::global_state::lmdb::LmdbGlobalState;
 use storage::history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
@@ -26,6 +28,12 @@ use storage::history::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
 const DEFAULT_DATA_DIR_RELATIVE: &str = ".casperlabs";
 const GLOBAL_STATE_DIR: &str = "global_state";
 
+// 1 GiB = 1073741824 bytes
+// page size on x86_64 linux = 4096 bytes
+// 1073741824 / 4096 = 262144
+const DEFAULT_PAGES: usize = 262144;
+
+const GET_PAGES_EXPECT: &str = "Could not parse pages argument";
 const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";
 const CREATE_DATA_DIR_EXPECT: &str = "Could not create directory";
 const LMDB_ENVIRONMENT_EXPECT: &str = "Could not create LmdbEnvironment";
@@ -41,6 +49,14 @@ fn main() {
                 .long("data-dir")
                 .value_name("DIR")
                 .help("Sets the data directory")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("pages")
+                .short("p")
+                .long("pages")
+                .value_name("NUM")
+                .help("Sets the number of max number of pages to use for lmdb's mmap")
                 .takes_value(true),
         )
         .get_matches();
@@ -67,8 +83,17 @@ fn main() {
         ret
     };
 
+    let map_size: usize = {
+        let page_size = get_page_size().unwrap();
+        let pages = matches
+            .value_of("pages")
+            .map_or(Ok(DEFAULT_PAGES), usize::from_str)
+            .expect(GET_PAGES_EXPECT);
+        page_size * pages
+    };
+
     let environment = {
-        let ret = LmdbEnvironment::new(&data_dir).expect(LMDB_ENVIRONMENT_EXPECT);
+        let ret = LmdbEnvironment::new(&data_dir, map_size).expect(LMDB_ENVIRONMENT_EXPECT);
         Arc::new(ret)
     };
 

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
                 .short("p")
                 .long("pages")
                 .value_name("NUM")
-                .help("Sets the number of max number of pages to use for lmdb's mmap")
+                .help("Sets the max number of pages to use for lmdb's mmap")
                 .takes_value(true),
         )
         .get_matches();

--- a/execution-engine/shared/Cargo.toml
+++ b/execution-engine/shared/Cargo.toml
@@ -10,6 +10,7 @@ chrono = "0.4.6"
 common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }
 hostname = "0.1.5"
 lazy_static = "1.3.0"
+libc = "0.2.54"
 machine-ip = "0.2.1"
 serde = { version = "1.0.90", features = ["derive"] }
 serde_json = "1.0.39"

--- a/execution-engine/shared/src/lib.rs
+++ b/execution-engine/shared/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate blake2;
 extern crate chrono;
 extern crate common;
-extern crate machine_ip;
+extern crate libc;
 #[macro_use]
 extern crate slog;
 extern crate slog_async;
@@ -11,4 +11,5 @@ extern crate slog_term;
 
 pub mod logging;
 pub mod newtypes;
+pub mod os;
 pub mod test_utils;

--- a/execution-engine/shared/src/os/mod.rs
+++ b/execution-engine/shared/src/os/mod.rs
@@ -1,0 +1,15 @@
+use std::io;
+
+use libc::{c_long, sysconf, _SC_PAGESIZE};
+
+/// Returns OS page size
+pub fn get_page_size() -> Result<usize, io::Error> {
+    // https://www.gnu.org/software/libc/manual/html_node/Sysconf.html
+    let value: c_long = unsafe { sysconf(_SC_PAGESIZE) };
+
+    if value < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(value as usize)
+}

--- a/execution-engine/storage/Cargo.toml
+++ b/execution-engine/storage/Cargo.toml
@@ -13,5 +13,6 @@ parking_lot = "0.7.1"
 shared = { path = "../shared" }
 
 [dev-dependencies]
+lazy_static = "1.3.0"
 proptest = "0.9.2"
 tempfile = "3"

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -145,7 +145,15 @@ mod tests {
     use super::*;
     use history::trie_store::operations::{write, WriteResult};
     use lmdb::DatabaseFlags;
+    use shared::os::get_page_size;
     use tempfile::tempdir;
+
+    lazy_static! {
+        static ref TEST_MAP_SIZE: usize = {
+            let page_size = get_page_size().unwrap();
+            page_size * 2560
+        };
+    }
 
     #[derive(Debug, Clone)]
     struct TestPair {
@@ -183,7 +191,9 @@ mod tests {
 
     fn create_test_state() -> LmdbGlobalState {
         let _temp_dir = tempdir().unwrap();
-        let environment = Arc::new(LmdbEnvironment::new(&_temp_dir.path().to_path_buf()).unwrap());
+        let environment = Arc::new(
+            LmdbEnvironment::new(&_temp_dir.path().to_path_buf(), *TEST_MAP_SIZE).unwrap(),
+        );
         let store =
             Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
         let mut ret = LmdbGlobalState::empty(environment, store).unwrap();

--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -149,6 +149,9 @@ mod tests {
     use tempfile::tempdir;
 
     lazy_static! {
+        // 10 MiB = 10485760 bytes
+        // page size on x86_64 linux = 4096 bytes
+        // 10485760 / 4096 = 2560
         static ref TEST_MAP_SIZE: usize = {
             let page_size = get_page_size().unwrap();
             page_size * 2560

--- a/execution-engine/storage/src/history/trie_store/lmdb.rs
+++ b/execution-engine/storage/src/history/trie_store/lmdb.rs
@@ -40,7 +40,8 @@
 //! // LMDB-backed implementations, the environment is the source of
 //! // transactions.
 //! let tmp_dir = tempdir().unwrap();
-//! let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf()).unwrap();
+//! let map_size = 4096 * 2560;  // map size should be a multiple of OS page size
+//! let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), map_size).unwrap();
 //! let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
 //!
 //! // First let's create a read-write transaction, persist the values, but
@@ -168,8 +169,8 @@ pub struct LmdbEnvironment {
 }
 
 impl LmdbEnvironment {
-    pub fn new(path: &PathBuf) -> Result<Self, error::Error> {
-        let env = Environment::new().open(path)?;
+    pub fn new(path: &PathBuf, map_size: usize) -> Result<Self, error::Error> {
+        let env = Environment::new().set_map_size(map_size).open(path)?;
         let path = path.to_owned();
         Ok(LmdbEnvironment { path, env })
     }

--- a/execution-engine/storage/src/history/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/operations/tests.rs
@@ -11,6 +11,9 @@ use tempfile::{tempdir, TempDir};
 use {error, failure};
 
 lazy_static! {
+    // 10 MiB = 10485760 bytes
+    // page size on x86_64 linux = 4096 bytes
+    // 10485760 / 4096 = 2560
     static ref TEST_MAP_SIZE: usize = {
         let page_size = get_page_size().unwrap();
         page_size * 2560

--- a/execution-engine/storage/src/history/trie_store/tests.rs
+++ b/execution-engine/storage/src/history/trie_store/tests.rs
@@ -6,6 +6,9 @@ use shared::newtypes::Blake2bHash;
 use shared::os::get_page_size;
 
 lazy_static! {
+    // 10 MiB = 10485760 bytes
+    // page size on x86_64 linux = 4096 bytes
+    // 10485760 / 4096 = 2560
     static ref TEST_MAP_SIZE: usize = {
         let page_size = get_page_size().unwrap();
         page_size * 2560

--- a/execution-engine/storage/src/lib.rs
+++ b/execution-engine/storage/src/lib.rs
@@ -11,6 +11,10 @@ extern crate shared;
 extern crate wasmi;
 
 #[cfg(test)]
+#[macro_use]
+extern crate lazy_static;
+
+#[cfg(test)]
 extern crate proptest;
 
 #[cfg(test)]


### PR DESCRIPTION
### Overview
This PR cherry-picks changes from [EE-319](https://casperlabs.atlassian.net/browse/EE-319) into the `release-v0.3` branch for our `0.3.1` release.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-245

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
See #485 for PR targeting `dev`.
