### PR TITLE
NODE-531: Validate block summary during sycing

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -43,7 +43,9 @@ final case class CasperConf(
     autoProposeCheckInterval: FiniteDuration,
     autoProposeMaxInterval: FiniteDuration,
     autoProposeMaxCount: Int
-) extends SubConfig
+) extends SubConfig {
+  def chainId = shardId
+}
 
 object CasperConf {
   private implicit val logSource: LogSource = LogSource(this.getClass)

--- a/casper/src/main/scala/io/casperlabs/casper/Validate.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Validate.scala
@@ -344,9 +344,8 @@ object Validate {
       beforeFuture = currentTime + DRIFT >= timestamp
       latestParentTimestamp <- b.getHeader.parentHashes.toList.foldM(0L) {
                                 case (latestTimestamp, parentHash) =>
-                                  // TODO: Fetch summary only.
                                   ProtoUtil
-                                    .unsafeGetBlock[F](parentHash)
+                                    .unsafeGetBlockSummary[F](parentHash)
                                     .map(parent => {
                                       val timestamp =
                                         parent.header.fold(latestTimestamp)(_.timestamp)
@@ -591,7 +590,7 @@ object Validate {
       _                   <- raiseNoParent.whenA(b.getHeader.parentHashes.isEmpty)
       justifiedValidators = b.getHeader.justifications.map(_.validatorPublicKey).toSet
       mainParentHash      = b.getHeader.parentHashes.head
-      mainParent          <- ProtoUtil.unsafeGetBlock[F](mainParentHash)
+      mainParent          <- ProtoUtil.unsafeGetBlockSummary[F](mainParentHash)
       bondedValidators    = ProtoUtil.bonds(mainParent).map(_.validatorPublicKey).toSet
       status <- if (bondedValidators == justifiedValidators) {
                  Applicative[F].unit
@@ -687,9 +686,9 @@ object Validate {
   ): F[Boolean] =
     for {
       currentBlockJustification <- ProtoUtil
-                                    .unsafeGetBlock[F](currentBlockJustificationHash)
+                                    .unsafeGetBlockSummary[F](currentBlockJustificationHash)
       previousBlockJustification <- ProtoUtil
-                                     .unsafeGetBlock[F](previousBlockJustificationHash)
+                                     .unsafeGetBlockSummary[F](previousBlockJustificationHash)
     } yield
       if (currentBlockJustification.getHeader.validatorBlockSeqNum < previousBlockJustification.getHeader.validatorBlockSeqNum) {
         true

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -92,10 +92,13 @@ object ProtoUtil {
     } yield block
 
   def creatorJustification(block: Block): Option[Justification] =
-    block.getHeader.justifications
+    creatorJustification(block.getHeader)
+
+  def creatorJustification(header: Block.Header): Option[Justification] =
+    header.justifications
       .find {
         case Justification(validator: Validator, _) =>
-          validator == block.getHeader.validatorPublicKey
+          validator == header.validatorPublicKey
       }
 
   def findCreatorJustificationAncestorWithSeqNum[F[_]: Monad: BlockStore](

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -216,7 +216,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
                           ].createBlock
       Created(block) = createBlockResult
       invalidBlock   = block.withSignature(block.getSignature.withSig((ByteString.EMPTY)))
-      _              <- MultiParentCasper[Effect].addBlock(invalidBlock)
+      _              <- MultiParentCasper[Effect].addBlock(invalidBlock) shouldBeF InvalidUnslashableBlock
       _              = logEff.warns.count(_.contains("because block signature")) should be(1)
       _              <- node.tearDownNode()
       result <- validateBlockStore(node) { blockStore =>

--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -144,7 +144,12 @@ class ValidateTest
       b.withSignature(b.getSignature.withSigAlgorithm(sigAlgorithm))
     def changeSig(sig: ByteString): Block =
       b.withSignature(b.getSignature.withSig(sig))
+
   }
+
+  // Originally validation methods wanted blocks, now they work on summaries.
+  implicit def `Block => BlockSummary`(b: Block) =
+    BlockSummary(b.blockHash, b.header, b.signature)
 
   "Block signature validation" should "return false on unknown algorithms" in withStorage {
     implicit blockStore => implicit blockDagStorage =>

--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -165,11 +165,13 @@ class ValidateTest
                    .map(_.changeSigAlgorithm(rsa))
         _ <- Validate.blockSignature[Task](block0) shouldBeF false
         _ = log.warns.last
-          .contains(s"signature algorithm $unknownAlgorithm is unsupported") should be(
+          .contains(s"signature algorithm '$unknownAlgorithm' is unsupported") should be(
           true
         )
-        _      <- Validate.blockSignature[Task](block1) shouldBeF false
-        result = log.warns.last.contains(s"signature algorithm $rsa is unsupported") should be(true)
+        _ <- Validate.blockSignature[Task](block1) shouldBeF false
+        result = log.warns.last.contains(s"signature algorithm '$rsa' is unsupported") should be(
+          true
+        )
       } yield result
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -364,7 +364,6 @@ object GossipServiceCasperTestNodeFactory {
                     )
                 _ <- Validate.blockSummary[F](
                       blockSummary,
-                      dag,
                       "casperlabs"
                     )
               } yield ()

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -6,6 +6,8 @@ import cats.implicits._
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper, ValidatorIdentity}
+import io.casperlabs.casper.consensus.{Block, Deploy}
+import io.casperlabs.casper.DeployBuffer
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.storage.BlockMsgWithTransform
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -5,14 +5,7 @@ import cats.effect.Sync
 import cats.implicits._
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockDagStorage, BlockStore}
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
-import io.casperlabs.casper.consensus.{Block, Deploy}
-import io.casperlabs.casper.{
-  BlockStatus,
-  CreateBlockStatus,
-  DeployBuffer,
-  MultiParentCasper,
-  ValidatorIdentity
-}
+import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper, ValidatorIdentity}
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.storage.BlockMsgWithTransform
 


### PR DESCRIPTION
### Overview
We had the same method to check the block summaries during the syncing, meaning to only check the block header, without the body, but there wasn't an actual method to call that didn't require the full body, so the validation happened only when we have already downloaded everything and were trying to add the block.

This PR adds a separate `Validate.blockSummary` which looks only at the things it can validate without having to look up parents, which would generally not yet be available as we're traversing the DAG backwards.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-531

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
`ProtoUtil` and `Validate` together are a mess, I'm sorry.
