### PR TITLE
NODE-477: Query state RPC

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -67,7 +67,7 @@ block-to-block.
 
 ### API
 
-The `queryState` gRPC method of the CasperLabs node accepts a message
+The `GetBlockState` gRPC method (`query-state` on the CLI client) of the CasperLabs node accepts a message
 with four parameters:
 
 - Block hash
@@ -76,8 +76,9 @@ with four parameters:
   - The hash is presented as a base-16 encoded string.
 - Key type
   - Specified the type of key from which to start the query. Allowed
-    values are "address", "hash" and "uref", same as the types of keys
+    values are `ADDRESS`, `HASH` and `UREF`, same as the types of keys
     described above.
+  - The key type is passed as lowercased string on the CLI.
 - Key bytes
   - The bytes which are used to identify the particular key. `URef`
     and `Hash` type keys use 32-byte identifiers, while `Address` uses
@@ -88,8 +89,8 @@ with four parameters:
   - The sequence of human-readable names which can be used to reach
     the desired key to query. This makes use of the human-readable
     name associations accounts and contracts have for keys.
-  - The path is presented as a '/'-separated string of identifiers.
-  
+  - The path is presented as a '/'-separated string of identifiers on the CLI.
+
 ### Example
 
 Consider the [counter contract from our contract examples
@@ -104,7 +105,7 @@ pub extern "C" fn counter_ext() {
     // Look up the key associated with the name "count".
     // This key points to the contract's state variable in the global state (key-value store).
     let i_key: UPointer<i32> = get_uref("count").to_u_ptr().unwrap();
-    
+
     // The first (zeroth) argument passed to this function is the method name
     // (i.e. action to perform during this call).
     let method_name: String = get_arg(0);
@@ -132,7 +133,7 @@ pub extern "C" fn call() {
     // CasperLabs system. The key it is stored under (which is the `Hash`-type)
     // is returned.
     let hash = store_function("counter_ext", counter_urefs);
-    
+
     // `call` is the session code run by the account storing the contract.
     // This last line associates the name "counter" with the key for the
     // stored contract, allowing us to easily refer to it in the future

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -34,6 +34,14 @@ object DeployRuntime {
   def showBlocks[F[_]: Sync: DeployService](depth: Int): F[Unit] =
     gracefulExit(DeployService[F].showBlocks(depth))
 
+  def queryState[F[_]: Sync: DeployService](
+      blockHash: String,
+      keyVariant: String,
+      keyValue: String,
+      path: String
+  ): F[Unit] =
+    gracefulExit(DeployService[F].queryState(blockHash, keyVariant, keyValue, path))
+
   def visualizeDag[F[_]: Sync: DeployService: Timer](
       depth: Int,
       showJustificationLines: Boolean,

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -1,6 +1,6 @@
 package io.casperlabs.client
-import io.casperlabs.casper.protocol._
 import io.casperlabs.casper.consensus
+import io.casperlabs.casper.consensus.info
 import simulacrum.typeclass
 
 import scala.util.Either
@@ -11,5 +11,10 @@ import scala.util.Either
   def showBlock(blockHash: String): F[Either[Throwable, String]]
   def showBlocks(depth: Int): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]
-  def queryState(q: QueryStateRequest): F[Either[Throwable, String]]
+  def queryState(
+      blockHash: String,
+      keyVariant: String,
+      keyValue: String,
+      path: String
+  ): F[Either[Throwable, String]]
 }

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -61,8 +61,6 @@ object Main {
         DeployRuntime.visualizeDag(depth, showJustificationLines, out, streaming)
 
       case Query(hash, keyType, keyValue, path) =>
-        DeployRuntime.gracefulExit(
-          DeployService[F].queryState(protocol.QueryStateRequest(hash, keyType, keyValue, path))
-        )
+        DeployRuntime.queryState(hash, keyType, keyValue, path)
     }
 }

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -3,19 +3,27 @@ package io.casperlabs.node.api
 import cats.effect._
 import cats.implicits._
 import com.google.protobuf.empty.Empty
+import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.BlockStore
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.SafetyOracle
 import io.casperlabs.casper.api.BlockAPI
 import io.casperlabs.casper.consensus.info._
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.node.api.casper._
 import io.casperlabs.shared.Log
+import io.casperlabs.comm.ServiceError.InvalidArgument
+import io.casperlabs.smartcontracts.ExecutionEngineService
+import io.casperlabs.models.SmartContractEngineError
+import io.casperlabs.ipc
+import monix.execution.Scheduler
 import monix.eval.{Task, TaskLike}
 import monix.reactive.Observable
 
-object GrpcCasperService {
-  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef: SafetyOracle: BlockStore](
+object GrpcCasperService extends StateConversions {
+
+  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef: SafetyOracle: BlockStore: ExecutionEngineService](
       ignoreDeploySignature: Boolean
   ): F[CasperGrpcMonix.CasperService] =
     BlockAPI.establishMetrics[F] *> Sync[F].delay {
@@ -44,6 +52,43 @@ object GrpcCasperService {
           }
           Observable.fromTask(infos).flatMap(Observable.fromIterable)
         }
+
+        def getBlockState(request: GetBlockStateRequest): Task[State.Value] =
+          batchGetBlockState(
+            BatchGetBlockStateRequest(request.blockHashBase16, List(request.getQuery))
+          ) map {
+            _.values.head
+          }
+
+        def batchGetBlockState(
+            request: BatchGetBlockStateRequest
+        ): Task[BatchGetBlockStateResponse] = TaskLike[F].toTask {
+          for {
+            info      <- BlockAPI.getBlockInfo[F](request.blockHashBase16)
+            stateHash = info.getSummary.getHeader.getState.postStateHash
+            values    <- request.queries.toList.traverse(getState(stateHash, _))
+          } yield BatchGetBlockStateResponse(values)
+        }
+
+        private def getState(stateHash: ByteString, query: StateQuery): F[State.Value] =
+          for {
+            key <- toKey[F](query.keyVariant, query.keyBase16)
+            possibleResponse <- ExecutionEngineService[F].query(
+                                 stateHash,
+                                 key,
+                                 query.pathSegments
+                               )
+            value <- Concurrent[F].fromEither(possibleResponse).handleErrorWith {
+                      case SmartContractEngineError(msg) =>
+                        MonadThrowable[F].raiseError(InvalidArgument(msg))
+                    }
+          } yield fromIpc(value)
       }
+    }
+
+  def toKey[F[_]: MonadThrowable](keyType: StateQuery.KeyVariant, keyValue: String): F[ipc.Key] =
+    GrpcDeployService.toKey[F](keyType.name, keyValue).handleErrorWith {
+      case ex: java.lang.IllegalArgumentException =>
+        MonadThrowable[F].raiseError(InvalidArgument(ex.getMessage))
     }
 }

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcDeployService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcDeployService.scala
@@ -18,6 +18,7 @@ import io.casperlabs.ipc
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
+import java.lang.IllegalArgumentException
 import monix.eval.{Task, TaskLike}
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -33,7 +34,7 @@ object GrpcDeployService {
           case 32 => ipc.Key(ipc.Key.KeyInstance.Hash(ipc.KeyHash(keyBytes))).pure[F]
           case n =>
             appErr.raiseError(
-              new Exception(
+              new IllegalArgumentException(
                 s"Key of type hash must have exactly 32 bytes, $n =/= 32 provided."
               )
             )
@@ -43,7 +44,7 @@ object GrpcDeployService {
           case 32 => ipc.Key(ipc.Key.KeyInstance.Uref(ipc.KeyURef(keyBytes))).pure[F]
           case n =>
             appErr.raiseError(
-              new Exception(
+              new IllegalArgumentException(
                 s"Key of type uref must have exactly 32 bytes, $n =/= 32 provided."
               )
             )
@@ -53,14 +54,14 @@ object GrpcDeployService {
           case 32 => ipc.Key(ipc.Key.KeyInstance.Account(ipc.KeyAddress(keyBytes))).pure[F]
           case n =>
             appErr.raiseError(
-              new Exception(
+              new IllegalArgumentException(
                 s"Key of type address must have exactly 32 bytes, $n =/= 32 provided."
               )
             )
         }
       case _ =>
         appErr.raiseError(
-          new Exception(
+          new IllegalArgumentException(
             s"Key variant $keyType not valid. Must be one of hash, uref, address."
           )
         )

--- a/node/src/main/scala/io/casperlabs/node/api/StateConversions.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/StateConversions.scala
@@ -1,0 +1,80 @@
+package io.casperlabs.node.api
+
+import io.casperlabs.casper.consensus.info.State
+import io.casperlabs.ipc
+
+trait StateConversions {
+  def fromIpc(value: ipc.Value): State.Value = {
+    import ipc.Value.ValueInstance
+    import State.Value.Value
+
+    val v = value.valueInstance match {
+      case ValueInstance.Integer(v) =>
+        Value.IntValue(v)
+      case ValueInstance.ByteArr(v) =>
+        Value.BytesValue(v)
+      case ValueInstance.IntList(ipc.IntList(vs)) =>
+        Value.IntList(State.IntList(vs))
+      case ValueInstance.StringVal(v) =>
+        Value.StringValue(v)
+      case ValueInstance.Account(v) =>
+        Value.Account(fromIpc(v))
+      case ValueInstance.Contract(v) =>
+        Value.Contract(fromIpc(v))
+      case ValueInstance.StringList(ipc.StringList(vs)) =>
+        Value.StringList(State.StringList(vs))
+      case ValueInstance.BigInt(v) =>
+        Value.BigInt(State.BigInt(v.value, v.bitWidth))
+      case ValueInstance.Key(v) =>
+        Value.Key(fromIpc(v))
+    }
+
+    State.Value(v)
+  }
+
+  private def fromIpc(account: ipc.Account): State.Account =
+    State.Account(
+      account.pubKey,
+      account.nonce,
+      account.knownUrefs.map(fromIpc),
+      account.associatedKeys.map { x =>
+        State.Account.AssociatedKey(x.pubKey, x.weight)
+      },
+      account.actionThreshold.map { x =>
+        State.Account.ActionThresholds(x.deploymentThreshold, x.keyManagementThreshold)
+      },
+      account.accountActivity.map { x =>
+        State.Account
+          .AccountActivity(x.keyManagementLastUsed, x.deploymentLastUsed, x.inactivityPeriodLimit)
+      }
+    )
+
+  private def fromIpc(contract: ipc.Contract): State.Contract =
+    State.Contract(
+      contract.body,
+      contract.knownUrefs.map(fromIpc),
+      contract.getProtocolVersion.version
+    )
+
+  private def fromIpc(namedKey: ipc.NamedKey): State.NamedKey =
+    State.NamedKey(namedKey.name, namedKey.key.map(fromIpc))
+
+  private def fromIpc(key: ipc.Key): State.Key = {
+    import ipc.Key.KeyInstance
+    import State.Key.Value
+
+    val v = key.keyInstance match {
+      case KeyInstance.Account(ipc.KeyAddress(v)) =>
+        Value.Address(State.Key.Address(v))
+      case KeyInstance.Hash(ipc.KeyHash(v)) =>
+        Value.Hash(State.Key.Hash(v))
+      case KeyInstance.Uref(ipc.KeyURef(v, r)) =>
+        Value.Uref(State.Key.URef(v, State.Key.URef.AccessRights.fromValue(r.value)))
+      case KeyInstance.Local(ipc.KeyLocal(s, h)) =>
+        Value.Local(State.Key.Local(s, h))
+    }
+
+    State.Key(v)
+  }
+
+}

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -18,3 +18,108 @@ message BlockStatus {
 		uint32 deploy_error_count = 2;
 	}
 }
+
+message State {
+
+	// Value stored under a key in global state.
+	message Value {
+	    oneof value {
+	        int32 int_value = 1;
+	        bytes bytes_value = 2;
+	        IntList int_list = 3;
+	        string string_value = 4;
+	        Account account = 5;
+	        Contract contract = 6;
+	        StringList string_list = 7;
+	        NamedKey named_key = 8;
+	        BigInt big_int = 9;
+	        Key key = 10;
+	    }
+	}
+
+	message IntList {
+    	repeated int32 values = 1;
+    }
+
+    message StringList {
+    	repeated string values = 2;
+    }
+
+    message BigInt {
+    	string value = 1;
+    	// Number of bits: 128 | 256 | 512.
+    	uint32 big_width = 2;
+    }
+
+	message Key {
+	    oneof value {
+	        Address address = 1;
+	        Hash hash = 2;
+	        URef uref = 3;
+	        Local local = 4;
+	    }
+
+		message Address {
+		    bytes account = 1;
+		}
+
+		message Hash {
+		    bytes hash = 1;
+		}
+
+		message URef {
+		    bytes uref = 1;
+		    AccessRights access_rights = 2;
+
+		    enum AccessRights {
+		        UNKNOWN        = 0;
+		        READ           = 1;
+		        WRITE          = 2;
+		        ADD            = 4;
+		        READ_ADD       = 5;
+		        READ_WRITE     = 3;
+		        ADD_WRITE      = 6;
+		        READ_ADD_WRITE = 7;
+		    }
+		}
+
+		message Local {
+		    bytes seed = 1;
+		    bytes key_hash = 2;
+		}
+	}
+
+	message NamedKey {
+    	string name = 1;
+    	Key key = 2;
+    }
+
+    message Contract {
+	    bytes body = 1;
+	    repeated NamedKey known_urefs = 2;
+	    uint64 protocol_version = 3;
+	}
+
+	message Account {
+	    bytes public_key = 1;
+	    uint64 nonce = 2;
+	    repeated NamedKey known_urefs = 3;
+	    repeated AssociatedKey associated_keys = 4;
+	    ActionThresholds action_thresholds = 5;
+	    AccountActivity account_activity = 6;
+
+	    message AssociatedKey {
+	        bytes public_key = 1;
+	        uint32 weight = 2;
+	    }
+	    message ActionThresholds {
+	        uint32 deployment_threshold = 1;
+	        uint32 key_management_threshold = 2;
+	    }
+	    message AccountActivity {
+	        uint64 key_management_last_used = 1;
+	        uint64 deployment_last_used = 2;
+	        uint64 inactivity_period_limit = 3;
+	    }
+	}
+}

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -23,103 +23,103 @@ message State {
 
 	// Value stored under a key in global state.
 	message Value {
-	    oneof value {
-	        int32 int_value = 1;
-	        bytes bytes_value = 2;
-	        IntList int_list = 3;
-	        string string_value = 4;
-	        Account account = 5;
-	        Contract contract = 6;
-	        StringList string_list = 7;
-	        NamedKey named_key = 8;
-	        BigInt big_int = 9;
-	        Key key = 10;
-	    }
+		oneof value {
+			int32 int_value = 1;
+			bytes bytes_value = 2;
+			IntList int_list = 3;
+			string string_value = 4;
+			Account account = 5;
+			Contract contract = 6;
+			StringList string_list = 7;
+			NamedKey named_key = 8;
+			BigInt big_int = 9;
+			Key key = 10;
+		}
 	}
 
 	message IntList {
-    	repeated int32 values = 1;
-    }
+		repeated int32 values = 1;
+	}
 
-    message StringList {
-    	repeated string values = 2;
-    }
+	message StringList {
+		repeated string values = 1;
+	}
 
-    message BigInt {
-    	string value = 1;
-    	// Number of bits: 128 | 256 | 512.
-    	uint32 big_width = 2;
-    }
+	message BigInt {
+		string value = 1;
+		// Number of bits: 128 | 256 | 512.
+		uint32 big_width = 2;
+	}
 
 	message Key {
-	    oneof value {
-	        Address address = 1;
-	        Hash hash = 2;
-	        URef uref = 3;
-	        Local local = 4;
-	    }
+		oneof value {
+			Address address = 1;
+			Hash hash = 2;
+			URef uref = 3;
+			Local local = 4;
+		}
 
 		message Address {
-		    bytes account = 1;
+			bytes account = 1;
 		}
 
 		message Hash {
-		    bytes hash = 1;
+			bytes hash = 1;
 		}
 
 		message URef {
-		    bytes uref = 1;
-		    AccessRights access_rights = 2;
+			bytes uref = 1;
+			AccessRights access_rights = 2;
 
-		    enum AccessRights {
-		        UNKNOWN        = 0;
-		        READ           = 1;
-		        WRITE          = 2;
-		        ADD            = 4;
-		        READ_ADD       = 5;
-		        READ_WRITE     = 3;
-		        ADD_WRITE      = 6;
-		        READ_ADD_WRITE = 7;
-		    }
+			enum AccessRights {
+				UNKNOWN        = 0;
+				READ           = 1;
+				WRITE          = 2;
+				ADD            = 4;
+				READ_ADD       = 5;
+				READ_WRITE     = 3;
+				ADD_WRITE      = 6;
+				READ_ADD_WRITE = 7;
+			}
 		}
 
 		message Local {
-		    bytes seed = 1;
-		    bytes key_hash = 2;
+			bytes seed = 1;
+			bytes key_hash = 2;
 		}
 	}
 
 	message NamedKey {
-    	string name = 1;
-    	Key key = 2;
-    }
+		string name = 1;
+		Key key = 2;
+	}
 
-    message Contract {
-	    bytes body = 1;
-	    repeated NamedKey known_urefs = 2;
-	    uint64 protocol_version = 3;
+	message Contract {
+		bytes body = 1;
+		repeated NamedKey known_urefs = 2;
+		uint64 protocol_version = 3;
 	}
 
 	message Account {
-	    bytes public_key = 1;
-	    uint64 nonce = 2;
-	    repeated NamedKey known_urefs = 3;
-	    repeated AssociatedKey associated_keys = 4;
-	    ActionThresholds action_thresholds = 5;
-	    AccountActivity account_activity = 6;
+		bytes public_key = 1;
+		uint64 nonce = 2;
+		repeated NamedKey known_urefs = 3;
+		repeated AssociatedKey associated_keys = 4;
+		ActionThresholds action_thresholds = 5;
+		AccountActivity account_activity = 6;
 
-	    message AssociatedKey {
-	        bytes public_key = 1;
-	        uint32 weight = 2;
-	    }
-	    message ActionThresholds {
-	        uint32 deployment_threshold = 1;
-	        uint32 key_management_threshold = 2;
-	    }
-	    message AccountActivity {
-	        uint64 key_management_last_used = 1;
-	        uint64 deployment_last_used = 2;
-	        uint64 inactivity_period_limit = 3;
-	    }
+		message AssociatedKey {
+			bytes public_key = 1;
+			uint32 weight = 2;
+		}
+		message ActionThresholds {
+			uint32 deployment_threshold = 1;
+			uint32 key_management_threshold = 2;
+		}
+		message AccountActivity {
+			uint64 key_management_last_used = 1;
+			uint64 deployment_last_used = 2;
+			uint64 inactivity_period_limit = 3;
+		}
 	}
 }

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -33,6 +33,22 @@ service CasperService {
     		get: "/v2/blocks"
     	};
     }
+
+    // Query the value of global state as it was after the execution of a block.
+    rpc GetBlockState(GetBlockStateRequest) returns (io.casperlabs.casper.consensus.info.State.Value) {
+        option (google.api.http) = {
+            post: "v2/blocks/{block_hash_base16=*}/state"
+            body: "*"
+        };
+    }
+
+    // Execute multiple state queries at once.
+    rpc BatchGetBlockState(BatchGetBlockStateRequest) returns (BatchGetBlockStateResponse) {
+        option (google.api.http) = {
+            post: "v2/blocks/{block_hash_base16=*}/state:batchGet",
+            body: "*"
+        };
+    }
 }
 
 message DeployRequest {
@@ -64,4 +80,33 @@ enum BlockInfoView {
 	// Include extra information that requires the full block,
 	// for example the size, number of errors in deploys, etc.
 	FULL = 1;
+}
+
+
+message StateQuery {
+    KeyVariant key_variant = 1;
+    string key_base16 = 2;
+    // Path of human readable names to the value.
+    repeated string path_segments = 3;
+
+    enum KeyVariant {
+        KEY_VARIANT_UNSPECIFIED = 0;
+        HASH = 1;
+        UREF = 2;
+        ADDRESS = 3;
+    }
+}
+
+message GetBlockStateRequest {
+    string block_hash_base16 = 1;
+    StateQuery query = 2;
+}
+
+message BatchGetBlockStateRequest {
+    string block_hash_base16 = 1;
+    repeated StateQuery queries = 2;
+}
+
+message BatchGetBlockStateResponse {
+    repeated io.casperlabs.casper.consensus.info.State.Value values = 1;
 }

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -15,7 +15,7 @@ service CasperService {
     // to be processed during subsequent block proposals.
     rpc Deploy(DeployRequest) returns (google.protobuf.Empty) {
         option (google.api.http) = {
-            put: "/v2/deploys/{deploy.deploy_hash=*}"
+            post: "/v2/deploys"
             body: "deploy"
         };
     }


### PR DESCRIPTION
### Overview
Added `GetBlockState` and `BatchGetBlockState` RPC methods to `CasperService`. Added `io.casperlabs.casper.consensus.info.State` with a bunch of nested message types to mimic the `ipc.*` messages that return state values, so that we can defer converting to strings to the CLI client and expose everything precisely to normal clients.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-477

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
