### PR TITLE
CON-310: Pass mutable reference of RuntimeContext random number generator to sub-call

### DIFF
--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -671,7 +671,7 @@ where
     let (instance, memory) = instance_and_memory(parity_module.clone(), protocol_version)?;
 
     let known_urefs = vec_key_rights_to_map(refs.values().cloned().chain(extra_urefs));
-    let rng = ChaChaRng::from_rng(current_runtime.context.rng().clone()).map_err(Error::Rng)?;
+    let rng = ChaChaRng::from_rng(current_runtime.context.rng()).map_err(Error::Rng)?;
     let mut runtime = Runtime {
         memory,
         module: parity_module,

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -95,8 +95,8 @@ where
         &self.args
     }
 
-    pub fn rng(&self) -> &ChaChaRng {
-        &self.rng
+    pub fn rng(&mut self) -> &mut ChaChaRng {
+        &mut self.rng
     }
 
     pub fn state(&self) -> Rc<RefCell<TrackingCopy<R>>> {


### PR DESCRIPTION
### Overview
If we do not do this there will be repeat URefs when two sub-calls are made in a row (because the call to `clone` means the sub-calls are only changing a copy of the rng, and so the same rng gets passed to both sub-calls).

P.S. I'm pretty sure I fixed this exact bug some time ago. We should really have an integration test for it...

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-310

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
