### PR TITLE
EE-274: Add action thresholds and account activity.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -110,9 +110,6 @@ object PrettyPrinter {
   private def buildString(at: ipc.Account.ActionThresholds): String =
     s"Deployment threshold ${at.deploymentThreshold}, Key management threshold: ${at.keyManagementThreshold}"
 
-//  keyManagementLastUsed: _root_.scala.Long = 0L,
-//  deploymentLastUsed: _root_.scala.Long = 0L,
-//  inactivityPeriodLimit: _root_.scala.Long = 0L
   private def buildString(ac: ipc.Account.AccountActivity): String =
     s"Last deploy: ${ac.deploymentLastUsed}, last key management change: ${ac.keyManagementLastUsed}, inactivity period limit: ${ac.inactivityPeriodLimit}"
 

--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -43,8 +43,12 @@ object PrettyPrinter {
 
   def buildString(v: ipc.Value): String = v.valueInstance match {
     case ipc.Value.ValueInstance.Empty => "ValueEmpty"
-    case ipc.Value.ValueInstance.Account(ipc.Account(pk, nonce, urefs, associatedKeys)) =>
-      s"Account(${buildString(pk)}, $nonce, {${urefs.map(buildString).mkString(",")}}, {${associatedKeys.map(buildString).mkString(",")})"
+    case ipc.Value.ValueInstance.Account(
+        ipc.Account(pk, nonce, urefs, associatedKeys, actionThresholds, accountActivity)
+        ) =>
+      s"Account(${buildString(pk)}, $nonce, {${urefs.map(buildString).mkString(",")}}, {${associatedKeys
+        .map(buildString)
+        .mkString(",")}, {${actionThresholds.map(buildString)}}, {${accountActivity.map(buildString)})"
     case ipc.Value.ValueInstance.ByteArr(bytes) => s"ByteArray(${buildString(bytes)})"
     case ipc.Value.ValueInstance.Contract(ipc.Contract(body, urefs, protocolVersion)) =>
       s"Contract(${buildString(body)}, {${urefs.map(buildString).mkString(",")}}, ${buildString(protocolVersion)})"
@@ -102,6 +106,15 @@ object PrettyPrinter {
     val weight = ak.weight
     s"$pk:$weight"
   }
+
+  private def buildString(at: ipc.Account.ActionThresholds): String =
+    s"Deployment threshold ${at.deploymentThreshold}, Key management threshold: ${at.keyManagementThreshold}"
+
+//  keyManagementLastUsed: _root_.scala.Long = 0L,
+//  deploymentLastUsed: _root_.scala.Long = 0L,
+//  inactivityPeriodLimit: _root_.scala.Long = 0L
+  private def buildString(ac: ipc.Account.AccountActivity): String =
+    s"Last deploy: ${ac.deploymentLastUsed}, last key management change: ${ac.keyManagementLastUsed}, inactivity period limit: ${ac.inactivityPeriodLimit}"
 
   def buildString(d: consensus.Deploy): String =
     s"Deploy #${d.getHeader.timestamp}"

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -4,7 +4,9 @@ use protobuf::ProtobufEnum;
 use std::collections::BTreeMap;
 use std::convert::{TryFrom, TryInto};
 
-use common::value::account::{AssociatedKeys, PublicKey, Weight};
+use common::value::account::{
+    AccountActivity, ActionThresholds, AssociatedKeys, BlockTime, PublicKey, Weight,
+};
 use engine_server::ipc::KeyURef_AccessRights;
 use execution_engine::engine_state::error::{Error as EngineError, RootNotFound};
 use execution_engine::engine_state::execution_effect::ExecutionEffect;
@@ -90,11 +92,50 @@ impl TryFrom<&super::ipc::Transform> for transform::Transform {
                     });
                     keys
                 };
+                let action_thresholds: ActionThresholds = {
+                    if !v.get_account().has_action_threshold() {
+                        return parse_error(
+                            "Missing ActionThresholds object of the Account IPC message."
+                                .to_string(),
+                        );
+                    };
+                    let mut tmp: ActionThresholds = Default::default();
+                    let action_thresholds_ipc = v.get_account().get_action_threshold();
+                    tmp.set_deployment_threshold(Weight::new(
+                        action_thresholds_ipc.get_deployment_threshold() as u8,
+                    ));
+                    tmp.set_key_management_threshold(Weight::new(
+                        action_thresholds_ipc.get_key_management_threshold() as u8,
+                    ));
+                    tmp
+                };
+                let account_activity: AccountActivity = {
+                    if !v.get_account().has_account_activity() {
+                        return parse_error(
+                            "Missing AccountActivity object of the Account IPC message."
+                                .to_string(),
+                        );
+                    };
+                    let account_activity_ipc = v.get_account().get_account_activity();
+                    let mut tmp = AccountActivity::new(BlockTime(0), BlockTime(0));
+                    tmp.update_deployment_last_used(BlockTime(
+                        account_activity_ipc.deployment_last_used,
+                    ));
+                    tmp.update_key_management_last_used(BlockTime(
+                        account_activity_ipc.key_management_last_used,
+                    ));
+                    tmp.update_inactivity_period_limit(BlockTime(
+                        account_activity_ipc.inactivity_period_limit,
+                    ));
+                    tmp
+                };
                 let account = common::value::Account::new(
                     pub_key,
                     v.get_account().nonce as u64,
                     uref_map.0,
                     associated_keys,
+                    action_thresholds,
+                    account_activity,
                 );
                 transform_write(common::value::Value::Account(account))
             } else if v.has_contract() {

--- a/execution-engine/common/benches/bytesrepr_bench.rs
+++ b/execution-engine/common/benches/bytesrepr_bench.rs
@@ -11,7 +11,9 @@ use test::Bencher;
 
 use casperlabs_contract_ffi::bytesrepr::{FromBytes, ToBytes};
 use casperlabs_contract_ffi::key::{AccessRights, Key};
-use casperlabs_contract_ffi::value::account::{AssociatedKeys, PublicKey, Weight};
+use casperlabs_contract_ffi::value::account::{
+    AccountActivity, AssociatedKeys, BlockTime, PublicKey, Weight,
+};
 use casperlabs_contract_ffi::value::{
     account::Account,
     contract::Contract,
@@ -352,11 +354,15 @@ fn make_contract() -> Contract {
 fn make_account() -> Account {
     let known_urefs = make_known_urefs();
     let associated_keys = AssociatedKeys::new(PublicKey::new([0u8; 32]), Weight::new(1));
+    let action_thresholds = Default::default();
+    let account_activity = AccountActivity::new(BlockTime(0), BlockTime(100));
     Account::new(
         [0u8; 32],
         2_635_333_365_164_409_670u64,
         known_urefs,
         associated_keys,
+        action_thresholds,
+        account_activity,
     )
 }
 

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -1,5 +1,7 @@
 use crate::key::*;
-use crate::value::account::{AssociatedKeys, PublicKey, Weight, MAX_KEYS};
+use crate::value::account::{
+    AccountActivity, ActionThresholds, AssociatedKeys, BlockTime, PublicKey, Weight, MAX_KEYS,
+};
 use crate::value::*;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
@@ -58,16 +60,29 @@ pub fn associated_keys_arb(size: usize) -> impl Strategy<Value = AssociatedKeys>
     })
 }
 
-pub fn account_arb() -> impl Strategy<Value = Account> {
-    u8_slice_32().prop_flat_map(|b| {
-        any::<u64>().prop_flat_map(move |u64arb| {
-            associated_keys_arb(MAX_KEYS - 1).prop_flat_map(move |mut associated_keys| {
-                associated_keys.add_key(b.into(), Weight::new(1));
-                uref_map_arb(3)
-                    .prop_map(move |urefs| Account::new(b, u64arb, urefs, associated_keys.clone()))
-            })
-        })
-    })
+pub fn action_threshold_arb() -> impl Strategy<Value = ActionThresholds> {
+    Just(Default::default())
+}
+
+pub fn account_activity_arb() -> impl Strategy<Value = AccountActivity> {
+    Just(AccountActivity::new(BlockTime(1), BlockTime(1000)))
+}
+
+prop_compose! {
+    pub fn account_arb()
+        (pub_key in u8_slice_32(), nonce in any::<u64>(), thresholds in action_threshold_arb(),
+        account_activity in account_activity_arb(), mut associated_keys in associated_keys_arb(MAX_KEYS - 1), urefs in uref_map_arb(3))
+     -> Account {
+            associated_keys.add_key(pub_key.into(), Weight::new(1));
+            Account::new(
+                pub_key,
+                nonce,
+                urefs,
+                associated_keys.clone(),
+                thresholds.clone(),
+                account_activity.clone(),
+            )
+    }
 }
 
 pub fn contract_arb() -> impl Strategy<Value = Contract> {

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -16,6 +16,7 @@ pub enum ActionType {
 /// Thresholds that has to be met when executing an action of certain type.
 /// Note that `InactiveAccountRecovery` doesn't have a threshold defined here.
 /// It's so that accounts don't change that value as it's system-wide set to 0.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ActionThresholds {
     deployment: Weight,
     key_management: Weight,
@@ -41,7 +42,7 @@ impl ActionThresholds {
 
     /// Sets new threshold for [ActionType::KeyManagement].
     pub fn set_key_management_threshold(&mut self, new_threshold: Weight) -> bool {
-        if self.deployment < new_threshold {
+        if self.deployment > new_threshold {
             false
         } else {
             self.key_management = new_threshold;
@@ -50,10 +51,20 @@ impl ActionThresholds {
     }
 }
 
-#[derive(Clone, Copy)]
-pub struct BlockTime(u64);
+impl Default for ActionThresholds {
+    fn default() -> Self {
+        ActionThresholds {
+            deployment: Weight::new(1),
+            key_management: Weight::new(1),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BlockTime(pub u64);
 
 /// Holds information about last usage time of specific action.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AccountActivity {
     // Last time `KeyManagementAction` was used.
     key_management_last_used: BlockTime,
@@ -64,6 +75,7 @@ pub struct AccountActivity {
 }
 
 impl AccountActivity {
+    // TODO: We need default for inactivity_period_limit.
     // `current_block_time` value is passed in from the node and is coming from the parent block.
     // [inactivity_period_limit] block time period after which account is eligible for recovery.
     pub fn new(
@@ -177,6 +189,8 @@ pub struct Account {
     nonce: u64,
     known_urefs: BTreeMap<String, Key>,
     associated_keys: AssociatedKeys,
+    action_thresholds: ActionThresholds,
+    account_activity: AccountActivity,
 }
 
 impl Account {
@@ -185,12 +199,16 @@ impl Account {
         nonce: u64,
         known_urefs: BTreeMap<String, Key>,
         associated_keys: AssociatedKeys,
+        action_thresholds: ActionThresholds,
+        account_activity: AccountActivity,
     ) -> Self {
         Account {
             public_key,
             nonce,
             known_urefs,
             associated_keys,
+            action_thresholds,
+            account_activity,
         }
     }
 
@@ -258,22 +276,123 @@ impl FromBytes for AssociatedKeys {
     }
 }
 
+const BLOCKTIME_SIZE: usize = U64_SIZE;
+
+impl ToBytes for BlockTime {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        self.0.to_bytes()
+    }
+}
+
+impl FromBytes for BlockTime {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (time, rem) = FromBytes::from_bytes(bytes)?;
+        Ok((BlockTime(time), rem))
+    }
+}
+
+const DEPLOYMENT_THRESHOLD_ID: u8 = 0;
+const KEY_MANAGEMENT_THRESHOLD_ID: u8 = 1;
+
+impl ToBytes for ActionThresholds {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let mut result = Vec::with_capacity(2 * (WEIGHT_SIZE + U8_SIZE));
+        result.push(DEPLOYMENT_THRESHOLD_ID);
+        result.extend(&self.deployment.to_bytes()?);
+        result.push(KEY_MANAGEMENT_THRESHOLD_ID);
+        result.extend(&self.key_management.to_bytes()?);
+        Ok(result)
+    }
+}
+
+impl FromBytes for ActionThresholds {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let mut action_thresholds: ActionThresholds = Default::default();
+        let (id_1, rem): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (weight_1, rem2): (Weight, &[u8]) = FromBytes::from_bytes(&rem)?;
+        let (id_2, rem3): (u8, &[u8]) = FromBytes::from_bytes(&rem2)?;
+        let (weight_2, rem4): (Weight, &[u8]) = FromBytes::from_bytes(&rem3)?;
+        match (id_1, id_2) {
+            (DEPLOYMENT_THRESHOLD_ID, KEY_MANAGEMENT_THRESHOLD_ID) => {
+                action_thresholds.set_key_management_threshold(weight_2);
+                action_thresholds.set_deployment_threshold(weight_1);
+                Ok((action_thresholds, rem4))
+            }
+            (KEY_MANAGEMENT_THRESHOLD_ID, DEPLOYMENT_THRESHOLD_ID) => {
+                action_thresholds.set_key_management_threshold(weight_1);
+                action_thresholds.set_deployment_threshold(weight_2);
+                Ok((action_thresholds, rem4))
+            }
+            _ => Err(Error::FormattingError),
+        }
+    }
+}
+
+const KEY_MANAGEMENT_LAST_USED_ID: u8 = 0;
+const DEPLOYMENT_LAST_USED_ID: u8 = 1;
+const INACTIVITY_PERIOD_LIMIT_ID: u8 = 2;
+
+impl ToBytes for AccountActivity {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let mut result = Vec::with_capacity(3 * (BLOCKTIME_SIZE + U8_SIZE));
+        result.push(KEY_MANAGEMENT_LAST_USED_ID);
+        result.extend(&self.key_management_last_used.to_bytes()?);
+        result.push(DEPLOYMENT_LAST_USED_ID);
+        result.extend(&self.deployment_last_used.to_bytes()?);
+        result.push(INACTIVITY_PERIOD_LIMIT_ID);
+        result.extend(&self.inactivity_period_limit.to_bytes()?);
+        Ok(result)
+    }
+}
+
+fn account_activity_parser_helper<'a>(
+    acc_activity: &mut AccountActivity,
+    bytes: &'a [u8],
+) -> Result<&'a [u8], Error> {
+    let (id, rem) = FromBytes::from_bytes(bytes)?;
+    let (block_time, rest): (BlockTime, &[u8]) = FromBytes::from_bytes(rem)?;
+    match id {
+        KEY_MANAGEMENT_LAST_USED_ID => acc_activity.update_key_management_last_used(block_time),
+        DEPLOYMENT_LAST_USED_ID => acc_activity.update_deployment_last_used(block_time),
+        INACTIVITY_PERIOD_LIMIT_ID => acc_activity.update_inactivity_period_limit(block_time),
+        _ => return Err(Error::FormattingError),
+    };
+    Ok(rest)
+}
+
+impl FromBytes for AccountActivity {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let mut acc_activity = AccountActivity::new(BlockTime(0), BlockTime(0));
+        let rem = account_activity_parser_helper(&mut acc_activity, bytes)?;
+        let rem2 = account_activity_parser_helper(&mut acc_activity, rem)?;
+        let rem3 = account_activity_parser_helper(&mut acc_activity, rem2)?;
+        Ok((acc_activity, rem3))
+    }
+}
+
 impl ToBytes for Account {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        let action_thresholds_size = 2 * (WEIGHT_SIZE + U8_SIZE);
+        let account_activity_size: usize = 3 * (BLOCKTIME_SIZE + U8_SIZE);
         let associated_keys_size =
             self.associated_keys.0.len() * (PUBLIC_KEY_SIZE + WEIGHT_SIZE) + U32_SIZE;
         let known_urefs_size = UREF_SIZE * self.known_urefs.len() + U32_SIZE;
-        if known_urefs_size + associated_keys_size
-            >= u32::max_value() as usize - KEY_SIZE - U64_SIZE
-        {
+        let serialized_account_size = KEY_SIZE // pub key
+            + U64_SIZE // nonce
+            + known_urefs_size
+            + associated_keys_size
+            + action_thresholds_size
+            + account_activity_size;
+        if serialized_account_size >= u32::max_value() as usize {
             return Err(Error::OutOfMemoryError);
         }
-        let mut result: Vec<u8> =
-            Vec::with_capacity(KEY_SIZE + U64_SIZE + known_urefs_size + associated_keys_size);
+        let mut result: Vec<u8> = Vec::with_capacity(serialized_account_size);
         result.extend(&self.public_key.to_bytes()?);
         result.append(&mut self.nonce.to_bytes()?);
         result.append(&mut self.known_urefs.to_bytes()?);
         result.append(&mut self.associated_keys.to_bytes()?);
+        result.append(&mut self.action_thresholds.to_bytes()?);
+        result.append(&mut self.account_activity.to_bytes()?);
         Ok(result)
     }
 }
@@ -284,14 +403,18 @@ impl FromBytes for Account {
         let (nonce, rem2): (u64, &[u8]) = FromBytes::from_bytes(rem1)?;
         let (known_urefs, rem3): (BTreeMap<String, Key>, &[u8]) = FromBytes::from_bytes(rem2)?;
         let (associated_keys, rem4): (AssociatedKeys, &[u8]) = FromBytes::from_bytes(rem3)?;
+        let (action_thresholds, rem5): (ActionThresholds, &[u8]) = FromBytes::from_bytes(rem4)?;
+        let (account_activity, rem6): (AccountActivity, &[u8]) = FromBytes::from_bytes(rem5)?;
         Ok((
             Account {
                 public_key,
                 nonce,
                 known_urefs,
                 associated_keys,
+                action_thresholds,
+                account_activity,
             },
-            rem4,
+            rem6,
         ))
     }
 }

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -372,7 +372,7 @@ mod tests {
     use storage::global_state::{CommitResult, History};
 
     use super::{Error, RuntimeContext, URefAddr, Validated};
-    use common::value::account::{AssociatedKeys, PublicKey, Weight};
+    use common::value::account::{AccountActivity, AssociatedKeys, BlockTime, PublicKey, Weight};
     use execution::{create_rng, vec_key_rights_to_map};
     use shared::newtypes::Blake2bHash;
     use tracking_copy::TrackingCopy;
@@ -403,7 +403,14 @@ mod tests {
 
     fn mock_account(addr: [u8; 32]) -> (Key, value::Account) {
         let associated_keys = AssociatedKeys::new(PublicKey::new(addr), Weight::new(1));
-        let account = value::account::Account::new(addr, 0, BTreeMap::new(), associated_keys);
+        let account = value::account::Account::new(
+            addr,
+            0,
+            BTreeMap::new(),
+            associated_keys,
+            Default::default(),
+            AccountActivity::new(BlockTime(0), BlockTime(100)),
+        );
         let key = Key::Account(addr);
 
         (key, account)

--- a/execution-engine/engine/src/tracking_copy.rs
+++ b/execution-engine/engine/src/tracking_copy.rs
@@ -283,7 +283,9 @@ mod tests {
     use storage::global_state::StateReader;
 
     use super::{AddResult, QueryResult, Validated};
-    use common::value::account::{AssociatedKeys, PublicKey, Weight, KEY_SIZE};
+    use common::value::account::{
+        AccountActivity, AssociatedKeys, BlockTime, PublicKey, Weight, KEY_SIZE,
+    };
     use engine_state::op::Op;
     use tracking_copy::TrackingCopy;
 
@@ -456,8 +458,14 @@ mod tests {
     fn tracking_copy_add_named_key() {
         // DB now holds an `Account` so that we can test adding a `NamedKey`
         let associated_keys = AssociatedKeys::new(PublicKey::new([0u8; KEY_SIZE]), Weight::new(1));
-        let account =
-            common::value::Account::new([0u8; KEY_SIZE], 0u64, BTreeMap::new(), associated_keys);
+        let account = common::value::Account::new(
+            [0u8; KEY_SIZE],
+            0u64,
+            BTreeMap::new(),
+            associated_keys,
+            Default::default(),
+            AccountActivity::new(BlockTime(0), BlockTime(100)),
+        );
         let db = CountingDb::new_init(Value::Account(account));
         let mut tc = TrackingCopy::new(db);
         let k = Key::Hash([0u8; 32]);
@@ -643,6 +651,8 @@ mod tests {
                 nonce,
                 known_urefs,
                 associated_keys,
+                Default::default(),
+                AccountActivity::new(BlockTime(0), BlockTime(100))
             );
             let account_key = Key::Account(address);
 
@@ -691,6 +701,8 @@ mod tests {
                 nonce,
                 account_known_urefs,
                 associated_keys,
+                Default::default(),
+                AccountActivity::new(BlockTime(0), BlockTime(100))
             );
             let account_key = Key::Account(address);
 

--- a/execution-engine/shared/src/init/mod.rs
+++ b/execution-engine/shared/src/init/mod.rs
@@ -1,7 +1,7 @@
 use std::collections::btree_map::BTreeMap;
 
 use common::key::Key;
-use common::value::account::{AssociatedKeys, PublicKey, Weight};
+use common::value::account::{AccountActivity, AssociatedKeys, BlockTime, PublicKey, Weight};
 use common::value::{Account, Value};
 
 pub fn mocked_account(account_addr: [u8; 32]) -> Vec<(Key, Value)> {
@@ -10,6 +10,13 @@ pub fn mocked_account(account_addr: [u8; 32]) -> Vec<(Key, Value)> {
         associated_keys.add_key(PublicKey::new(account_addr), Weight::new(1));
         associated_keys
     };
-    let account = Account::new(account_addr, 0, BTreeMap::new(), associated_keys);
+    let account = Account::new(
+        account_addr,
+        0,
+        BTreeMap::new(),
+        associated_keys,
+        Default::default(),
+        AccountActivity::new(BlockTime(0), BlockTime(100)),
+    );
     vec![(Key::Account(account_addr), Value::Account(account))]
 }

--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -268,8 +268,8 @@ mod tests {
     #[test]
     fn initial_state_has_the_expected_hash() {
         let expected_bytes = vec![
-            193u8, 151, 167, 126, 241, 141, 9, 163, 43, 169, 238, 19, 93, 87, 183, 131, 99, 160,
-            96, 216, 8, 39, 227, 218, 246, 90, 65, 57, 207, 242, 61, 205,
+            213u8, 28, 115, 132, 250, 129, 55, 111, 27, 68, 13, 5, 143, 211, 111, 190, 243, 87,
+            140, 228, 21, 158, 179, 104, 240, 16, 70, 251, 167, 153, 156, 43,
         ];
         let init_state = mocked_account([48u8; 32]);
         let global_state = InMemoryGlobalState::from_pairs(&init_state).unwrap();

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -150,10 +150,21 @@ message Account {
         bytes pub_key = 1; // Should have 32 elements
         uint32 weight = 2;
     }
+    message ActionThresholds {
+        uint32 deployment_threshold = 1;
+        uint32 key_management_threshold = 2;
+    }
+    message AccountActivity {
+        uint64 key_management_last_used = 1;
+        uint64 deployment_last_used = 2;
+        uint64 inactivity_period_limit = 3;
+    }
     bytes pub_key = 1; // Should have 32 elements
     uint64 nonce = 2;
     repeated NamedKey known_urefs = 3;
     repeated AssociatedKey associated_keys = 4;
+    ActionThresholds action_threshold = 5;
+    AccountActivity account_activity = 6;
 }
 message Contract {
     bytes body = 1;

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -43,8 +43,8 @@ class GrpcExecutionEngineService[F[_]: Defer: Sync: Log: TaskLift] private[smart
   private var bonds = initialBonds.map(p => Bond(ByteString.copyFrom(p._1), p._2)).toSeq
 
   override def emptyStateHash: ByteString = {
-    val arr: Array[Byte] = Array(193, 151, 167, 126, 241, 141, 9, 163, 43, 169, 238, 19, 93, 87,
-      183, 131, 99, 160, 96, 216, 8, 39, 227, 218, 246, 90, 65, 57, 207, 242, 61, 205).map(_.toByte)
+    val arr: Array[Byte] = Array(213, 28, 115, 132, 250, 129, 55, 111, 27, 68, 13, 5, 143, 211, 111,
+      190, 243, 87, 140, 228, 21, 158, 179, 104, 240, 16, 70, 251, 167, 153, 156, 43).map(_.toByte)
     ByteString.copyFrom(arr)
   }
 


### PR DESCRIPTION
### Overview
Adds action thresholds and account activity structs to Account object. Note that it doesn't wire it with FFI/API yet.

This is iterative change (depends on #527 PR). Interesting diff can be found here: https://github.com/CasperLabs/CasperLabs/compare/gorski-ee-273...gorski-ee-274

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-274

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
[Account (recovery) specification](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/97058817/Account+specification+creation+recovery)