### PR TITLE
NODE-506: Make genesis approval optional.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
@@ -156,6 +156,9 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
     tryAddApproval(blockHash, approval) flatMap {
       case Right(Some(newStatus)) =>
         for {
+          _ <- Log[F].info(
+                s"Added new approval; got ${newStatus.candidate.approvals.size} in total."
+              )
           transitioned <- tryTransition(newStatus)
           _            <- Concurrent[F].start(relayApproval(blockHash, approval))
         } yield {

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
@@ -101,7 +101,7 @@ object GenesisApproverImpl {
       connectToGossip: GossipService.Connector[F],
       relayFactor: Int,
       genesis: Block,
-      approval: Approval
+      maybeApproval: Option[Approval]
   ): Resource[F, GenesisApprover[F]] =
     Resource.liftF {
       for {
@@ -119,7 +119,7 @@ object GenesisApproverImpl {
           relayFactor
         )
         // Gossip, trigger as usual.
-        _ <- approver.addApprovals(genesis.blockHash, List(approval))
+        _ <- approver.addApprovals(genesis.blockHash, maybeApproval.toList)
       } yield approver
     }
 }

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -316,7 +316,12 @@ package object gossiping {
               }
 
       validatorId <- Resource.liftF {
-                      ValidatorIdentity.fromConfig[F](conf.casper)
+                      for {
+                        id <- ValidatorIdentity.fromConfig[F](conf.casper)
+                        _ <- Log[F].info(
+                              s"Starting ${if (id.nonEmpty) "with" else "without"} a validator identity."
+                            )
+                      } yield id
                     }
 
       maybeApproveBlock = (block: Block) =>


### PR DESCRIPTION
### Overview
Currently the bootstrap (i.e. the first, standalone) node was expected to have a validator identity and able to approve the genesis candidate. This may not be the case: a standalone node may just create the genesis and wait for nodes started with the `--casper-approve-genesis` flag to connect to it (using it as their bootstrap), and submit their approvals to the genesis it serves. The reason this came out was because an accidental omission of the validator keys resulted in a cryptic exception.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-506

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
