### PR TITLE
OP-297 Adding local folder volume for integration-testing folder.

### DIFF
--- a/integration-testing/Dockerfile
+++ b/integration-testing/Dockerfile
@@ -8,8 +8,8 @@ RUN python3 -m pip install pipenv docker pytest pytest-json pytest-mypy pytest-p
 ENTRYPOINT ["/root/integration-testing/run_tests.sh"]
 
 WORKDIR /root/integration-testing
+RUN mkdir -p /root/integration-testing
+COPY ./ /root/integration-testing/
 
-# We still need to copy this rather than volume,
-# because it is "behind" the location where we docker-compose.
 RUN mkdir -p /root/protobuf
 COPY ./protobuf/ /root/protobuf/

--- a/integration-testing/Dockerfile
+++ b/integration-testing/Dockerfile
@@ -2,19 +2,14 @@ FROM python:3.6.8-slim
 
 LABEL MAINTAINER="CasperLabs, LLC. <info@casperlabs.io>"
 
-USER root
 RUN apt-get update && apt-get -y install gcc
 RUN python3 -m pip install pipenv docker pytest pytest-json pytest-mypy pytest-pylint typing-extensions dataclasses grpcio grpcio_tools protobuf in-place ed25519 pyblake2
-
-# EXPOSE 50000-60000
 
 ENTRYPOINT ["/root/integration-testing/run_tests.sh"]
 
 WORKDIR /root/integration-testing
-RUN mkdir -p /root/integration-testing
-COPY ./ /root/integration-testing/
+
+# We still need to copy this rather than volume,
+# because it is "behind" the location where we docker-compose.
 RUN mkdir -p /root/protobuf
 COPY ./protobuf/ /root/protobuf/
-
-RUN cd /root/integration-testing/client/CasperClient && ./install.sh
-

--- a/integration-testing/docker-compose.yml.template
+++ b/integration-testing/docker-compose.yml.template
@@ -33,7 +33,6 @@ services:
     volumes:
       - /tmp:/tmp
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./:/root/integration-testing
     networks:
       - cl-||TAG||-0
       - cl-||TAG||-1

--- a/integration-testing/docker-compose.yml.template
+++ b/integration-testing/docker-compose.yml.template
@@ -33,6 +33,7 @@ services:
     volumes:
       - /tmp:/tmp
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./:/root/integration-testing
     networks:
       - cl-||TAG||-0
       - cl-||TAG||-1
@@ -47,3 +48,4 @@ services:
       - cl-||TAG||-10
     environment:
       - TAG_NAME=${TAG_NAME}
+      - TEST_RUN_ARGS=${TEST_RUN_ARGS}

--- a/integration-testing/docker_run_tests.sh
+++ b/integration-testing/docker_run_tests.sh
@@ -8,6 +8,8 @@ else
     export TAG_NAME="test"
 fi
 
+export TEST_RUN_ARGS=$@
+
 # We need networks for the Python Client to talk directly to the DockerNode.
 # We cannot share a network as we might have DockerNodes partitioned.
 # This number of networks is the count of CasperLabNodes we can have active at one time.

--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -8,7 +8,10 @@ if [[ -n $TAG_NAME ]] && [[ "$TAG_NAME" != "test" ]]; then
     PYTEST_ARGS="--maxfail=3"
 fi
 
+if [[ "$TEST_RUN_ARGS" == "" ]]; then
+    TEST_RUN_ARGS=$@
+fi
+
 pipenv sync
 pipenv run client/CasperClient/install.sh
-pipenv run py.test ${PYTEST_ARGS} -v "$@"
-pipenv run python3 ./docker_cleanup_assurance.py
+pipenv run py.test ${PYTEST_ARGS} -v "$TEST_RUN_ARGS"

--- a/integration-testing/test/cl_node/docker_node.py
+++ b/integration-testing/test/cl_node/docker_node.py
@@ -128,7 +128,9 @@ class DockerNode(LoggingDockerBase):
         java_options = os.environ.get('_JAVA_OPTIONS')
         if java_options is not None:
             env['_JAVA_OPTIONS'] = java_options
-
+        # Eliminate UPnP for docker, to not have delay
+        if self.is_in_docker:
+            env['CL_SERVER_NO_UPNP'] = 'true'
         self.deploy_dir = tempfile.mkdtemp(dir="/tmp", prefix='deploy_')
         self.create_resources_dir()
 


### PR DESCRIPTION
### Overview
Uses local integration-testing folder for docker image.
Allows test file argument to limit docker_run_tests.sh scope

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-297

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
