### PR TITLE
NODE-535: Don't use zero timeout for testing immediacy

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -24,7 +24,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
     "started with a candidate that passes the threshold" should {
       "immediately trigger the transition" in {
         TestFixture.fromGenesis() { approver =>
-          approver.awaitApproval.timeout(Duration.Zero).map { blockHash =>
+          approver.awaitApproval.timeout(500.millis).map { blockHash =>
             blockHash shouldBe genesis.blockHash
           }
         }


### PR DESCRIPTION
### Overview
This test sometimes fails on Drone.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-535

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
