### PR TITLE
OP-246: bump version numbers to 0.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,7 @@ lazy val models = (project in file("models"))
   )
   .dependsOn(crypto, shared % "compile->compile;test->test")
 
-val nodeAndClientVersion = "0.3"
+val nodeAndClientVersion = "0.3.1"
 
 lazy val node = (project in file("node"))
   .settings(commonSettings: _*)

--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-engine-grpc-server"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "casperlabs-contract-ffi 0.5.0",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution-engine/comm/Cargo.toml
+++ b/execution-engine/comm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-grpc-server"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 description = "WASM execution engine for CasperLabs smart contracts"
 license = "Apache-2.0"


### PR DESCRIPTION
### Overview
This PR bumps the version numbers to 0.3.1 in the `release-v0.3` branch.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-246

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
