### PR TITLE
NODE-537: Fix race condition in StashingSynchronizer

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
@@ -1,7 +1,7 @@
 package io.casperlabs.comm.gossiping
 
 import cats.effect.Timer
-import cats.effect.concurrent.{Deferred, Ref}
+import cats.effect.concurrent.{Deferred, Ref, Semaphore}
 import cats.effect.implicits._
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
@@ -14,44 +14,45 @@ import scala.concurrent.duration._
 
 class StashingSynchronizer[F[_]: Concurrent: Par: Timer](
     underlying: Synchronizer[F],
-    stashedRequestsRef: Ref[F, Map[
-      Node,
-      (Deferred[F, Either[Throwable, Either[SyncError, Vector[BlockSummary]]]], Set[ByteString])
-    ]],
-    transitionedRef: Ref[F, Boolean]
+    stashedRequestsRef: Ref[F, StashingSynchronizer.Stash[F]],
+    transitionedRef: Ref[F, Boolean],
+    semaphore: Semaphore[F]
 ) extends Synchronizer[F] {
+  import StashingSynchronizer.SyncResult
 
+  // The checking of the transitioned state and the adding to the stash has to be atomic.
+  private def schedule(
+      source: Node,
+      targetBlockHashes: Set[ByteString]
+  ): F[F[Either[Throwable, SyncResult]]] =
+    semaphore.withPermit {
+      transitionedRef.get.ifM(
+        underlying.syncDag(source, targetBlockHashes).attempt.pure[F],
+        for {
+          _                    <- Timer[F].sleep(50.millis)
+          maybeInitialDeferred <- Deferred[F, Either[Throwable, SyncResult]]
+          deferred <- stashedRequestsRef.modify { stashedRequests =>
+                       val (d, hashes) =
+                         stashedRequests.getOrElse(source, (maybeInitialDeferred, Set.empty))
+                       (stashedRequests.updated(source, (d, hashes ++ targetBlockHashes)), d)
+                     }
+        } yield deferred.get
+      )
+    }
+
+  // Schedule a sync and await result.
   override def syncDag(
       source: Node,
       targetBlockHashes: Set[ByteString]
-  ): F[Either[SyncError, Vector[BlockSummary]]] =
+  ): F[SyncResult] =
     for {
-      transitioned <- transitionedRef.get
-      dag <- if (transitioned) {
-              underlying.syncDag(source, targetBlockHashes)
-            } else {
-              for {
-                _ <- Timer[F].sleep(50.millis)
-                maybeInitialDeferred <- Deferred[F, Either[Throwable, Either[SyncError, Vector[
-                                         BlockSummary
-                                       ]]]]
-                deferred <- stashedRequestsRef.modify { stashedRequests =>
-                             val (d, hashes) =
-                               stashedRequests.getOrElse(source, (maybeInitialDeferred, Set.empty))
-                             (stashedRequests.updated(source, (d, hashes ++ targetBlockHashes)), d)
-                           }
-                either <- deferred.get
-                res <- either.fold(
-                        Sync[F].raiseError[Either[SyncError, Vector[BlockSummary]]],
-                        Sync[F].pure
-                      )
-              } yield res
-            }
-    } yield dag
+      attempt <- schedule(source, targetBlockHashes)
+      res     <- attempt.rethrow
+    } yield res
 
   private def run: F[Unit] =
     for {
-      _               <- transitionedRef.set(true)
+      _               <- semaphore.withPermit(transitionedRef.set(true))
       stashedRequests <- stashedRequestsRef.get
       _ <- stashedRequests.toList.parTraverse {
             case (source, (deferred, hashes)) =>
@@ -62,28 +63,23 @@ class StashingSynchronizer[F[_]: Concurrent: Par: Timer](
 
 object StashingSynchronizer {
 
+  type SyncResult  = Either[SyncError, Vector[BlockSummary]]
+  type Stash[F[_]] = Map[Node, (Deferred[F, Either[Throwable, SyncResult]], Set[ByteString])]
+
   def wrap[F[_]: Concurrent: Par: Timer](
       underlying: Synchronizer[F],
       awaitApproved: F[Unit]
   ): F[Synchronizer[F]] =
     for {
-      stashedRequestsRef <- Ref
-                             .of[F, Map[
-                               Node,
-                               (
-                                   Deferred[
-                                     F,
-                                     Either[Throwable, Either[SyncError, Vector[BlockSummary]]]
-                                   ],
-                                   Set[ByteString]
-                               )
-                             ]](Map.empty)
-      transitionedRef <- Ref.of[F, Boolean](false)
+      stashedRequestsRef <- Ref.of[F, Stash[F]](Map.empty)
+      transitionedRef    <- Ref.of[F, Boolean](false)
+      semaphore          <- Semaphore[F](1)
       s <- Sync[F].delay(
             new StashingSynchronizer[F](
               underlying,
               stashedRequestsRef,
-              transitionedRef
+              transitionedRef,
+              semaphore
             )
           )
       _ <- (awaitApproved >> s.run).start

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
@@ -174,7 +174,7 @@ object StashingSynchronizerSpec {
           parallelism = 100,
           executionModel = ExecutionModel.AlwaysAsyncExecution
         )
-      run.runSyncUnsafe(10.seconds)
+      run.runSyncUnsafe(5.seconds)
     }
   }
 }


### PR DESCRIPTION
### Overview
There was a race condition between the `syncDag` checking `transitionedRef` and putting a new `Deferred` in the stash. If during that time `run` was called then it only completed the deferreds it got before that new one was added, leaving that one unfinished. This is why the tests timed out on Drone, it couldn't finish adding 10 items in 30 ms and sometimes the approval trigger intersected with one of the items.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-537

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
