### PR TITLE
NODE-550 Global state querying via GraphQL

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -29,7 +29,7 @@ import io.casperlabs.metrics.Metrics
 import io.casperlabs.node.api.graphql.FinalizedBlocksStream
 import io.casperlabs.node.configuration.Configuration
 import io.casperlabs.shared._
-import io.casperlabs.smartcontracts.GrpcExecutionEngineService
+import io.casperlabs.smartcontracts.{ExecutionEngineService, GrpcExecutionEngineService}
 import monix.eval.{Task, TaskLike}
 import monix.execution.Scheduler
 
@@ -79,11 +79,13 @@ class NodeRuntime private[node] (
 
     rpConfState >>= (_.runState { implicit state =>
       val resources = for {
-        executionEngineService <- GrpcExecutionEngineService[Effect](
-                                   conf.grpc.socket,
-                                   conf.server.maxMessageSize,
-                                   initBonds = Map.empty
-                                 )
+        implicit0(executionEngineService: ExecutionEngineService[Effect]) <- GrpcExecutionEngineService[
+                                                                              Effect
+                                                                            ](
+                                                                              conf.grpc.socket,
+                                                                              conf.server.maxMessageSize,
+                                                                              initBonds = Map.empty
+                                                                            )
 
         metrics                     = diagnostics.effects.metrics[Task]
         metricsEff: Metrics[Effect] = Metrics.eitherT[CommError, Task](Monad[Task], metrics)

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -2,8 +2,8 @@ package io.casperlabs.node.api
 
 import cats.effect._
 import cats.implicits._
-import com.google.protobuf.empty.Empty
 import com.google.protobuf.ByteString
+import com.google.protobuf.empty.Empty
 import io.casperlabs.blockstorage.BlockStore
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.SafetyOracle
@@ -12,14 +12,13 @@ import io.casperlabs.casper.consensus.Block
 import io.casperlabs.casper.consensus.info._
 import io.casperlabs.casper.consensus.state
 import io.casperlabs.catscontrib.MonadThrowable
+import io.casperlabs.comm.ServiceError.InvalidArgument
+import io.casperlabs.ipc
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.models.SmartContractEngineError
 import io.casperlabs.node.api.casper._
 import io.casperlabs.shared.Log
-import io.casperlabs.comm.ServiceError.InvalidArgument
 import io.casperlabs.smartcontracts.ExecutionEngineService
-import io.casperlabs.models.SmartContractEngineError
-import io.casperlabs.ipc
-import monix.execution.Scheduler
 import monix.eval.{Task, TaskLike}
 import monix.reactive.Observable
 
@@ -124,7 +123,7 @@ object GrpcCasperService extends StateConversions {
     }
 
   def toKey[F[_]: MonadThrowable](keyType: StateQuery.KeyVariant, keyValue: String): F[ipc.Key] =
-    GrpcDeployService.toKey[F](keyType.name, keyValue).handleErrorWith {
+    Utils.toKey[F](keyType.name, keyValue).handleErrorWith {
       case ex: java.lang.IllegalArgumentException =>
         MonadThrowable[F].raiseError(InvalidArgument(ex.getMessage))
     }

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcDeployService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcDeployService.scala
@@ -3,70 +3,25 @@ package io.casperlabs.node.api
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
-import cats.{ApplicativeError, Id}
 import com.google.protobuf.ByteString
 import com.google.protobuf.empty.Empty
 import io.casperlabs.blockstorage.BlockStore
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.SafetyOracle
-import io.casperlabs.casper.api.{BlockAPI}
-import io.casperlabs.casper.protocol.{DeployData, DeployServiceResponse, _}
+import io.casperlabs.casper.api.BlockAPI
+import io.casperlabs.casper.protocol._
 import io.casperlabs.catscontrib.TaskContrib._
-import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.comm.ServiceError.Unimplemented
-import io.casperlabs.ipc
+import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.node.api.Utils.toKey
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
-import java.lang.IllegalArgumentException
 import monix.eval.{Task, TaskLike}
 import monix.execution.Scheduler
 import monix.reactive.Observable
 
 object GrpcDeployService {
-  def toKey[F[_]](keyType: String, keyValue: String)(
-      implicit appErr: ApplicativeError[F, Throwable]
-  ): F[ipc.Key] = {
-    val keyBytes = ByteString.copyFrom(Base16.decode(keyValue))
-    keyType.toLowerCase match {
-      case "hash" =>
-        keyBytes.size match {
-          case 32 => ipc.Key(ipc.Key.KeyInstance.Hash(ipc.KeyHash(keyBytes))).pure[F]
-          case n =>
-            appErr.raiseError(
-              new IllegalArgumentException(
-                s"Key of type hash must have exactly 32 bytes, $n =/= 32 provided."
-              )
-            )
-        }
-      case "uref" =>
-        keyBytes.size match {
-          case 32 => ipc.Key(ipc.Key.KeyInstance.Uref(ipc.KeyURef(keyBytes))).pure[F]
-          case n =>
-            appErr.raiseError(
-              new IllegalArgumentException(
-                s"Key of type uref must have exactly 32 bytes, $n =/= 32 provided."
-              )
-            )
-        }
-      case "address" =>
-        keyBytes.size match {
-          case 32 => ipc.Key(ipc.Key.KeyInstance.Account(ipc.KeyAddress(keyBytes))).pure[F]
-          case n =>
-            appErr.raiseError(
-              new IllegalArgumentException(
-                s"Key of type address must have exactly 32 bytes, $n =/= 32 provided."
-              )
-            )
-        }
-      case _ =>
-        appErr.raiseError(
-          new IllegalArgumentException(
-            s"Key variant $keyType not valid. Must be one of hash, uref, address."
-          )
-        )
-    }
-  }
 
   def splitPath(path: String): Seq[String] =
     path.split("/").filter(_.nonEmpty)

--- a/node/src/main/scala/io/casperlabs/node/api/Servers.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Servers.scala
@@ -104,7 +104,7 @@ object Servers {
     ) *>
       Resource.liftF(Log[F].info(s"External gRPC services started on port ${port}."))
 
-  def httpServerR[F[_]: Log: NodeDiscovery: ConnectionsCell: Timer: ConcurrentEffect: MultiParentCasperRef: SafetyOracle: BlockStore: ContextShift: FinalizedBlocksStream](
+  def httpServerR[F[_]: Log: NodeDiscovery: ConnectionsCell: Timer: ConcurrentEffect: MultiParentCasperRef: SafetyOracle: BlockStore: ContextShift: FinalizedBlocksStream: ExecutionEngineService](
       port: Int,
       conf: Configuration,
       id: NodeIdentifier,

--- a/node/src/main/scala/io/casperlabs/node/api/Utils.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Utils.scala
@@ -1,0 +1,53 @@
+package io.casperlabs.node.api
+
+import cats.ApplicativeError
+import cats.syntax.applicative._
+import com.google.protobuf.ByteString
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.ipc
+
+object Utils {
+  def toKey[F[_]](keyType: String, keyValue: String)(
+      implicit appErr: ApplicativeError[F, Throwable]
+  ): F[ipc.Key] = {
+    val keyBytes = ByteString.copyFrom(Base16.decode(keyValue))
+    keyType.toLowerCase match {
+      case "hash" =>
+        keyBytes.size match {
+          case 32 => ipc.Key(ipc.Key.KeyInstance.Hash(ipc.KeyHash(keyBytes))).pure[F]
+          case n =>
+            appErr.raiseError(
+              new IllegalArgumentException(
+                s"Key of type hash must have exactly 32 bytes, $n =/= 32 provided."
+              )
+            )
+        }
+      case "uref" =>
+        keyBytes.size match {
+          case 32 => ipc.Key(ipc.Key.KeyInstance.Uref(ipc.KeyURef(keyBytes))).pure[F]
+          case n =>
+            appErr.raiseError(
+              new IllegalArgumentException(
+                s"Key of type uref must have exactly 32 bytes, $n =/= 32 provided."
+              )
+            )
+        }
+      case "address" =>
+        keyBytes.size match {
+          case 32 => ipc.Key(ipc.Key.KeyInstance.Account(ipc.KeyAddress(keyBytes))).pure[F]
+          case n =>
+            appErr.raiseError(
+              new IllegalArgumentException(
+                s"Key of type address must have exactly 32 bytes, $n =/= 32 provided."
+              )
+            )
+        }
+      case _ =>
+        appErr.raiseError(
+          new IllegalArgumentException(
+            s"Key variant $keyType not valid. Must be one of hash, uref, address."
+          )
+        )
+    }
+  }
+}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
@@ -15,6 +15,7 @@ import io.casperlabs.node.api.graphql.ProtocolState.Subscriptions
 import io.casperlabs.node.api.graphql.circe._
 import io.casperlabs.node.api.graphql.schema.GraphQLSchemaBuilder
 import io.casperlabs.shared.{Log, LogSource}
+import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.{Json, JsonObject}
@@ -39,7 +40,7 @@ object GraphQL {
   private implicit val logSource: LogSource = LogSource(getClass)
 
   /* Entry point */
-  def service[F[_]: ConcurrentEffect: ContextShift: Timer: Log: MultiParentCasperRef: SafetyOracle: BlockStore: FinalizedBlocksStream](
+  def service[F[_]: ConcurrentEffect: ContextShift: Timer: Log: MultiParentCasperRef: SafetyOracle: BlockStore: FinalizedBlocksStream: ExecutionEngineService](
       executionContext: ExecutionContext
   ): HttpRoutes[F] = {
     import io.casperlabs.node.api.graphql.RunToFuture.fromEffect

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
@@ -4,6 +4,8 @@ import cats.effect._
 import cats.effect.concurrent.Deferred
 import cats.effect.implicits._
 import cats.implicits._
+import fs2.concurrent.Queue
+import fs2.{Pipe, Stream}
 import io.casperlabs.blockstorage.BlockStore
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.SafetyOracle
@@ -16,8 +18,6 @@ import io.casperlabs.shared.{Log, LogSource}
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.{Json, JsonObject}
-import fs2._
-import fs2.concurrent.Queue
 import org.http4s.circe._
 import org.http4s.server.websocket.WebSocketBuilder
 import org.http4s.websocket.WebSocketFrame
@@ -42,6 +42,7 @@ object GraphQL {
   def service[F[_]: ConcurrentEffect: ContextShift: Timer: Log: MultiParentCasperRef: SafetyOracle: BlockStore: FinalizedBlocksStream](
       executionContext: ExecutionContext
   ): HttpRoutes[F] = {
+    import io.casperlabs.node.api.graphql.RunToFuture.fromEffect
     implicit val ec: ExecutionContext                            = executionContext
     implicit val fs2SubscriptionStream: Fs2SubscriptionStream[F] = new Fs2SubscriptionStream[F]()
     val schemaBuilder                                            = new GraphQLSchemaBuilder[F]

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
@@ -11,6 +11,7 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.node.api.graphql.GraphQLQuery._
 import io.casperlabs.node.api.graphql.ProtocolState.Subscriptions
 import io.casperlabs.node.api.graphql.circe._
+import io.casperlabs.node.api.graphql.schema.GraphQLSchemaBuilder
 import io.casperlabs.shared.{Log, LogSource}
 import io.circe.parser.parse
 import io.circe.syntax._

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/RunToFuture.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/RunToFuture.scala
@@ -1,0 +1,17 @@
+package io.casperlabs.node.api.graphql
+
+import cats.effect.Effect
+import cats.effect.implicits._
+import simulacrum.typeclass
+
+import scala.concurrent.Future
+
+@typeclass trait RunToFuture[F[_]] {
+  def unsafeToFuture[A](fa: F[A]): Future[A]
+}
+
+object RunToFuture {
+  implicit def fromEffect[F[_]: Effect]: RunToFuture[F] = new RunToFuture[F] {
+    override def unsafeToFuture[A](fa: F[A]): Future[A] = fa.toIO.unsafeToFuture()
+  }
+}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
@@ -1,0 +1,114 @@
+package io.casperlabs.node.api.graphql.schema
+
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
+import cats.effect.Effect
+import cats.effect.implicits._
+import cats.implicits._
+import io.casperlabs.blockstorage.BlockStore
+import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
+import io.casperlabs.casper.SafetyOracle
+import io.casperlabs.casper.api.BlockAPI
+import io.casperlabs.node.api.graphql.{FinalizedBlocksStream, Fs2SubscriptionStream}
+import io.casperlabs.shared.Log
+import sangria.schema._
+
+private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Effect: MultiParentCasperRef: SafetyOracle: BlockStore: FinalizedBlocksStream] {
+
+  // Not defining inputs yet because it's a read-only field
+  val DateType: ScalarType[Long] = ScalarType[Long](
+    "Date",
+    coerceUserInput = _ => ???,
+    coerceOutput =
+      (l, _) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(l), ZoneId.of("Z")).toString,
+    coerceInput = _ => ???
+  )
+
+  val requireFullBlockFields = Set("blockSizeBytes", "deployErrorCount", "deploys")
+
+  def hasAtLeastOne(projections: Vector[ProjectedName], fields: Set[String]): Boolean = {
+    def flatToSet(ps: Vector[ProjectedName], acc: Set[String]): Set[String] =
+      if (ps.isEmpty) {
+        acc
+      } else {
+        val h = ps.head
+        flatToSet(ps.tail, acc + h.name) ++ flatToSet(h.children, acc)
+      }
+
+    flatToSet(projections, Set.empty).intersect(fields).nonEmpty
+  }
+
+  def createSchema: Schema[Unit, Unit] =
+    Schema(
+      query = ObjectType(
+        "Query",
+        fields[Unit, Unit](
+          Field(
+            "block",
+            OptionType(blocks.types.BlockType),
+            arguments = blocks.arguments.BlockHashPrefix :: Nil,
+            resolve = Projector { (context, projections) =>
+              BlockAPI
+                .getBlockInfoOpt[F](
+                  blockHashBase16 = context.arg(blocks.arguments.BlockHashPrefix),
+                  full = hasAtLeastOne(projections, requireFullBlockFields)
+                )
+                .toIO
+                .unsafeToFuture()
+            }
+          ),
+          Field(
+            "dagSlice",
+            ListType(blocks.types.BlockType),
+            arguments = blocks.arguments.Depth :: blocks.arguments.MaxRank :: Nil,
+            resolve = Projector { (context, projections) =>
+              BlockAPI
+                .getBlockInfosMaybeWithBlocks[F](
+                  depth = context.arg(blocks.arguments.Depth),
+                  maxRank = context.arg(blocks.arguments.MaxRank),
+                  full = hasAtLeastOne(projections, requireFullBlockFields)
+                )
+                .toIO
+                .unsafeToFuture()
+            }
+          ),
+          Field(
+            "deploy",
+            OptionType(blocks.types.DeployInfoType),
+            arguments = blocks.arguments.DeployHash :: Nil,
+            resolve = c =>
+              BlockAPI.getDeployInfoOpt[F](c.arg(blocks.arguments.DeployHash)).toIO.unsafeToFuture()
+          )
+        )
+      ),
+      subscription = ObjectType(
+        "Subscription",
+        fields[Unit, Unit](
+          Field.subs(
+            "finalizedBlocks",
+            blocks.types.BlockType,
+            "Subscribes to new finalized blocks".some,
+            resolve = { c =>
+              // Projectors don't work with Subscriptions
+              val requireFullBlock = c.query.renderCompact
+                .split("[^a-zA-Z0-9]")
+                .collect {
+                  case s if s.trim.nonEmpty => s.trim
+                }
+                .toSet
+                .intersect(requireFullBlockFields)
+                .nonEmpty
+              FinalizedBlocksStream[F].subscribe.evalMap { blockHash =>
+                BlockAPI
+                  .getBlockInfoWithBlock[F](
+                    blockHash = blockHash,
+                    full = requireFullBlock
+                  )
+                  .map(Action(_))
+              }
+            }
+          )
+        )
+      ).some
+    )
+}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/arguments/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/arguments/package.scala
@@ -1,0 +1,34 @@
+package io.casperlabs.node.api.graphql.schema.blocks
+
+import sangria.schema._
+
+package object arguments {
+  val BlockHashPrefix =
+    Argument(
+      "blockHashBase16Prefix",
+      StringType,
+      description = "Prefix or full base-16 hash of a block"
+    )
+
+  val Depth =
+    Argument(
+      "depth",
+      IntType,
+      description = "How many of the top ranks of the DAG to show"
+    )
+
+  val MaxRank =
+    Argument(
+      "maxRank",
+      OptionInputType(LongType),
+      "The maximum rank to to go back from, 0 means go from the current tip of the DAG",
+      0L
+    )
+
+  val DeployHash =
+    Argument(
+      "deployHashBase16",
+      StringType,
+      description = "Base-16 hash of a deploy, must be 64 characters long"
+    )
+}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
@@ -1,33 +1,16 @@
-package io.casperlabs.node.api.graphql
+package io.casperlabs.node.api.graphql.schema.blocks
 
-import java.time.{Instant, ZoneId, ZonedDateTime}
-
-import cats.effect.Effect
-import cats.effect.implicits._
-import cats.implicits._
-import io.casperlabs.blockstorage.BlockStore
-import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
-import io.casperlabs.casper.SafetyOracle
-import io.casperlabs.casper.api.BlockAPI
-import io.casperlabs.casper.consensus.Block.ProcessedDeploy
+import cats.syntax.either._
+import cats.syntax.option._
+import io.casperlabs.casper.consensus.Block._
+import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
-import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
-import io.casperlabs.casper.consensus.{Approval, Block, Deploy, Signature}
+import io.casperlabs.casper.consensus.info._
 import io.casperlabs.crypto.codec.{Base16, Base64}
-import io.casperlabs.shared.Log
-import sangria.schema.{fields, _}
+import io.casperlabs.node.api.graphql.schema.utils.DateType
+import sangria.schema._
 
-private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Effect: MultiParentCasperRef: SafetyOracle: BlockStore: FinalizedBlocksStream] {
-
-  // Not defining inputs yet because it's a read-only field
-  val DateType: ScalarType[Long] = ScalarType[Long](
-    "Date",
-    coerceUserInput = _ => ???,
-    coerceOutput =
-      (l, _) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(l), ZoneId.of("Z")).toString,
-    coerceInput = _ => ???
-  )
-
+package object types {
   val SignatureType = ObjectType(
     "Signature",
     "Signature used to sign Block or Deploy",
@@ -284,120 +267,4 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ef
       )
     )
   )
-
-  val BlockHashPrefix =
-    Argument(
-      "blockHashBase16Prefix",
-      StringType,
-      description = "Prefix or full base-16 hash of a block"
-    )
-
-  val Depth =
-    Argument(
-      "depth",
-      IntType,
-      description = "How many of the top ranks of the DAG to show"
-    )
-
-  val MaxRank =
-    Argument(
-      "maxRank",
-      OptionInputType(LongType),
-      "The maximum rank to to go back from, 0 means go from the current tip of the DAG",
-      0L
-    )
-
-  val DeployHash =
-    Argument(
-      "deployHashBase16",
-      StringType,
-      description = "Base-16 hash of a deploy, must be 64 characters long"
-    )
-
-  val requireFullBlockFields = Set("blockSizeBytes", "deployErrorCount", "deploys")
-
-  def hasAtLeastOne(projections: Vector[ProjectedName], fields: Set[String]): Boolean = {
-    def flatToSet(ps: Vector[ProjectedName], acc: Set[String]): Set[String] =
-      if (ps.isEmpty) {
-        acc
-      } else {
-        val h = ps.head
-        flatToSet(ps.tail, acc + h.name) ++ flatToSet(h.children, acc)
-      }
-
-    flatToSet(projections, Set.empty).intersect(fields).nonEmpty
-  }
-
-  def createSchema: Schema[Unit, Unit] =
-    Schema(
-      query = ObjectType(
-        "Query",
-        fields[Unit, Unit](
-          Field(
-            "block",
-            OptionType(BlockType),
-            arguments = BlockHashPrefix :: Nil,
-            resolve = Projector { (context, projections) =>
-              BlockAPI
-                .getBlockInfoOpt[F](
-                  blockHashBase16 = context.arg(BlockHashPrefix),
-                  full = hasAtLeastOne(projections, requireFullBlockFields)
-                )
-                .toIO
-                .unsafeToFuture()
-            }
-          ),
-          Field(
-            "dagSlice",
-            ListType(BlockType),
-            arguments = Depth :: MaxRank :: Nil,
-            resolve = Projector { (context, projections) =>
-              BlockAPI
-                .getBlockInfosMaybeWithBlocks[F](
-                  depth = context.arg(Depth),
-                  maxRank = context.arg(MaxRank),
-                  full = hasAtLeastOne(projections, requireFullBlockFields)
-                )
-                .toIO
-                .unsafeToFuture()
-            }
-          ),
-          Field(
-            "deploy",
-            OptionType(DeployInfoType),
-            arguments = DeployHash :: Nil,
-            resolve = c => BlockAPI.getDeployInfoOpt[F](c.arg(DeployHash)).toIO.unsafeToFuture()
-          )
-        )
-      ),
-      subscription = ObjectType(
-        "Subscription",
-        fields[Unit, Unit](
-          Field.subs(
-            "finalizedBlocks",
-            BlockType,
-            "Subscribes to new finalized blocks".some,
-            resolve = { c =>
-              // Projectors don't work with Subscriptions
-              val requireFullBlock = c.query.renderCompact
-                .split("[^a-zA-Z0-9]")
-                .collect {
-                  case s if s.trim.nonEmpty => s.trim
-                }
-                .toSet
-                .intersect(requireFullBlockFields)
-                .nonEmpty
-              FinalizedBlocksStream[F].subscribe.evalMap { blockHash =>
-                BlockAPI
-                  .getBlockInfoWithBlock[F](
-                    blockHash = blockHash,
-                    full = requireFullBlock
-                  )
-                  .map(Action(_))
-              }
-            }
-          )
-        )
-      ).some
-    )
 }

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/arguments/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/arguments/package.scala
@@ -1,3 +1,74 @@
 package io.casperlabs.node.api.graphql.schema.globalstate
 
-package object arguments {}
+import cats.syntax.option._
+import sangria.marshalling.{CoercedScalaResultMarshaller, FromInput, ResultMarshaller}
+import sangria.schema._
+
+package object arguments {
+  val GlobalStateKeyType = EnumType(
+    "KeyType",
+    "Type of key used to query the global state".some,
+    List(
+      EnumValue(
+        "Hash",
+        value = "Hash"
+      ),
+      EnumValue(
+        "URef",
+        value = "URef"
+      ),
+      EnumValue(
+        "Address",
+        value = "Address"
+      )
+    )
+  )
+
+  val KeyType = Argument(
+    "keyType",
+    GlobalStateKeyType,
+    "Type of key used to query the global state"
+  )
+
+  val Key = Argument(
+    "keyBase16",
+    StringType,
+    "Base-16 encoded key"
+  )
+
+  case class StateQuery(keyType: String, key: String, pathSegments: Seq[String])
+
+  implicit val decoder = new FromInput[StateQuery] {
+    override val marshaller: ResultMarshaller = CoercedScalaResultMarshaller.default
+
+    override def fromResult(node: marshaller.Node): StateQuery = {
+      val ad = node.asInstanceOf[Map[String, Any]]
+      StateQuery(
+        ad("keyType").asInstanceOf[String],
+        ad("keyBase16").asInstanceOf[String],
+        ad("pathSegments").asInstanceOf[Seq[String]]
+      )
+    }
+  }
+
+  val StateQueryType: InputObjectType[StateQuery] = InputObjectType[StateQuery](
+    "StateQuery",
+    List(
+      InputField(
+        "keyType",
+        GlobalStateKeyType
+      ),
+      InputField(
+        "keyBase16",
+        StringType,
+        "Must be 32 bytes long"
+      ),
+      InputField(
+        "pathSegments",
+        ListInputType(StringType)
+      )
+    )
+  )
+
+  val StateQueryArgument = Argument("StateQueries", ListInputType(StateQueryType))
+}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/arguments/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/arguments/package.scala
@@ -1,0 +1,3 @@
+package io.casperlabs.node.api.graphql.schema.globalstate
+
+package object arguments {}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/types/package.scala
@@ -1,3 +1,288 @@
 package io.casperlabs.node.api.graphql.schema.globalstate
 
-package object types {}
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.ipc
+import sangria.schema._
+
+package object types {
+  // Everything defined as ObjectTypes because
+  // sangria doesn't support UnionTypes created from with ScalarTypes.
+
+  lazy val AccessRightsEnum: EnumType[ipc.KeyURef.AccessRights] =
+    EnumType[ipc.KeyURef.AccessRights](
+      "AccessRightsType",
+      values = List(
+        EnumValue(
+          "UNKNOWN",
+          value = ipc.KeyURef.AccessRights.UNKNOWN
+        ),
+        EnumValue(
+          "READ",
+          value = ipc.KeyURef.AccessRights.READ
+        ),
+        EnumValue(
+          "WRITE",
+          value = ipc.KeyURef.AccessRights.WRITE
+        ),
+        EnumValue(
+          "ADD",
+          value = ipc.KeyURef.AccessRights.ADD
+        ),
+        EnumValue(
+          "READ_ADD",
+          value = ipc.KeyURef.AccessRights.READ_ADD
+        ),
+        EnumValue(
+          "READ_WRITE",
+          value = ipc.KeyURef.AccessRights.READ_WRITE
+        ),
+        EnumValue(
+          "ADD_WRITE",
+          value = ipc.KeyURef.AccessRights.ADD_WRITE
+        ),
+        EnumValue(
+          "READ_ADD_WRITE",
+          value = ipc.KeyURef.AccessRights.READ_ADD_WRITE
+        )
+      )
+    )
+
+  lazy val KeyAddress =
+    ObjectType(
+      "KeyAddress",
+      fields[Unit, ipc.KeyAddress](
+        Field(
+          "value",
+          StringType,
+          resolve = c => Base16.encode(c.value.account.toByteArray)
+        )
+      )
+    )
+
+  lazy val KeyHash = ObjectType(
+    "KeyHash",
+    fields[Unit, ipc.KeyHash](
+      Field(
+        "value",
+        StringType,
+        resolve = c => Base16.encode(c.value.key.toByteArray)
+      )
+    )
+  )
+
+  lazy val KeyURef = ObjectType(
+    "KeyUref",
+    fields[Unit, ipc.KeyURef](
+      Field(
+        "uref",
+        StringType,
+        resolve = c => Base16.encode(c.value.uref.toByteArray)
+      ),
+      Field(
+        "accessRights",
+        AccessRightsEnum,
+        resolve = _.value.accessRights
+      )
+    )
+  )
+
+  lazy val KeyLocal = ObjectType(
+    "KeyLocal",
+    fields[Unit, ipc.KeyLocal](
+      Field(
+        "seed",
+        StringType,
+        resolve = c => Base16.encode(c.value.seed.toByteArray)
+      ),
+      Field(
+        "keyHash",
+        StringType,
+        resolve = c => Base16.encode(c.value.keyHash.toByteArray)
+      )
+    )
+  )
+
+  lazy val KeyUnion = UnionType(
+    "KeyUnion",
+    types = List(
+      KeyAddress,
+      KeyHash,
+      KeyURef,
+      KeyLocal
+    )
+  )
+
+  lazy val Key = ObjectType(
+    "Key",
+    fields[Unit, ipc.Key](
+      Field(
+        "value",
+        KeyUnion,
+        resolve = _.value.keyInstance match {
+          case ipc.Key.KeyInstance.Account(value) => value
+          case ipc.Key.KeyInstance.Hash(value)    => value
+          case ipc.Key.KeyInstance.Uref(value)    => value
+          case ipc.Key.KeyInstance.Local(value)   => value
+          case ipc.Key.KeyInstance.Empty          => ???
+        }
+      )
+    )
+  )
+
+  lazy val NamedKey = ObjectType(
+    "NamedKey",
+    fields[Unit, ipc.NamedKey](
+      Field("name", StringType, resolve = _.value.name),
+      Field("key", Key, resolve = _.value.key.get)
+    )
+  )
+
+  lazy val Contract = ObjectType(
+    "Contract",
+    fields[Unit, ipc.Contract](
+      Field("body", StringType, resolve = c => Base16.encode(c.value.body.toByteArray)),
+      Field("knownUrefs", ListType(NamedKey), resolve = _.value.knownUrefs),
+      Field("protocolVersion", LongType, resolve = _.value.protocolVersion.get.version)
+    )
+  )
+
+  lazy val AccountAssociatedKey = ObjectType(
+    "AccountAssociatedKey",
+    fields[Unit, ipc.Account.AssociatedKey](
+      Field(
+        "pubKey",
+        StringType,
+        resolve = c => Base16.encode(c.value.pubKey.toByteArray)
+      ),
+      Field("weight", IntType, resolve = _.value.weight)
+    )
+  )
+
+  lazy val AccountActionThresholds = ObjectType(
+    "AccountActionThresholds",
+    fields[Unit, ipc.Account.ActionThresholds](
+      Field("deploymentThreshold", IntType, resolve = _.value.deploymentThreshold),
+      Field("keyManagementThreshold", IntType, resolve = _.value.keyManagementThreshold)
+    )
+  )
+
+  lazy val AccountAccountActivity = ObjectType(
+    "AccountAccountActivity",
+    fields[Unit, ipc.Account.AccountActivity](
+      Field("keyManagementLastUsed", LongType, resolve = _.value.keyManagementLastUsed),
+      Field("deploymentLastUsed", LongType, resolve = _.value.deploymentLastUsed),
+      Field("inactivityPeriodLimit", LongType, resolve = _.value.inactivityPeriodLimit)
+    )
+  )
+
+  lazy val Account = ObjectType(
+    "Account",
+    fields[Unit, ipc.Account](
+      Field("pubKey", StringType, resolve = c => Base16.encode(c.value.pubKey.toByteArray)),
+      Field("nonce", LongType, resolve = _.value.nonce),
+      Field("knownUrefs", ListType(NamedKey), resolve = _.value.knownUrefs),
+      Field("associatedKeys", ListType(AccountAssociatedKey), resolve = _.value.associatedKeys),
+      Field("actionThreshold", AccountActionThresholds, resolve = _.value.actionThreshold.get),
+      Field("accountActivity", AccountAccountActivity, resolve = _.value.accountActivity.get)
+    )
+  )
+
+  lazy val ValueInt =
+    ObjectType(
+      "IntValue",
+      fields[Unit, ipc.Value.ValueInstance.Integer](
+        Field(
+          "value",
+          IntType,
+          resolve = _.value.value
+        )
+      )
+    )
+
+  lazy val ValueByteArray =
+    ObjectType(
+      "ByteString",
+      fields[Unit, ipc.Value.ValueInstance.ByteArr](
+        Field(
+          "value",
+          StringType,
+          resolve = c => Base16.encode(c.value.value.toByteArray)
+        )
+      )
+    )
+
+  lazy val IntList =
+    ObjectType(
+      "IntList",
+      fields[Unit, ipc.IntList](
+        Field("value", ListType(IntType), resolve = _.value.list)
+      )
+    )
+
+  lazy val ValueString =
+    ObjectType(
+      "StringValue",
+      fields[Unit, ipc.Value.ValueInstance.StringVal](
+        Field("value", StringType, resolve = _.value.value)
+      )
+    )
+
+  lazy val StringList =
+    ObjectType(
+      "StringList",
+      fields[Unit, ipc.StringList](
+        Field("value", ListType(StringType), resolve = _.value.list)
+      )
+    )
+
+  lazy val RustBigInt =
+    ObjectType(
+      "BigIntValue",
+      fields[Unit, ipc.RustBigInt](
+        Field("value", StringType, resolve = _.value.value),
+        Field("bitWidth", IntType, resolve = _.value.bitWidth)
+      )
+    )
+
+  lazy val UnitValue = ObjectType("Unit", fields[Unit, ipc.UnitValue]())
+
+  lazy val ValueUnion = UnionType(
+    "ValueUnion",
+    types = List(
+      ValueInt,
+      ValueByteArray,
+      IntList,
+      ValueString,
+      Account,
+      Contract,
+      StringList,
+      NamedKey,
+      RustBigInt,
+      Key
+    )
+  )
+
+  lazy val Value = ObjectType(
+    "Value",
+    fields[Unit, ipc.Value](
+      Field(
+        "value",
+        ValueUnion,
+        resolve = _.value.valueInstance match {
+          case ipc.Value.ValueInstance.Empty             => ???
+          case value: ipc.Value.ValueInstance.Integer    => value
+          case value: ipc.Value.ValueInstance.ByteArr    => value
+          case ipc.Value.ValueInstance.IntList(value)    => value
+          case value: ipc.Value.ValueInstance.StringVal  => value
+          case ipc.Value.ValueInstance.Account(value)    => value
+          case ipc.Value.ValueInstance.Contract(value)   => value
+          case ipc.Value.ValueInstance.StringList(value) => value
+          case ipc.Value.ValueInstance.NamedKey(value)   => value
+          case ipc.Value.ValueInstance.BigInt(value)     => value
+          case ipc.Value.ValueInstance.Key(value)        => value
+          case ipc.Value.ValueInstance.Unit(value)       => value
+        }
+      )
+    )
+  )
+}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/types/package.scala
@@ -1,0 +1,3 @@
+package io.casperlabs.node.api.graphql.schema.globalstate
+
+package object types {}

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/utils/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/utils/package.scala
@@ -1,0 +1,16 @@
+package io.casperlabs.node.api.graphql.schema
+
+import java.time.{Instant, ZoneId, ZonedDateTime}
+
+import sangria.schema.ScalarType
+
+package object utils {
+  // Not defining inputs yet because it's a read-only field
+  val DateType: ScalarType[Long] = ScalarType[Long](
+    "Date",
+    coerceUserInput = _ => ???,
+    coerceOutput =
+      (l, _) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(l), ZoneId.of("Z")).toString,
+    coerceInput = _ => ???
+  )
+}

--- a/node/src/test/scala/io/casperlabs/node/api/GrpcDeployServiceTest.scala
+++ b/node/src/test/scala/io/casperlabs/node/api/GrpcDeployServiceTest.scala
@@ -84,5 +84,5 @@ class GrpcCasperService extends FlatSpec with EitherValues with Matchers {
     Base16.encode(Array.fill(length)(util.Random.nextInt(256).toByte))
 
   private def attemptToKey(keyType: String, keyValue: String): Either[Throwable, ipc.Key] =
-    GrpcDeployService.toKey[Task](keyType, keyValue).attempt.runSyncUnsafe()
+    Utils.toKey[Task](keyType, keyValue).attempt.runSyncUnsafe()
 }


### PR DESCRIPTION
### Overview
Adds new query: `Query { globalState }`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-550

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
For testing, spin up the node, execute some contract to fill the global state, open the `http://<node hostname>:40403/graphql` in a browser and try running the next query substituting arguments (replacing `FIX ME` placeholders):

```graphql
query {
  globalState(
    blockHashBase16Prefix: "FIX ME"
    StateQueries: [
      { keyType: FIX ME, keyBase16: "FIX ME", pathSegments: ["FIX ME", "FIX ME"] }
      { keyType: FIX ME, keyBase16: "FIX ME", pathSegments: ["FIX ME", "FIX ME"] }
    ]
  ) {
    value {
      ... on IntValue {
        int: value
      }
      ... on ByteString {
        bytes: value
      }
      ... on IntList {
        ints: value
      }
      ... on StringValue {
        string: value
      }
      ... on Account {
        pubKey
        nonce
        knownUrefs {
          name
          key {
            ...AllKeyFields
          }
        }
      }
      ... on Contract {
        body
        knownUrefs {
          name
          key {
            ...AllKeyFields
          }
        }
        protocolVersion
      }
      ... on StringList {
        strings: value
      }
      ... on NamedKey {
        name
        key {
          ...AllKeyFields
        }
      }
      ... on BigIntValue {
        bigint: value
        bitWidth
      }
      ... on Key {
        ...AllKeyFields
      }
    }
  }
}

fragment AllKeyFields on Key {
  value {
    ... on KeyAddress {
      value
    }
    ... on KeyHash {
      value
    }
    ... on KeyUref {
      uref
      accessRights
    }
    ... on KeyLocal {
      seed
      keyHash
    }
  }
}
```