### PR TITLE
[Quick-Fix] OP-272 add rust compile for push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -71,9 +71,6 @@ pipeline:
       - "~/.cargo/bin/cargo build"
       - "~/.cargo/bin/cargo test"
     image: "casperlabs/buildenv:latest"
-    environment:
-      - "_JAVA_OPTIONS=-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
-    image: "casperlabs/buildenv:latest"
     when:
       event:
         - pull_request
@@ -128,9 +125,6 @@ pipeline:
       - "~/.cargo/bin/cargo update"
       - "~/.cargo/bin/cargo build"
       - "~/.cargo/bin/cargo test"
-    image: "casperlabs/buildenv:latest"
-    environment:
-      - "_JAVA_OPTIONS=-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
     image: "casperlabs/buildenv:latest"
     when:
       branch:
@@ -215,6 +209,21 @@ pipeline:
         - trying
 
 # The below section is for post-bors push webhooks
+  rust-compile-for-make:
+    commands:
+      - "cd execution-engine/"
+      - "~/.cargo/bin/cargo update"
+      - "~/.cargo/bin/cargo build"
+    image: "casperlabs/buildenv:latest"
+    when:
+      branch:
+        - dev
+        - release-*
+        - master
+      event:
+        - push
+        - tag
+
   docker-build-artifacts-merge:
     commands:
       - "sbt node/docker:publishLocal client/docker:publishLocal"


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._
Quick fix of makefile failure. Cargo rpm build will fail if we don't compile first.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._
Relates to: https://casperlabs.atlassian.net/browse/OP-272

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
