### PR TITLE
EE-365: remove correlation_id from time series data

### DIFF
--- a/execution-engine/shared/src/logging/mod.rs
+++ b/execution-engine/shared/src/logging/mod.rs
@@ -149,12 +149,8 @@ pub fn log_metric(
 
     // https://prometheus.io/docs/instrumenting/exposition_formats/
     let tsd_metric = format!(
-        "{}{{tag=\"{}\", correlation_id=\"{}\"}} {} {:?}",
-        metric,
-        tag,
-        correlation_id.to_string(),
-        metric_value,
-        milliseconds_since_epoch
+        "{}{{tag=\"{}\"}} {} {:?}",
+        metric, tag, metric_value, milliseconds_since_epoch
     );
 
     properties.insert("correlation_id".to_string(), correlation_id.to_string());


### PR DESCRIPTION
correlation_id was originally included in time series data (tsd) string sent to prometheus to tie metrics generated by single source together.

the correlation_id is stored in properties and is usable for other purposes, but should not be included in the tsd as it results in overly granular visualization / scatter in prometheus and is counter to guidance in the prometheus docu. 

https://casperlabs.atlassian.net/browse/EE-365

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

discussed this with @aakoshh 
