### PR TITLE
CON-309: resolve seed FFI function in host

### DIFF
--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -117,6 +117,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 IS_VALID_FN_INDEX,
             ),
+            "seed" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                SEED_FN_INDEX,
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",


### PR DESCRIPTION
### Overview
Seed FFI needs to be exposed in host in order for `*_local` functions to work (otherwise you get a "host does not export function seed" error).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-309

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
