### PR TITLE
EE-273: Add AssociatedKeys data structure to an Account.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -4,7 +4,6 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.protocol._
 import io.casperlabs.crypto.codec._
 import io.casperlabs.ipc
-import scalapb.GeneratedMessage
 
 object PrettyPrinter {
 
@@ -44,8 +43,8 @@ object PrettyPrinter {
 
   def buildString(v: ipc.Value): String = v.valueInstance match {
     case ipc.Value.ValueInstance.Empty => "ValueEmpty"
-    case ipc.Value.ValueInstance.Account(ipc.Account(pk, nonce, urefs)) =>
-      s"Account(${buildString(pk)}, $nonce, {${urefs.map(buildString).mkString(",")}})"
+    case ipc.Value.ValueInstance.Account(ipc.Account(pk, nonce, urefs, associatedKeys)) =>
+      s"Account(${buildString(pk)}, $nonce, {${urefs.map(buildString).mkString(",")}}, {${associatedKeys.map(buildString).mkString(",")})"
     case ipc.Value.ValueInstance.ByteArr(bytes) => s"ByteArray(${buildString(bytes)})"
     case ipc.Value.ValueInstance.Contract(ipc.Contract(body, urefs, protocolVersion)) =>
       s"Contract(${buildString(body)}, {${urefs.map(buildString).mkString(",")}}, ${buildString(protocolVersion)})"
@@ -97,6 +96,12 @@ object PrettyPrinter {
       case ipc.KeyURef.AccessRights.READ_WRITE     => "ReadWrite"
       case ipc.KeyURef.AccessRights.READ_ADD_WRITE => "ReadAddWrite"
     }
+
+  private def buildString(ak: ipc.Account.AssociatedKey): String = {
+    val pk     = buildString(ak.pubKey)
+    val weight = ak.weight
+    s"$pk:$weight"
+  }
 
   def buildString(d: consensus.Deploy): String =
     s"Deploy #${d.getHeader.timestamp}"

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -86,13 +86,14 @@ impl TryFrom<&super::ipc::Transform> for transform::Transform {
                         let weight = k.get_weight() as u8;
                         // NOTE: we are assuming that `add_key` will always return `true`.
                         // Meaning we assume that IPC message will always contain correct `AssociatedKeys`.
-                        keys.add_key(PublicKey::new(pub_key), Weight::new(weight));
+                        keys.add_key(PublicKey::new(pub_key), Weight::new(weight))
+                            .unwrap();
                     });
                     keys
                 };
                 let account = common::value::Account::new(
                     pub_key,
-                    v.get_account().nonce.into(),
+                    v.get_account().nonce,
                     uref_map.0,
                     associated_keys,
                 );

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -75,20 +75,28 @@ impl TryFrom<&super::ipc::Transform> for transform::Transform {
             } else if v.has_string_val() {
                 transform_write(common::value::Value::String(v.get_string_val().to_string()))
             } else if v.has_account() {
-                let mut pub_key = [0u8; 32];
+                let pub_key = {
+                    let mut tmp = [0u8; 32];
+                    tmp.clone_from_slice(&v.get_account().pub_key);
+                    tmp
+                };
                 let uref_map: URefMap = v.get_account().get_known_urefs().try_into()?;
-                pub_key.clone_from_slice(&v.get_account().pub_key);
                 let associated_keys: AssociatedKeys = {
                     let mut keys = AssociatedKeys::empty();
-                    v.get_account().get_associated_keys().iter().for_each(|k| {
-                        let mut pub_key = [0u8; 32];
-                        pub_key.copy_from_slice(k.get_pub_key());
-                        let weight = k.get_weight() as u8;
-                        // NOTE: we are assuming that `add_key` will always return `true`.
-                        // Meaning we assume that IPC message will always contain correct `AssociatedKeys`.
-                        keys.add_key(PublicKey::new(pub_key), Weight::new(weight))
-                            .unwrap();
-                    });
+                    v.get_account()
+                        .get_associated_keys()
+                        .iter()
+                        .try_for_each(|k| {
+                            k.try_into().and_then(|(pub_key, weight)| {
+                                match keys.add_key(pub_key, weight) {
+                                    Err(add_key_failure) => parse_error(format!(
+                                        "Error when parsing associated keys: {:?}",
+                                        add_key_failure
+                                    )),
+                                    Ok(_) => Ok(()),
+                                }
+                            })
+                        })?;
                     keys
                 };
                 let account = common::value::Account::new(
@@ -280,6 +288,24 @@ impl From<URefMap> for Vec<super::ipc::NamedKey> {
                 nk
             })
             .collect()
+    }
+}
+
+impl TryFrom<&ipc::Account_AssociatedKey> for (PublicKey, Weight) {
+    type Error = ParsingError;
+
+    fn try_from(value: &ipc::Account_AssociatedKey) -> Result<Self, Self::Error> {
+        // Weight is a newtype wrapper around u8 type.
+        if value.get_weight() > u8::max_value().into() {
+            parse_error("Key weight cannot be bigger 256.".to_string())
+        } else {
+            let mut pub_key = [0u8; 32];
+            pub_key.copy_from_slice(value.get_pub_key());
+            Ok((
+                PublicKey::new(pub_key),
+                Weight::new(value.get_weight() as u8),
+            ))
+        }
     }
 }
 

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -92,7 +92,7 @@ impl TryFrom<&super::ipc::Transform> for transform::Transform {
                 };
                 let account = common::value::Account::new(
                     pub_key,
-                    v.get_account().nonce as u64,
+                    v.get_account().nonce.into(),
                     uref_map.0,
                     associated_keys,
                 );

--- a/execution-engine/common/benches/bytesrepr_bench.rs
+++ b/execution-engine/common/benches/bytesrepr_bench.rs
@@ -11,6 +11,7 @@ use test::Bencher;
 
 use casperlabs_contract_ffi::bytesrepr::{FromBytes, ToBytes};
 use casperlabs_contract_ffi::key::{AccessRights, Key};
+use casperlabs_contract_ffi::value::account::{AssociatedKeys, PublicKey, Weight};
 use casperlabs_contract_ffi::value::{
     account::Account,
     contract::Contract,
@@ -350,7 +351,13 @@ fn make_contract() -> Contract {
 
 fn make_account() -> Account {
     let known_urefs = make_known_urefs();
-    Account::new([0u8; 32], 2_635_333_365_164_409_670u64, known_urefs)
+    let associated_keys = AssociatedKeys::new(PublicKey::new([0u8; 32]), Weight::new(1));
+    Account::new(
+        [0u8; 32],
+        2_635_333_365_164_409_670u64,
+        known_urefs,
+        associated_keys,
+    )
 }
 
 #[bench]

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -41,11 +41,11 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
 }
 
 pub fn public_key_arb() -> impl Strategy<Value = PublicKey> {
-    u8_slice_32().prop_map(|key| key.into())
+    u8_slice_32().prop_map(Into::into)
 }
 
 pub fn weight_arb() -> impl Strategy<Value = Weight> {
-    any::<u8>().prop_map(|weight| Weight::new(weight))
+    any::<u8>().prop_map(Weight::new)
 }
 
 pub fn associated_keys_arb(size: usize) -> impl Strategy<Value = AssociatedKeys> {
@@ -53,7 +53,6 @@ pub fn associated_keys_arb(size: usize) -> impl Strategy<Value = AssociatedKeys>
         let mut associated_keys = AssociatedKeys::empty();
         keys.into_iter().for_each(|(k, v)| {
             associated_keys.add_key(k, v);
-            ()
         });
         associated_keys
     })

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -52,7 +52,7 @@ pub fn associated_keys_arb(size: usize) -> impl Strategy<Value = AssociatedKeys>
     proptest::collection::btree_map(public_key_arb(), weight_arb(), size).prop_map(|keys| {
         let mut associated_keys = AssociatedKeys::empty();
         keys.into_iter().for_each(|(k, v)| {
-            associated_keys.add_key(k, v);
+            associated_keys.add_key(k, v).unwrap();
         });
         associated_keys
     })
@@ -62,7 +62,7 @@ pub fn account_arb() -> impl Strategy<Value = Account> {
     u8_slice_32().prop_flat_map(|b| {
         any::<u64>().prop_flat_map(move |u64arb| {
             associated_keys_arb(MAX_KEYS - 1).prop_flat_map(move |mut associated_keys| {
-                associated_keys.add_key(b.into(), Weight::new(1));
+                associated_keys.add_key(b.into(), Weight::new(1)).unwrap();
                 uref_map_arb(3)
                     .prop_map(move |urefs| Account::new(b, u64arb, urefs, associated_keys.clone()))
             })

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -1,4 +1,5 @@
 use crate::key::*;
+use crate::value::account::{AssociatedKeys, PublicKey, Weight, MAX_KEYS};
 use crate::value::*;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -39,10 +40,33 @@ pub fn key_arb() -> impl Strategy<Value = Key> {
     ]
 }
 
+pub fn public_key_arb() -> impl Strategy<Value = PublicKey> {
+    u8_slice_32().prop_map(|key| key.into())
+}
+
+pub fn weight_arb() -> impl Strategy<Value = Weight> {
+    any::<u8>().prop_map(|weight| Weight::new(weight))
+}
+
+pub fn associated_keys_arb(size: usize) -> impl Strategy<Value = AssociatedKeys> {
+    proptest::collection::btree_map(public_key_arb(), weight_arb(), size).prop_map(|keys| {
+        let mut associated_keys = AssociatedKeys::empty();
+        keys.into_iter().for_each(|(k, v)| {
+            associated_keys.add_key(k, v);
+            ()
+        });
+        associated_keys
+    })
+}
+
 pub fn account_arb() -> impl Strategy<Value = Account> {
     u8_slice_32().prop_flat_map(|b| {
         any::<u64>().prop_flat_map(move |u64arb| {
-            uref_map_arb(3).prop_map(move |urefs| Account::new(b, u64arb, urefs))
+            associated_keys_arb(MAX_KEYS - 1).prop_flat_map(move |mut associated_keys| {
+                associated_keys.add_key(b.into(), Weight::new(1));
+                uref_map_arb(3)
+                    .prop_map(move |urefs| Account::new(b, u64arb, urefs, associated_keys.clone()))
+            })
         })
     })
 }

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -5,6 +5,83 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 pub const KEY_SIZE: usize = 32;
+/// Maximum number of associated keys.
+/// Value chosen arbitrary, shouldn't be too large to prevent bloating
+/// `associated_keys` table.
+pub const MAX_KEYS: usize = 10;
+
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
+pub struct Weight(u8);
+
+impl Weight {
+    pub fn new(weight: u8) -> Weight {
+        Weight(weight)
+    }
+}
+
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
+pub struct PublicKey([u8; KEY_SIZE]);
+
+impl PublicKey {
+    pub fn new(key: [u8; KEY_SIZE]) -> PublicKey {
+        PublicKey(key)
+    }
+}
+
+impl From<[u8; KEY_SIZE]> for PublicKey {
+    fn from(key: [u8; KEY_SIZE]) -> Self {
+        PublicKey(key)
+    }
+}
+
+// Represents a key associated with some account and its weight.
+pub struct AssociatedKey {
+    key: PublicKey,
+    weight: Weight,
+}
+
+impl AssociatedKey {
+    pub fn new(key: PublicKey, weight: Weight) -> AssociatedKey {
+        AssociatedKey { key, weight }
+    }
+}
+
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
+pub struct AssociatedKeys(BTreeMap<PublicKey, Weight>);
+
+impl AssociatedKeys {
+    pub fn empty() -> AssociatedKeys {
+        AssociatedKeys(BTreeMap::new())
+    }
+    pub fn new(key: PublicKey, weight: Weight) -> AssociatedKeys {
+        let mut bt: BTreeMap<PublicKey, Weight> = BTreeMap::new();
+        bt.insert(key, weight);
+        AssociatedKeys(bt)
+    }
+    /// Adds new AssociatedKey to the set.
+    /// Returns true if added successfully, false otherwise.
+    pub fn add_key(&mut self, key: PublicKey, weight: Weight) -> bool {
+        if self.0.len() == MAX_KEYS || self.0.contains_key(&key) {
+            false
+        } else {
+            self.0.insert(key, weight);
+            true
+        }
+    }
+
+    /// Removes key from the associated keys set.
+    /// Returns true if value was found in the set prior to the removal, false otherwise.
+    pub fn remove_key(&mut self, key: &PublicKey) -> bool {
+        match self.0.remove(key) {
+            Some(_) => true,
+            None => false,
+        }
+    }
+
+    pub fn get(&self, key: &PublicKey) -> Option<&Weight> {
+        self.0.get(key)
+    }
+}
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Account {
@@ -70,5 +147,52 @@ impl FromBytes for Account {
             },
             rem3,
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::value::account::{AssociatedKeys, PublicKey, Weight, KEY_SIZE, MAX_KEYS};
+
+    #[test]
+    fn associated_keys_add() {
+        let mut keys = AssociatedKeys::new([0u8; KEY_SIZE].into(), Weight::new(1));
+        let new_pk = PublicKey([1u8; KEY_SIZE]);
+        let new_pk_weight = Weight::new(2);
+        assert!(keys.add_key(new_pk.clone(), new_pk_weight.clone()));
+        assert_eq!(keys.get(&new_pk), Some(&new_pk_weight))
+    }
+
+    #[test]
+    fn associated_keys_add_full() {
+        let map = (0..MAX_KEYS)
+            .map(|k| (PublicKey([k as u8; KEY_SIZE]), Weight::new(k as u8)));
+        assert_eq!(map.len(), 10);
+        let mut keys = {
+            let mut tmp = AssociatedKeys::empty();
+            map.for_each(|(key, weight)| {
+                assert!(tmp.add_key(key, weight))
+            });
+            tmp
+        };
+        assert!(!keys.add_key(PublicKey([100u8; KEY_SIZE]), Weight::new(100)))
+    }
+
+    #[test]
+    fn associated_keys_add_duplicate() {
+        let pk = PublicKey([0u8; KEY_SIZE]);
+        let weight = Weight::new(1);
+        let mut keys = AssociatedKeys::new(pk.clone(), weight.clone());
+        assert!(!keys.add_key(pk.clone(), Weight::new(10)));
+        assert_eq!(keys.get(&pk), Some(&weight));
+    }
+
+    #[test]
+    fn associated_keys_remove() {
+        let pk = PublicKey([0u8; KEY_SIZE]);
+        let weight = Weight::new(1);
+        let mut keys = AssociatedKeys::new(pk.clone(), weight.clone());
+        assert!(keys.remove_key(&pk));
+        assert!(!keys.remove_key(&PublicKey([1u8; KEY_SIZE])));
     }
 }

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -51,11 +51,13 @@ impl AssociatedKeys {
     pub fn empty() -> AssociatedKeys {
         AssociatedKeys(BTreeMap::new())
     }
+
     pub fn new(key: PublicKey, weight: Weight) -> AssociatedKeys {
         let mut bt: BTreeMap<PublicKey, Weight> = BTreeMap::new();
         bt.insert(key, weight);
         AssociatedKeys(bt)
     }
+
     /// Adds new AssociatedKey to the set.
     /// Returns true if added successfully, false otherwise.
     #[allow(clippy::map_entry)]

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -58,6 +58,7 @@ impl AssociatedKeys {
     }
     /// Adds new AssociatedKey to the set.
     /// Returns true if added successfully, false otherwise.
+    #[allow(clippy::map_entry)]
     pub fn add_key(&mut self, key: PublicKey, weight: Weight) -> Result<(), AddKeyFailure> {
         if self.0.len() == MAX_KEYS {
             Err(AddKeyFailure::MaxKeysLimit)
@@ -161,7 +162,10 @@ impl FromBytes for AssociatedKeys {
         let (keys_map, rem): (BTreeMap<PublicKey, Weight>, &[u8]) = FromBytes::from_bytes(bytes)?;
         let mut keys = AssociatedKeys::empty();
         keys_map.into_iter().for_each(|(k, v)| {
-            keys.add_key(k, v);
+            // NOTE: we're ignoring potential errors (duplicate key, maximum number of elements).
+            // This is safe, for now, as we were the ones that serialized `AssociatedKeys` in the
+            // first place.
+            keys.add_key(k, v).unwrap();
         });
         Ok((keys, rem))
     }

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -77,10 +77,7 @@ impl AssociatedKeys {
     /// Removes key from the associated keys set.
     /// Returns true if value was found in the set prior to the removal, false otherwise.
     pub fn remove_key(&mut self, key: &PublicKey) -> bool {
-        match self.0.remove(key) {
-            Some(_) => true,
-            None => false,
-        }
+        self.0.remove(key).is_some()
     }
 
     pub fn get(&self, key: &PublicKey) -> Option<&Weight> {
@@ -170,7 +167,6 @@ impl FromBytes for AssociatedKeys {
         let mut keys = AssociatedKeys::empty();
         keys_map.into_iter().for_each(|(k, v)| {
             keys.add_key(k, v);
-            ()
         });
         Ok((keys, rem))
     }

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -372,6 +372,7 @@ mod tests {
     use storage::global_state::{CommitResult, History};
 
     use super::{Error, RuntimeContext, URefAddr, Validated};
+    use common::value::account::{AssociatedKeys, PublicKey, Weight};
     use execution::{create_rng, vec_key_rights_to_map};
     use shared::newtypes::Blake2bHash;
     use tracking_copy::TrackingCopy;
@@ -401,7 +402,8 @@ mod tests {
     }
 
     fn mock_account(addr: [u8; 32]) -> (Key, value::Account) {
-        let account = value::account::Account::new(addr, 0, BTreeMap::new());
+        let associated_keys = AssociatedKeys::new(PublicKey::new(addr), Weight::new(1));
+        let account = value::account::Account::new(addr, 0, BTreeMap::new(), associated_keys);
         let key = Key::Account(addr);
 
         (key, account)

--- a/execution-engine/engine/src/tracking_copy.rs
+++ b/execution-engine/engine/src/tracking_copy.rs
@@ -283,6 +283,7 @@ mod tests {
     use storage::global_state::StateReader;
 
     use super::{AddResult, QueryResult, Validated};
+    use common::value::account::{AssociatedKeys, PublicKey, Weight, KEY_SIZE};
     use engine_state::op::Op;
     use tracking_copy::TrackingCopy;
 
@@ -454,7 +455,9 @@ mod tests {
     #[test]
     fn tracking_copy_add_named_key() {
         // DB now holds an `Account` so that we can test adding a `NamedKey`
-        let account = common::value::Account::new([0u8; 32], 0u64, BTreeMap::new());
+        let associated_keys = AssociatedKeys::new(PublicKey::new([0u8; KEY_SIZE]), Weight::new(1));
+        let account =
+            common::value::Account::new([0u8; KEY_SIZE], 0u64, BTreeMap::new(), associated_keys);
         let db = CountingDb::new_init(Value::Account(account));
         let mut tc = TrackingCopy::new(db);
         let k = Key::Hash([0u8; 32]);
@@ -634,10 +637,12 @@ mod tests {
             address in u8_slice_32(), // address for account key
         ) {
             let known_urefs = iter::once((name.clone(), k)).collect();
+            let associated_keys = AssociatedKeys::new(PublicKey::new(pk), Weight::new(1));
             let account = Account::new(
                 pk,
                 nonce,
                 known_urefs,
+                associated_keys,
             );
             let account_key = Key::Account(address);
 
@@ -680,10 +685,12 @@ mod tests {
             // create account which knows about contract
             let mut account_known_urefs = BTreeMap::new();
             account_known_urefs.insert(contract_name.clone(), contract_key);
+            let associated_keys = AssociatedKeys::new(PublicKey::new(pk), Weight::new(1));
             let account = Account::new(
                 pk,
                 nonce,
                 account_known_urefs,
+                associated_keys,
             );
             let account_key = Key::Account(address);
 

--- a/execution-engine/shared/src/init/mod.rs
+++ b/execution-engine/shared/src/init/mod.rs
@@ -7,7 +7,9 @@ use common::value::{Account, Value};
 pub fn mocked_account(account_addr: [u8; 32]) -> Vec<(Key, Value)> {
     let associated_keys = {
         let mut associated_keys = AssociatedKeys::empty();
-        associated_keys.add_key(PublicKey::new(account_addr), Weight::new(1));
+        associated_keys
+            .add_key(PublicKey::new(account_addr), Weight::new(1))
+            .unwrap();
         associated_keys
     };
     let account = Account::new(account_addr, 0, BTreeMap::new(), associated_keys);

--- a/execution-engine/shared/src/init/mod.rs
+++ b/execution-engine/shared/src/init/mod.rs
@@ -1,9 +1,15 @@
 use std::collections::btree_map::BTreeMap;
 
 use common::key::Key;
+use common::value::account::{AssociatedKeys, PublicKey, Weight};
 use common::value::{Account, Value};
 
 pub fn mocked_account(account_addr: [u8; 32]) -> Vec<(Key, Value)> {
-    let account = Account::new(account_addr, 0, BTreeMap::new());
+    let associated_keys = {
+        let mut associated_keys = AssociatedKeys::empty();
+        associated_keys.add_key(PublicKey::new(account_addr), Weight::new(1));
+        associated_keys
+    };
+    let account = Account::new(account_addr, 0, BTreeMap::new(), associated_keys);
     vec![(Key::Account(account_addr), Value::Account(account))]
 }

--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -268,8 +268,8 @@ mod tests {
     #[test]
     fn initial_state_has_the_expected_hash() {
         let expected_bytes = vec![
-            176u8, 48, 219, 9, 47, 224, 193, 80, 164, 168, 1, 230, 1, 75, 255, 199, 211, 67, 213,
-            61, 31, 192, 211, 77, 59, 244, 219, 236, 53, 253, 100, 159,
+            193u8, 151, 167, 126, 241, 141, 9, 163, 43, 169, 238, 19, 93, 87, 183, 131, 99, 160,
+            96, 216, 8, 39, 227, 218, 246, 90, 65, 57, 207, 242, 61, 205,
         ];
         let init_state = mocked_account([48u8; 32]);
         let global_state = InMemoryGlobalState::from_pairs(&init_state).unwrap();

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -146,9 +146,14 @@ message Value {
 }
 
 message Account {
+    message AssociatedKey {
+        bytes pub_key = 1; // Should have 32 elements
+        uint32 weight = 2;
+    }
     bytes pub_key = 1; // Should have 32 elements
     uint64 nonce = 2;
     repeated NamedKey known_urefs = 3;
+    repeated AssociatedKey associated_keys = 4;
 }
 message Contract {
     bytes body = 1;

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -43,8 +43,8 @@ class GrpcExecutionEngineService[F[_]: Defer: Sync: Log: TaskLift] private[smart
   private var bonds = initialBonds.map(p => Bond(ByteString.copyFrom(p._1), p._2)).toSeq
 
   override def emptyStateHash: ByteString = {
-    val arr: Array[Byte] = Array(176, 48, 219, 9, 47, 224, 193, 80, 164, 168, 1, 230, 1, 75, 255,
-      199, 211, 67, 213, 61, 31, 192, 211, 77, 59, 244, 219, 236, 53, 253, 100, 159).map(_.toByte)
+    val arr: Array[Byte] = Array(193, 151, 167, 126, 241, 141, 9, 163, 43, 169, 238, 19, 93, 87,
+      183, 131, 99, 160, 96, 216, 8, 39, 227, 218, 246, 90, 65, 57, 207, 242, 61, 205).map(_.toByte)
     ByteString.copyFrom(arr)
   }
 


### PR DESCRIPTION
### Overview
This PR adds `associated_keys` field to `Account` struct. It doesn't add support for adding (or removing) keys to an account (although such methods are available on `AssociatedKeys` instance). This will come in later PRs.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-273

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
For more information about associated keys, read [documentation](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/97058817/Account+specification+creation+recovery).