### PR TITLE
NODE-530: Replace Deploy.signature with Deploy.approvals

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Validate.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Validate.scala
@@ -118,26 +118,39 @@ object Validate {
     }
 
   def deploySignature[F[_]: Applicative: Log](d: consensus.Deploy): F[Boolean] =
-    signatureVerifiers(d.getSignature.sigAlgorithm)
-      .map { verify =>
-        Try {
-          verify(
-            d.deployHash.toByteArray,
-            Signature(d.getSignature.sig.toByteArray),
-            PublicKey(d.getHeader.accountPublicKey.toByteArray)
-          )
-        } match {
-          case Success(true) =>
-            true.pure[F]
-          case _ =>
-            Log[F].warn(
-              s"Signature of deploy ${PrettyPrinter.buildString(d.deployHash)} is invalid."
-            ) *> false.pure[F]
-        }
-      } getOrElse {
+    if (d.approvals.isEmpty) {
       Log[F].warn(
-        s"Signature algorithm ${d.getSignature.sigAlgorithm} of deploy ${PrettyPrinter.buildString(d.deployHash)} is unsupported."
+        s"Deploy ${PrettyPrinter.buildString(d.deployHash)} has no signatures."
       ) *> false.pure[F]
+    } else {
+      d.approvals.toList.traverse { a =>
+        val publicKey =
+          if (a.approverPublicKey.isEmpty) d.getHeader.accountPublicKey else a.approverPublicKey
+        signatureVerifiers(a.getSignature.sigAlgorithm)
+          .map { verify =>
+            Try {
+              verify(
+                d.deployHash.toByteArray,
+                Signature(a.getSignature.sig.toByteArray),
+                PublicKey(publicKey.toByteArray)
+              )
+            } match {
+              case Success(true) =>
+                true.pure[F]
+              case _ =>
+                Log[F].warn(
+                  s"Signature of deploy ${PrettyPrinter.buildString(d.deployHash)} is invalid."
+                ) *> false.pure[F]
+            }
+          } getOrElse {
+          Log[F].warn(
+            s"Signature algorithm ${a.getSignature.sigAlgorithm} of deploy ${PrettyPrinter
+              .buildString(d.deployHash)} is unsupported."
+          ) *> false.pure[F]
+        }
+      } map {
+        _.forall(identity)
+      }
     }
 
   def blockSender[F[_]: Monad: Log: BlockStore](

--- a/casper/src/main/scala/io/casperlabs/casper/Validate.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Validate.scala
@@ -124,15 +124,13 @@ object Validate {
       ) *> false.pure[F]
     } else {
       d.approvals.toList.traverse { a =>
-        val publicKey =
-          if (a.approverPublicKey.isEmpty) d.getHeader.accountPublicKey else a.approverPublicKey
         signatureVerifiers(a.getSignature.sigAlgorithm)
           .map { verify =>
             Try {
               verify(
                 d.deployHash.toByteArray,
                 Signature(a.getSignature.sig.toByteArray),
-                PublicKey(publicKey.toByteArray)
+                PublicKey(a.approverPublicKey.toByteArray)
               )
             } match {
               case Success(true) =>

--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -30,9 +30,11 @@ import io.casperlabs.shared.Time
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.BlockMsgWithTransform
 import monix.eval.Task
+import monix.execution.Scheduler
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.immutable.HashMap
+import scala.concurrent.duration._
 
 class ValidateTest
     extends FlatSpec
@@ -55,6 +57,11 @@ class ValidateTest
   override def beforeEach(): Unit = {
     log.reset()
     timeEff.reset()
+  }
+
+  def withoutStorage(t: => Task[_]) = {
+    import Scheduler.Implicits.global
+    t.runSyncUnsafe(5.seconds)
   }
 
   def createChain[F[_]: Monad: Time: BlockStore: IndexedBlockDagStorage](
@@ -198,40 +205,40 @@ class ValidateTest
       } yield result
   }
 
-  "Deploy signature validation" should "return true for valid signatures" in {
+  "Deploy signature validation" should "return true for valid signatures" in withoutStorage {
     val deploy = sample(arbitrary[consensus.Deploy])
     Validate.deploySignature[Task](deploy) shouldBeF true
   }
 
-  it should "return true if the signature matches the account public key" in {
+  it should "return false if a key in an approval is empty" in withoutStorage {
     val genDeploy = for {
       d <- arbitrary[consensus.Deploy]
     } yield d.withApprovals(d.approvals.map(x => x.withApproverPublicKey(ByteString.EMPTY)))
 
     val deploy = sample(genDeploy)
-    Validate.deploySignature[Task](deploy) shouldBeF true
+    Validate.deploySignature[Task](deploy) shouldBeF false
   }
 
-  it should "return false for missing signatures" in {
+  it should "return false for missing signatures" in withoutStorage {
     val genDeploy = for {
       d <- arbitrary[consensus.Deploy]
     } yield d.withApprovals(Nil)
 
     val deploy = sample(genDeploy)
-    Validate.deploySignature[Task](deploy) shouldBeF true
+    Validate.deploySignature[Task](deploy) shouldBeF false
   }
 
-  it should "return false for invalid signatures" in {
+  it should "return false for invalid signatures" in withoutStorage {
     val genDeploy = for {
       d <- arbitrary[consensus.Deploy]
       h <- genHash
     } yield d.withApprovals(d.approvals.map(a => a.withSignature(a.getSignature.withSig(h))))
 
     val deploy = sample(genDeploy)
-    Validate.deploySignature[Task](deploy) shouldBeF true
+    Validate.deploySignature[Task](deploy) shouldBeF false
   }
 
-  it should "return false if there are valid and invalid signatures mixed" in {
+  it should "return false if there are valid and invalid signatures mixed" in withoutStorage {
     val genDeploy = for {
       d <- arbitrary[consensus.Deploy]
       h <- genHash
@@ -241,7 +248,7 @@ class ValidateTest
       )
 
     val deploy = sample(genDeploy)
-    Validate.deploySignature[Task](deploy) shouldBeF true
+    Validate.deploySignature[Task](deploy) shouldBeF false
   }
 
   "Timestamp validation" should "not accept blocks with future time" in withStorage {

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -206,11 +206,18 @@ object DeployRuntime {
 
     def sign(privateKey: PrivateKey) = {
       val sig = Ed25519.sign(d.deployHash.toByteArray, privateKey)
-      d.withSignature(
-        consensus
-          .Signature()
-          .withSigAlgorithm(Ed25519.name)
-          .withSig(ByteString.copyFrom(sig))
+      d.withApprovals(
+        List(
+          consensus
+            .Approval()
+            .withApproverPublicKey(d.getHeader.accountPublicKey)
+            .withSignature(
+              consensus
+                .Signature()
+                .withSigAlgorithm(Ed25519.name)
+                .withSig(ByteString.copyFrom(sig))
+            )
+        )
       )
     }
   }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
@@ -277,13 +277,13 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
       case Some(Status(_, block))
           if !block.getHeader.getState.bonds
             .map(_.validatorPublicKey)
-            .contains(approval.validatorPublicKey) =>
+            .contains(approval.approverPublicKey) =>
         Left(InvalidArgument("The signatory is not one of the bonded validators."))
 
       case _
           if !backend.validateSignature(
             blockHash,
-            approval.validatorPublicKey,
+            approval.approverPublicKey,
             approval.getSignature
           ) =>
         Left(InvalidArgument("Could not validate signature."))
@@ -351,7 +351,7 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
         .delay {
           backend.canTransition(
             status.block,
-            status.candidate.approvals.map(_.validatorPublicKey).toSet
+            status.candidate.approvals.map(_.approverPublicKey).toSet
           )
         }
         .ifM(

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -106,7 +106,7 @@ trait ArbitraryConsensus {
     for {
       pk  <- genKey
       sig <- arbitrary[Signature]
-    } yield Approval().withValidatorPublicKey(pk).withSignature(sig)
+    } yield Approval().withApproverPublicKey(pk).withSignature(sig)
   }
 
   implicit val arbBond: Arbitrary[Bond] = Arbitrary {
@@ -182,7 +182,13 @@ trait ArbitraryConsensus {
         .withDeployHash(deployHash)
         .withHeader(header)
         .withBody(body)
-        .withSignature(signature)
+        .withApprovals(
+          List(
+            Approval()
+              .withApproverPublicKey(header.accountPublicKey)
+              .withSignature(signature)
+          )
+        )
     } yield deploy
   }
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -160,7 +160,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
           .withSignature(sample(arbitrary[Signature]).withSigAlgorithm("XXX")),
         // Good one.
         sample(arbitrary[Approval])
-          .copy(validatorPublicKey = genesis.getHeader.getState.bonds.head.validatorPublicKey)
+          .withApproverPublicKey(genesis.getHeader.getState.bonds.head.validatorPublicKey)
       )
       TestFixture.fromBootstrap(
         remoteCandidate = () =>
@@ -324,7 +324,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
           r1 <- approver.addApproval(genesis.blockHash, correctApproval)
           r2 <- approver.addApproval(
                  genesis.blockHash,
-                 correctApproval.withValidatorPublicKey(
+                 correctApproval.withApproverPublicKey(
                    genesis.getHeader.getState.bonds(1).validatorPublicKey
                  )
                )
@@ -338,7 +338,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
     "accumulate approvals arriving in parallel" in {
       TestFixture.fromGenesis() { approver =>
         val approvals = genesis.getHeader.getState.bonds.tail.map { b =>
-          sample(arbitrary[Approval]).withValidatorPublicKey(b.validatorPublicKey)
+          sample(arbitrary[Approval]).withApproverPublicKey(b.validatorPublicKey)
         }
         for {
           _ <- Task.gatherUnordered(approvals.map(approver.addApproval(genesis.blockHash, _)))
@@ -444,7 +444,7 @@ object GenesisApproverSpec extends ArbitraryConsensus {
 
   // Example of an approval that we can use in tests that won't be rejected.
   val correctApproval = sample(arbitrary[Approval])
-    .withValidatorPublicKey(genesis.getHeader.getState.bonds.last.validatorPublicKey)
+    .withApproverPublicKey(genesis.getHeader.getState.bonds.last.validatorPublicKey)
 
   class MockNodeDiscovery(peers: List[Node]) extends NodeDiscovery[Task] {
     override def discover                    = ???
@@ -560,7 +560,7 @@ object GenesisApproverSpec extends ArbitraryConsensus {
           relayFactor,
           genesis,
           maybeApproval = sample(arbitrary[Approval])
-            .withValidatorPublicKey(genesis.getHeader.getState.bonds.head.validatorPublicKey)
+            .withApproverPublicKey(genesis.getHeader.getState.bonds.head.validatorPublicKey)
             .some
             .filter(_ => approve)
         )

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -336,7 +336,7 @@ package object gossiping {
         validatorId.map { id =>
           val sig = id.signature(block.blockHash.toByteArray)
           Approval()
-            .withValidatorPublicKey(sig.publicKey)
+            .withApproverPublicKey(sig.publicKey)
             .withSignature(
               Signature()
                 .withSigAlgorithm(sig.algorithm)

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -10,6 +10,13 @@ message Signature {
     bytes sig = 2;
 }
 
+// A signature together with the corresponding public key that can be used to validate it
+// for situations where the key is not part of the data being signed, which is usually the
+// case where multiple signatures are required.
+message Approval {
+    bytes approver_public_key = 1;
+    Signature signature = 2;
+}
 
 // A smart contract invocation, singed by the account that sent it.
 message Deploy {
@@ -17,8 +24,11 @@ message Deploy {
     bytes deploy_hash = 1;
     Header header = 2;
     Body body = 3;
-    // Signature over `deploy_hash`.
-    Signature signature = 4;
+
+    // Signatures over `deploy_hash` with either the `account_public_key`, or some other keys in case of
+    // multi-sig wallets and account recovery (when the private key corresponding to `account_public_key`
+    // is lost.)
+    repeated Approval approvals = 4;
 
     message Header {
         // Identifying the Account is the key used to sign the Deploy.
@@ -56,7 +66,7 @@ message BlockSummary {
     // blake2b256 hash of the `header`.
     bytes block_hash = 1;
     Block.Header header = 2;
-    // Signature over `block_hash`.
+    // Signature over `block_hash` using `validator_public_key`.
     Signature signature = 3;
 }
 
@@ -131,9 +141,4 @@ message GenesisCandidate {
 
     // Approvals from bonded validators with signatures over the `block_hash`.
     repeated Approval approvals = 2;
-}
-
-message Approval {
-    bytes validator_public_key = 1;
-    Signature signature = 2;
 }


### PR DESCRIPTION
### Overview
To support multi-sig wallets and account recovery the `Deploy` needs multiple signatures. Normally we'd verify with `account_public_key` but if it's lost the account might have other keys associated with it that can be used for recovery, if all of them are present. 

Since we already had the `Approval` data type which has both a public key and a signature in it I reused that one in the `Deploy` type. I thought adding an optional public key to the `Signature` would make every time we use it problematic: is it in there, or is it the `Block.validator_public_key` or `Approval.validator_public_key` we need to use? In a sense with multiple wallets it's a kind of approval; I think we can get used it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-530

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
We discussed a little bit that maybe deriving the public key from the signature could be another option, and then all we'd need is a list of `Signature` records, however some sources linked in the ticket indicated that it may not be as straight forward to get a unique key back that we can pass on to the execution engine to check against the account. 
