### PR TITLE
EE-327: Fix TOCTOU

### DIFF
--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
+use std::io::ErrorKind;
 use std::marker::{Send, Sync};
 
 use common::key::Key;
@@ -245,8 +246,11 @@ pub fn new<E: ExecutionEngineService + Sync + Send + 'static>(
     e: E,
 ) -> grpc::ServerBuilder {
     let socket_path = std::path::Path::new(socket);
-    if socket_path.exists() {
-        std::fs::remove_file(socket_path).expect("failed to remove old socket file");
+
+    if let Err(e) = std::fs::remove_file(socket_path) {
+        if e.kind() != ErrorKind::NotFound {
+            panic!("failed to remove old socket file: {:?}", e);
+        }
     }
 
     let mut server = grpc::ServerBuilder::new_plain();

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -106,8 +106,10 @@ fn main() {
 
     let socket = get_socket(matches);
 
-    logging::log_info(REMOVING_SOCKET_FILE_MESSAGE);
-    socket.remove_file().expect(REMOVING_SOCKET_FILE_EXPECT);
+    match socket.remove_file() {
+        Err(e) => panic!("{}: {:?}", REMOVING_SOCKET_FILE_EXPECT, e),
+        Ok(_) => logging::log_info(REMOVING_SOCKET_FILE_MESSAGE),
+    }
 
     let data_dir = get_data_dir(matches);
 

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -106,10 +106,8 @@ fn main() {
 
     let socket = get_socket(matches);
 
-    if socket.file_exists() {
-        logging::log_info(REMOVING_SOCKET_FILE_MESSAGE);
-        socket.remove_file().expect(REMOVING_SOCKET_FILE_EXPECT);
-    }
+    logging::log_info(REMOVING_SOCKET_FILE_MESSAGE);
+    socket.remove_file().expect(REMOVING_SOCKET_FILE_EXPECT);
 
     let data_dir = get_data_dir(matches);
 

--- a/execution-engine/shared/src/socket/mod.rs
+++ b/execution-engine/shared/src/socket/mod.rs
@@ -20,17 +20,11 @@ impl Socket {
         std::path::Path::new(&self.0)
     }
 
-    pub fn file_exists(&self) -> bool {
-        self.get_path().exists()
-    }
-
     pub fn remove_file(&self) -> io::Result<()> {
         let path = self.get_path();
-
-        if !path.exists() {
-            return Ok(());
+        match std::fs::remove_file(path) {
+            Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+            result => result,
         }
-
-        std::fs::remove_file(path)
     }
 }

--- a/execution-engine/shared/src/socket/mod.rs
+++ b/execution-engine/shared/src/socket/mod.rs
@@ -20,6 +20,11 @@ impl Socket {
         std::path::Path::new(&self.0)
     }
 
+    /// Safely removes file pointed out by a path.
+    ///
+    /// In practice this file tries to remove file, and if
+    /// the file does not exist, it ignores it, and propagates
+    /// any other error.
     pub fn remove_file(&self) -> io::Result<()> {
         let path = self.get_path();
         match std::fs::remove_file(path) {


### PR DESCRIPTION
### Overview

This changes behaviour of places where a file is going tobe removed. Instead of first checking if a file exists, it actually does remove the file, and in case of `NotFound` error it's just suppressing it. This way we can avoid possible TOCTOU[1] issues, but regardless of this, it's also a good practice when doing something with a file system.

### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/secure/RapidBoard.jspa?rapidView=6&modal=detail&selectedIssue=EE-327

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes

[1]: https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use