### PR TITLE
NO-TICKET: tweak storage

### DIFF
--- a/execution-engine/storage/src/global_state/lmdb.rs
+++ b/execution-engine/storage/src/global_state/lmdb.rs
@@ -147,20 +147,9 @@ mod tests {
     use lmdb::DatabaseFlags;
     use tempfile::tempdir;
 
-    use shared::os::get_page_size;
-
     use super::*;
     use trie_store::operations::{write, WriteResult};
-
-    lazy_static! {
-        // 10 MiB = 10485760 bytes
-        // page size on x86_64 linux = 4096 bytes
-        // 10485760 / 4096 = 2560
-        static ref TEST_MAP_SIZE: usize = {
-            let page_size = get_page_size().unwrap();
-            page_size * 2560
-        };
-    }
+    use TEST_MAP_SIZE;
 
     #[derive(Debug, Clone)]
     struct TestPair {

--- a/execution-engine/storage/src/global_state/mod.rs
+++ b/execution-engine/storage/src/global_state/mod.rs
@@ -1,3 +1,6 @@
+pub mod in_memory;
+pub mod lmdb;
+
 use std::collections::HashMap;
 use std::hash::BuildHasher;
 
@@ -9,9 +12,6 @@ use shared::transform::{self, Transform, TypeMismatch};
 use trie::Trie;
 use trie_store::operations::{read, write, ReadResult, WriteResult};
 use trie_store::{Transaction, TransactionSource, TrieStore};
-
-pub mod in_memory;
-pub mod lmdb;
 
 /// A reader of state
 pub trait StateReader<K, V> {

--- a/execution-engine/storage/src/lib.rs
+++ b/execution-engine/storage/src/lib.rs
@@ -28,3 +28,14 @@ pub mod error;
 pub mod global_state;
 pub mod trie;
 pub mod trie_store;
+
+#[cfg(test)]
+lazy_static! {
+    // 10 MiB = 10485760 bytes
+    // page size on x86_64 linux = 4096 bytes
+    // 10485760 / 4096 = 2560
+    static ref TEST_MAP_SIZE: usize = {
+        let page_size = shared::os::get_page_size().unwrap();
+        page_size * 2560
+    };
+}

--- a/execution-engine/storage/src/trie/tests.rs
+++ b/execution-engine/storage/src/trie/tests.rs
@@ -8,6 +8,8 @@ fn radix_is_256() {
 }
 
 mod pointer_block {
+    use shared::newtypes::Blake2bHash;
+
     use trie::*;
 
     /// A defense against changes to [`RADIX`](history::trie::RADIX).

--- a/execution-engine/storage/src/trie_store/mod.rs
+++ b/execution-engine/storage/src/trie_store/mod.rs
@@ -2,17 +2,15 @@
 //!
 //! See the [in_memory](in_memory/index.html#usage) and
 //! [lmdb](lmdb/index.html#usage) modules for usage examples.
+pub mod in_memory;
+pub mod lmdb;
+pub(crate) mod operations;
+#[cfg(test)]
+mod tests;
 
 use shared::newtypes::Blake2bHash;
 
 use trie::Trie;
-
-pub mod in_memory;
-pub mod lmdb;
-pub(crate) mod operations;
-
-#[cfg(test)]
-mod tests;
 
 /// A transaction which can be committed or aborted.
 pub trait Transaction: Sized {

--- a/execution-engine/storage/src/trie_store/operations/tests.rs
+++ b/execution-engine/storage/src/trie_store/operations/tests.rs
@@ -4,7 +4,6 @@ use tempfile::{tempdir, TempDir};
 
 use common::bytesrepr::{self, FromBytes, ToBytes};
 use shared::newtypes::Blake2bHash;
-use shared::os::get_page_size;
 
 use error;
 use trie::{Pointer, Trie};
@@ -12,16 +11,7 @@ use trie_store::in_memory::{self, InMemoryEnvironment, InMemoryTrieStore};
 use trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
 use trie_store::operations::{read, write, ReadResult, WriteResult};
 use trie_store::{Readable, Transaction, TransactionSource, TrieStore};
-
-lazy_static! {
-    // 10 MiB = 10485760 bytes
-    // page size on x86_64 linux = 4096 bytes
-    // 10485760 / 4096 = 2560
-    static ref TEST_MAP_SIZE: usize = {
-        let page_size = get_page_size().unwrap();
-        page_size * 2560
-    };
-}
+use TEST_MAP_SIZE;
 
 const TEST_KEY_LENGTH: usize = 7;
 

--- a/execution-engine/storage/src/trie_store/tests.rs
+++ b/execution-engine/storage/src/trie_store/tests.rs
@@ -1,20 +1,10 @@
 use common::bytesrepr::ToBytes;
 use shared::newtypes::Blake2bHash;
-use shared::os::get_page_size;
 
 use trie::Trie;
 use trie::{Pointer, PointerBlock};
 use trie_store::{Readable, TrieStore, Writable};
-
-lazy_static! {
-    // 10 MiB = 10485760 bytes
-    // page size on x86_64 linux = 4096 bytes
-    // 10485760 / 4096 = 2560
-    static ref TEST_MAP_SIZE: usize = {
-        let page_size = get_page_size().unwrap();
-        page_size * 2560
-    };
-}
+use TEST_MAP_SIZE;
 
 #[derive(Clone)]
 struct TestData<K, V>(Blake2bHash, Trie<K, V>);


### PR DESCRIPTION
### Overview
This PR:
- eliminates duplicate definitions of `TEST_MAP_SIZE`,
- moves module declarations above imports (which is how we are doing it in `engine`), and
- adds an explicit import of Blake2bHash in one of the test modules.  The crate will build without this change, but I have no idea why and CLion doesn't like it.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
