### PR TITLE
NO-TICKET: remove constraint on TrackingCopy

### DIFF
--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -103,7 +103,7 @@ impl From<ResolverError> for Error {
 
 impl HostError for Error {}
 
-pub struct Runtime<'a, R: StateReader<Key, Value>> {
+pub struct Runtime<'a, R> {
     memory: MemoryRef,
     module: Module,
     result: Vec<u8>,

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -16,7 +16,7 @@ use storage::global_state::{ExecutionEffect, StateReader};
 use trackingcopy::{AddResult, TrackingCopy};
 
 /// Holds information specific to the deployed contract.
-pub struct RuntimeContext<'a, R: StateReader<Key, Value>> {
+pub struct RuntimeContext<'a, R> {
     state: Rc<RefCell<TrackingCopy<R>>>,
     // Enables look up of specific uref based on human-readable name
     uref_lookup: &'a mut BTreeMap<String, Key>,

--- a/execution-engine/engine/src/trackingcopy.rs
+++ b/execution-engine/engine/src/trackingcopy.rs
@@ -78,7 +78,7 @@ impl<M: Meter<Key, Value>> TrackingCopyCache<M> {
     }
 }
 
-pub struct TrackingCopy<R: StateReader<Key, Value>> {
+pub struct TrackingCopy<R> {
     reader: R,
     cache: TrackingCopyCache<HeapSize>,
     ops: HashMap<Key, Op>,


### PR DESCRIPTION
### Overview
This PR removes the `StateReader` constraint on `TrackingCopy`.  As discussed with @goral09 and @birchmd, we should prefer to constrain usage/behavior rather than the types themselves.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
