### PR TITLE
OP-216: Update integration tests to work with new gossiping

### DIFF
--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -92,8 +92,8 @@ class CasperLabsNetwork:
     def start_cl_node(self, node_number: int) -> None:
         self.cl_nodes[node_number].execution_engine.start()
         node = self.cl_nodes[node_number].node
-        with wait_for_log_watcher(RequestedForkTipFromPeersInLogLine(node.container)):
-            node.start()
+        node.start()
+        wait_for_approved_block_received_handler_state(node, node.config.command_timeout)
 
     def wait_for_peers(self) -> None:
         if self.node_count < 2:

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -92,6 +92,7 @@ class CasperLabsNetwork:
     def start_cl_node(self, node_number: int) -> None:
         self.cl_nodes[node_number].execution_engine.start()
         node = self.cl_nodes[node_number].node
+        node.truncate_logs()
         node.start()
         wait_for_approved_block_received_handler_state(node, node.config.command_timeout)
 

--- a/integration-testing/test/cl_node/docker_base.py
+++ b/integration-testing/test/cl_node/docker_base.py
@@ -59,7 +59,7 @@ class DockerConfig:
     is_bootstrap: bool = False
     is_validator: bool = True
     bootstrap_address: Optional[str] = None
-    is_gossiping: bool = False
+    is_gossiping: bool = True
 
     def __post_init__(self):
         if self.rand_str is None:

--- a/integration-testing/test/cl_node/docker_base.py
+++ b/integration-testing/test/cl_node/docker_base.py
@@ -201,6 +201,7 @@ class LoggingDockerBase(DockerBase):
         super().__init__(config, socket_volume)
         self.terminate_background_logging_event = threading.Event()
         self._start_logging_thread()
+        self._truncatedLength = 0
 
     def _start_logging_thread(self):
         self.background_logging = LoggingThread(
@@ -223,7 +224,10 @@ class LoggingDockerBase(DockerBase):
         return super()._get_container()
 
     def logs(self) -> str:
-        return self.container.logs().decode('utf-8')
+        return self.container.logs().decode('utf-8')[self._truncatedLength:]
+
+    def truncate_logs(self):
+        self._truncatedLength = len(self.container.logs().decode('utf-8'))
 
     def cleanup(self):
         super().cleanup()

--- a/integration-testing/test/cl_node/docker_base.py
+++ b/integration-testing/test/cl_node/docker_base.py
@@ -59,7 +59,7 @@ class DockerConfig:
     is_bootstrap: bool = False
     is_validator: bool = True
     bootstrap_address: Optional[str] = None
-    is_gossiping: bool = True
+    use_new_gossiping: bool = True
 
     def __post_init__(self):
         if self.rand_str is None:
@@ -81,7 +81,7 @@ class DockerConfig:
             options['--server-bootstrap'] = self.bootstrap_address
         if self.node_public_key:
             options['--casper-validator-public-key'] = self.node_public_key
-        if self.is_gossiping:
+        if self.use_new_gossiping:
             options['--server-use-gossiping'] = ''
         return options
 

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 import pytest
 import typing_extensions
@@ -9,8 +9,7 @@ import typing_extensions
 from .common import Network, WaitTimeoutError
 
 
-if TYPE_CHECKING:
-    from .casperlabsnode import Node, NonZeroExitCodeError
+from .casperlabsnode import NonZeroExitCodeError
 
 
 class PredicateProtocol(typing_extensions.Protocol):
@@ -35,14 +34,28 @@ class LogsContainMessage:
         return self.node.logs().count(self.message) >= self.times
 
 
+class LogsContainOneOf:
+    def __init__(self, node: 'Node', messages: List[str]) -> None:
+        self.node = node
+        self.messages = messages
+
+    def __str__(self) -> str:
+        args = ', '.join(repr(a) for a in (self.node.name, str(self.messages)))
+        return '<{}({})>'.format(self.__class__.__name__, args)
+
+    def is_satisfied(self) -> bool:
+        return any(m in self.node.logs() for m in self.messages)
+
+
 class NodeStarted(LogsContainMessage):
     def __init__(self, node: 'Node', times: int) -> None:
         super().__init__(node, 'io.casperlabs.node.NodeRuntime - Listening for traffic on casperlabs', times)
 
 
-class ApprovedBlockReceivedHandlerStateEntered(LogsContainMessage):
+class ApprovedBlockReceivedHandlerStateEntered(LogsContainOneOf):
     def __init__(self, node: 'Node') -> None:
-        super().__init__(node, 'Making a transition to ApprovedBlockRecievedHandler state.')
+        super().__init__(node, ['Making a transition to ApprovedBlockRecievedHandler state.',
+                                'Making the transition to block processing.'])
 
 
 class RegexBlockRequest:
@@ -70,7 +83,7 @@ class SendingApprovedBlockRequest(RegexBlockRequest):
 
 
 class ConnectedToOtherNode(RegexBlockRequest):
-    regex = r"Connected to casperlabs:"
+    regex = r"(Connected to casperlabs:)|(Listening for traffic on casperlabs:)"
 
     def __init__(self, node: 'Node', node_name: str, times: int) -> None:
         self.times = times
@@ -135,6 +148,8 @@ class HasAtLeastPeers:
         self.node = node
         self.minimum_peers_number = minimum_peers_number
         self.metric_regex = re.compile(r"^casperlabs_comm_rp_connect_peers (\d+).0\s*$", re.MULTILINE | re.DOTALL)
+        self.new_metric_regex = re.compile(r"^casperlabs_comm_discovery_kademlia_peers (\d+).0\s*$",
+                                           re.MULTILINE | re.DOTALL)
 
     def __str__(self) -> str:
         args = ', '.join(repr(a) for a in (self.node.name, self.minimum_peers_number))
@@ -144,7 +159,9 @@ class HasAtLeastPeers:
         output = self.node.get_metrics_strict()
         match = self.metric_regex.search(output)
         if match is None:
-            return False
+            match = self.new_metric_regex.search(output)
+            if match is None:
+                return False
         peers = int(match[1])
         return peers >= self.minimum_peers_number
 

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -136,10 +136,10 @@ class TotalBlocksOnNode:
         total_blocks = received_blocks_pattern.search(data)
         dup_blocks = duplicates_blocks_pattern.search(data)
         api_blocks = api_created_blocks_pattern.search(data)
+        if None in [total_blocks, dup_blocks, api_blocks]:
+            return False
         count = int(total_blocks.group(1)) - int(dup_blocks.group(1) or 0) + int(api_blocks.group(1) or 0)
         logging.info(count)
-        if total_blocks is None:
-            return False
         return count == self.number_of_blocks
 
 
@@ -240,7 +240,7 @@ def wait_for_finalised_hash(node: 'Node', hash_string: str, timeout_seconds: int
 
 def wait_for_blocks_count_at_least(node: 'Node', expected_blocks_count: int, max_retrieved_blocks: int, timeout_seconds: int = 10):
     predicate = BlocksCountAtLeast(node, expected_blocks_count, max_retrieved_blocks)
-    wait_on_using_wall_clock_time(predicate, timeout_seconds)
+    wait_using_wall_clock_time_or_fail(predicate, timeout_seconds)
 
 
 def wait_for_node_started(node: 'Node', startup_timeout: int, times: int = 1):

--- a/integration-testing/test/test_block_propagation.py
+++ b/integration-testing/test/test_block_propagation.py
@@ -91,7 +91,7 @@ def n(request):
 # This fixture will be parametrized so it runs on node set up to use gossiping as well as the old method.
 @pytest.fixture()
 def three_nodes(docker_client_fixture, timeout):
-    with ThreeNodeNetwork(docker_client_fixture, extra_docker_params={'is_gossiping': True}) as network:
+    with ThreeNodeNetwork(docker_client_fixture, extra_docker_params={'use_new_gossiping': True}) as network:
         network.create_cl_network()
         #wait_for_approved_block_received(network, timeout)
         yield [node.node for node in network.cl_nodes]

--- a/integration-testing/test/test_call_contracts_one_another.py
+++ b/integration-testing/test/test_call_contracts_one_another.py
@@ -5,7 +5,7 @@ from .cl_node.casperlabsnode import (
     MAILING_LIST_CALL,
     get_contract_state,
 )
-from .cl_node.wait import wait_for_count_the_blocks_on_node
+from .cl_node.wait import wait_for_blocks_count_at_least
 
 
 def test_call_contracts_one_another(three_node_network):
@@ -13,7 +13,7 @@ def test_call_contracts_one_another(three_node_network):
     bootstrap, node1, node2 = tnn.docker_nodes
     bootstrap.deploy_and_propose(session_contract=COMBINED_CONTRACT, payment_contract=COMBINED_CONTRACT)
     for node in tnn.docker_nodes:
-        wait_for_count_the_blocks_on_node(node, timeout_seconds=node.timeout, number_of_blocks=1)
+        wait_for_blocks_count_at_least(node, 1, 2, node.timeout)
     generated_hashes = {}
     for contract_name in (COUNTER_CALL, MAILING_LIST_CALL, HELLO_WORLD):
         list_of_hashes = []

--- a/integration-testing/test/test_persistent_dag_store.py
+++ b/integration-testing/test/test_persistent_dag_store.py
@@ -1,4 +1,3 @@
-import logging
 
 from test import conftest
 from test.cl_node.casperlabsnode import (
@@ -66,6 +65,9 @@ def test_storage_after_multiple_node_deploy_propose_and_shutdown(two_node_networ
         tnn.stop_cl_node(node_num)
     for node_num in range(2):
         tnn.start_cl_node(node_num)
+
+    wait_for_blocks_count_at_least(node0, 3, 4, 20)
+    wait_for_blocks_count_at_least(node1, 3, 4, 20)
 
     assert dag0 == node0.vdag(10)
     assert dag1 == node1.vdag(10)


### PR DESCRIPTION
### Overview
Update integration tests to work with new gossiping

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-216

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
There is a flag `use_new_gossiping` in `docker_base.py` which, if `True`, will cause starting node with the gossiping on. The idea was to fix the integration test suite so it can work with both the new gossiping on and off.
