### PR TITLE
FIX: Newly joined node test

### DIFF
--- a/integration-testing/client/CasperClient/.gitignore
+++ b/integration-testing/client/CasperClient/.gitignore
@@ -1,0 +1,7 @@
+*_pb2.py
+*_pb2_grpc.py
+build
+dist
+casper_client/proto
+report.json
+*.egg-info


### PR DESCRIPTION
### Overview
I think this test failed sometimes on Drone because it captured the gossip count too early:
```

test-DRONE-451 \| =================================== FAILURES =================================== | 1270s
-- | --
6407 | test-DRONE-451 \| _______________ test_newly_joined_node_should_not_gossip_blocks ________________ | 1270s
...
6436 | test-DRONE-451 \| wait_for_gossip_metrics_and_assert_blocks_gossiped(node2, node2.timeout, 0) | 1270s
6437 | test-DRONE-451 \| > assert node0_new_blocks_requests_total == get_new_blocks_requests_total(node0) | 1270s
6438 | test-DRONE-451 \| E assert 1 == 2
```

Changed the test, up to 2 is fine, 3 would be a fail.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
