### PR TITLE
NODE-511: Deploy info RPC

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -358,6 +358,15 @@ object BlockAPI {
       }
     }
 
+  def getBlockDeploys[F[_]: MonadThrowable: Log: MultiParentCasperRef: BlockStore](
+      blockHashBase16: String
+  ): F[Seq[Block.ProcessedDeploy]] =
+    unsafeWithCasper[F, Seq[Block.ProcessedDeploy]]("Could not show deploys.") { implicit casper =>
+      getByHashPrefix(blockHashBase16) {
+        ProtoUtil.unsafeGetBlock[F](_).map(_.some)
+      }.map(_.get.getBody.deploys)
+    }
+
   def makeBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle](
       summary: BlockSummary,
       maybeBlock: Option[Block]

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -310,6 +310,81 @@ object BlockAPI {
       .traverse(ProtoUtil.unsafeGetBlock[F](_))
       .map(blocks => blocks.find(ProtoUtil.containsDeploy(_, accountPublicKey, timestamp)))
 
+  def getDeployInfo[F[_]: MonadThrowable: Log: MultiParentCasperRef: SafetyOracle: BlockStore](
+      deployHashBase16: String
+  ): F[DeployInfo] =
+    unsafeWithCasper[F, DeployInfo]("Could not show deploy.") { implicit casper =>
+      val deployHash = ByteString.copyFrom(Base16.decode(deployHashBase16))
+
+      BlockStore[F].findBlockHashesWithDeployhash(deployHash) flatMap {
+        case blockHashes if blockHashes.nonEmpty =>
+          for {
+            blocks <- blockHashes.toList.traverse(ProtoUtil.unsafeGetBlock[F](_))
+            blockInfos <- blocks.traverse { block =>
+                           val summary =
+                             BlockSummary(block.blockHash, block.header, block.signature)
+                           makeBlockInfo[F](summary, block.some)
+                         }
+            results = (blocks zip blockInfos).flatMap {
+              case (block, info) =>
+                block.getBody.deploys
+                  .find(_.getDeploy.deployHash == deployHash)
+                  .map(_ -> info)
+            }
+            info = DeployInfo(
+              deploy = results.headOption.flatMap(_._1.deploy),
+              processingResults = results.map {
+                case (processedDeploy, blockInfo) =>
+                  DeployInfo
+                    .ProcessingResult(
+                      cost = processedDeploy.cost,
+                      isError = processedDeploy.isError,
+                      errorMessage = processedDeploy.errorMessage
+                    )
+                    .withBlockInfo(blockInfo)
+              }
+            )
+          } yield info
+
+        case _ =>
+          casper.bufferedDeploys.flatMap { deploys =>
+            deploys.find(_.deployHash == deployHash) map { deploy =>
+              DeployInfo().withDeploy(deploy).pure[F]
+            } getOrElse {
+              MonadThrowable[F]
+                .raiseError[DeployInfo](NotFound(s"Cannot find deploy with hash $deployHashBase16"))
+            }
+          }
+      }
+    }
+
+  def makeBlockInfo[F[_]: Monad: MultiParentCasper: SafetyOracle](
+      summary: BlockSummary,
+      maybeBlock: Option[Block]
+  ): F[BlockInfo] =
+    for {
+      dag            <- MultiParentCasper[F].blockDag
+      faultTolerance <- SafetyOracle[F].normalizedFaultTolerance(dag, summary.blockHash)
+      initialFault <- MultiParentCasper[F].normalizedInitialFault(
+                       ProtoUtil.weightMap(summary.getHeader)
+                     )
+      maybeStats = maybeBlock.map { block =>
+        BlockStatus
+          .Stats()
+          .withBlockSizeBytes(block.serializedSize)
+          .withDeployErrorCount(
+            block.getBody.deploys.count(_.isError)
+          )
+      }
+      status = BlockStatus(
+        faultTolerance = faultTolerance - initialFault,
+        stats = maybeStats
+      )
+      info = BlockInfo()
+        .withSummary(summary)
+        .withStatus(status)
+    } yield info
+
   def getBlockInfoOpt[F[_]: MonadThrowable: Log: MultiParentCasperRef: SafetyOracle: BlockStore](
       blockHashBase16: String,
       full: Boolean = false
@@ -325,30 +400,15 @@ object BlockAPI {
             initialFault <- MultiParentCasper[F].normalizedInitialFault(
                              ProtoUtil.weightMap(summary.getHeader)
                            )
-            maybeBlockAndStats <- if (full) {
-                                   BlockStore[F]
-                                     .get(summary.blockHash)
-                                     .map(_.get.getBlockMessage)
-                                     .map { block =>
-                                       val stats = BlockStatus
-                                         .Stats()
-                                         .withBlockSizeBytes(block.serializedSize)
-                                         .withDeployErrorCount(
-                                           block.getBody.deploys.count(_.isError)
-                                         )
-                                       (block, stats).some
-                                     }
-                                 } else {
-                                   none[(Block, BlockStatus.Stats)].pure[F]
-                                 }
-            status = BlockStatus(
-              faultTolerance = faultTolerance - initialFault,
-              stats = maybeBlockAndStats.map(_._2)
-            )
-            result = BlockInfo()
-              .withSummary(summary)
-              .withStatus(status)
-          } yield result.some
+            maybeBlock <- if (full) {
+                           BlockStore[F]
+                             .get(summary.blockHash)
+                             .map(_.get.blockMessage)
+                         } else {
+                           none[Block].pure[F]
+                         }
+            info <- makeBlockInfo[F](summary, maybeBlock)
+          } yield info.some
         }
       }
     }

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -34,6 +34,9 @@ object DeployRuntime {
   def showDeploys[F[_]: Sync: DeployService](hash: String): F[Unit] =
     gracefulExit(DeployService[F].showDeploys(hash))
 
+  def showDeploy[F[_]: Sync: DeployService](hash: String): F[Unit] =
+    gracefulExit(DeployService[F].showDeploy(hash))
+
   def showBlocks[F[_]: Sync: DeployService](depth: Int): F[Unit] =
     gracefulExit(DeployService[F].showBlocks(depth))
 

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -31,6 +31,9 @@ object DeployRuntime {
   def showBlock[F[_]: Sync: DeployService](hash: String): F[Unit] =
     gracefulExit(DeployService[F].showBlock(hash))
 
+  def showDeploys[F[_]: Sync: DeployService](hash: String): F[Unit] =
+    gracefulExit(DeployService[F].showDeploys(hash))
+
   def showBlocks[F[_]: Sync: DeployService](depth: Int): F[Unit] =
     gracefulExit(DeployService[F].showBlocks(depth))
 

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -9,6 +9,7 @@ import scala.util.Either
   def deploy(d: consensus.Deploy): F[Either[Throwable, String]]
   def propose(): F[Either[Throwable, String]]
   def showBlock(blockHash: String): F[Either[Throwable, String]]
+  def showDeploys(blockHash: String): F[Either[Throwable, String]]
   def showBlocks(depth: Int): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]
   def queryState(

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -10,6 +10,7 @@ import scala.util.Either
   def propose(): F[Either[Throwable, String]]
   def showBlock(blockHash: String): F[Either[Throwable, String]]
   def showDeploys(blockHash: String): F[Either[Throwable, String]]
+  def showDeploy(blockHash: String): F[Either[Throwable, String]]
   def showBlocks(depth: Int): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]
   def queryState(

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -16,6 +16,7 @@ import io.casperlabs.node.api.casper.{
   DeployRequest,
   GetBlockInfoRequest,
   GetBlockStateRequest,
+  GetDeployInfoRequest,
   StateQuery,
   StreamBlockDeploysRequest,
   StreamBlockInfosRequest
@@ -73,16 +74,22 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
       .map(Printer.printToUnicodeString(_))
       .attempt
 
+  def showDeploy(hash: String): Task[Either[Throwable, String]] =
+    casperServiceStub
+      .getDeployInfo(GetDeployInfoRequest(hash, DeployInfo.View.BASIC))
+      .map(Printer.printToUnicodeString(_))
+      .attempt
+
   def showDeploys(hash: String): Task[Either[Throwable, String]] =
     casperServiceStub
-      .streamBlockDeploys(StreamBlockDeploysRequest(hash, DeployInfo.View.FULL))
+      .streamBlockDeploys(StreamBlockDeploysRequest(hash, DeployInfo.View.BASIC))
       .zipWithIndex
       .map {
         case (d, idx) =>
           s"""
-         |------------- deploy # $idx ---------------
+         |------------- deploy # $hash / $idx ---------------
          |${Printer.printToUnicodeString(d)}
-         |-------------------------------------------
+         |---------------------------------------------------
          |""".stripMargin
       }
       .toListL

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -9,9 +9,9 @@ import java.util.concurrent.TimeUnit
 import com.google.protobuf.empty.Empty
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.casper.consensus
+import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.graphz
 import io.casperlabs.node.api.casper.{
-  BlockInfoView,
   CasperGrpcMonix,
   DeployRequest,
   GetBlockInfoRequest,
@@ -68,7 +68,7 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
 
   def showBlock(hash: String): Task[Either[Throwable, String]] =
     casperServiceStub
-      .getBlockInfo(GetBlockInfoRequest(hash, BlockInfoView.FULL))
+      .getBlockInfo(GetBlockInfoRequest(hash, BlockInfo.View.FULL))
       .map(Printer.printToUnicodeString(_))
       .attempt
 
@@ -98,7 +98,7 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
 
   def visualizeDag(depth: Int, showJustificationLines: Boolean): Task[Either[Throwable, String]] =
     casperServiceStub
-      .streamBlockInfos(StreamBlockInfosRequest(depth = depth, view = BlockInfoView.BASIC))
+      .streamBlockInfos(StreamBlockInfosRequest(depth = depth, view = BlockInfo.View.BASIC))
       .toListL
       .map { infos =>
         type G[A] = StateT[Id, StringBuffer, A]
@@ -110,7 +110,7 @@ class GrpcDeployService(host: String, portExternal: Int, portInternal: Int)
 
   def showBlocks(depth: Int): Task[Either[Throwable, String]] =
     casperServiceStub
-      .streamBlockInfos(StreamBlockInfosRequest(depth = depth, view = BlockInfoView.BASIC))
+      .streamBlockInfos(StreamBlockInfosRequest(depth = depth, view = BlockInfo.View.BASIC))
       .map { bi =>
         s"""
          |------------- block @ ${bi.getSummary.getHeader.rank} ---------------

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -40,8 +40,9 @@ object Main {
       configuration: Configuration
   ): F[Unit] =
     configuration match {
-      case ShowBlock(hash) => DeployRuntime.showBlock(hash)
-
+      case ShowBlock(hash)   => DeployRuntime.showBlock(hash)
+      case ShowDeploy(hash)  => DeployRuntime.showDeploy(hash)
+      case ShowDeploys(hash) => DeployRuntime.showDeploys(hash)
       case ShowBlocks(depth) => DeployRuntime.showBlocks(depth)
 
       case Deploy(from, nonce, sessionCode, paymentCode, maybePublicKey, maybePrivateKey) =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -20,8 +20,9 @@ final case class Deploy(
 
 final case object Propose extends Configuration
 
-final case class ShowBlock(hash: String) extends Configuration
-final case class ShowBlocks(depth: Int)  extends Configuration
+final case class ShowBlock(hash: String)   extends Configuration
+final case class ShowDeploys(hash: String) extends Configuration
+final case class ShowBlocks(depth: Int)    extends Configuration
 final case class VisualizeDag(
     depth: Int,
     showJustificationLines: Boolean,
@@ -60,6 +61,8 @@ object Configuration {
         Propose
       case options.showBlock =>
         ShowBlock(options.showBlock.hash())
+      case options.showDeploys =>
+        ShowDeploys(options.showDeploys.hash())
       case options.showBlocks =>
         ShowBlocks(options.showBlocks.depth())
       case options.visualizeBlocks =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -20,9 +20,10 @@ final case class Deploy(
 
 final case object Propose extends Configuration
 
-final case class ShowBlock(hash: String)   extends Configuration
-final case class ShowDeploys(hash: String) extends Configuration
-final case class ShowBlocks(depth: Int)    extends Configuration
+final case class ShowBlock(blockHash: String)   extends Configuration
+final case class ShowDeploys(blockHash: String) extends Configuration
+final case class ShowDeploy(deployHash: String) extends Configuration
+final case class ShowBlocks(depth: Int)         extends Configuration
 final case class VisualizeDag(
     depth: Int,
     showJustificationLines: Boolean,
@@ -63,6 +64,8 @@ object Configuration {
         ShowBlock(options.showBlock.hash())
       case options.showDeploys =>
         ShowDeploys(options.showDeploys.hash())
+      case options.showDeploy =>
+        ShowDeploy(options.showDeploy.hash())
       case options.showBlocks =>
         ShowBlocks(options.showBlocks.depth())
       case options.visualizeBlocks =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -111,10 +111,24 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       trailArg[String](
         name = "hash",
         required = true,
-        descr = "Value of the block hash, full, base16 encoded."
+        descr = "Value of the block hash, base16 encoded."
       )
   }
   addSubcommand(showBlock)
+
+  val showDeploys = new Subcommand("show-deploys") {
+    descr(
+      "View deploys included in a block."
+    )
+
+    val hash =
+      trailArg[String](
+        name = "hash",
+        required = true,
+        descr = "Value of the block hash, base16 encoded."
+      )
+  }
+  addSubcommand(showDeploys)
 
   val showBlocks = new Subcommand("show-blocks") {
     descr(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -130,6 +130,20 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showDeploys)
 
+  val showDeploy = new Subcommand("show-deploy") {
+    descr(
+      "View properties of a deploy known by Casper on an existing running node."
+    )
+
+    val hash =
+      trailArg[String](
+        name = "hash",
+        required = true,
+        descr = "Value of the deploy hash, base16 encoded."
+      )
+  }
+  addSubcommand(showDeploy)
+
   val showBlocks = new Subcommand("show-blocks") {
     descr(
       "View list of blocks in the current Casper view on an existing running node."

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -54,7 +54,19 @@ object GrpcCasperService extends StateConversions {
         }
 
         override def getDeployInfo(request: GetDeployInfoRequest): Task[DeployInfo] =
-          ???
+          TaskLike[F].toTask {
+            BlockAPI
+              .getDeployInfo[F](
+                request.deployHashBase16
+              ) map { info =>
+              request.view match {
+                case DeployInfo.View.BASIC =>
+                  info.withDeploy(info.getDeploy.copy(body = None))
+                case _ =>
+                  info
+              }
+            }
+          }
 
         override def streamBlockDeploys(
             request: StreamBlockDeploysRequest

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -38,7 +38,7 @@ object GrpcCasperService extends StateConversions {
             BlockAPI
               .getBlockInfo[F](
                 request.blockHashBase16,
-                full = request.view == BlockInfoView.FULL
+                full = request.view == BlockInfo.View.FULL
               )
           }
 
@@ -47,20 +47,27 @@ object GrpcCasperService extends StateConversions {
             BlockAPI.getBlockInfos[F](
               depth = request.depth,
               maxRank = request.maxRank,
-              full = request.view == BlockInfoView.FULL
+              full = request.view == BlockInfo.View.FULL
             )
           }
           Observable.fromTask(infos).flatMap(Observable.fromIterable)
         }
 
-        def getBlockState(request: GetBlockStateRequest): Task[State.Value] =
+        override def getDeployInfo(request: GetDeployInfoRequest): Task[DeployInfo] =
+          ???
+
+        override def streamBlockDeploys(
+            request: StreamBlockDeploysRequest
+        ): Observable[DeployInfo] = ???
+
+        override def getBlockState(request: GetBlockStateRequest): Task[State.Value] =
           batchGetBlockState(
             BatchGetBlockStateRequest(request.blockHashBase16, List(request.getQuery))
           ) map {
             _.values.head
           }
 
-        def batchGetBlockState(
+        override def batchGetBlockState(
             request: BatchGetBlockStateRequest
         ): Task[BatchGetBlockStateResponse] = TaskLike[F].toTask {
           for {

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -4,8 +4,16 @@ package io.casperlabs.casper.consensus.info;
 import "io/casperlabs/casper/consensus/consensus.proto";
 
 message BlockInfo {
-	BlockSummary summary = 1;
+	io.casperlabs.casper.consensus.BlockSummary summary = 1;
 	BlockStatus status = 2;
+
+	enum View {
+    	// Only includes information which is based on the header.
+    	BASIC = 0;
+    	// Includes extra information that requires the full block,
+    	// for example the size, number of errors in deploys, etc.
+    	FULL = 1;
+    }
 }
 
 message BlockStatus {
@@ -17,6 +25,25 @@ message BlockStatus {
 		uint32 block_size_bytes = 1;
 		uint32 deploy_error_count = 2;
 	}
+}
+
+message DeployInfo {
+	io.casperlabs.casper.consensus.Deploy deploy = 1;
+	repeated ProcessingResult processing_results = 2;
+
+	message ProcessingResult {
+		BlockInfo block_info = 1;
+		uint64 cost = 2;
+        bool is_error = 3;
+        string error_message = 4;
+	}
+
+    enum View {
+        // Only includes the header of the deploys, not the body with the code.
+        BASIC = 0;
+        // Includes the body with the code.
+        FULL = 1;
+    }
 }
 
 message State {

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -41,8 +41,8 @@ service CasperService {
         };
     }
 
-    // Get slices of the DAG, going backwards, rank by rank.
-    rpc StreamBlockDeploys(StreamBlockDeploysRequest) returns (stream io.casperlabs.casper.consensus.info.DeployInfo) {
+    // Get the processed deploys within a block.
+    rpc StreamBlockDeploys(StreamBlockDeploysRequest) returns (stream io.casperlabs.casper.consensus.Block.ProcessedDeploy) {
         option (google.api.http) = {
             get: "/v2/blocks{block_hash_base16=*}/deploys"
         };

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -34,6 +34,20 @@ service CasperService {
     	};
     }
 
+    // Retrieve information about a single deploy by hash.
+    rpc GetDeployInfo(GetDeployInfoRequest) returns (io.casperlabs.casper.consensus.info.DeployInfo) {
+        option (google.api.http) = {
+            get: "/v2/deploys/{deploy_hash_base16=*}"
+        };
+    }
+
+    // Get slices of the DAG, going backwards, rank by rank.
+    rpc StreamBlockDeploys(StreamBlockDeploysRequest) returns (stream io.casperlabs.casper.consensus.info.DeployInfo) {
+        option (google.api.http) = {
+            get: "/v2/blocks{block_hash_base16=*}/deploys"
+        };
+    }
+
     // Query the value of global state as it was after the execution of a block.
     rpc GetBlockState(GetBlockStateRequest) returns (io.casperlabs.casper.consensus.info.State.Value) {
         option (google.api.http) = {
@@ -59,8 +73,7 @@ message GetBlockInfoRequest {
 	// Either the full or just the first few characters of the block hash in base16 encoding,
 	// so that it works with the client's redacted displays.
 	string block_hash_base16 = 1;
-
-	BlockInfoView view = 2;
+	io.casperlabs.casper.consensus.info.BlockInfo.View view = 2;
 }
 
 message StreamBlockInfosRequest {
@@ -71,17 +84,20 @@ message StreamBlockInfosRequest {
 	// 0 means go from the current tip of the DAG.
 	uint64 max_rank = 2;
 
-	BlockInfoView view = 3;
+	io.casperlabs.casper.consensus.info.BlockInfo.View view = 3;
 }
 
-enum BlockInfoView {
-	// Only include information which is based on the header.
-	BASIC = 0;
-	// Include extra information that requires the full block,
-	// for example the size, number of errors in deploys, etc.
-	FULL = 1;
+
+
+message GetDeployInfoRequest {
+    string deploy_hash_base16 = 1;
+    io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
 }
 
+message StreamBlockDeploysRequest {
+    string block_hash_base16 = 1;
+    io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
+}
 
 message StateQuery {
     KeyVariant key_variant = 1;


### PR DESCRIPTION
### Overview
Adds two new RPC methods to `CasperService`:
* `GetDeployInfo` returns the deploy and the status of the blocks it's included in.
* `StreamBlockInfos` returns the processed deploys of a block.

Added the corresponding `show-deploy <deploy-hash>` and `show-deploys <block-hash>` methods to the CLI.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-511

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I'm not entirely happy with these enums that have just `BASIC` and `FULL` views; the idea comes from [resource views](https://cloud.google.com/apis/design/design_patterns#resource_view), and it's certainly easier to implement then [partial responses](https://cloud.google.com/apis/design/design_patterns#partial_response) but I can't help but feel a few flags like `include_body` and `include_stats` would make just as much sense.