### PR TITLE
NO-TICKET: remove constraint on EngineState

### DIFF
--- a/execution-engine/engine/src/engine.rs
+++ b/execution-engine/engine/src/engine.rs
@@ -15,10 +15,7 @@ use wasm_prep::Preprocessor;
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RootNotFound(pub Blake2bHash);
 
-pub struct EngineState<H>
-where
-    H: History,
-{
+pub struct EngineState<H> {
     // Tracks the "state" of the blockchain (or is an interface to it).
     // I think it should be constrained with a lifetime parameter.
     state: Mutex<H>,


### PR DESCRIPTION
### Overview
This PR removes the `History` constraint on `EngineState`.  As discussed with @goral09 and @birchmd, we should prefer to constrain usage/behavior rather than the types themselves.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
