### PR TITLE
NODE-509: Carry on with genesis ASAP if no approvals are required.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
@@ -182,8 +182,11 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
         case Right(transitioned) =>
           transitioned.pure[F]
       }
-    } map {
-      _ contains true
+    } flatMap {
+      case Nil =>
+        statusRef.get flatMap { _.fold(false.pure[F])(tryTransition) }
+      case transitioned =>
+        transitioned.contains(true).pure[F]
     }
 
   /** Get the Genesis candidate from the bootstrap node and keep polling until we can do the transition. */


### PR DESCRIPTION
### Overview
The `GenesisApprover` only checked for transition conditions when approvals were added, but it might be the case that the node doesn't require any approvals, and the bootstrap for example doesn't add its own approval because it's not a validator. The PR changes it so transition check happens even when there candidate has no approvals yet. This is to avoid misconfigurations where all nodes are started in default (non genesis validator) mode and the bootstrap isn't configured with a validator key, then every node would just sit there waiting.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-509

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
