### PR TITLE
OP-222: Block Gossiping Integration Test - Blocks 'infect' network and 'closest' see blocks first

### DIFF
--- a/integration-testing/features/block_gossiping.feature
+++ b/integration-testing/features/block_gossiping.feature
@@ -1,6 +1,6 @@
 Feature: Block gossiping and transport
 
-  # test_block_propagation.py
+  # test_block_propagation.py: test_blocks_infect_network
   Scenario: Blocks 'infect' the network and nodes 'closest' to the propose see the blocks first.
     Given: Network where not all nodes are connected to each other directly
      When: Block is deployed and proposed on a node

--- a/integration-testing/features/block_gossiping.feature
+++ b/integration-testing/features/block_gossiping.feature
@@ -1,8 +1,10 @@
 Feature: Block gossiping and transport
 
-  # Not Implemented
+  # test_block_propagation.py
   Scenario: Blocks 'infect' the network and nodes 'closest' to the propose see the blocks first.
-    # TODO Workout scenario
+    Given: Network where not all nodes are connected to each other directly
+     When: Block is deployed and proposed on a node
+     Then: Block reaches all nodes in the network
 
   # Not Implemented
   Scenario: Network partition occurs and rejoin occurs

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -218,6 +218,7 @@ class CustomConnectionNetwork(CasperLabsNetwork):
         :param node_count: Number of nodes to create.
         :param network_connections: A list of lists of node indexes that should be joined.
         """
+        self.network_names = {}
         kp = self.get_key()
         config = DockerConfig(self.docker_client,
                               node_private_key=kp.private_key,
@@ -234,6 +235,7 @@ class CustomConnectionNetwork(CasperLabsNetwork):
 
         for network_members in network_connections:
             network_name = self.create_docker_network()
+            self.network_names[tuple(network_members)] = network_name
             for node_num in network_members:
                 self.docker_nodes[node_num].connect_to_network(network_name)
 
@@ -251,6 +253,12 @@ class CustomConnectionNetwork(CasperLabsNetwork):
         for node_num, peer_count in enumerate(peer_counts):
             if peer_count > 0:
                 wait_for_peers_count_at_least(self.docker_nodes[node_num], peer_count, timeout)
+
+
+    def disconnect(self, connection):
+        network_name = self.network_names[tuple(connection)]
+        for node_num in connection:
+            self.docker_nodes[node_num].disconnect_from_network(network_name)
 
 
 if __name__ == '__main__':

--- a/integration-testing/test/test_block_propagation.py
+++ b/integration-testing/test/test_block_propagation.py
@@ -2,40 +2,18 @@ import threading
 from test.cl_node.client_parser import parse_show_blocks
 from test.cl_node.docker_node import DockerNode
 from typing import List
-
-import ed25519
 import pytest
 
 from . import conftest
 from .cl_node.casperlabs_network import ThreeNodeNetwork
 from .cl_node.casperlabsnode import extract_block_hash_from_propose_output
 from .cl_node.common import random_string
-from .cl_node.pregenerated_keypairs import PREGENERATED_KEYPAIRS
 from .cl_node.wait import wait_for_blocks_count_at_least
 
 
-BOOTSTRAP_NODE_KEYS = PREGENERATED_KEYPAIRS[0]
-
-
-def generate_keys(prefix):
-    signing_key_file, verifying_key_file = f'{prefix}_signing_key', f'{prefix}_verifying_key'
-
-    signing_key, verifying_key = ed25519.create_keypair()
-
-    def write_key(key_file, key):
-        with open(key_file, 'wb') as f:
-            f.write(key.to_bytes())
-
-    write_key(signing_key_file, signing_key) 
-    write_key(verifying_key_file, verifying_key) 
-        
-    return signing_key_file, verifying_key_file
-
-
 class DeployThread(threading.Thread):
-    def __init__(self, name: str, node: DockerNode, batches_of_contracts: List[List[str]]) -> None:
+    def __init__(self, node: DockerNode, batches_of_contracts: List[List[str]]) -> None:
         threading.Thread.__init__(self)
-        self.name = name
         self.node = node
         self.batches_of_contracts = batches_of_contracts
         self.deployed_blocks_hashes = set()
@@ -60,10 +38,10 @@ def n(request):
     return request.param
 
 @pytest.fixture()
-def three_nodes(docker_client_fixture):
+def nodes(docker_client_fixture):
     with ThreeNodeNetwork(docker_client_fixture, extra_docker_params={'use_new_gossiping': True}) as network:
         network.create_cl_network()
-        # Wait for the genesis block reacing each node.
+        # Wait for the genesis block reaching each node.
         for node in network.docker_nodes:
             wait_for_blocks_count_at_least(node, 1, 1, node.timeout)
         yield network.docker_nodes
@@ -75,15 +53,14 @@ def three_nodes(docker_client_fixture):
 
                          ])
 # Curently nodes is a network of three bootstrap connected nodes.
-def test_block_propagation(three_nodes,
+def test_block_propagation(nodes,
                            contract_paths: List[List[str]], expected_number_of_blocks):
     """
     Feature file: consensus.feature
     Scenario: test_helloworld.wasm deploy and propose by all nodes and stored in all nodes blockstores
     """
 
-    deploy_threads = [DeployThread("node" + str(i+1), node, contract_paths)
-                      for i, node in enumerate(three_nodes)]
+    deploy_threads = [DeployThread(node, contract_paths) for node in nodes]
 
     for t in deploy_threads:
         t.start()
@@ -91,15 +68,15 @@ def test_block_propagation(three_nodes,
     for t in deploy_threads:
         t.join()
 
-    for node in three_nodes:
+    for node in nodes:
         wait_for_blocks_count_at_least(node, expected_number_of_blocks, expected_number_of_blocks * 2, node.timeout)
 
-    for node in three_nodes:
+    for node in nodes:
         blocks = parse_show_blocks(node.client.show_blocks(expected_number_of_blocks * 100))
         # What propose returns is first 10 characters of block hash, so we can compare only first 10 charcters.
         blocks_hashes = set([b.block_hash[:10] for b in blocks])
         for t in deploy_threads:
             assert t.deployed_blocks_hashes.issubset(blocks_hashes), \
-                   f"Not all blocks deployed and proposed on {t.name} were propagated to {node.name}"
+                   f"Not all blocks deployed and proposed on {t.node.container_name} were propagated to {node.container_name}"
 
 

--- a/integration-testing/test/test_block_propagation.py
+++ b/integration-testing/test/test_block_propagation.py
@@ -46,9 +46,7 @@ def nodes(docker_client_fixture):
 
 
 @pytest.mark.parametrize("contract_paths, expected_number_of_blocks", [
-
                          ([['test_helloname.wasm'],['test_helloworld.wasm']], 5),
-
                          ])
 def test_block_propagation(nodes,
                            contract_paths: List[List[str]], expected_number_of_blocks):
@@ -93,17 +91,26 @@ def not_all_connected_directly_nodes(docker_client_fixture):
     node0 -- node1 -- node2
     """
     with CustomConnectionNetwork(docker_client_fixture) as network:
-        network.create_cl_network(3, [(0, 1), (1, 2)])
+        # All nodes need to be connected to bootstrap in order to download the genesis block.
+        network.create_cl_network(3, [(0, 1), (1, 2), (0, 2)])
         # Wait for the genesis block reaching each node.
         for node in network.docker_nodes:
             wait_for_blocks_count_at_least(node, 1, 1, node.timeout)
+        # All nodes have the genesis block now, so we can disconnect one from the bootstrap.
+        network.disconnect((0, 2))
         yield network.docker_nodes
 
     
 def test_blocks_infect_network(not_all_connected_directly_nodes):
-    block_hash = deploy_and_propose(not_all_connected_directly_nodes[0], 'test_helloname.wasm')
-    wait_for_blocks_count_at_least(not_all_connected_directly_nodes[2], 2, 2)
-    blocks = parse_show_blocks(node.client.show_blocks(2))
+    """
+    Feature file: block_gossiping.feature
+    Scenario: Blocks 'infect' the network and nodes 'closest' to the propose see the blocks first.
+    """
+    first, last = not_all_connected_directly_nodes[0], not_all_connected_directly_nodes[-1]
+
+    block_hash = deploy_and_propose(first, 'test_helloname.wasm')
+    wait_for_blocks_count_at_least(last, 2, 2)
+    blocks = parse_show_blocks(last.client.show_blocks(2))
     blocks_hashes = set([b.block_hash[:10] for b in blocks])
     assert block_hash in blocks_hashes
     


### PR DESCRIPTION
### Overview
This is a PR for OP-222: Block Gossiping Integration Test - Blocks 'infect' network and 'closest' see blocks first.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-222

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
