### PR TITLE
OP-254 Allowing only 1 failure for pytest.

### DIFF
--- a/integration-testing/pytest.ini
+++ b/integration-testing/pytest.ini
@@ -8,3 +8,4 @@ log_file_level=info
 log_file_format = [%(filename)10s:%(lineno)3d] %(asctime)s %(message)s
 json_report=report.json
 jsonapi=anything
+addopts = --maxfail=1


### PR DESCRIPTION
### Overview
Terminates integration tests after one failure occurs.  We are never going to pass an integration test run with one failure.  Stop running to reduce CI load.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-254

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
