### PR TITLE
OP-217 Network adding to container and star network fixture and test.

### DIFF
--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -239,10 +239,17 @@ class CustomConnectionNetwork(CasperLabsNetwork):
         for node_number in range(1, node_count):
             self.wait_method(wait_for_approved_block_received_handler_state, node_number)
 
+        # Calculate how many peers should be connected to each node.
+        # Assumes duplicate network connections are not given, else wait_for_peers will time out.
+        peer_counts = [0] * node_count
+        for network in network_connections:
+            for node_num in network:
+                peer_counts[node_num] += len(network) - 1
+
         timeout = self.docker_nodes[0].timeout
-        wait_for_peers_count_at_least(self.docker_nodes[0], node_count - 1, timeout)
-        for node in self.docker_nodes[1:]:
-            wait_for_peers_count_at_least(node, 1, timeout)
+        for node_num, peer_count in enumerate(peer_counts):
+            if peer_count > 0:
+                wait_for_peers_count_at_least(self.docker_nodes[node_num], peer_count, timeout)
 
 
 if __name__ == '__main__':

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -204,7 +204,7 @@ class CustomConnectionNetwork(CasperLabsNetwork):
 
     def create_cl_network(self, node_count: int = 3, network_connections: List[List[int]] = None) -> None:
         """
-        Allow creation of a network where all nodes are not connected to node-0.
+        Allow creation of a network where all nodes are not connected to node-0's network and therefore each other.
 
         Ex:  Star Network
 

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -45,6 +45,11 @@ class ApprovedBlockReceivedHandlerStateEntered(LogsContainMessage):
         super().__init__(node, 'Making a transition to ApprovedBlockRecievedHandler state.')
 
 
+class NewForkChoiceTipBlock(LogsContainMessage):
+    def __init__(self, node: 'Node', block: str) -> None:
+        super().__init__(node, f'New fork-choice tip is block {block}....')
+
+
 class RegexBlockRequest:
     regex = None
 
@@ -218,6 +223,11 @@ def wait_for_block_contains(node: 'Node', block_hash: str, expected_string: str,
 
 def wait_for_finalised_hash(node: 'Node', hash_string: str, timeout_seconds: int):
     predicate = LastFinalisedHash(node, hash_string)
+    wait_on_using_wall_clock_time(predicate, timeout_seconds)
+
+
+def wait_for_new_fork_choice_tip_block(node: 'Node', block: str, timeout_seconds: int):
+    predicate = NewForkChoiceTipBlock(node, block)
     wait_on_using_wall_clock_time(predicate, timeout_seconds)
 
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -21,6 +21,7 @@ from .cl_node.casperlabs_network import (
     OneNodeNetwork,
     TwoNodeNetwork,
     ThreeNodeNetwork,
+    CustomConnectionNetwork,
 )
 
 
@@ -193,6 +194,15 @@ def three_node_network(docker_client_fixture):
     with ThreeNodeNetwork(docker_client_fixture) as tnn:
         tnn.create_cl_network()
         yield tnn
+
+
+@pytest.fixture()
+def star_network(docker_client_fixture):
+    with CustomConnectionNetwork(docker_client_fixture) as ccn:
+        node_count = 4
+        network_connections = [[0, n] for n in range(1, 4)]
+        ccn.create_cl_network(node_count=node_count, network_connections=network_connections)
+        yield ccn
 
 
 @pytest.hookimpl(tryfirst=True)


### PR DESCRIPTION
### Overview
Create generic network configurability for CasperLabNodes.
Uses this to make a star network and test block propagation from the tip through the network.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-217

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
