### PR TITLE
Add `is_valid` FFI for checking that URefs (or values containing URefs) are not not forged

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -129,6 +129,9 @@ impl TryFrom<&super::ipc::Transform> for transform::Transform {
                 let name = nk.get_name().to_string();
                 let key = nk.get_key().try_into()?;
                 transform_write(common::value::Value::NamedKey(name, key))
+            } else if v.has_key() {
+                let key = v.get_key().try_into()?;
+                transform_write(common::value::Value::Key(key))
             } else {
                 parse_error(format!(
                     "TransformEntry write contained unknown value: {:?}",
@@ -175,6 +178,9 @@ impl From<common::value::Value> for super::ipc::Value {
                     nk
                 };
                 tv.set_named_key(named_key);
+            }
+            common::value::Value::Key(key) => {
+                tv.set_key((&key).into());
             }
             common::value::Value::Account(account) => {
                 let mut acc = super::ipc::Account::new();

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -286,9 +286,7 @@ pub fn call_contract<A: ArgsParser, T: FromBytes>(
 pub fn is_valid<T: Into<Value>>(t: T) -> bool {
     let value = t.into();
     let (value_ptr, value_size, _bytes) = to_ptr(&value);
-    let result = unsafe {
-        ext_ffi::is_valid(value_ptr, value_size)
-    };
+    let result = unsafe { ext_ffi::is_valid(value_ptr, value_size) };
     if result == 0 {
         false
     } else {

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -287,9 +287,5 @@ pub fn is_valid<T: Into<Value>>(t: T) -> bool {
     let value = t.into();
     let (value_ptr, value_size, _bytes) = to_ptr(&value);
     let result = unsafe { ext_ffi::is_valid(value_ptr, value_size) };
-    if result == 0 {
-        false
-    } else {
-        true
-    }
+    result != 0
 }

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -277,3 +277,21 @@ pub fn call_contract<A: ArgsParser, T: FromBytes>(
     };
     deserialize(&res_bytes).unwrap()
 }
+
+/// Checks if all the keys contained in the given `Value`
+/// (rather, thing that can be turned into a `Value`) are
+/// valid, in the sense that all of the urefs (and their access rights)
+/// are known in the current context.
+#[allow(clippy::ptr_arg)]
+pub fn is_valid<T: Into<Value>>(t: T) -> bool {
+    let value = t.into();
+    let (value_ptr, value_size, _bytes) = to_ptr(&value);
+    let result = unsafe {
+        ext_ffi::is_valid(value_ptr, value_size)
+    };
+    if result == 0 {
+        false
+    } else {
+        true
+    }
+}

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -99,6 +99,7 @@ pub fn value_arb() -> impl Strategy<Value = Value> {
         ("\\PC*".prop_map(Value::String)),
         (vec(any::<String>(), 1..500).prop_map(Value::ListString)),
         ("\\PC*", key_arb()).prop_map(|(n, k)| Value::NamedKey(n, k)),
+        key_arb().prop_map(Value::Key),
         account_arb().prop_map(Value::Account),
         contract_arb().prop_map(Value::Contract),
         u128_arb().prop_map(Value::UInt128),

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -75,6 +75,7 @@ mod ext_ffi {
         pub fn add_uref(name_ptr: *const u8, name_size: usize, key_ptr: *const u8, key_size: usize);
         pub fn protocol_version() -> u64;
         pub fn seed(dest: *mut u8);
+        pub fn is_valid(value_ptr: *const u8, value_size: usize) -> i32;
     }
 }
 

--- a/execution-engine/engine/src/byte_size.rs
+++ b/execution-engine/engine/src/byte_size.rs
@@ -58,6 +58,7 @@ impl ByteSize for Value {
                 // NOTE: We don't measure `key` as its size will be returned with `std::mem::size_of::<Value>()` call
                 // Similarly, we don't measure stack size of name, account and contract as they're
                 // accounted for in the `std::mem::size_of::<Self>()` call.
+                Value::Key(_) => 0,
                 Value::NamedKey(name, _key) => name.heap_size(),
                 Value::Account(account) => account.heap_size(),
                 Value::Contract(contract) => contract.heap_size(),

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -213,7 +213,7 @@ where
     pub fn is_valid(&mut self, value_ptr: u32, value_size: u32) -> Result<bool, Trap> {
         let value = self.value_from_mem(value_ptr, value_size)?;
 
-        Ok( self.context.validate_keys(&value).is_ok() )
+        Ok(self.context.validate_keys(&value).is_ok())
     }
 
     /// Load the i-th argument invoked as part of a `sub_call` into

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -212,11 +212,8 @@ where
 
     pub fn is_valid(&mut self, value_ptr: u32, value_size: u32) -> Result<bool, Trap> {
         let value = self.value_from_mem(value_ptr, value_size)?;
-        if let Ok(_) = self.context.validate_keys(&value) {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
+
+        Ok( self.context.validate_keys(&value).is_ok() )
     }
 
     /// Load the i-th argument invoked as part of a `sub_call` into
@@ -642,9 +639,8 @@ where
                 // args(0) = pointer to value to validate
                 // args(1) = size of value
                 let (value_ptr, value_size) = Args::parse(args)?;
-                let result = self.is_valid(value_ptr, value_size)?;
 
-                if result {
+                if self.is_valid(value_ptr, value_size)? {
                     Ok(Some(RuntimeValue::I32(1)))
                 } else {
                     Ok(Some(RuntimeValue::I32(0)))

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -210,7 +210,7 @@ where
         }
     }
 
-    pub fn is_valid(&mut self, value_ptr: u32, value_size: u32) -> Result<bool, Trap> {
+    pub fn value_is_valid(&mut self, value_ptr: u32, value_size: u32) -> Result<bool, Trap> {
         let value = self.value_from_mem(value_ptr, value_size)?;
 
         Ok(self.context.validate_keys(&value).is_ok())
@@ -640,7 +640,7 @@ where
                 // args(1) = size of value
                 let (value_ptr, value_size) = Args::parse(args)?;
 
-                if self.is_valid(value_ptr, value_size)? {
+                if self.value_is_valid(value_ptr, value_size)? {
                     Ok(Some(RuntimeValue::I32(1)))
                 } else {
                     Ok(Some(RuntimeValue::I32(0)))

--- a/execution-engine/engine/src/functions.rs
+++ b/execution-engine/engine/src/functions.rs
@@ -17,3 +17,4 @@ pub const ADD_UREF_FUNC_INDEX: usize = 15;
 pub const STORE_FN_INDEX: usize = 16;
 pub const PROTOCOL_VERSION_FUNC_INDEX: usize = 17;
 pub const SEED_FN_INDEX: usize = 18;
+pub const IS_VALID_FN_INDEX: usize = 19;

--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -113,6 +113,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(vec![], Some(ValueType::I64)),
                 PROTOCOL_VERSION_FUNC_INDEX,
             ),
+            "is_valid" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
+                IS_VALID_FN_INDEX,
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -237,6 +237,7 @@ where
             | Value::String(_)
             | Value::ListString(_) => Ok(()),
             Value::NamedKey(_, key) => self.validate_key(&key),
+            Value::Key(key) => self.validate_key(&key),
             Value::Account(account) => {
                 // This should never happen as accounts can't be created by contracts.
                 // I am putting this here for the sake of completness.

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -142,6 +142,7 @@ message Value {
         StringList string_list = 7;
         NamedKey named_key = 8;
         RustBigInt big_int = 9;
+        Key key = 10;
     }
 }
 


### PR DESCRIPTION
### Overview
The Mint uses `PurseId` as an indirection so that users do not have direct access to the `U512` which represents their balance. However, we want `PurseId` to still have security properties (you can only transfer from a purse which you have proper access to), so it will also be a `URef` type. Due to the indirection, we never do any system operations (e.g. `read`, `write`, `add`) on the `PurseId`, which means no validation is done on purses given as input to the Mint, unless we manually force it to happen. This PR introduces an FFI for manually validating a `URef`, which will be used in the Mint.

Note: A better long term solution would be to give all contracts a header field (i.e. something which represents its type signature), then the system could validate the arguments given to a `sub_call` automatically, thus this sort of manual validation would not be needed. This is a stop gap because the mint is a blocker.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-308

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
