### PR TITLE
NODE-567: Add more logging around the rank bug.

### DIFF
--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/util/TopologicalSortUtil.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/util/TopologicalSortUtil.scala
@@ -1,7 +1,9 @@
 package io.casperlabs.blockstorage.util
 
+import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.BlockStore.BlockHash
 import io.casperlabs.casper.consensus.Block
+import io.casperlabs.crypto.codec.Base16
 
 object TopologicalSortUtil {
   type BlockSort = Vector[Vector[BlockHash]]
@@ -14,7 +16,13 @@ object TopologicalSortUtil {
 
     //block numbers must be sequential, so a new block can only be
     //at a known height or 1 greater than a known height
-    assert(number <= sort.length)
+    if (number > sort.length) {
+      throw new java.lang.IllegalArgumentException(
+        s"Block ${hex(block.blockHash)} has rank ${number} " +
+          s"which is higher then the maximum expected height ${sort.length} at this DAG state. " +
+          s"Parents are [${block.getHeader.parentHashes.map(hex).mkString(", ")}]"
+      )
+    }
 
     number match {
       //this is a new block height
@@ -26,4 +34,6 @@ object TopologicalSortUtil {
         sort.updated(number, curr :+ hash)
     }
   }
+
+  private def hex(hash: ByteString) = Base16.encode(hash.toByteArray)
 }


### PR DESCRIPTION
### Overview
This test sometimes fails on Drone but I can't reproduce it. The PR just adds more context information.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-567

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
