### PR TITLE
NODE-541: Fix exponential backoff and other test timings.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -27,7 +27,7 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
 
   behavior of "AutoProposer"
 
-  val waitForCheck = Timer[Task].sleep(5 * DefaultCheckInterval)
+  val waitForCheck = Timer[Task].sleep(10 * DefaultCheckInterval)
 
   it should "propose if more than max-count deploys are accumulated within max-interval" in TestFixture(
     maxInterval = 5.seconds,
@@ -126,7 +126,7 @@ object AutoProposerTest {
     def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
   }
 
-  val DefaultCheckInterval = 10.millis
+  val DefaultCheckInterval = 25.millis
 
   object TestFixture {
     def apply(

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/PeerTableConcurrencySuite.scala
@@ -64,7 +64,7 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
         bucket    <- peerTable.tableRef.get.map(_(distance).map(_.node))
       } yield bucket
 
-      addNodesParallel.runSyncUnsafe() should contain theSameElementsAs unique
+      addNodesParallel.runSyncUnsafe(5.seconds) should contain theSameElementsAs unique
       pingCounter shouldBe 0
     }
   }
@@ -86,11 +86,10 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
       fillBucket.runSyncUnsafe()
       hangUp.runAsyncAndForget
 
-      Task
-        .race(Task.sleep(1.second), peerTable.peersAscendingDistance)
-        .runSyncUnsafe()
-        .right
-        .get should contain theSameElementsAs initial
+      val peers = peerTable.peersAscendingDistance
+        .runSyncUnsafe(5.seconds)
+
+      peers should contain theSameElementsAs initial
     }
   }
 
@@ -115,7 +114,7 @@ class PeerTableConcurrencySuite extends PropSpec with GeneratorDrivenPropertyChe
         peers     <- peerTable.peersAscendingDistance
       } yield peers
 
-      addNodesParallel.runSyncUnsafe() should contain theSameElementsAs initial
+      addNodesParallel.runSyncUnsafe(15.seconds) should contain theSameElementsAs initial
       pingsCounter.get() shouldBe restReplicated.size
     }
   }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -414,22 +414,22 @@ class DownloadManagerSpec
             for {
               w <- manager
                     .scheduleDownload(summaryOf(block), source, false)
-              _ <- Task.sleep(500.milliseconds)
+              _ <- Task.sleep(200.millis)
               _ <- Task {
                     log.warns should have size 1
                     log.warns.last should include("attempt: 1")
                   }
-              _ <- Task.sleep(1.second)
+              _ <- Task.sleep(1800.millis)
               _ <- Task {
                     log.warns should have size 2
                     log.warns.last should include("attempt: 2")
                   }
-              _ <- Task.sleep(2.seconds)
+              _ <- Task.sleep(3000.millis)
               _ <- Task {
                     log.warns should have size 3
                     log.warns.last should include("attempt: 3")
                   }
-              _ <- Task.sleep(5.seconds)
+              _ <- Task.sleep(4000.millis)
               _ <- Task {
                     log.warns should have size 3
                     log.warns.last should include("attempt: 3")

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -98,7 +98,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
       ) { approver =>
         for {
           r0 <- approver.getCandidate
-          _  <- Task.sleep(200.millis)
+          _  <- Task.sleep(500.millis)
           r1 <- approver.getCandidate
         } yield {
           r0.isLeft shouldBe true

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -54,7 +54,7 @@ class InitialSynchronizationSpec
         ) { (initialSynchronizer, _) =>
           for {
             w <- initialSynchronizer.sync()
-            _ <- w.timeout(250.millis)
+            _ <- w.timeout(1.second)
           } yield {
             counter.get() shouldBe 2
           }


### PR DESCRIPTION
### Overview
This test failed at least once in CI due to timing.

I added 3 others from https://drone-auto.casperlabs.io/CasperLabs/CasperLabs/511/1/4

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-541

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
