### PR TITLE
NODE-415: Add support for public and private key and deploy signing in CLI client.

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -340,7 +340,7 @@ cargo run --bin casperlabs-engine-grpc-server ~/.casperlabs/.casper-node.sock
 
 In the root of CasperLabs.
 
-[Generate secp256r1 key and X.509 certificate firstly](/VALIDATOR.md/setting-up-keys).
+[Generate secp256r1 key and X.509 certificate firstly](/VALIDATOR.md#setting-up-keys).
 
 ```bash
 ./node/target/universal/stage/bin/casperlabs-node run -s \

--- a/VALIDATOR.md
+++ b/VALIDATOR.md
@@ -65,7 +65,7 @@ Server is listening on socket: casperlabs-node-data/.caspernode.sock
 
 
 ### Setting up keys
-1. `secp256r1` (required) private key encoded in unencrypted `PKCS#8` format and `X.509` certificate. Used for node-to-node interaction. 
+1. `secp256r1` (required) private key encoded in unencrypted `PKCS#8` format and `X.509` certificate. Used for node-to-node interaction.
 2. `ed25519` (optional) private and public keys. Used as a validator identity. If not provided then a node starts in the read-only mode.
 
 #### Prerequisites: OpenSSL
@@ -90,8 +90,8 @@ To continue to have working lib folder, consider adding last line to bottom of `
 Download and install the latest version of the [sha3sum](https://github.com/maandree/sha3sum).
 
 1. macOS: `brew install sha3sum`
-2. Ubunt 18.04: 
-    
+2. Ubunt 18.04:
+
  Build libkeccak:
 
 ```bash
@@ -113,7 +113,7 @@ sudo make install
 ```
 
 #### Script
-You may want to use [the script](/docker/gen-keys.sh) which will generate all the keys. The commands below are excerpts from this script. 
+You may want to use [the script](/docker/gen-keys.sh) which will generate all the keys. The commands below are excerpts from this script.
 
 #### ed25519
 Generate private key:
@@ -167,7 +167,7 @@ casperlabs://c0a6c82062461c9b7f9f5c3120f44589393edf31@<NODE ADDRESS>?protocol=40
 ```
 The address above contains `c0a6c82062461c9b7f9f5c3120f44589393edf31` as a node ID.
 
-Generate certificate from the generated private key. Fill asked questions and enter the above `NODE_ID` as a `Common Name (CN)` 
+Generate certificate from the generated private key. Fill asked questions and enter the above `NODE_ID` as a `Common Name (CN)`
 ```bash
 openssl req \
     -new \
@@ -219,7 +219,8 @@ $ casperlabs-node \
      --tls-key secp256r1-private-pkcs8.pem \
      --casper-validator-private-key-path ed25519-private.pem \
      --casper-validator-public-key-path ed25519-public.pem \
-     --grpc-socket casperlabs-node-data/.caspernode.sock
+     --grpc-socket casperlabs-node-data/.caspernode.sock \
+     --casper-auto-propose-enabled
 ```
 
 

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -44,8 +44,15 @@ object Main {
 
       case ShowBlocks(depth) => DeployRuntime.showBlocks(depth)
 
-      case Deploy(from, nonce, sessionCode, paymentCode) =>
-        DeployRuntime.deployFileProgram(from, nonce, sessionCode, paymentCode)
+      case Deploy(from, nonce, sessionCode, paymentCode, maybePublicKey, maybePrivateKey) =>
+        DeployRuntime.deployFileProgram(
+          from,
+          nonce,
+          sessionCode,
+          paymentCode,
+          maybePublicKey,
+          maybePrivateKey
+        )
 
       case Propose =>
         DeployRuntime.propose()

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -13,7 +13,9 @@ final case class Deploy(
     from: String,
     nonce: Long,
     sessionCode: File,
-    paymentCode: File
+    paymentCode: File,
+    publicKey: Option[File],
+    privateKey: Option[File]
 ) extends Configuration
 
 final case object Propose extends Configuration
@@ -50,7 +52,9 @@ object Configuration {
           options.deploy.from(),
           options.deploy.nonce(),
           options.deploy.session(),
-          options.deploy.payment()
+          options.deploy.payment(),
+          options.deploy.publicKey.toOption,
+          options.deploy.privateKey.toOption
         )
       case options.propose =>
         Propose

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -75,9 +75,23 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val session =
       opt[File](required = true, descr = "Path to the file with session code", validate = fileCheck)
+
     val payment =
       opt[File](required = true, descr = "Path to the file with payment code", validate = fileCheck)
 
+    val publicKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account public key (Ed25519)",
+        validate = fileCheck
+      )
+
+    val privateKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account private key (Ed25519)",
+        validate = fileCheck
+      )
   }
   addSubcommand(deploy)
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,6 +72,7 @@ Assuming that you cloned and compiled the [contract-examples](https://github.com
 ```console
 ./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
      --from 00000000000000000000 \
+     --gas-price 1 \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm
 ```
@@ -102,6 +103,7 @@ To sign deploy you'll need to [generate and ed25519 keypair](/VALIDATOR.md#setti
 
 ```console
 ./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
+     --gas-price 1 \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm \
      --public-key /keys/public.key \

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,6 @@ Assuming that you cloned and compiled the [contract-examples](https://github.com
 ```console
 ./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
      --from 00000000000000000000 \
-     --gas-price 1 \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm
 ```
@@ -96,6 +95,18 @@ Response: Success! Block f876efed8d... created and added.
 ```
 
 If you check the log output, each node should get the block and provide some feedback about the execution as well.
+
+### Signing Deploys
+
+To sign deploy you'll need to [generate and ed25519 keypair](/VALIDATOR.md#setting-up-keys) and save them into `docker/keys`. The `client.sh` script will automatically mount this as a volume and you can pass them as CLI arguments, for example:
+
+```console
+./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
+     --session /data/helloname.wasm \
+     --payment /data/helloname.wasm \
+     --public-key /keys/public.key \
+     --private-key /keys/private.key
+```
 
 ## Monitoring
 

--- a/docker/client.sh
+++ b/docker/client.sh
@@ -37,6 +37,7 @@ function run_with_vol() {
     docker run --rm \
         --network casperlabs \
         --volume $VOL:/data \
+        --volume $PWD/keys:/keys \
         casperlabs/client:latest \
         --host $NODE $CMD $@
 }


### PR DESCRIPTION
### Overview
Client needs to sign the deploy. This PR adds `--public-key` and `--private-key` parameters but makes them optional since the integration tests need to be updated first, as well as the examples, and we're waiting for the Base64 PR as well to be merged, which will change this code and add docs about how to generate keys. Currently it's still expecting Base16.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-415

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
