### PR TITLE
NO-TICKET: Always require --from field

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -10,7 +10,7 @@ final case class ConnectOptions(
 sealed trait Configuration
 
 final case class Deploy(
-    from: String,
+    from: Option[String],
     nonce: Long,
     sessionCode: File,
     paymentCode: File,
@@ -51,7 +51,7 @@ object Configuration {
     val conf = options.subcommand.map {
       case options.deploy =>
         Deploy(
-          options.deploy.from(),
+          options.deploy.from.toOption,
           options.deploy.nonce(),
           options.deploy.session(),
           options.deploy.payment(),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -51,7 +51,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val from = opt[String](
       descr = "Purse address that will be used to pay for the deployment.",
-      default = Option("00"),
       required = false
     )
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -52,7 +52,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val from = opt[String](
       descr = "Purse address that will be used to pay for the deployment.",
       default = Option("00"),
-      required = true
+      required = false
     )
 
     val gasLimit =

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -51,7 +51,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val from = opt[String](
       descr = "Purse address that will be used to pay for the deployment.",
-      default = Option("00")
+      default = Option("00"),
+      required = true
     )
 
     val gasLimit =

--- a/docker/README.md
+++ b/docker/README.md
@@ -104,6 +104,7 @@ To sign deploy you'll need to [generate and ed25519 keypair](/VALIDATOR.md#setti
 ```console
 ./client.sh node-0 deploy $PWD/../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
      --gas-price 1 \
+     --from='00000000000000000000000000000000'
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm \
      --public-key /keys/public.key \

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -1,6 +1,5 @@
 import os
 import logging
-from collections import defaultdict
 from typing import Callable, Dict, List
 
 import docker
@@ -37,7 +36,7 @@ class CasperLabsNetwork:
         self.docker_client = docker_client
         self.cl_nodes: List[CasperLabsNode] = []
         self._created_networks: List[str] = []
-        NonceRegistry.registry = defaultdict(lambda: 1)
+        NonceRegistry.reset()
 
     @property
     def node_count(self) -> int:

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -52,9 +52,9 @@ class DockerClient(CasperLabsClient):
                from_address: str = "3030303030303030303030303030303030303030303030303030303030303030",
                gas_limit: int = 1000000,
                gas_price: int = 1,
-               nonce: int = None,
-               session_contract: Optional[str] = 'test_helloname.wasm',
-               payment_contract: Optional[str] = 'test_helloname.wasm',
+               nonce: Optional[int] = None,
+               session_contract: str = 'test_helloname.wasm',
+               payment_contract: str = 'test_helloname.wasm',
                private_key: Optional[str] = None,
                public_key: Optional[str] = None) -> str:
 

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -58,7 +58,7 @@ class DockerClient(CasperLabsClient):
                private_key: Optional[str] = None,
                public_key: Optional[str] = None) -> str:
 
-        deploy_nonce = nonce if nonce is not None else NonceRegistry.registry[from_address]
+        deploy_nonce = nonce if nonce is not None else NonceRegistry.next(from_address)
 
         command = (f"deploy --from {from_address}"
                    f" --gas-limit {gas_limit}"
@@ -68,17 +68,15 @@ class DockerClient(CasperLabsClient):
 
         # For testing CLI: option will not be passed to CLI if nonce is ''
         if deploy_nonce != '':
-            command += f" --nonce {deploy_nonce}" 
+            command += f" --nonce {deploy_nonce}"
 
         if public_key and private_key:
             command += (f" --private-key=/data/{private_key}"
                         f" --public-key=/data/{public_key}")
 
         r = self.invoke_client(command)
-        if 'Success' in r and nonce is None:
-            NonceRegistry.registry[from_address] += 1
         return r
-        
+
 
     def show_block(self, block_hash: str) -> str:
         return self.invoke_client(f'show-block {block_hash}')

--- a/integration-testing/test/cl_node/docker_node.py
+++ b/integration-testing/test/cl_node/docker_node.py
@@ -124,7 +124,8 @@ class DockerNode(LoggingDockerBase):
         env = {
             'RUST_BACKTRACE': 'full',
             'CL_LOG_LEVEL': 'DEBUG',
-            'CL_CASPER_IGNORE_DEPLOY_SIGNATURE': 'true'
+            'CL_CASPER_IGNORE_DEPLOY_SIGNATURE': 'true',
+            'CL_SERVER_NO_UPNP': 'true'
         }
         java_options = os.environ.get('_JAVA_OPTIONS')
         if java_options is not None:

--- a/integration-testing/test/cl_node/nonce_registry.py
+++ b/integration-testing/test/cl_node/nonce_registry.py
@@ -1,4 +1,25 @@
+from collections import defaultdict
+import threading
 
 class NonceRegistry:
-    registry = None
+    _registry = None
+    _lock = threading.Lock()
+
+    @staticmethod
+    def reset():
+        NonceRegistry._registry = defaultdict(lambda: 1)
+
+    @staticmethod
+    def next(address):
+        if NonceRegistry._registry is None:
+            raise Exception("Registry is empty! Did you forget to call `reset()`?")
+        with NonceRegistry._lock:
+            nonce = NonceRegistry._registry[address]
+            # Alternatively there could be a `with_nonce` method that that accepts a
+            # lambda, passes the nonce to it, and only increases if it succeeds.
+            NonceRegistry._registry[address] = nonce + 1
+            return nonce
+
+
+
 

--- a/integration-testing/test/cl_node/python_client.py
+++ b/integration-testing/test/cl_node/python_client.py
@@ -29,7 +29,7 @@ class PythonClient(CasperLabsClient):
                session_contract: Optional[str] = 'test_helloname.wasm',
                payment_contract: Optional[str] = 'test_helloname.wasm') -> str:
 
-        deploy_nonce = nonce if nonce is not None else NonceRegistry.registry[from_address]
+        deploy_nonce = nonce if nonce is not None else NonceRegistry.next(from_address)
 
         resources_path = self.node.resources_folder
         session_contract_path = str(resources_path / session_contract)
@@ -40,8 +40,6 @@ class PythonClient(CasperLabsClient):
                      f'nonce={deploy_nonce})')
 
         r = self.client.deploy(from_address.encode('UTF-8'), gas_limit, gas_price, payment_contract, session_contract, deploy_nonce)
-        if nonce is None:
-            NonceRegistry.registry[from_address] += 1
         return r
 
     def propose(self) -> str:

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -212,17 +212,17 @@ class LastFinalisedHash(LogsContainMessage):
 
 
 class BlocksCountAtLeast:
-    def __init__(self, node: 'Node', blocks_count: int, max_retrieved_blocks: int) -> None:
+    def __init__(self, node: 'Node', blocks_count: int, depth: int) -> None:
         self.node = node
         self.blocks_count = blocks_count
-        self.max_retrieved_blocks = max_retrieved_blocks
+        self.depth = depth
 
     def __str__(self) -> str:
-        args = ', '.join(repr(a) for a in (self.node.name, self.blocks_count, self.max_retrieved_blocks))
+        args = ', '.join(repr(a) for a in (self.node.name, self.blocks_count, self.depth))
         return '<{}({})>'.format(self.__class__.__name__, args)
 
     def is_satisfied(self) -> bool:
-        actual_blocks_count = self.node.client.get_blocks_count(self.max_retrieved_blocks)
+        actual_blocks_count = self.node.client.get_blocks_count(self.depth)
         logging.info("THE ACTUAL BLOCKS COUNT: {}".format(actual_blocks_count))
         return actual_blocks_count >= self.blocks_count
 


### PR DESCRIPTION
### Overview
Our initial assumption that we first check if `--public-key` is defined and put it into a deploy as an `AccountPublicKey` was wrong  because the engine will return errors like:
```
"Key Account([0, 160, 11, 66, 69, 224, 116, 88, 144, 226, 209, 150, 19, 103, 180, 144, 168, 39, 168, 207, 234, 141, 215, 97, 102, 126, 223, 33, 85, 175, 149, 163]) not found.",
```

The `--from` option won't be removed in the future. In the future when we get support for multiple keys we'll still need an option to specify a special "context key". 

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._