### PR TITLE
NODE-528: Log validator identity upon startup.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -305,9 +305,14 @@ package object gossiping {
       validatorId <- Resource.liftF {
                       for {
                         id <- ValidatorIdentity.fromConfig[F](conf.casper)
-                        _ <- Log[F].info(
-                              s"Starting ${if (id.nonEmpty) "with" else "without"} a validator identity."
-                            )
+                        _ <- id match {
+                              case Some(ValidatorIdentity(publicKey, _, _)) =>
+                                Log[F].info(
+                                  s"Starting with validator identity ${Base16.encode(publicKey)}"
+                                )
+                              case None =>
+                                Log[F].info("Starting without a validator identity.")
+                            }
                       } yield id
                     }
 


### PR DESCRIPTION
### Overview
We could easily tell that two nodes were using the same validator identity by looking at the Unix logs showing the CLI command that started the node, but if they were pointing at files instead of including `--casper-validator-public-key` verbatim it wouldn't be so clear.

The PR just adds logging of the validator public key so we'll always have it in the logs.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-528

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
