### PR TITLE
NODE-546: Do one deploy per account

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.implicits._
 import cats.effect._
 import cats.effect.concurrent._
+import com.google.protobuf.ByteString
 import io.casperlabs.casper.api.BlockAPI
 import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
@@ -26,8 +27,8 @@ class AutoProposer[F[_]: Concurrent: Time: Log: Metrics: MultiParentCasperRef](
     val maxElapsedMillis = maxInterval.toMillis
 
     def loop(
-        // Deploys we saw at the last auto-proposal.
-        prevDeploys: Set[Deploy],
+        // Deploys which were new when we tried to propose last time.
+        prevDeploys: Set[ByteString],
         // Time we saw the first new deploy after an auto-proposal.
         startMillis: Long
     ): F[Unit] = {
@@ -35,29 +36,27 @@ class AutoProposer[F[_]: Concurrent: Time: Log: Metrics: MultiParentCasperRef](
       val snapshot = for {
         currentMillis <- Time[F].currentMillis
         casper        <- MultiParentCasperRef[F].get
-        // NOTE: Currently the `remainingDeploys` method is private and quite inefficient
-        // (easily goes back to Genesis), but in theory we could try to detect orphans and
-        // propose again automatically.
-        deploys <- casper.fold(Set.empty[Deploy].pure[F])(_.bufferedDeploys)
-      } yield (currentMillis, currentMillis - startMillis, deploys, deploys diff prevDeploys)
+        deployBuffer  <- casper.fold(DeployBuffer.empty.pure[F])(_.bufferedDeploys)
+        newDeploys    = deployBuffer.newDeploys.keySet
+      } yield (currentMillis, currentMillis - startMillis, newDeploys)
 
       snapshot flatMap {
         // Reset time when we see a new deploy.
-        case (currentMillis, _, _, newDeploys) if newDeploys.nonEmpty && startMillis == 0 =>
-          Time[F].sleep(checkInterval) *>
-            loop(prevDeploys, currentMillis)
+        case (currentMillis, _, newDeploys) if newDeploys.nonEmpty && startMillis == 0 =>
+          Time[F].sleep(checkInterval) *> loop(prevDeploys, currentMillis)
 
-        case (_, elapsedMillis, deploys, newDeploys)
-            if newDeploys.nonEmpty && (elapsedMillis >= maxElapsedMillis || newDeploys.size >= maxCount) =>
+        case (_, elapsedMillis, newDeploys)
+            if newDeploys.nonEmpty
+              && newDeploys != prevDeploys
+              && (elapsedMillis >= maxElapsedMillis || newDeploys.size >= maxCount) =>
           Log[F].info(
-            s"Proposing block after ${elapsedMillis} ms and ${newDeploys.size} new deploys."
+            s"Proposing block after ${elapsedMillis} ms with ${newDeploys.size} new deploys."
           ) *>
             tryPropose() *>
-            loop(deploys, 0)
+            loop(newDeploys, 0)
 
         case _ =>
-          Time[F].sleep(checkInterval) *>
-            loop(prevDeploys, startMillis)
+          Time[F].sleep(checkInterval) *> loop(prevDeploys, startMillis)
       }
     }
 

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -33,38 +33,38 @@ case class DeployBuffer(
     // Deploys that have been processed at least once,
     // waiting to be finalized or orphaned.
     processedDeploys: Map[ByteString, Deploy],
-    // Deploys we never looked at.
-    newDeploys: Map[ByteString, Deploy]
+    // Deploys not yet included in a block.
+    pendingDeploys: Map[ByteString, Deploy]
 ) {
   def size =
-    processedDeploys.size + newDeploys.size
+    processedDeploys.size + pendingDeploys.size
 
   def add(deploy: Deploy) =
     if (!contains(deploy))
-      copy(newDeploys = newDeploys + (deploy.deployHash -> deploy))
+      copy(pendingDeploys = pendingDeploys + (deploy.deployHash -> deploy))
     else
       this
 
   // Removes deploys that were included in a block.
-  // They could be in newDeploys too if they were sent to multiple nodes.
+  // They could be in pendingDeploys too if they were sent to multiple nodes.
   def remove(deployHashes: Set[ByteString]) =
     copy(
       processedDeploys = processedDeploys.filterKeys(h => !deployHashes(h)),
-      newDeploys = newDeploys.filterKeys(h => !deployHashes(h))
+      pendingDeploys = pendingDeploys.filterKeys(h => !deployHashes(h))
     )
 
   // Move some deploys from new to processed.
   def processed(deployHashes: Set[ByteString]) =
     copy(
-      processedDeploys = processedDeploys ++ newDeploys.filterKeys(deployHashes),
-      newDeploys = newDeploys.filterKeys(h => !deployHashes(h))
+      processedDeploys = processedDeploys ++ pendingDeploys.filterKeys(deployHashes),
+      pendingDeploys = pendingDeploys.filterKeys(h => !deployHashes(h))
     )
 
   def get(deployHash: ByteString): Option[Deploy] =
-    newDeploys.get(deployHash) orElse processedDeploys.get(deployHash)
+    pendingDeploys.get(deployHash) orElse processedDeploys.get(deployHash)
 
   def contains(deploy: Deploy) =
-    newDeploys.contains(deploy.deployHash) || processedDeploys.contains(deploy.deployHash)
+    pendingDeploys.contains(deploy.deployHash) || processedDeploys.contains(deploy.deployHash)
 }
 object DeployBuffer {
   val empty = DeployBuffer(Map.empty, Map.empty)

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -45,11 +45,11 @@ case class DeployBuffer(
     else
       this
 
-  // Removes deploys that were included in a block.
-  // They could be in pendingDeploys too if they were sent to multiple nodes.
+  // Removes deploys that were included in a finalized block.
   def remove(deployHashes: Set[ByteString]) =
     copy(
       processedDeploys = processedDeploys.filterKeys(h => !deployHashes(h)),
+      // They could be in pendingDeploys too if they were sent to multiple nodes.
       pendingDeploys = pendingDeploys.filterKeys(h => !deployHashes(h))
     )
 

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -339,7 +339,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
                        if (remDeploys.nonEmpty) Left(remDeploys) else Right(Set.empty)
                    }
       // Pending deploys are most likely not in the past, or we'd have to go back indefinitely to
-      // prove they aren't. The EE will ignore them if the nonce is less then the expected,
+      // prove they aren't. The EE will ignore them if the nonce is less than the expected,
       // so it should be fine to include and see what happens.
       candidates = orphaned.toSeq ++ state.deployBuffer.pendingDeploys.values
 
@@ -429,7 +429,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
             }
             .whenA(deploysToDiscard.nonEmpty)
 
-          status <* discardDeploys
+          discardDeploys *> status
       }
       .handleErrorWith {
         case ex @ SmartContractEngineError(error_msg) =>
@@ -507,7 +507,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
     // Mark deploys we have observed in blocks as processed.
     val processedDeployHashes = attempts
       .collect {
-        case (block, status) if canRemove(status) =>
+        case (block, _) if addedBlockHashes(block.blockHash) =>
           block.getBody.deploys.map(_.getDeploy.deployHash)
       }
       .flatten

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -338,10 +338,10 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
                        val remDeploys       = prevProcessedDeploys -- processedDeploys
                        if (remDeploys.nonEmpty) Left(remDeploys) else Right(Set.empty)
                    }
-      // New deploys are most likely not in the past, or we'd have to go back indefinitely to
+      // Pending deploys are most likely not in the past, or we'd have to go back indefinitely to
       // prove they aren't. The EE will ignore them if the nonce is less then the expected,
       // so it should be fine to include and see what happens.
-    } yield orphaned.toSeq ++ state.deployBuffer.newDeploys.values
+    } yield orphaned.toSeq ++ state.deployBuffer.pendingDeploys.values
 
   //TODO: Need to specify SEQ vs PAR type block?
   /** Execute a set of deploys in the context of chosen parents. Compile them into a block if everything goes fine. */

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -352,7 +352,7 @@ object BlockAPI {
 
           case _ =>
             casper.bufferedDeploys.map { deploys =>
-              deploys.find(_.deployHash == deployHash) map { deploy =>
+              deploys.get(deployHash) map { deploy =>
                 DeployInfo().withDeploy(deploy)
               }
             }

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -182,7 +182,7 @@ object AutoProposerTest {
     override def createBlock: F[CreateBlockStatus] =
       Sync[F].delay {
         proposalCount += 1
-        val keys = deployBuffer.newDeploys.keySet.toSet
+        val keys = deployBuffer.pendingDeploys.keySet.toSet
         deployBuffer = deployBuffer.processed(keys)
         ReadOnlyMode
       }

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -184,7 +184,8 @@ object AutoProposerTest {
         proposalCount += 1
         val keys = deployBuffer.pendingDeploys.keySet.toSet
         deployBuffer = deployBuffer.processed(keys)
-        ReadOnlyMode
+        // Doesn't matter what we return in this test.
+        if (keys.nonEmpty) Created(Block()) else NoNewDeploys
       }
 
     override def addBlock(block: Block): F[BlockStatus] = ???

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -233,7 +233,10 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     val data1 = ProtoUtil.basicDeploy(2, dummyContract, 2)
 
     for {
-      nodes              <- networkEff(validatorKeys.take(2), genesis, transforms)
+      // NOTE: Not validating nonces because after adding creating the 1st block it expects the nonce
+      // will increase, but instead we make the block invalid and try again with the same deploy.
+      // It would work if the nonces were tracked per pre-state-hash.
+      nodes              <- networkEff(validatorKeys.take(2), genesis, transforms, validateNonces = false)
       List(node0, node1) = nodes.toList
       unsignedBlock <- (node0.casperEff.deploy(data0) *> node0.casperEff.createBlock)
                         .map {
@@ -249,6 +252,9 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       signedBlock <- (node0.casperEff.deploy(data1) *> node0.casperEff.createBlock)
                       .map { case Created(block) => block }
+
+      // NOTE: It won't actually include `data1` in the block because it still has `data0`.
+      _ = signedBlock.getBody.deploys.map(_.getDeploy) should contain only (data0)
 
       _ <- node0.casperEff.addBlock(signedBlock)
       _ <- node1.receive() //receives block1; should not ask for block0
@@ -1187,6 +1193,8 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     }
   }
 
+  it should "remove deploys with lower than expected nonces from the buffer" in (pending)
+
   it should "return NoNewDeploys status if there are no deploys to put into the block after executing contracts" in effectTest {
     val node = standaloneEff(genesis, transforms, validatorKeys.head)
     import node._
@@ -1199,6 +1207,42 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       invalidDeploy     <- ProtoUtil.basicDeploy[Effect](invalidNonce)
       _                 <- node.casperEff.deploy(invalidDeploy)
       createBlockStatus <- MultiParentCasper[Effect].createBlock shouldBeF io.casperlabs.casper.NoNewDeploys
+    } yield ()
+  }
+
+  it should "only execute the next deploy per account in one proposal" in effectTest {
+    val node = standaloneEff(genesis, transforms, validatorKeys.head)
+    import node._
+    implicit val timeEff = new LogicalTime[Effect]
+
+    def propose() =
+      for {
+        create         <- node.casperEff.createBlock
+        Created(block) = create
+        _              <- node.casperEff.addBlock(block)
+      } yield block
+
+    for {
+      deploy1 <- ProtoUtil.basicDeploy[Effect](1)
+      deploy2 <- ProtoUtil.basicDeploy[Effect](2)
+      _       <- node.casperEff.deploy(deploy1)
+      _       <- node.casperEff.deploy(deploy2)
+
+      block1 <- propose()
+      _      = block1.getBody.deploys.map(_.getDeploy) should contain only (deploy1)
+      state1 <- node.casperState.read
+      _      = state1.deployBuffer.processedDeploys.keySet should contain only (deploy1.deployHash)
+      _      = state1.deployBuffer.pendingDeploys.keySet should contain only (deploy2.deployHash)
+
+      block2 <- propose()
+      _      = block2.getBody.deploys.map(_.getDeploy) should contain only (deploy2)
+      state2 <- node.casperState.read
+      _ = state2.deployBuffer.processedDeploys.keySet should contain theSameElementsAs List(
+        deploy1.deployHash,
+        deploy2.deployHash
+      )
+      _ = state2.deployBuffer.pendingDeploys shouldBe empty
+
     } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -233,8 +233,8 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     val data1 = ProtoUtil.basicDeploy(2, dummyContract, 2)
 
     for {
-      // NOTE: Not validating nonces because after adding creating the 1st block it expects the nonce
-      // will increase, but instead we make the block invalid and try again with the same deploy.
+      // NOTE: Not validating nonces because after creating the 1st block it expects the nonce will increase,
+      // but instead we make the block invalid and try creating another again with the same deploy still in the buffer.
       // It would work if the nonces were tracked per pre-state-hash.
       nodes              <- networkEff(validatorKeys.take(2), genesis, transforms, validateNonces = false)
       List(node0, node1) = nodes.toList
@@ -1208,10 +1208,8 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _           <- node.casperEff.deploy(deploy0)
       stateBefore <- node.casperState.read
       _           = stateBefore.deployBuffer.contains(deploy0) shouldBe true
-      _           = println(s"BEFORE: ${stateBefore.deployBuffer}")
       _           <- node.casperEff.createBlock shouldBeF NoNewDeploys
       stateAfter  <- node.casperState.read
-      _           = println(s"AFTER: ${stateAfter.deployBuffer}")
       _           = stateAfter.deployBuffer.contains(deploy0) shouldBe false
 
     } yield ()

--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -888,7 +888,7 @@ class ValidateTest
                               deploys,
                               ProtocolVersion(1)
                             )
-        DeploysCheckpoint(preStateHash, computedPostStateHash, processedDeploys, _, _, _) = deploysCheckpoint
+        DeploysCheckpoint(preStateHash, computedPostStateHash, processedDeploys, _, _, _, _) = deploysCheckpoint
         block <- createBlock[Task](
                   Seq.empty,
                   deploys = processedDeploys,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -6,7 +6,13 @@ import cats.implicits._
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus.{Block, Deploy}
-import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper, ValidatorIdentity}
+import io.casperlabs.casper.{
+  BlockStatus,
+  CreateBlockStatus,
+  DeployBuffer,
+  MultiParentCasper,
+  ValidatorIdentity
+}
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.storage.BlockMsgWithTransform
 
@@ -36,7 +42,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
   def lastFinalizedBlock: F[Block]                                    = Block().pure[F]
   def fetchDependencies: F[Unit]                                      = ().pure[F]
-  def bufferedDeploys: F[Set[Deploy]]                                 = Set.empty.pure[F]
+  def bufferedDeploys: F[DeployBuffer]                                = DeployBuffer.empty.pure[F]
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -119,7 +119,7 @@ class ExecEngineUtilTest
                           deploy,
                           protocolVersion
                         )
-      DeploysCheckpoint(_, _, result, _, _, _) = computeResult
+      DeploysCheckpoint(_, _, result, _, _, _, _) = computeResult
     } yield result
 
   "computeDeploysCheckpoint" should "aggregate the result of deploying multiple programs within the block" in withStorage {


### PR DESCRIPTION
### Overview
Currently `MultiParentCasperImpl` tries to put all the deploys in its buffer into the next block it proposes, however we know that if the same account submitted multiple deploys then only one can succeed, because they have to update the nonce. It makes sense to only include the deploy with the lowest one per account.

The PR splits the `deployBuffer` from being a set of deploys to be two maps: one for deploys we already processed at least in one block and one for deploys never attempted before. If a deploy's nonce is higher than the minimum deploy among the candidates for the block it stays in the pending buffer. This split also makes it more efficient to look for deploys already included in the past of the current block since we don't have to consider the pending ones, and so it won't traverse back to Genesis like it did so far.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-546

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
