### PR TITLE
NO-TICKET: execution-engine: remove Unreachable variants

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -460,9 +460,6 @@ impl From<ExecutionResult> for ipc::DeployResult {
                             err
                         }
                     },
-                    EngineError::Unreachable => {
-                        panic!("From<ExecutionResult> for ipc::DeployResult reached unreachable.")
-                    }
                 }
             }
         }

--- a/execution-engine/engine/src/engine_state/error.rs
+++ b/execution-engine/engine/src/engine_state/error.rs
@@ -51,8 +51,8 @@ impl From<::execution::Error> for Error {
 }
 
 impl From<!> for Error {
-    fn from(_error: !) -> Self {
-        unreachable!()
+    fn from(error: !) -> Self {
+        match error {}
     }
 }
 

--- a/execution-engine/engine/src/engine_state/error.rs
+++ b/execution-engine/engine/src/engine_state/error.rs
@@ -10,8 +10,6 @@ pub enum Error {
     ExecError(::execution::Error),
     #[fail(display = "Storage error")]
     StorageError(storage::error::Error),
-    #[fail(display = "Unreachable")]
-    Unreachable,
 }
 
 impl From<wasm_prep::PreprocessingError> for Error {
@@ -54,7 +52,7 @@ impl From<::execution::Error> for Error {
 
 impl From<!> for Error {
     fn from(_error: !) -> Self {
-        Error::Unreachable
+        unreachable!()
     }
 }
 

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -55,7 +55,6 @@ pub enum Error {
     GasLimit,
     Ret(Vec<Key>),
     Rng(rand::Error),
-    Unreachable,
     ResolverError(ResolverError),
 }
 
@@ -91,7 +90,7 @@ impl From<BytesReprError> for Error {
 
 impl From<!> for Error {
     fn from(_err: !) -> Error {
-        Error::Unreachable
+        unreachable!()
     }
 }
 

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -89,8 +89,8 @@ impl From<BytesReprError> for Error {
 }
 
 impl From<!> for Error {
-    fn from(_err: !) -> Error {
-        unreachable!()
+    fn from(error: !) -> Error {
+        match error {}
     }
 }
 


### PR DESCRIPTION
### Overview
This PR removes `Unreachable` variants in `Error` types in favor of using the `unreachable!` macro in `From<!>` impls.

### Which JIRA ticket does this PR relate to?
This is unticketed work

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Documentation on `unreachable!` here:
https://doc.rust-lang.org/std/macro.unreachable.html
