### PR TITLE
NODE-516: Block Info RPC

### DIFF
--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockStore.scala
@@ -31,7 +31,7 @@ trait BlockStore[F[_]] {
 
   def get(blockHash: BlockHash): F[Option[BlockMsgWithTransform]]
 
-  def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMsgWithTransform)]]
+  def findBlockHash(p: BlockHash => Boolean): F[Option[BlockHash]]
 
   def put(f: => (BlockHash, BlockMsgWithTransform)): F[Unit]
 
@@ -64,10 +64,10 @@ object BlockStore {
     ): F[Option[BlockMsgWithTransform]] =
       incAndMeasure("get", super.get(blockHash))
 
-    abstract override def find(
+    abstract override def findBlockHash(
         p: BlockHash => Boolean
-    ): F[Seq[(BlockHash, BlockMsgWithTransform)]] =
-      incAndMeasure("find", super.find(p))
+    ): F[Option[BlockHash]] =
+      incAndMeasure("findBlockHash", super.findBlockHash(p))
 
     abstract override def getBlockSummary(blockHash: BlockHash): F[Option[BlockSummary]] =
       incAndMeasure("getBlockSummary", super.getBlockSummary(blockHash))

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/FileLMDBIndexBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/FileLMDBIndexBlockStore.scala
@@ -155,24 +155,19 @@ class FileLMDBIndexBlockStore[F[_]: Monad: Sync: RaiseIOError: Log] private (
       } yield result
     )
 
-  override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMsgWithTransform)]] =
+  override def findBlockHash(p: BlockHash => Boolean): F[Option[BlockHash]] =
     lock.withPermit(
-      for {
-        filteredIndex <- withReadTxn { txn =>
-                          withResource(index.iterate(txn)) { iterator =>
-                            iterator.asScala
-                              .map(kv => (ByteString.copyFrom(kv.key()), kv.`val`()))
-                              .withFilter { case (key, _) => p(key) }
-                              .map { case (key, value) => (key, IndexEntry.load(value)) }
-                              .toList
-                          }
-                        }
-        result <- filteredIndex.flatTraverse {
-                   case (blockHash, indexEntry) =>
-                     readBlockMsgWithTransform(indexEntry)
-                       .map(block => List(blockHash -> block))
-                 }
-      } yield result
+      withReadTxn { txn =>
+        withResource(index.iterate(txn)) { iterator =>
+          iterator.asScala
+            .map(kv => (ByteString.copyFrom(kv.key()), kv.`val`()))
+            .withFilter { case (key, _) => p(key) }
+            .map { case (key, _) => key }
+            .take(1)
+            .toList
+            .headOption
+        }
+      }
     )
 
   override def put(f: => (BlockHash, BlockMsgWithTransform)): F[Unit] =

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/InMemBlockStore.scala
@@ -23,10 +23,8 @@ class InMemBlockStore[F[_]] private (
   def get(blockHash: BlockHash): F[Option[BlockMsgWithTransform]] =
     refF.get.map(_.get(blockHash).map(_._1))
 
-  override def find(p: BlockHash => Boolean): F[Seq[(BlockHash, BlockMsgWithTransform)]] =
-    refF.get.map(_.filterKeys(p).map {
-      case (k, (b, s)) => (k, b)
-    }.toSeq)
+  override def findBlockHash(p: BlockHash => Boolean): F[Option[BlockHash]] =
+    refF.get.map(_.keys.find(p))
 
   def put(f: => (BlockHash, BlockMsgWithTransform)): F[Unit] =
     refF.update(

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/LMDBBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/LMDBBlockStore.scala
@@ -94,14 +94,8 @@ class LMDBBlockStore[F[_]] private (
 
   override def findBlockHash(p: BlockHash => Boolean): F[Option[BlockHash]] =
     withReadTxn { txn =>
-      withResource(blocks.iterate(txn)) { iterator =>
-        iterator.asScala
-          .map(kv => (ByteString.copyFrom(kv.key()), kv.`val`()))
-          .withFilter { case (key, _) => p(key) }
-          .map { case (key, _) => key }
-          .take(1)
-          .toList
-          .headOption
+      withResource(blocks.iterate(txn)) { it =>
+        it.asScala.map(kv => ByteString.copyFrom(kv.key)).find(p)
       }
     }
 

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/BlockStoreBench.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/BlockStoreBench.scala
@@ -49,11 +49,11 @@ abstract class BlockStoreBench {
 
   @Benchmark
   def findRandom() =
-    blockStore.find(_ == randomHash).runSyncUnsafe()
+    blockStore.findBlockHash(_ == randomHash).runSyncUnsafe()
 
   @Benchmark
   def findInserted() =
-    blockStore.find(_ == inserted.next()).runSyncUnsafe()
+    blockStore.findBlockHash(_ == inserted.next()).runSyncUnsafe()
 
   @Benchmark
   def checkpoint() =

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -381,7 +381,6 @@ object BlockAPI {
                      }
         status = BlockStatus(faultTolerance = faultTolerance - initialFault, stats = maybeStats)
         info = BlockInfo()
-          .withBlockHashBase16(Base16.encode(summary.blockHash.toByteArray))
           .withSummary(summary)
           .withStatus(status)
       } yield info

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -380,7 +380,11 @@ object BlockAPI {
                        }
                      }
         status = BlockStatus(faultTolerance = faultTolerance - initialFault, stats = maybeStats)
-      } yield BlockInfo().withSummary(summary).withStatus(status)
+        info = BlockInfo()
+          .withBlockHashBase16(Base16.encode(summary.blockHash.toByteArray))
+          .withSummary(summary)
+          .withStatus(status)
+      } yield info
     }
 
   def showBlock[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -11,10 +11,12 @@ import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockStore}
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
-import io.casperlabs.casper._
+import io.casperlabs.casper.{BlockStatus => _, _}
+import io.casperlabs.casper.consensus.info._
 import io.casperlabs.casper.consensus._
+import io.casperlabs.casper.protocol
 import io.casperlabs.casper.protocol.{
-  BlockInfo,
+  BlockInfo => BlockInfoWithTuplespace,
   BlockInfoWithoutTuplespace,
   BlockQuery,
   BlockQueryResponse,
@@ -29,6 +31,7 @@ import io.casperlabs.comm.ServiceError.{
   FailedPrecondition,
   Internal,
   InvalidArgument,
+  NotFound,
   OutOfRange,
   ResourceExhausted,
   Unavailable,
@@ -347,6 +350,35 @@ object BlockAPI {
       .traverse(ProtoUtil.unsafeGetBlock[F](_))
       .map(blocks => blocks.find(ProtoUtil.containsDeploy(_, accountPublicKey, timestamp)))
 
+  def getBlockInfo[F[_]: MonadThrowable: Log: MultiParentCasperRef: SafetyOracle: BlockStore](
+      blockHash: ByteString,
+      full: Boolean
+  ): F[BlockInfo] =
+    unsafeWithCasper[F, BlockInfo]("Could not show block.") { implicit casper =>
+      for {
+        maybeSummary   <- BlockStore[F].getBlockSummary(blockHash)
+        notFound       = MonadThrowable[F].raiseError[BlockSummary](NotFound.block(blockHash))
+        summary        <- maybeSummary.fold(notFound)(_.pure[F])
+        dag            <- MultiParentCasper[F].blockDag
+        faultTolerance <- SafetyOracle[F].normalizedFaultTolerance(dag, summary.blockHash)
+        initialFault <- MultiParentCasper[F].normalizedInitialFault(
+                         ProtoUtil.weightMap(summary.getHeader)
+                       )
+        maybeStats <- if (!full) {
+                       none[BlockStatus.Stats].pure[F]
+                     } else {
+                       BlockStore[F].get(blockHash).map(_.get.getBlockMessage) map { block =>
+                         BlockStatus
+                           .Stats()
+                           .withBlockSizeBytes(block.serializedSize)
+                           .withDeployErrorCount(block.getBody.deploys.count(_.isError))
+                           .some
+                       }
+                     }
+        status = BlockStatus(faultTolerance = faultTolerance - initialFault, stats = maybeStats)
+      } yield BlockInfo().withSummary(summary).withStatus(status)
+    }
+
   def showBlock[F[_]: Monad: MultiParentCasperRef: Log: SafetyOracle: BlockStore](
       q: BlockQuery
   ): F[BlockQueryResponse] = {
@@ -420,7 +452,9 @@ object BlockAPI {
 
   private def getFullBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: Block
-  ): F[BlockInfo] = getBlockInfo[BlockInfo, F](block, constructBlockInfo[F])
+  ): F[BlockInfoWithTuplespace] =
+    getBlockInfo[BlockInfoWithTuplespace, F](block, constructBlockInfo[F])
+
   private def getBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: Block
   ): F[BlockInfoWithoutTuplespace] =
@@ -436,21 +470,23 @@ object BlockAPI {
       parentsHashList: Seq[BlockHash],
       normalizedFaultTolerance: Float,
       initialFault: Float
-  ): F[BlockInfo] =
-    BlockInfo(
-      blockHash = PrettyPrinter.buildStringNoLimit(block.blockHash),
-      blockSize = block.serializedSize.toString,
-      blockNumber = ProtoUtil.blockNumber(block),
-      protocolVersion = protocolVersion,
-      deployCount = deployCount,
-      globalStateRootHash = PrettyPrinter.buildStringNoLimit(postStateHash),
-      timestamp = timestamp,
-      faultTolerance = normalizedFaultTolerance - initialFault,
-      mainParentHash = PrettyPrinter.buildStringNoLimit(mainParent),
-      parentsHashList = parentsHashList.map(PrettyPrinter.buildStringNoLimit),
-      sender = PrettyPrinter.buildStringNoLimit(block.getHeader.validatorPublicKey),
-      shardId = block.getHeader.chainId
-    ).pure[F]
+  ): F[BlockInfoWithTuplespace] =
+    protocol
+      .BlockInfo(
+        blockHash = PrettyPrinter.buildStringNoLimit(block.blockHash),
+        blockSize = block.serializedSize.toString,
+        blockNumber = ProtoUtil.blockNumber(block),
+        protocolVersion = protocolVersion,
+        deployCount = deployCount,
+        globalStateRootHash = PrettyPrinter.buildStringNoLimit(postStateHash),
+        timestamp = timestamp,
+        faultTolerance = normalizedFaultTolerance - initialFault,
+        mainParentHash = PrettyPrinter.buildStringNoLimit(mainParent),
+        parentsHashList = parentsHashList.map(PrettyPrinter.buildStringNoLimit),
+        sender = PrettyPrinter.buildStringNoLimit(block.getHeader.validatorPublicKey),
+        shardId = block.getHeader.chainId
+      )
+      .pure[F]
 
   private def constructBlockInfoWithoutTuplespace[F[_]: Monad: MultiParentCasper: SafetyOracle: BlockStore](
       block: Block,

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -172,7 +172,10 @@ object ProtoUtil {
     } yield creatorJustificationAsList).fold(List.empty[BlockHash])(id)
 
   def weightMap(block: Block): Map[ByteString, Long] =
-    block.getHeader.getState.bonds.map {
+    weightMap(block.getHeader)
+
+  def weightMap(header: Block.Header): Map[ByteString, Long] =
+    header.getState.bonds.map {
       case Bond(validator, stake) => validator -> stake
     }.toMap
 

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -29,7 +29,7 @@ object DeployRuntime {
     )
 
   def showBlock[F[_]: Sync: DeployService](hash: String): F[Unit] =
-    gracefulExit(DeployService[F].showBlock(BlockQuery(hash)))
+    gracefulExit(DeployService[F].showBlock(hash))
 
   def showBlocks[F[_]: Sync: DeployService](depth: Int): F[Unit] =
     gracefulExit(DeployService[F].showBlocks(BlocksQuery(depth)))

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -8,7 +8,7 @@ import scala.util.Either
 @typeclass trait DeployService[F[_]] {
   def deploy(d: consensus.Deploy): F[Either[Throwable, String]]
   def propose(): F[Either[Throwable, String]]
-  def showBlock(q: BlockQuery): F[Either[Throwable, String]]
+  def showBlock(blockHash: String): F[Either[Throwable, String]]
   def showBlocks(q: BlocksQuery): F[Either[Throwable, String]]
   def visualizeDag(q: VisualizeDagQuery): F[Either[Throwable, String]]
   def queryState(q: QueryStateRequest): F[Either[Throwable, String]]

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -57,7 +57,7 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
   def showBlock(hash: String): Task[Either[Throwable, String]] =
     casperServiceStub
       .getBlockInfo(GetBlockInfoRequest(hash, GetBlockInfoRequest.View.FULL))
-      .map(_.toProtoString)
+      .map(Printer.printToUnicodeString(_))
       .attempt
 
   def queryState(q: QueryStateRequest): Task[Either[Throwable, String]] =

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -1,12 +1,11 @@
 package io.casperlabs.client
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-import com.google.protobuf.ByteString
 import com.google.protobuf.empty.Empty
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.consensus
-import io.casperlabs.node.api.casper.{CasperGrpcMonix, DeployRequest, GetBlockRequest}
+import io.casperlabs.node.api.casper.{CasperGrpcMonix, DeployRequest, GetBlockInfoRequest}
 import io.casperlabs.node.api.control.{ControlGrpcMonix, ProposeRequest}
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 import monix.eval.Task
@@ -55,14 +54,11 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
       }
       .attempt
 
-  def showBlock(hash: String): Task[Either[Throwable, String]] = {
-    val blockHash = ByteString.copyFrom(Base16.decode(hash))
-
+  def showBlock(hash: String): Task[Either[Throwable, String]] =
     casperServiceStub
-      .getBlock(GetBlockRequest(blockHash, GetBlockRequest.View.FULL))
+      .getBlockInfo(GetBlockInfoRequest(hash, GetBlockInfoRequest.View.FULL))
       .map(_.toProtoString)
       .attempt
-  }
 
   def queryState(q: QueryStateRequest): Task[Either[Throwable, String]] =
     deployServiceStub

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -1,12 +1,12 @@
 package io.casperlabs.client
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-
+import com.google.protobuf.ByteString
 import com.google.protobuf.empty.Empty
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.consensus
-import io.casperlabs.node.api.casper.{CasperGrpcMonix, DeployRequest}
+import io.casperlabs.node.api.casper.{CasperGrpcMonix, DeployRequest, GetBlockRequest}
 import io.casperlabs.node.api.control.{ControlGrpcMonix, ProposeRequest}
 import io.grpc.{ManagedChannel, ManagedChannelBuilder}
 import monix.eval.Task
@@ -55,11 +55,14 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
       }
       .attempt
 
-  def showBlock(q: BlockQuery): Task[Either[Throwable, String]] =
-    deployServiceStub.showBlock(q).map { response =>
-      if (response.status == "Success") Right(response.toProtoString)
-      else Left(new RuntimeException(response.status))
-    }
+  def showBlock(hash: String): Task[Either[Throwable, String]] = {
+    val blockHash = ByteString.copyFrom(Base16.decode(hash))
+
+    casperServiceStub
+      .getBlock(GetBlockRequest(blockHash, GetBlockRequest.View.FULL))
+      .map(_.toProtoString)
+      .attempt
+  }
 
   def queryState(q: QueryStateRequest): Task[Either[Throwable, String]] =
     deployServiceStub

--- a/client/src/main/scala/io/casperlabs/client/Printer.scala
+++ b/client/src/main/scala/io/casperlabs/client/Printer.scala
@@ -1,0 +1,95 @@
+package io.casperlabs.client
+
+import io.casperlabs.crypto.codec.Base16
+import java.math.BigInteger
+import scalapb.GeneratedMessage
+import scalapb.descriptors.{FieldDescriptor, PByteString, PEmpty, PMessage, PRepeated, PValue}
+import scalapb.textformat.{TextGenerator}
+
+/** Based on what scalapb `toProtoString` does but using Base16 for bytes. */
+object Printer {
+  def printToUnicodeString(m: GeneratedMessage) = {
+    val out = new TextGenerator(singleLine = false, escapeNonAscii = false)
+    print(m.toPMessage, out)
+    out.result()
+  }
+
+  def print(p: PMessage, out: TextGenerator): Unit =
+    p.value.toSeq.sortBy(_._1.number).foreach {
+      case (fd, value) => printField(fd, value, out)
+    }
+
+  def printField(fd: FieldDescriptor, value: PValue, out: TextGenerator): Unit = value match {
+    case PRepeated(values) =>
+      values.foreach(v => printSingleField(fd, v, out))
+    case PEmpty =>
+    case _ =>
+      printSingleField(fd, value, out)
+  }
+
+  def printSingleField(fd: FieldDescriptor, value: PValue, out: TextGenerator) = {
+    out.add(fd.name)
+    value match {
+      case PMessage(_) =>
+        out.addNewLine(" {").indent()
+        printFieldValue(fd, value, out)
+        out.outdent().addNewLine("}")
+      case _ =>
+        out.add(": ")
+        printFieldValue(fd, value, out)
+        out.addNewLine("")
+    }
+  }
+
+  def printFieldValue(fd: FieldDescriptor, value: PValue, out: TextGenerator): Unit =
+    value match {
+      case scalapb.descriptors.PInt(v) =>
+        if (fd.protoType.isTypeUint32 || fd.protoType.isTypeFixed32)
+          out.add(unsignedToString(v))
+        else
+          out.add(v.toString)
+      case scalapb.descriptors.PLong(v) =>
+        if (fd.protoType.isTypeUint64 || fd.protoType.isTypeFixed64)
+          out.add(unsignedToString(v))
+        else
+          out.add(v.toString)
+      case scalapb.descriptors.PBoolean(v) =>
+        out.add(v.toString)
+      case scalapb.descriptors.PFloat(v) =>
+        out.add(v.toString)
+      case scalapb.descriptors.PDouble(v) =>
+        out.add(v.toString)
+      case scalapb.descriptors.PEnum(v) =>
+        if (!v.isUnrecognized)
+          out.add(v.name)
+        else
+          out.add(v.number.toString)
+      case e: scalapb.descriptors.PMessage =>
+        print(e, out)
+      case scalapb.descriptors.PString(v) =>
+        out
+          .add("\"")
+          .addMaybeEscape(v)
+          .add("\"")
+      case scalapb.descriptors.PByteString(v) =>
+        out
+          .add("\"")
+          //.add(textformat.TextFormatUtils.escapeBytes(v))
+          .add(Base16.encode(v.toByteArray))
+          .add("\"")
+      case scalapb.descriptors.PRepeated(_) =>
+        throw new RuntimeException("Should not happen.")
+      case scalapb.descriptors.PEmpty =>
+        throw new RuntimeException("Should not happen.")
+    }
+
+  /** Convert an unsigned 32-bit integer to a string. */
+  def unsignedToString(value: Int): String =
+    if (value >= 0) java.lang.Integer.toString(value)
+    else java.lang.Long.toString(value & 0X00000000FFFFFFFFL)
+
+  /** Convert an unsigned 64-bit integer to a string. */
+  def unsignedToString(value: Long): String =
+    if (value >= 0) java.lang.Long.toString(value)
+    else BigInteger.valueOf(value & 0X7FFFFFFFFFFFFFFFL).setBit(63).toString
+}

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -104,12 +104,15 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val showBlock = new Subcommand("show-block") {
     descr(
-      "View properties of a block known by Casper on an existing running node." +
-        "Output includes: parent hashes, storage contents of the tuplespace."
+      "View properties of a block known by Casper on an existing running node."
     )
 
     val hash =
-      trailArg[String](name = "hash", required = true, descr = "the hash value of the block")
+      trailArg[String](
+        name = "hash",
+        required = true,
+        descr = "Value of the block hash, full, base16 encoded."
+      )
   }
   addSubcommand(showBlock)
 

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -27,16 +27,14 @@ object GrpcCasperService {
             BlockAPI.deploy[F](request.getDeploy, ignoreDeploySignature).map(_ => Empty())
           }
 
-        override def getBlock(request: GetBlockRequest): monix.eval.Task[BlockInfo] =
+        override def getBlockInfo(request: GetBlockInfoRequest): monix.eval.Task[BlockInfo] =
           TaskLike[F].toTask {
             BlockAPI
-              .getBlockInfo[F](request.blockHash, full = request.view == GetBlockRequest.View.FULL)
+              .getBlockInfo[F](
+                request.blockHashBase16,
+                full = request.view == GetBlockInfoRequest.View.FULL
+              )
           }
-
-        override def listBlockDeploys(
-            request: ListBlockDeploysRequest
-        ): monix.eval.Task[ListBlockDeploysResponse] = ???
-
       }
     }
 }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -4,8 +4,9 @@ package io.casperlabs.casper.consensus.info;
 import "io/casperlabs/casper/consensus/consensus.proto";
 
 message BlockInfo {
-	BlockSummary summary = 1;
-	BlockStatus status = 2;
+	string block_hash_base16 = 1;
+	BlockSummary summary = 2;
+	BlockStatus status = 3;
 }
 
 message BlockStatus {

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -4,9 +4,8 @@ package io.casperlabs.casper.consensus.info;
 import "io/casperlabs/casper/consensus/consensus.proto";
 
 message BlockInfo {
-	string block_hash_base16 = 1;
-	BlockSummary summary = 2;
-	BlockStatus status = 3;
+	BlockSummary summary = 1;
+	BlockStatus status = 2;
 }
 
 message BlockStatus {

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package io.casperlabs.casper.consensus.info;
+
+import "io/casperlabs/casper/consensus/consensus.proto";
+
+message BlockInfo {
+	BlockSummary summary = 1;
+	BlockStatus status = 2;
+}
+
+message BlockStatus {
+	float fault_tolerance = 1;
+	Stats stats = 2;
+
+	// Statistics derived from the full block.
+	message Stats {
+		uint32 block_size_bytes = 1;
+		uint32 deploy_error_count = 2;
+	}
+}

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -5,6 +5,7 @@ package io.casperlabs.node.api.casper;
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";
 import "io/casperlabs/casper/consensus/consensus.proto";
+import "io/casperlabs/casper/consensus/info.proto";
 
 // CasperService is the way for user and dApp developer to interact with the system,
 // including deploying contracts, looking at the DAG and querying state.
@@ -18,8 +19,54 @@ service CasperService {
             body: "deploy"
         };
     }
+
+    // Get the block summary with extra information about finality.
+    rpc GetBlock(GetBlockRequest) returns (io.casperlabs.casper.consensus.info.BlockInfo) {
+    	option (google.api.http) = {
+    		get: "/v2/blocks/{block_hash=*}"
+    	};
+    }
+
+    // List the processed deploys inside a block.
+    rpc ListBlockDeploys(ListBlockDeploysRequest) returns (ListBlockDeploysResponse) {
+    	option (google.api.http) = {
+    		get: "/v2/blocks/{block_hash=*}/deploys"
+    	};
+    }
 }
 
 message DeployRequest {
     io.casperlabs.casper.consensus.Deploy deploy = 1;
+}
+
+message GetBlockRequest {
+	bytes block_hash = 1;
+	View view = 2;
+
+	enum View {
+		// Only include information which is based on the header.
+		BASIC = 0;
+		// Include extra information that requires the full block,
+		// for example the size, number of errors in deploys, etc.
+		FULL = 1;
+	}
+}
+
+message ListBlockDeploysRequest {
+	bytes block_hash = 1;
+	View view = 2;
+	uint32 page_size = 3;
+	string page_token = 4;
+
+	enum View {
+		// Only include the header and the execution results, not the body with the code.
+		BASIC = 0;
+		// Retrieve the full deploy.
+		FULL = 1;
+	}
+}
+
+message ListBlockDeploysResponse {
+	repeated io.casperlabs.casper.consensus.Block.ProcessedDeploy deploys = 1;
+	string next_page_token = 2;
 }

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -40,6 +40,9 @@ message DeployRequest {
 }
 
 message GetBlockRequest {
+	// NOTE: Leaving `block_hash` as bytes so that if you list block summaries then however
+	// the JSON formatter prints it can be substituted back into the URL.
+
 	bytes block_hash = 1;
 	View view = 2;
 

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -21,16 +21,9 @@ service CasperService {
     }
 
     // Get the block summary with extra information about finality.
-    rpc GetBlock(GetBlockRequest) returns (io.casperlabs.casper.consensus.info.BlockInfo) {
+    rpc GetBlockInfo(GetBlockInfoRequest) returns (io.casperlabs.casper.consensus.info.BlockInfo) {
     	option (google.api.http) = {
-    		get: "/v2/blocks/{block_hash=*}"
-    	};
-    }
-
-    // List the processed deploys inside a block.
-    rpc ListBlockDeploys(ListBlockDeploysRequest) returns (ListBlockDeploysResponse) {
-    	option (google.api.http) = {
-    		get: "/v2/blocks/{block_hash=*}/deploys"
+    		get: "/v2/blocks/{block_hash_base16=*}"
     	};
     }
 }
@@ -39,11 +32,10 @@ message DeployRequest {
     io.casperlabs.casper.consensus.Deploy deploy = 1;
 }
 
-message GetBlockRequest {
-	// NOTE: Leaving `block_hash` as bytes so that if you list block summaries then however
-	// the JSON formatter prints it can be substituted back into the URL.
-
-	bytes block_hash = 1;
+message GetBlockInfoRequest {
+	// Either the full or just the first few characters of the block hash in base16 encoding,
+	// so that it works with the client's redacted displays.
+	string block_hash_base16 = 1;
 	View view = 2;
 
 	enum View {
@@ -53,23 +45,4 @@ message GetBlockRequest {
 		// for example the size, number of errors in deploys, etc.
 		FULL = 1;
 	}
-}
-
-message ListBlockDeploysRequest {
-	bytes block_hash = 1;
-	View view = 2;
-	uint32 page_size = 3;
-	string page_token = 4;
-
-	enum View {
-		// Only include the header and the execution results, not the body with the code.
-		BASIC = 0;
-		// Retrieve the full deploy.
-		FULL = 1;
-	}
-}
-
-message ListBlockDeploysResponse {
-	repeated io.casperlabs.casper.consensus.Block.ProcessedDeploy deploys = 1;
-	string next_page_token = 2;
 }


### PR DESCRIPTION
### Overview
Adds `CasperMessage.getBlockInfo` that returns similar data to `DeployService.showBlock` but using the `BlockSummary` as the underlying data structure. Optimised and renamed `BlockStore.find` to stop as soon as it matches a block hash, and only return the hash, not the full block. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-516

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
