### PR TITLE
NODE-522: update some uses of --from after EE-333

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -353,7 +353,7 @@ In the root of CasperLabs.
 In the root of CasperLabs, run:
 
 ```
-./client/target/universal/stage/bin/casperlabs-client --host 127.0.0.1 --port 40401 deploy --from 00000000000000000000 --gas-price 1 --session <contract wasm file> --payment <payment wasm file>
+./client/target/universal/stage/bin/casperlabs-client --host 127.0.0.1 --port 40401 deploy --from 00000000000000000000000000000000 --gas-price 1 --session <contract wasm file> --payment <payment wasm file>
 ```
 
 At the moment, payment wasm file is not used so use the same file as for the `--session`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -71,7 +71,7 @@ Assuming that you cloned and compiled the [contract-examples](https://github.com
 
 ```console
 ./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
-     --from 00000000000000000000 \
+     --from 00000000000000000000000000000000 \
      --gas-price 1 \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm

--- a/docker/client.sh
+++ b/docker/client.sh
@@ -9,7 +9,7 @@ set -e
 # for example:
 #
 # ./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release \
-#     --from 00000000000000000000 \
+#     --from 00000000000000000000000000000000 \
 #     --gas-price 1 \
 #     --session /data/helloname.wasm \
 #     --payment /data/helloname.wasm


### PR DESCRIPTION
### Overview
This PR updates a few places in documentation/demo code where `--from` still had a 20-byte argument.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-522

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
