### PR TITLE
STOR-94: In-memory block cache

### DIFF
--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockDagFileStorage.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockDagFileStorage.scala
@@ -824,15 +824,15 @@ object BlockDagFileStorage {
     )
 
   def apply[F[_]: Concurrent: Log: RaiseIOError: Metrics](
-      dataDir: Path,
       dagStoragePath: Path,
+      latestMessagesLogMaxSizeFactor: Int,
       blockStore: BlockStore[F]
   ): Resource[F, BlockDagStorage[F]] =
     Resource.make {
       for {
-        _         <- fileIO.makeDirectory(dagStoragePath)
-        dagConfig = BlockDagFileStorage.Config(dagStoragePath)
-        storage <- BlockDagFileStorage.create(dagConfig)(
+        _      <- fileIO.makeDirectory(dagStoragePath)
+        config = Config(dagStoragePath, latestMessagesLogMaxSizeFactor)
+        storage <- BlockDagFileStorage.create(config)(
                     Concurrent[F],
                     Log[F],
                     blockStore,

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/BlockStore.scala
@@ -81,12 +81,12 @@ object BlockStore {
       incAndMeasure("put", super.put(blockHash, blockMsgWithTransform))
 
     abstract override def checkpoint(): F[Unit] =
-      super.checkpoint().timer("checkpoint-time")
+      incAndMeasure("checkpoint", super.checkpoint())
 
     abstract override def contains(
         blockHash: BlockHash
     )(implicit applicativeF: Applicative[F]): F[Boolean] =
-      super.contains(blockHash).timer("contains-time")
+      incAndMeasure("contains", super.contains(blockHash))
   }
 
   implicit class RichBlockStore[F[_]](blockStore: BlockStore[F]) {

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/CachingBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/CachingBlockStore.scala
@@ -3,15 +3,15 @@ package io.casperlabs.blockstorage
 import cats._
 import cats.effect._
 import cats.implicits._
+import cats.data.OptionT
 import com.google.protobuf.ByteString
 import com.google.common.cache.{Cache, CacheBuilder, Weigher}
 import io.casperlabs.blockstorage.BlockStore.{BlockHash, MeteredBlockStore}
 import io.casperlabs.casper.protocol.ApprovedBlock
-import io.casperlabs.casper.consensus.{Block, BlockSummary}
-import io.casperlabs.ipc.TransformEntry
+import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.metrics.{Metered, Metrics}
-import io.casperlabs.metrics.implicits._
 import io.casperlabs.storage.BlockMsgWithTransform
+import scala.collection.JavaConverters._
 
 /** Caches recently created blocks so queries that need the full body
   * (e.g. ones that return a deploy, or ones that want block statistics)
@@ -22,24 +22,24 @@ class CachingBlockStore[F[_]: Sync](
     cache: Cache[BlockHash, BlockMsgWithTransform]
 ) extends BlockStore[F] {
 
+  private def cacheOrUnderlying[A](fromCache: => Option[A], fromUnderlying: F[Option[A]]) =
+    OptionT(Sync[F].delay(fromCache)).orElseF(fromUnderlying).value
+
   override def get(blockHash: BlockHash): F[Option[BlockMsgWithTransform]] =
-    Sync[F].delay {
-      Option(cache.getIfPresent(blockHash))
-    } flatMap {
-      _.fold(underlying.get(blockHash))(_.some.pure[F])
-    }
+    cacheOrUnderlying(Option(cache.getIfPresent(blockHash)), underlying.get(blockHash))
 
   override def findBlockHash(p: BlockHash => Boolean): F[Option[BlockHash]] =
-    underlying.findBlockHash(p)
+    cacheOrUnderlying(cache.asMap.keySet.asScala.find(p), underlying.findBlockHash(p))
 
   override def put(blockHash: BlockHash, blockMsgWithTransform: BlockMsgWithTransform): F[Unit] =
-    Sync[F].delay {
-      cache.put(blockHash, blockMsgWithTransform)
-    } *>
+    Sync[F]
+      .delay(cache.put(blockHash, blockMsgWithTransform)) *>
       underlying.put(blockHash, blockMsgWithTransform)
 
   override def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
-    underlying.contains(blockHash)
+    Sync[F]
+      .delay(cache.asMap.keySet.contains(blockHash))
+      .ifM(true.pure[F], underlying.contains(blockHash))
 
   override def getApprovedBlock(): F[Option[ApprovedBlock]] =
     underlying.getApprovedBlock()
@@ -48,7 +48,12 @@ class CachingBlockStore[F[_]: Sync](
     underlying.putApprovedBlock(block)
 
   override def getBlockSummary(blockHash: BlockHash): F[Option[BlockSummary]] =
-    underlying.getBlockSummary(blockHash)
+    cacheOrUnderlying(
+      Option(cache.getIfPresent(blockHash)).map(_.getBlockMessage).map { x =>
+        BlockSummary(x.blockHash, x.header, x.signature)
+      },
+      underlying.getBlockSummary(blockHash)
+    )
 
   override def findBlockHashesWithDeployhash(deployHash: ByteString): F[Seq[BlockHash]] =
     underlying.findBlockHashesWithDeployhash(deployHash)

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/CachingBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/CachingBlockStore.scala
@@ -83,7 +83,7 @@ object CachingBlockStore {
                   .maximumWeight(maxSizeBytes)
                   .weigher(new Weigher[BlockHash, BlockMsgWithTransform] {
                     def weigh(key: BlockHash, value: BlockMsgWithTransform): Int =
-                      value.toByteArray.length
+                      value.serializedSize
                   })
                   .build[BlockHash, BlockMsgWithTransform]()
               }

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/CachingBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/CachingBlockStore.scala
@@ -1,0 +1,96 @@
+package io.casperlabs.blockstorage
+
+import cats._
+import cats.effect._
+import cats.implicits._
+import com.google.protobuf.ByteString
+import com.google.common.cache.{Cache, CacheBuilder, Weigher}
+import io.casperlabs.blockstorage.BlockStore.{BlockHash, MeteredBlockStore}
+import io.casperlabs.casper.protocol.ApprovedBlock
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.ipc.TransformEntry
+import io.casperlabs.metrics.{Metered, Metrics}
+import io.casperlabs.metrics.implicits._
+import io.casperlabs.storage.BlockMsgWithTransform
+
+/** Caches recently created blocks so queries that need the full body
+  * (e.g. ones that return a deploy, or ones that want block statistics)
+  * don't have to hit the disk based storage. It is assumed that users
+  * will mostly be interested in the front of the DAG. */
+class CachingBlockStore[F[_]: Sync](
+    underlying: BlockStore[F],
+    cache: Cache[BlockHash, BlockMsgWithTransform]
+) extends BlockStore[F] {
+
+  override def get(blockHash: BlockHash): F[Option[BlockMsgWithTransform]] =
+    Sync[F].delay {
+      Option(cache.getIfPresent(blockHash))
+    } flatMap {
+      _.fold(underlying.get(blockHash))(_.some.pure[F])
+    }
+
+  override def findBlockHash(p: BlockHash => Boolean): F[Option[BlockHash]] =
+    underlying.findBlockHash(p)
+
+  override def put(blockHash: BlockHash, blockMsgWithTransform: BlockMsgWithTransform): F[Unit] =
+    Sync[F].delay {
+      cache.put(blockHash, blockMsgWithTransform)
+    } *>
+      underlying.put(blockHash, blockMsgWithTransform)
+
+  override def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =
+    underlying.contains(blockHash)
+
+  override def getApprovedBlock(): F[Option[ApprovedBlock]] =
+    underlying.getApprovedBlock()
+
+  override def putApprovedBlock(block: ApprovedBlock): F[Unit] =
+    underlying.putApprovedBlock(block)
+
+  override def getBlockSummary(blockHash: BlockHash): F[Option[BlockSummary]] =
+    underlying.getBlockSummary(blockHash)
+
+  override def findBlockHashesWithDeployhash(deployHash: ByteString): F[Seq[BlockHash]] =
+    underlying.findBlockHashesWithDeployhash(deployHash)
+
+  override def checkpoint(): F[Unit] =
+    underlying.checkpoint()
+
+  override def clear(): F[Unit] =
+    Sync[F].delay(cache.invalidateAll()) *>
+      underlying.clear()
+
+  override def close(): F[Unit] =
+    underlying.close()
+}
+
+object CachingBlockStore {
+  def apply[F[_]: Sync: Metrics](
+      underlying: BlockStore[F],
+      maxSizeBytes: Long,
+      name: String = "cache"
+  ): F[BlockStore[F]] = {
+    val metricsF = Metrics[F]
+    for {
+      cache <- Sync[F].delay {
+                CacheBuilder
+                  .newBuilder()
+                  .maximumWeight(maxSizeBytes)
+                  .weigher(new Weigher[BlockHash, BlockMsgWithTransform] {
+                    def weigh(key: BlockHash, value: BlockMsgWithTransform): Int =
+                      value.toByteArray.length
+                  })
+                  .build[BlockHash, BlockMsgWithTransform]()
+              }
+      store = new CachingBlockStore[F](
+        underlying,
+        cache
+      ) with MeteredBlockStore[F] {
+        override implicit val m: Metrics[F] = metricsF
+        override implicit val ms: Metrics.Source =
+          Metrics.Source(BlockStorageMetricsSource, name)
+        override implicit val a: Apply[F] = Sync[F]
+      }
+    } yield store
+  }
+}

--- a/block-storage/src/main/scala/io/casperlabs/blockstorage/InMemBlockStore.scala
+++ b/block-storage/src/main/scala/io/casperlabs/blockstorage/InMemBlockStore.scala
@@ -86,4 +86,11 @@ object InMemBlockStore {
   ): F[Ref[F, Map[BlockHash, V]]] =
     Ref[F].of(Map.empty[BlockHash, V])
 
+  def empty[F[_]: Sync: Metrics] =
+    for {
+      blockMapRef      <- Ref[F].of(Map.empty[BlockHash, (BlockMsgWithTransform, BlockSummary)])
+      deployMapRef     <- Ref[F].of(Map.empty[DeployHash, Seq[BlockHash]])
+      approvedBlockRef <- Ref.of[F, Option[ApprovedBlock]](None)
+      store            = create[F](Sync[F], blockMapRef, deployMapRef, approvedBlockRef, Metrics[F])
+    } yield store
 }

--- a/block-storage/src/test/scala/io/casperlabs/blockstorage/CachingBlockStoreTest.scala
+++ b/block-storage/src/test/scala/io/casperlabs/blockstorage/CachingBlockStoreTest.scala
@@ -1,0 +1,171 @@
+package io.casperlabs.blockstorage
+
+import cats._
+import cats.effect._
+import cats.effect.concurrent._
+import cats.implicits._
+import com.google.protobuf.ByteString
+import monix.eval.Task
+import monix.execution.Scheduler
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.storage.BlockMsgWithTransform
+import org.scalatest._
+import scala.concurrent.duration._
+
+class CachingBlockStoreTest extends WordSpecLike with Matchers {
+  import BlockStore.BlockHash
+  import CachingBlockStoreTest.TestFixture
+
+  val sampleBlock = blockImplicits.blockMsgWithTransformGen.sample.get
+
+  def verifyCached[A](
+      name: String,
+      expected: A
+  )(
+      get: BlockStore[Task] => BlockHash => Task[A]
+  ) = {
+    // Store it through cache
+    TestFixture() { x =>
+      for {
+        _        <- x.cache.put(sampleBlock)
+        thing    <- get(x.cache)(sampleBlock.getBlockMessage.blockHash)
+        _        = thing shouldBe expected
+        counters <- x.metrics.counterRef.get
+        _        = counters(name) shouldBe 1
+      } yield ()
+    }
+    // Store it through underlying
+    TestFixture() { x =>
+      for {
+        _        <- x.underlying.put(sampleBlock)
+        thing    <- get(x.cache)(sampleBlock.getBlockMessage.blockHash)
+        _        = thing shouldBe expected
+        counters <- x.metrics.counterRef.get
+        _        = counters(name) shouldBe 2
+      } yield ()
+    }
+  }
+
+  "CachingBlockStore" when {
+    "a block is not in the cache" should {
+      "get it from the underlying store and not cache it" in {
+        TestFixture() { x =>
+          for {
+            _        <- x.underlying.put(sampleBlock)
+            block    <- x.cache.get(sampleBlock.getBlockMessage.blockHash)
+            _        = block shouldBe Some(sampleBlock)
+            _        <- x.cache.get(sampleBlock.getBlockMessage.blockHash)
+            counters <- x.metrics.counterRef.get
+            _        = counters("get") shouldBe (2 + 2)
+          } yield ()
+        }
+      }
+    }
+
+    "a block is added to the store" should {
+      "cache it" in {
+        TestFixture() { x =>
+          for {
+            _        <- x.cache.put(sampleBlock)
+            blockC   <- x.cache.get(sampleBlock.getBlockMessage.blockHash)
+            _        = blockC shouldBe Some(sampleBlock)
+            counters <- x.metrics.counterRef.get
+            _        = counters("put") shouldBe 2
+            _        = counters("get") shouldBe 1
+            blockU   <- x.cache.get(sampleBlock.getBlockMessage.blockHash)
+            _        = blockU shouldBe Some(sampleBlock)
+          } yield ()
+        }
+      }
+
+      "evict older items" in {
+        val otherBlocks = List.range(0, 100) map { i =>
+          sampleBlock.withBlockMessage(
+            sampleBlock.getBlockMessage.copy(
+              blockHash = ByteString.copyFromUtf8(i.toString)
+            )
+          )
+        }
+        TestFixture(
+          maxSizeBytes = sampleBlock.toByteArray.length.toLong * 10
+        ) { x =>
+          for {
+            _        <- x.cache.put(sampleBlock)
+            _        <- x.cache.get(sampleBlock.getBlockMessage.blockHash)
+            _        <- otherBlocks.traverse(x.cache.put(_))
+            _        <- x.cache.get(sampleBlock.getBlockMessage.blockHash)
+            _        <- x.cache.get(otherBlocks.last.getBlockMessage.blockHash)
+            counters <- x.metrics.counterRef.get
+            _        = counters("get") shouldBe (1 + 2 + 1)
+          } yield ()
+        }
+      }
+    }
+  }
+
+  "CachingBlockStore" should {
+    "cache `contains`" in {
+      verifyCached("contains", true) { store =>
+        store.contains(_)
+      }
+    }
+    "cache `findBlockHash`" in {
+      verifyCached("findBlockHash", Option(sampleBlock.getBlockMessage.blockHash)) {
+        store => hash =>
+          store.findBlockHash(_ == hash)
+      }
+    }
+    "cache `getBlockSummary`" in {
+      val summary = BlockSummary(
+        sampleBlock.getBlockMessage.blockHash,
+        sampleBlock.getBlockMessage.header,
+        sampleBlock.getBlockMessage.signature
+      )
+      verifyCached("getBlockSummary", Option(summary)) { store =>
+        store.getBlockSummary(_)
+      }
+    }
+  }
+}
+
+object CachingBlockStoreTest {
+  import BlockStore.BlockHash
+  import Scheduler.Implicits.global
+
+  // Using the metrics added by MeteredBlockStore
+  class MockMetrics() extends Metrics.MetricsNOP[Task] {
+    val counterRef = Ref.unsafe[Task, Map[String, Long]](Map.empty)
+
+    override def incrementCounter(name: String, delta: Long = 1)(
+        implicit ev: Metrics.Source
+    ): Task[Unit] =
+      counterRef.update {
+        _ |+| Map(name -> delta)
+      }
+  }
+
+  case class TestFixture(
+      underlying: BlockStore[Task],
+      cache: BlockStore[Task],
+      metrics: MockMetrics
+  )
+
+  object TestFixture {
+    def apply(
+        maxSizeBytes: Long = Long.MaxValue
+    )(f: TestFixture => Task[Unit]): Unit = {
+      implicit val metrics = new MockMetrics()
+
+      val test = {
+        for {
+          underlying <- InMemBlockStore.empty[Task]
+          cache      <- CachingBlockStore[Task](underlying, maxSizeBytes)
+          _          <- f(TestFixture(underlying, cache, metrics))
+        } yield ()
+      }
+
+      test.runSyncUnsafe(5.seconds)
+    }
+  }
+}

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -247,7 +247,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
         relayFactor = 5
       ) { approver =>
         for {
-          _ <- Task.sleep(50.millis)
+          _ <- Task.sleep(500.millis)
           r <- approver.getCandidate
         } yield {
           r.isRight shouldBe true

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -129,6 +129,8 @@ use-tls = false
 # Size factor for squashing block storage latest messages.
 latest-messages-log-max-size-factor = 10
 
+# Maximum size of the in-memory block cache in bytes.
+cache-max-size-bytes = 262144000
 
 # io.casperlabs.node.configuration.Configuration.GrpcServer
 [grpc]

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -31,7 +31,7 @@ final case class Configuration(
     tls: Tls,
     casper: CasperConf,
     lmdb: LMDBBlockStore.Config,
-    blockstorage: BlockDagFileStorage.Config,
+    blockstorage: Configuration.BlockStorage,
     metrics: Configuration.Kamon,
     influx: Option[Configuration.Influx]
 )
@@ -89,6 +89,11 @@ object Configuration extends ParserImplicits {
       relayMaxParallelBlocks: Int,
       relayBlockChunkConsumerTimeout: FiniteDuration,
       cleanBlockStorage: Boolean
+  ) extends SubConfig
+
+  case class BlockStorage(
+      latestMessagesLogMaxSizeFactor: Int,
+      cacheMaxSizeBytes: Long
   ) extends SubConfig
 
   case class GrpcServer(

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -488,6 +488,10 @@ private[configuration] final case class Options private (
       gen[Int]("Size factor for squashing block storage latest messages.")
 
     @scallop
+    val blockstorageCacheMaxSizeBytes =
+      gen[Long]("Maximum size of the in-memory block cache in bytes.")
+
+    @scallop
     val casperValidatorPublicKey =
       gen[String](
         "base-64 or PEM encoding of the public key to use for signing a proposed blocks. " +

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -82,6 +82,7 @@ auto-propose-max-count = 1
 
 [blockstorage]
 latest-messages-log-max-size-factor = 1
+cache-max-size-bytes = 1
 
 [metrics]
 prometheus = false

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -127,9 +127,9 @@ class ConfigurationSpec
       maxReaders = 1,
       useTls = false
     )
-    val blockStorage = BlockDagFileStorage.Config(
+    val blockStorage = Configuration.BlockStorage(
       latestMessagesLogMaxSizeFactor = 1,
-      dir = Paths.get("/tmp/block-dag-file-storage")
+      cacheMaxSizeBytes = 1
     )
     val kamonSettings = Configuration.Kamon(
       prometheus = false,


### PR DESCRIPTION
### Overview
Adds a cache that holds on to a fixed size (by default 250MB) of recently added blocks so that methods that need the block body don't have to read it back from file, locking the block store. Methods like that include the ones that show a block with statistics, and ones which list deploys, or one specific deploy.

Also adds `MeteredBlockStore` metrics to the `FileLMDBIndexBlockStore`, they were missing for some reason. The `CachedBlockStore` will have its own similar metrics, so that we can calculate cache miss by comparing the number of `get` ops in the cache vs the underlying store.


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/STOR-94

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

