### PR TITLE
NODE-529: Warn about downloading blocks created by doppelgangers.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -44,6 +44,7 @@ import monix.execution.Scheduler
 import monix.eval.TaskLike
 import scala.io.Source
 import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
 
 /** Create the Casper stack using the GossipService. */
 package object gossiping {
@@ -177,7 +178,8 @@ package object gossiping {
         case other =>
           Log[F].debug(s"Received invalid block ${show(block.blockHash)}: $other") *>
             MonadThrowable[F].raiseError[Unit](
-              new RuntimeException(s"Non-valid status: $other")
+              // Raise an exception to stop the DownloadManager from progressing with this block.
+              new RuntimeException(s"Non-valid status: $other") with NoStackTrace
             )
       }
 
@@ -264,32 +266,46 @@ package object gossiping {
       connectToGossip: GossipService.Connector[F],
       relaying: Relaying[F]
   ): Resource[F, DownloadManager[F]] =
-    Resource.liftF(DownloadManagerImpl.establishMetrics[F]) *>
-      DownloadManagerImpl[F](
-        // TODO: Add to config.
-        maxParallelDownloads = 10,
-        connectToGossip = connectToGossip,
-        backend = new DownloadManagerImpl.Backend[F] {
-          override def hasBlock(blockHash: ByteString): F[Boolean] =
-            isInDag(blockHash)
+    for {
+      _           <- Resource.liftF(DownloadManagerImpl.establishMetrics[F])
+      validatorId <- Resource.liftF(ValidatorIdentity.fromConfig[F](conf.casper))
+      maybeValidatorPublicKey = validatorId
+        .map(x => ByteString.copyFrom(x.publicKey))
+        .filterNot(_.isEmpty)
+      downloadManager <- DownloadManagerImpl[F](
+                          // TODO: Add to config.
+                          maxParallelDownloads = 10,
+                          connectToGossip = connectToGossip,
+                          backend = new DownloadManagerImpl.Backend[F] {
+                            override def hasBlock(blockHash: ByteString): F[Boolean] =
+                              isInDag(blockHash)
 
-          override def validateBlock(block: Block): F[Unit] =
-            validateAndAddBlock(conf.casper.shardId, block)
+                            override def validateBlock(block: Block): F[Unit] =
+                              maybeValidatorPublicKey
+                                .filter(_ == block.getHeader.validatorPublicKey)
+                                .fold(().pure[F]) { _ =>
+                                  Log[F]
+                                    .warn(
+                                      s"Block ${PrettyPrinter.buildString(block)} seems to be created by a doppelganger using the same validator key!"
+                                    )
+                                } *>
+                                validateAndAddBlock(conf.casper.shardId, block)
 
-          override def storeBlock(block: Block): F[Unit] =
-            // Validation has already stored it.
-            ().pure[F]
+                            override def storeBlock(block: Block): F[Unit] =
+                              // Validation has already stored it.
+                              ().pure[F]
 
-          override def storeBlockSummary(
-              summary: BlockSummary
-          ): F[Unit] =
-            // TODO: Add separate storage for summaries.
-            ().pure[F]
-        },
-        relaying = relaying,
-        // TODO: Configure retry.
-        retriesConf = DownloadManagerImpl.RetriesConf.noRetries
-      )
+                            override def storeBlockSummary(
+                                summary: BlockSummary
+                            ): F[Unit] =
+                              // TODO: Add separate storage for summaries.
+                              ().pure[F]
+                          },
+                          relaying = relaying,
+                          // TODO: Configure retry.
+                          retriesConf = DownloadManagerImpl.RetriesConf.noRetries
+                        )
+    } yield downloadManager
 
   private def makeGenesisApprover[F[_]: Concurrent: Log: Time: Timer: NodeDiscovery: BlockStore: BlockDagStorage: MultiParentCasperRef: ExecutionEngineService](
       conf: Configuration,


### PR DESCRIPTION
### Overview
The new gossiping setup was lacking the warning about doppelgangers, which could be helpful if somebody accidentally configures the same validator ID on multiple nodes, leading to equivocations. After this PR when a node is downloading a block and tries to validate it and the creator is the same as itself (which means the block should have been present on the node already, not downloaded) we'll see a warning in the logs.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-529

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
