### PR TITLE
NODE-448: Fix docker keygen on Ubuntu

### DIFF
--- a/VALIDATOR.md
+++ b/VALIDATOR.md
@@ -86,6 +86,8 @@ To continue to have working lib folder, consider adding last line to bottom of `
 
 `echo "export LD_LIBRARY_PATH=/use/local/lib" >> ~/.bashrc`
 
+You might want to add `/usr/local/ssh/bin` to your `/etc/environment` file so that the right executable is found; check it by running `openssl version`.
+
 #### Prerequisites: sha3sum
 Download and install the latest version of the [sha3sum](https://github.com/maandree/sha3sum).
 
@@ -99,7 +101,7 @@ cd /tmp
 git clone https://github.com/maandree/libkeccak.git
 cd libkeccak
 make
-sudo make install
+sudo make install PREFIX=/usr
 ```
 
  Build sha3sum:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -101,13 +101,13 @@ slow:
 	cp -r .casperlabs/node-0/node-id .casperlabs/bootstrap/node-id
 	(cat .casperlabs/node-0/validator-id; echo " $(CL_CASPER_NUM_VALIDATORS)") >> .casperlabs/genesis/bonds.txt
 
-	i=1 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \
+	bash -c 'i=1 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \
 		mkdir -p .casperlabs/node-$$i ; \
 		./gen-keys.sh .casperlabs/node-$$i ; \
 		BOND=$$(( $(CL_CASPER_NUM_VALIDATORS)+2*$$i )) ; \
 		(cat .casperlabs/node-$$i/validator-id; echo " $$BOND") >> .casperlabs/genesis/bonds.txt ; \
 		((i = i + 1)) ; \
-	done
+	done'
 
 	@# Check that the files we wanted exist and aren't empty.
 	[ -s .casperlabs/genesis/bonds.txt ]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -8,7 +8,7 @@ REFRESH_TARGETS := ./monitoring/prometheus/refresh-targets.sh
 .SECONDARY:
 
 # Remove all node-N environments.
-clean: down $(shell find . -type d -name "node-*" | awk -F '/' '{print $$2"/down"}')
+clean: down $(shell find . -type d -name "node-*" | grep -v .casperlabs | awk -F '/' '{print $$2"/down"}')
 	docker network rm casperlabs || exit 0
 	rm -rf .casperlabs
 	rm -rf .make
@@ -100,6 +100,7 @@ slow:
 	./gen-keys.sh .casperlabs/node-0
 	cp -r .casperlabs/node-0/node-id .casperlabs/bootstrap/node-id
 	(cat .casperlabs/node-0/validator-id; echo " $(CL_CASPER_NUM_VALIDATORS)") >> .casperlabs/genesis/bonds.txt
+
 	i=1 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \
 		mkdir -p .casperlabs/node-$$i ; \
 		./gen-keys.sh .casperlabs/node-$$i ; \


### PR DESCRIPTION
### Overview
Tried to set up and tear down the docker network with the new updated Makefile which uses openssl key generation and ran into some problems.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-448

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
