### PR TITLE
NO TICKET: ensure reads are tracked in the transforms map

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -24,7 +24,7 @@ object PrettyPrinter {
     case ipc.Transform.TransformInstance.AddKeys(ipc.TransformAddKeys(ks)) =>
       s"Insert(${ks.map(buildString).mkString(",")})"
     case ipc.Transform.TransformInstance.Failure(_)  => "TransformFailure"
-    case ipc.Transform.TransformInstance.Identity(_) => "Identity"
+    case ipc.Transform.TransformInstance.Identity(_) => "Read"
     case ipc.Transform.TransformInstance.Write(ipc.TransformWrite(mv)) =>
       mv match {
         case None    => "Write(Nothing)"

--- a/execution-engine/engine/src/tracking_copy.rs
+++ b/execution-engine/engine/src/tracking_copy.rs
@@ -372,8 +372,9 @@ mod tests {
             .unwrap();
         // value read correctly
         assert_eq!(value, zero);
-        // read does not cause any transform
-        assert_eq!(tc.fns.is_empty(), true);
+        // read produces an identity transform
+        assert_eq!(tc.fns.len(), 1);
+        assert_eq!(tc.fns.get(&k), Some(&Transform::Identity));
         // read does produce an op
         assert_eq!(tc.ops.len(), 1);
         assert_eq!(tc.ops.get(&k), Some(&Op::Read));

--- a/execution-engine/engine/src/tracking_copy.rs
+++ b/execution-engine/engine/src/tracking_copy.rs
@@ -121,6 +121,7 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     pub fn read(&mut self, k: &Validated<Key>) -> Result<Option<Value>, R::Error> {
         if let Some(value) = self.get(k)? {
             add(&mut self.ops, **k, Op::Read);
+            add(&mut self.fns, **k, Transform::Identity);
             Ok(Some(value))
         } else {
             Ok(None)


### PR DESCRIPTION
### Overview
This change is needed since only the transforms are persisted in the scala layer block store and reads are needed when doing commutativity checking between blocks. Note that commutativity checking within a newly created block was already correct because it was using the Ops directly from EE, where as for doing checking between blocks we need to rely on only the information in the blockstore (which is just the transforms).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-346

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
