### PR TITLE
NODE-534: Longer wait time in AutoProposer test.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -27,7 +27,7 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
 
   behavior of "AutoProposer"
 
-  val waitForCheck = Timer[Task].sleep(2 * DefaultCheckInterval)
+  val waitForCheck = Timer[Task].sleep(5 * DefaultCheckInterval)
 
   it should "propose if more than max-count deploys are accumulated within max-interval" in TestFixture(
     maxInterval = 5.seconds,
@@ -53,7 +53,7 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
       _      <- casper.deploy(sampleDeployData)
       _      <- waitForCheck
       _      = casper.proposalCount shouldBe 0
-      _      <- Timer[Task].sleep(300.millis)
+      _      <- Timer[Task].sleep(500.millis)
       _      = casper.proposalCount shouldBe 1
     } yield ()
   }
@@ -126,7 +126,7 @@ object AutoProposerTest {
     def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
   }
 
-  val DefaultCheckInterval = 50.millis
+  val DefaultCheckInterval = 10.millis
 
   object TestFixture {
     def apply(


### PR DESCRIPTION
### Overview
AutoPropser tests were flaky on Drone, probably due to timing issues. Try increasing the check frequency and wait more cycles before assertions.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-534

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
