### PR TITLE
CON-303: Allow second attempt to add block

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
@@ -7,6 +7,9 @@ sealed trait BlockStatus {
 final case object Processing extends BlockStatus {
   override val inDag: Boolean = false
 }
+final case object Processed extends BlockStatus {
+  override val inDag: Boolean = true
+}
 final case class BlockException(ex: Throwable) extends BlockStatus {
   override val inDag: Boolean = false
 }
@@ -49,7 +52,8 @@ final case object InvalidBlockHash        extends InvalidBlock with Slashable
 final case object InvalidDeployCount      extends InvalidBlock with Slashable
 
 object BlockStatus {
-  def valid: BlockStatus                    = Valid
-  def processing: BlockStatus               = Processing
+  val valid: BlockStatus                    = Valid
+  val processing: BlockStatus               = Processing
+  val processed: BlockStatus                = Processed
   def exception(ex: Throwable): BlockStatus = BlockException(ex)
 }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -76,25 +76,32 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
     Sync[F].bracket(blockProcessingLock.acquire)(
       _ =>
         for {
-          dag            <- blockDag
-          blockHash      = block.blockHash
-          containsResult <- dag.contains(blockHash)
-          casperState    <- Cell[F, CasperState].read
-          attempts <- if (containsResult || casperState.seenBlockHashes
-                            .contains(blockHash)) {
+          dag         <- blockDag
+          blockHash   = block.blockHash
+          inDag       <- dag.contains(blockHash)
+          casperState <- Cell[F, CasperState].read
+          inBuffer    = casperState.blockBuffer.exists(_.blockHash == blockHash)
+          attempts <- if (inDag) {
                        Log[F]
                          .info(
                            s"Block ${PrettyPrinter.buildString(blockHash)} has already been processed by another thread."
-                         )
-                         .map(
-                           _ =>
-                             List(
-                               block -> BlockStatus.processing
-                             )
-                         )
+                         ) *>
+                         List(block -> BlockStatus.processed).pure[F]
+                     } else if (inBuffer) {
+                       // Waiting for dependencies to become available.
+                       Log[F]
+                         .info(
+                           s"Block ${PrettyPrinter.buildString(blockHash)} is already in the buffer."
+                         ) *>
+                         List(block -> BlockStatus.processing).pure[F]
                      } else {
+                       // This might be the first time we see this block, or it may not have been added to the state
+                       // because it was an IgnorableEquivocation, but then we saw a child and now we got it again.
                        Cell[F, CasperState].modify { s =>
                          s.copy(
+                           // Take a note that we have seen this block,
+                           // so it won't be required as a dependency any more.
+                           // If the processing were to die though we'd be stuck.
                            seenBlockHashes = s.seenBlockHashes + blockHash
                          )
                        } *> internalAddBlock(block, dag)
@@ -601,9 +608,11 @@ object MultiParentCasperImpl {
       validationStatus.flatMap {
         case Right(effects) =>
           addEffects(Valid, block, effects, dag).tupleLeft(Valid)
+
         case Left(ValidateErrorWrapper(invalid)) =>
           addEffects(invalid, block, Seq.empty, dag)
             .tupleLeft(invalid)
+
         case Left(unexpected) =>
           for {
             _ <- Log[F].error(
@@ -686,7 +695,7 @@ object MultiParentCasperImpl {
             InvalidPostStateHash =>
           handleInvalidBlockEffect(status, block, transforms)
 
-        case Processing =>
+        case Processing | Processed =>
           throw new RuntimeException(s"A block should not be processing at this stage.")
 
         case BlockException(ex) =>
@@ -786,7 +795,7 @@ object MultiParentCasperImpl {
                 InvalidSequenceNumber | NeglectedInvalidBlock | NeglectedEquivocation |
                 InvalidTransaction | InvalidBondsCache | InvalidRepeatDeploy | InvalidChainId |
                 InvalidBlockHash | InvalidDeployCount | InvalidPreStateHash | InvalidPostStateHash |
-                Processing =>
+                Processing | Processed =>
               Log[F].debug(
                 s"Not sending notification about ${PrettyPrinter.buildString(block.blockHash)}: $status"
               )
@@ -816,7 +825,10 @@ object MultiParentCasperImpl {
             missingUnseenDependencies = missingDependencies.filter(
               blockHash => !casperState.seenBlockHashes.contains(blockHash)
             )
-            _ <- missingUnseenDependencies.traverse(hash => requestMissingDependency(hash))
+            // NOTE: Requesting not just unseen dependencies so that something that was originally
+            // an `IgnorableEquivocation` can second time be fetched again and be an `AdmissibleEquivocation`.
+            //_ <- missingUnseenDependencies.traverse(hash => requestMissingDependency(hash))
+            _ <- missingDependencies.traverse(hash => requestMissingDependency(hash))
           } yield ()
       }
 
@@ -855,7 +867,7 @@ object MultiParentCasperImpl {
               InvalidSequenceNumber | NeglectedInvalidBlock | NeglectedEquivocation |
               InvalidTransaction | InvalidBondsCache | InvalidRepeatDeploy | InvalidChainId |
               InvalidBlockHash | InvalidDeployCount | InvalidPreStateHash | InvalidPostStateHash |
-              Processing =>
+              Processing | Processed =>
             ().pure[F]
 
           case BlockException(_) =>

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -144,7 +144,7 @@ object BlockAPI {
         DeployServiceResponse(success = false, s"Error while creating block: $msg")
       case OutOfRange(msg) =>
         DeployServiceResponse(success = false, s"Error while creating block: $msg")
-      case Unavailable(msg) =>
+      case Unavailable(_) =>
         DeployServiceResponse(success = false, s"Error: Could not create block.")
     }
 
@@ -171,7 +171,7 @@ object BlockAPI {
                                      raise(InvalidArgument(s"Invalid block: $status"))
                                    case BlockException(ex) =>
                                      raise(Internal(s"Error during block processing: $ex"))
-                                   case Processing =>
+                                   case Processing | Processed =>
                                      raise(
                                        Aborted(
                                          "No action taken since other thread is already processing the block."

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -96,10 +96,11 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
                    }
                )
     } yield result
+
     val threadStatuses: (BlockStatus, BlockStatus) =
       testProgram.value.unsafeRunSync(scheduler).right.get
 
-    threadStatuses should matchPattern { case (Processing, Valid) | (Valid, Processing) => }
+    threadStatuses should matchPattern { case (Processed, Valid) | (Valid, Processed) => }
     node.tearDown().value.unsafeRunSync
   }
 
@@ -312,7 +313,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  // FIXME
   it should "handle multi-parent blocks correctly" in effectTest {
     for {
       nodes       <- networkEff(validatorKeys.take(2), genesis, transforms)
@@ -575,7 +575,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
-  // FIXME
   it should "ask peers for blocks it is missing" in effectTest {
     for {
       nodes <- networkEff(validatorKeys.take(3), genesis, transforms)
@@ -655,7 +654,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
    *  f2 has in its justifications list c2. This should be handled properly.
    *
    */
-  // FIXME
   it should "ask peers for blocks it is missing and add them" in effectTest {
     //TODO: figure out a way to get wasm into deploys for tests
     val deployDatasFs = Vector[() => Deploy](
@@ -732,7 +730,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  // FIXME
   it should "ignore adding equivocation blocks" in effectTest {
     for {
       nodes <- networkEff(validatorKeys.take(2), genesis, transforms)
@@ -768,7 +765,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
   }
 
   // See [[/docs/casper/images/minimal_equivocation_neglect.png]] but cross out genesis block
-  // FIXME
   it should "not ignore equivocation blocks that are required for parents of proper nodes" in effectTest {
     for {
       nodes       <- networkEff(validatorKeys.take(3), genesis, transforms)
@@ -871,6 +867,45 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield result
   }
 
+  it should "not ignore adding equivocation blocks when a child is revealed later" in effectTest {
+    for {
+      nodes <- networkEff(validatorKeys.take(2), genesis, transforms)
+
+      makeDeploy = (n: Int, i: Int) => {
+        for {
+          deploy         <- ProtoUtil.basicDeploy[Effect](i)
+          result         <- nodes(n).casperEff.deploy(deploy) *> nodes(n).casperEff.createBlock
+          Created(block) = result
+        } yield block
+      }
+
+      // Creates a pair that constitutes equivocation blocks
+      block1      <- makeDeploy(0, 0)
+      block1Prime <- makeDeploy(0, 1)
+
+      _ <- nodes(0).casperEff.addBlock(block1) shouldBeF Valid
+      _ <- nodes(0).casperEff.addBlock(block1Prime) shouldBeF IgnorableEquivocation
+      _ <- nodes(1).clearMessages()
+      _ <- nodes(1).casperEff.addBlock(block1Prime) shouldBeF Valid
+      _ <- nodes(0).receive()
+
+      _ <- nodes(0).casperEff.contains(block1) shouldBeF true
+      _ <- nodes(0).casperEff.contains(block1Prime) shouldBeF false
+
+      block2Prime <- makeDeploy(1, 2)
+      _           <- nodes(1).casperEff.addBlock(block2Prime) shouldBeF Valid
+      _           <- nodes(0).receive()
+      // Process dependencies
+      _ <- nodes(1).receive()
+      _ <- nodes(0).receive()
+
+      _ <- nodes(0).casperEff.contains(block2Prime) shouldBeF true
+      _ <- nodes(0).casperEff.contains(block1Prime) shouldBeF true
+
+      _ <- nodes.toList.traverse(_.tearDown())
+    } yield ()
+  }
+
   it should "prepare to slash a block that includes a invalid block pointer" in effectTest {
     for {
       nodes           <- networkEff(validatorKeys.take(3), genesis, transforms)
@@ -965,7 +1000,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield ()
   }
 
-  // FIXME
   it should "increment last finalized block as appropriate in round robin" in effectTest {
     val stake      = 10L
     val equalBonds = validators.map(_ -> stake).toMap

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -330,7 +330,7 @@ trait ArbitraryConsensus {
                               s.getHeader
                                 .withParentHashes(Seq.empty)
                                 .withJustifications(Seq.empty)
-                                .withRank(c.dagDepth - depth)
+                                .withRank((c.dagDepth - depth).toLong)
                             )
                         )
                       )
@@ -349,7 +349,7 @@ trait ArbitraryConsensus {
             newest.getHeader
               .withParentHashes(Seq.empty)
               .withJustifications(Seq.empty)
-              .withRank(c.dagDepth)
+              .withRank(c.dagDepth.toLong)
           )
         ),
         1


### PR DESCRIPTION
### Overview
`MultiParentCasperImpl` used `seenBlockHashes` for two things:
* refuse adding blocks which were already attempted
* not try to fetch dependencies it has already seen

The problem is that if a block turns out to be an `IgnorableEquivocation` but other blocks build on it then it should be recognised as an `AdmissibleEquivocation`. That will be defeated if the attempts to download the parent block a second time result in `Processing` error rather than execution and storage.

I removed the `seenBlockHashes` and rely on the storage or the block buffer to decide if a block needs adding: 
* if it's in storage, obviously it doesn't
* if it's in the buffer, it's missing some dependencies, so we don't have to deal with it again in `addBlock`, it will be handled by `reAttemptBuffer` when the parent is eventually processed; this only applies to the transport layer setup, since the `DownloadManager` will never try to add blocks with missing parents
* if it's in neither then we can try to add the block (again)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-303

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
