### PR TITLE
execution-engine/shared: add use gens feature in common

### DIFF
--- a/execution-engine/shared/Cargo.toml
+++ b/execution-engine/shared/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 blake2 = "0.8"
 chrono = "0.4.6"
-common = { path = "../common", features = ["std"], package = "casperlabs-contract-ffi" }
+common = { path = "../common", features = ["std", "gens"], package = "casperlabs-contract-ffi" }
 hostname = "0.1.5"
 lazy_static = "1.3.0"
 libc = "0.2.54"


### PR DESCRIPTION
### Overview
@EdHastingsCasperLabs and I discovered this problem:
```
ht@thalassa:~/src/casperlabs/CasperLabs/execution-engine
[0]> cargo test --color=always --no-run -p shared --all-features -- --nocapture
   Compiling shared v0.2.0 (/home/ht/src/casperlabs/CasperLabs/execution-engine/shared)
error[E0432]: unresolved import `common::gens`
   --> shared/src/transform/mod.rs:242:17
    |
242 |     use common::gens::value_arb;
    |                 ^^^^ could not find `gens` in `common`

error[E0432]: unresolved import `common::gens`
   --> shared/src/transform/mod.rs:242:17
    |
242 |     use common::gens::value_arb;
    |                 ^^^^ could not find `gens` in `common`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `shared`.
warning: build failed, waiting for other jobs to finish...
error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `shared`.

To learn more, run the command again with --verbose.
```

This PR fixes the problem.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
