### PR TITLE
OP-271: Added new node should not gossip old blocks from network. 

### DIFF
--- a/integration-testing/features/node_added_to_established_network.feature
+++ b/integration-testing/features/node_added_to_established_network.feature
@@ -1,5 +1,6 @@
-Feature: Node added to established network
 
+Feature: Node added to established network
+  # Implemented test_node_added_to_established_network.py : test_newly_joined_node_should_not_gossip_blocks
   Scenario: New node should not gossip old blocks back to network
     Given Existing network with old blocks
      When New node joins network

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -1,3 +1,4 @@
+import logging
 from test.cl_node.casperlabs_node import CasperLabsNode
 from test.cl_node.common import random_string
 from test.cl_node.docker_base import DockerConfig

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -1,24 +1,17 @@
-import docker
-import logging
-
-from typing import List, Callable, Dict
-
-
-from test.cl_node.docker_base import DockerConfig
 from test.cl_node.casperlabs_node import CasperLabsNode
-from test.cl_node.docker_node import DockerNode
 from test.cl_node.common import random_string
+from test.cl_node.docker_base import DockerConfig
+from test.cl_node.docker_node import DockerNode
+from test.cl_node.log_watcher import GoodbyeInLogLine, wait_for_log_watcher
 from test.cl_node.pregenerated_keypairs import PREGENERATED_KEYPAIRS
 from test.cl_node.wait import (
     wait_for_approved_block_received_handler_state,
     wait_for_node_started,
     wait_for_peers_count_at_least,
 )
-from test.cl_node.log_watcher import (
-    wait_for_log_watcher,
-    GoodbyeInLogLine,
-    RequestedForkTipFromPeersInLogLine,
-)
+from typing import Callable, Dict, List
+
+import docker
 
 
 class CasperLabsNetwork:
@@ -165,8 +158,7 @@ class NodeJoinExistingNetwork(TwoNodeNetwork):
 
     def add_node_to_existing_network(self):
         """
-        This method should be called separately
-        :return:
+        Add a new node to the existing network.
         """
         kp = self.get_key()
         config = DockerConfig(self.docker_client, node_private_key=kp.private_key)

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -161,8 +161,21 @@ class TwoNodeNetwork(CasperLabsNetwork):
         self.wait_for_peers()
 
 
-class ThreeNodeNetwork(CasperLabsNetwork):
+class NodeJoinExistingNetwork(TwoNodeNetwork):
 
+    def add_node_to_existing_network(self):
+        """
+        This method should be called separately
+        :return:
+        """
+        kp = self.get_key()
+        config = DockerConfig(self.docker_client, node_private_key=kp.private_key)
+        self.add_cl_node(config)
+        self.wait_method(wait_for_approved_block_received_handler_state, 2)
+        self.wait_for_peers()
+
+
+class ThreeNodeNetwork(CasperLabsNetwork):
     def create_cl_network(self):
         kp = self.get_key()
         config = DockerConfig(self.docker_client,

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -62,6 +62,13 @@ class CasperLabsNetwork:
         cl_node = CasperLabsNode(config)
         self.cl_nodes.append(cl_node)
 
+    def add_new_node_to_network(self) -> None:
+        kp = self.get_key()
+        config = DockerConfig(self.docker_client, node_private_key=kp.private_key)
+        self.add_cl_node(config)
+        self.wait_method(wait_for_approved_block_received_handler_state, 1)
+        self.wait_for_peers()
+
     def add_bootstrap(self, config: DockerConfig) -> None:
         if self.node_count > 0:
             raise Exception('There can be only one bootstrap')
@@ -148,24 +155,7 @@ class TwoNodeNetwork(CasperLabsNetwork):
                               network=self.create_docker_network())
         self.add_bootstrap(config)
 
-        kp = self.get_key()
-        config = DockerConfig(self.docker_client, node_private_key=kp.private_key)
-        self.add_cl_node(config)
-        self.wait_method(wait_for_approved_block_received_handler_state, 1)
-        self.wait_for_peers()
-
-
-class NodeJoinExistingNetwork(TwoNodeNetwork):
-
-    def add_node_to_existing_network(self):
-        """
-        Add a new node to the existing network.
-        """
-        kp = self.get_key()
-        config = DockerConfig(self.docker_client, node_private_key=kp.private_key)
-        self.add_cl_node(config)
-        self.wait_method(wait_for_approved_block_received_handler_state, 2)
-        self.wait_for_peers()
+        self.add_new_node_to_network()
 
 
 class ThreeNodeNetwork(CasperLabsNetwork):

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -146,7 +146,7 @@ class TotalBlocksOnNode:
         return count == self.number_of_blocks
 
 
-class AcceptedAndRejectedBlocksOnNewNode:
+class NodeDidNotGossip:
     def __init__(self, node: 'Node') -> None:
         self.node = node
 
@@ -319,7 +319,7 @@ def wait_for_metrics_and_assert_blocks_avaialable(node: 'Node', timeout_seconds:
 
 
 def wait_for_gossip_metrics_and_assert_blocks_gossiped(node: 'Node', timeout_seconds: int, number_of_blocks: int) -> None:
-    predicate = AcceptedAndRejectedBlocksOnNewNode(node)
+    predicate = NodeDidNotGossip(node)
     wait_using_wall_clock_time_or_fail(predicate, timeout_seconds)
 
 

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -146,10 +146,9 @@ class TotalBlocksOnNode:
         return count == self.number_of_blocks
 
 
-class GossipedBlocksOnNode:
-    def __init__(self, node: 'Node', number_of_blocks: int) -> None:
+class AcceptedAndRejectedBlocksOnNewNode:
+    def __init__(self, node: 'Node') -> None:
         self.node = node
-        self.number_of_blocks = number_of_blocks
 
     def is_satisfied(self) -> bool:
         _, data = self.node.get_metrics()
@@ -159,7 +158,7 @@ class GossipedBlocksOnNode:
         rejected_blocks = relay_rejected_total.search(data)
         if None in [accepted_blocks, rejected_blocks]:
             return False
-        return int(accepted_blocks.group(1)) == self.number_of_blocks and int(rejected_blocks.group(1)) == self.number_of_blocks
+        return int(accepted_blocks.group(1)) == 0 and int(rejected_blocks.group(1)) == 0
 
 
 def get_new_blocks_requests_total(node: 'Node') -> int:
@@ -320,7 +319,7 @@ def wait_for_metrics_and_assert_blocks_avaialable(node: 'Node', timeout_seconds:
 
 
 def wait_for_gossip_metrics_and_assert_blocks_gossiped(node: 'Node', timeout_seconds: int, number_of_blocks: int) -> None:
-    predicate = GossipedBlocksOnNode(node, number_of_blocks)
+    predicate = AcceptedAndRejectedBlocksOnNewNode(node)
     wait_using_wall_clock_time_or_fail(predicate, timeout_seconds)
 
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -4,11 +4,10 @@ import docker as docker_py
 import pytest
 
 from .cl_node.casperlabs_network import (
-    OneNodeNetwork,
-    TwoNodeNetwork,
-    ThreeNodeNetwork,
     CustomConnectionNetwork,
-    NodeJoinExistingNetwork,
+    OneNodeNetwork,
+    ThreeNodeNetwork,
+    TwoNodeNetwork,
 )
 
 
@@ -43,13 +42,6 @@ def two_node_network(docker_client_fixture):
 @pytest.fixture()
 def three_node_network(docker_client_fixture):
     with ThreeNodeNetwork(docker_client_fixture) as tnn:
-        tnn.create_cl_network()
-        yield tnn
-
-
-@pytest.fixture()
-def node_join_existing_network(docker_client_fixture):
-    with NodeJoinExistingNetwork(docker_client_fixture) as tnn:
         tnn.create_cl_network()
         yield tnn
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -8,6 +8,7 @@ from .cl_node.casperlabs_network import (
     TwoNodeNetwork,
     ThreeNodeNetwork,
     CustomConnectionNetwork,
+    NodeJoinExistingNetwork,
 )
 
 
@@ -42,6 +43,13 @@ def two_node_network(docker_client_fixture):
 @pytest.fixture()
 def three_node_network(docker_client_fixture):
     with ThreeNodeNetwork(docker_client_fixture) as tnn:
+        tnn.create_cl_network()
+        yield tnn
+
+
+@pytest.fixture()
+def node_join_existing_network(docker_client_fixture):
+    with NodeJoinExistingNetwork(docker_client_fixture) as tnn:
         tnn.create_cl_network()
         yield tnn
 

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -2,6 +2,7 @@ from test.cl_node.casperlabsnode import HELLO_NAME
 from test.cl_node.wait import (
     get_new_blocks_requests_total,
     wait_for_gossip_metrics_and_assert_blocks_gossiped,
+    wait_for_blocks_count_at_least
 )
 
 
@@ -16,6 +17,8 @@ def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
         block_hashes.append(node.deploy_and_propose(session_contract=HELLO_NAME,
                                                     private_key="validator-0-private.pem",
                                                     public_key="validator-0-public.pem"))
+    for node in node_join_existing_network.docker_nodes:
+        wait_for_blocks_count_at_least(node, 3, 3, node.timeout)
     node0_new_blocks_requests_total = get_new_blocks_requests_total(node0)
     node1_new_blocks_requests_total = get_new_blocks_requests_total(node1)
 

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -1,5 +1,15 @@
-def test_newly_joined_node_should_not_gossip_blocks():
+from test.cl_node.casperlabsnode import HELLO_NAME
+
+
+def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
     """
     Feature file: node_added_to_established_network.feature
     Scenario: New node should not gossip old blocks back to network
     """
+    block_hashes = []
+    for node in node_join_existing_network.docker_nodes:
+        block_hashes.append(node.deploy_and_propose(session_contract=HELLO_NAME,
+                                                    private_key="validator-0-private.pem",
+                                                    public_key="validator-0-public.pem"))
+    node_join_existing_network.add_node_to_existing_network()
+    node0, node1, node2 = node_join_existing_network.docker_nodes

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -1,29 +1,29 @@
 from test.cl_node.casperlabsnode import HELLO_NAME
 from test.cl_node.wait import (
     get_new_blocks_requests_total,
+    wait_for_blocks_count_at_least,
     wait_for_gossip_metrics_and_assert_blocks_gossiped,
-    wait_for_blocks_count_at_least
 )
 
 
-def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
+def test_newly_joined_node_should_not_gossip_blocks(two_node_network):
     """
     Feature file: node_added_to_established_network.feature
     Scenario: New node should not gossip old blocks back to network
     """
     block_hashes = []
-    node0, node1 = node_join_existing_network.docker_nodes
-    for node in node_join_existing_network.docker_nodes:
+    node0, node1 = two_node_network.docker_nodes
+    for node in two_node_network.docker_nodes:
         block_hashes.append(node.deploy_and_propose(session_contract=HELLO_NAME,
                                                     private_key="validator-0-private.pem",
                                                     public_key="validator-0-public.pem"))
-    for node in node_join_existing_network.docker_nodes:
+    for node in two_node_network.docker_nodes:
         wait_for_blocks_count_at_least(node, 3, 3, node.timeout)
     node0_new_blocks_requests_total = get_new_blocks_requests_total(node0)
     node1_new_blocks_requests_total = get_new_blocks_requests_total(node1)
 
-    node_join_existing_network.add_node_to_existing_network()
-    node0, node1, node2 = node_join_existing_network.docker_nodes
+    two_node_network.add_new_node_to_network()
+    node0, node1, node2 = two_node_network.docker_nodes
     for block in block_hashes:
         assert f"Attempting to add Block {block}... to DAG" in node2.logs()
     wait_for_gossip_metrics_and_assert_blocks_gossiped(node2, node2.timeout, 0)

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -1,0 +1,5 @@
+def test_newly_joined_node_should_not_gossip_blocks():
+    """
+    Feature file: node_added_to_established_network.feature
+    Scenario: New node should not gossip old blocks back to network
+    """

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -13,3 +13,5 @@ def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
                                                     public_key="validator-0-public.pem"))
     node_join_existing_network.add_node_to_existing_network()
     node0, node1, node2 = node_join_existing_network.docker_nodes
+    for block in block_hashes:
+        assert f"Attempting to add Block {block}... to DAG" in node2.logs()

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -1,5 +1,5 @@
 from test.cl_node.casperlabsnode import HELLO_NAME
-
+from test.cl_node.wait import wait_for_gossip_metrics_and_assert_blocks_gossiped
 
 def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
     """
@@ -15,3 +15,4 @@ def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
     node0, node1, node2 = node_join_existing_network.docker_nodes
     for block in block_hashes:
         assert f"Attempting to add Block {block}... to DAG" in node2.logs()
+    wait_for_gossip_metrics_and_assert_blocks_gossiped(node2, node2.timeout, 0)

--- a/integration-testing/test/test_node_added_to_established_network.py
+++ b/integration-testing/test/test_node_added_to_established_network.py
@@ -1,5 +1,9 @@
 from test.cl_node.casperlabsnode import HELLO_NAME
-from test.cl_node.wait import wait_for_gossip_metrics_and_assert_blocks_gossiped
+from test.cl_node.wait import (
+    get_new_blocks_requests_total,
+    wait_for_gossip_metrics_and_assert_blocks_gossiped,
+)
+
 
 def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
     """
@@ -7,12 +11,18 @@ def test_newly_joined_node_should_not_gossip_blocks(node_join_existing_network):
     Scenario: New node should not gossip old blocks back to network
     """
     block_hashes = []
+    node0, node1 = node_join_existing_network.docker_nodes
     for node in node_join_existing_network.docker_nodes:
         block_hashes.append(node.deploy_and_propose(session_contract=HELLO_NAME,
                                                     private_key="validator-0-private.pem",
                                                     public_key="validator-0-public.pem"))
+    node0_new_blocks_requests_total = get_new_blocks_requests_total(node0)
+    node1_new_blocks_requests_total = get_new_blocks_requests_total(node1)
+
     node_join_existing_network.add_node_to_existing_network()
     node0, node1, node2 = node_join_existing_network.docker_nodes
     for block in block_hashes:
         assert f"Attempting to add Block {block}... to DAG" in node2.logs()
     wait_for_gossip_metrics_and_assert_blocks_gossiped(node2, node2.timeout, 0)
+    assert node0_new_blocks_requests_total == get_new_blocks_requests_total(node0)
+    assert node1_new_blocks_requests_total == get_new_blocks_requests_total(node1)


### PR DESCRIPTION
### Overview

 OP-271: Added new node should not gossip old blocks from network.

### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/browse/OP-271

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._