### PR TITLE
OP-321: Add integration test for queryState error handling

### DIFF
--- a/integration-testing/test/cl_node/client_base.py
+++ b/integration-testing/test/cl_node/client_base.py
@@ -30,3 +30,7 @@ class CasperLabsClient(ABC):
     @abstractmethod
     def show_blocks(self, depth: int):
         pass
+
+    @abstractmethod
+    def queryState(self, blockHash: str, key: str, path: str, keyType: str):
+        pass

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -29,22 +29,27 @@ class DockerClient(CasperLabsClient):
                 'mode': 'ro'
             }
         }
-        try:
-            command = f'--host {self.node.container_name} {command}'
-            logging.info(f"COMMAND {command}")
-            output = self.docker_client.containers.run(
-                image=f"casperlabs/client:{self.node.docker_tag}",
-                auto_remove=True,
-                name=f"client-{self.node.config.number}-{random_string(5)}",
-                command=command,
-                network=self.node.network,
-                volumes=volumes,
-            ).decode('utf-8')
-            logging.debug(f"OUTPUT {self.node.container_name} {output}")
-            return output
-        except ContainerError as err:
-            logging.warning(f"EXITED code={err.exit_status} command='{err.command}' stderr='{err.stderr}'")
-            raise NonZeroExitCodeError(command=(command, err.exit_status), exit_code=err.exit_status, output=err.stderr)
+        command = f'--host {self.node.container_name} {command}'
+        logging.info(f"COMMAND {command}")
+        container = self.docker_client.containers.run(
+            image = f"casperlabs/client:{self.node.docker_tag}",
+            name = f"client-{self.node.config.number}-{random_string(5)}",
+            command = command,
+            network = self.node.network,
+            volumes = volumes,
+            detach = True,
+            stderr = True,
+            stdout = True,
+        )
+        r = container.wait()
+        error, status_code = r['Error'], r['StatusCode']
+        stdout = container.logs(stdout=True, stderr=False).decode('utf-8')
+        stderr = container.logs(stdout=False, stderr=True).decode('utf-8')
+        logging.info(f"EXITED exit_code: {status_code} STDERR: {stderr} STDOUT: {stdout}")
+        if status_code: 
+            logging.warning(f"EXITED code={status_code} command='{command}' stderr='{stderr}'")
+            raise NonZeroExitCodeError(command=(command, status_code), exit_code=status_code, output=stderr)
+        return stdout
 
     def propose(self) -> str:
         return self.invoke_client('propose')
@@ -109,3 +114,21 @@ class DockerClient(CasperLabsClient):
     def vdag(self, depth: int, show_justification_lines: bool = False) -> str:
         just_text = '--show-justification-lines' if show_justification_lines else ''
         return self.invoke_client(f'vdag --depth {depth} {just_text}')
+
+    def queryState(self, blockHash: str, key: str, path: str, keyType: str):
+        """
+        Subcommand: query-state - Query a value in the global state.
+          -b, --block-hash  <arg>   Hash of the block to query the state of
+          -k, --key  <arg>          Base16 encoding of the base key.
+          -p, --path  <arg>         Path to the value to query. Must be of the form
+                                    'key1/key2/.../keyn'
+          -t, --type  <arg>         Type of base key. Must be one of 'hash', 'uref',
+                                    'address'
+          -h, --help                Show help message
+
+        """
+        return self.invoke_client(f'query-state '
+                                  f' --block-hash "{blockHash}"'
+                                  f' --key "{key}"'
+                                  f' --path "{path}"'
+                                  f' --type "{keyType}"')

--- a/integration-testing/test/cl_node/python_client.py
+++ b/integration-testing/test/cl_node/python_client.py
@@ -46,6 +46,9 @@ class PythonClient(CasperLabsClient):
         logging.info(f'PY_CLIENT.propose() for {self.node.container_name}')
         return self.client.propose()
 
+    def queryState(self, blockHash: str, key: str, path: str, keyType: str):
+        return self.client.queryState(blockHash, key, path, keyType)
+
     def show_block(self, block_hash: str) -> str:
         # TODO:
         pass
@@ -55,3 +58,4 @@ class PythonClient(CasperLabsClient):
 
     def get_blocks_count(self, depth: int) -> int:
         return len(list(self.show_blocks(depth)))
+

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -32,6 +32,13 @@ def one_node_network(docker_client_fixture):
         yield onn
 
 
+@pytest.fixture(scope='module')
+def one_node_network_module_scope(docker_client_fixture):
+    with OneNodeNetwork(docker_client_fixture) as onn:
+        onn.create_cl_network()
+        yield onn
+
+
 @pytest.fixture()
 def two_node_network(docker_client_fixture):
     with TwoNodeNetwork(docker_client_fixture) as tnn:

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -7,19 +7,20 @@ import pytest
 import casper_client
 import logging
 
-"""
-aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 propose
-Response: Success! Block 9d38836598... created and added.
-aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
-NOT_FOUND: Cannot find block matching hash "9d"
 
-aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key '"a91208047c"' --path file.xxx --type hash
-INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes, 5 =/= 32 provided.
+# Examples of query-state executed with the Scala client that result in errors:
 
-aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key 3030303030303030303030303030303030303030303030303030303030303030 --path file.xxx --type hash
-INVALID_ARGUMENT: Value not found: " Hash([48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48])"
-aakoshh@af-dp:~/projects/CasperLabs/docker$
-"""
+# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 propose
+# Response: Success! Block 9d38836598... created and added.
+# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
+# NOT_FOUND: Cannot find block matching hash "9d"
+
+# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key '"a91208047c"' --path file.xxx --type hash
+# INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes, 5 =/= 32 provided.
+
+# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key 3030303030303030303030303030303030303030303030303030303030303030 --path file.xxx --type hash
+# INVALID_ARGUMENT: Value not found: " Hash([48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48])"
+
 
 KEY = '30' * 32
 assert KEY == "3030303030303030303030303030303030303030303030303030303030303030"

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -1,0 +1,37 @@
+from .cl_node.wait import wait_for_blocks_count_at_least
+from .cl_node.casperlabsnode import get_contract_state
+from .cl_node.errors import NonZeroExitCodeError
+
+import pytest
+import casper_client
+import logging
+
+"""
+aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 propose
+Response: Success! Block 9d38836598... created and added.
+aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
+NOT_FOUND: Cannot find block matching hash "9d"
+
+aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key '"a91208047c"' --path file.xxx --type hash
+INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes, 5 =/= 32 provided.
+
+aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key 3030303030303030303030303030303030303030303030303030303030303030 --path file.xxx --type hash
+INVALID_ARGUMENT: Value not found: " Hash([48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48])"
+aakoshh@af-dp:~/projects/CasperLabs/docker$
+"""
+
+def resource(file_name):
+    return f'resources/{file_name}'
+
+
+def test_query_state_error_handling(one_node_network):
+
+    net = one_node_network
+    node = net.docker_nodes[0]
+    client = node.d_client
+
+    with pytest.raises(NonZeroExitCodeError) as excinfo:
+        response = client.queryState(blockHash = "9d", key = "a91208047c", path = "file.xxx", keyType = "hash")
+    assert  "NOT_FOUND: Cannot find block matching" in excinfo.value.output
+
+

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -10,15 +10,16 @@ import logging
 
 # Examples of query-state executed with the Scala client that result in errors:
 
-# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 propose
+# CasperLabs/docker $ ./client.sh node-0 propose
 # Response: Success! Block 9d38836598... created and added.
-# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
+
+# CasperLabs/docker $ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
 # NOT_FOUND: Cannot find block matching hash "9d"
 
-# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key '"a91208047c"' --path file.xxx --type hash
+# CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key '"a91208047c"' --path file.xxx --type hash
 # INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes, 5 =/= 32 provided.
 
-# aakoshh@af-dp:~/projects/CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key 3030303030303030303030303030303030303030303030303030303030303030 --path file.xxx --type hash
+# CasperLabs/docker$ ./client.sh node-0 query-state --block-hash 9d --key 3030303030303030303030303030303030303030303030303030303030303030 --path file.xxx --type hash
 # INVALID_ARGUMENT: Value not found: " Hash([48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48])"
 
 
@@ -39,13 +40,13 @@ def block_hash(node):
     return node.deploy_and_propose()
 
 block_hash_queries = [
-    (dict(blockHash = "9d", key = "a91208047c", path = "file.xxx", keyType = "hash"),
+    ({'blockHash': "9d", 'key': "a91208047c", 'path': "file.xxx", 'keyType': "hash"},
      "NOT_FOUND: Cannot find block matching"),
 
-    (dict(                  key = "a91208047c", path = "file.xxx", keyType = "hash"),
+    ({                   'key': "a91208047c", 'path': "file.xxx", 'keyType': "hash"},
      "INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes"),
 
-    (dict(                  key = KEY,          path = "file.xxx", keyType = "hash"),
+    ({                   'key': KEY,          'path': "file.xxx", 'keyType': "hash"},
      "INVALID_ARGUMENT: Value not found"),
 ]
 

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -25,15 +25,15 @@ KEY = '30' * 32
 assert KEY == "3030303030303030303030303030303030303030303030303030303030303030"
 
 
-@pytest.fixture()
-def node(one_node_network):
-    return one_node_network.docker_nodes[0]
+@pytest.fixture(scope='module')
+def node(one_node_network_module_scope):
+    return one_node_network_module_scope.docker_nodes[0]
 
-@pytest.fixture()
+@pytest.fixture(scope='module')
 def client(node):
     return node.d_client
 
-@pytest.fixture()
+@pytest.fixture(scope='module')
 def block_hash(node):
     return node.deploy_and_propose()
 


### PR DESCRIPTION
### Overview
This PR adds an integration test for query-state error handling, as well as a fix for calling docker client in the test framework - now stderr is captured properly when the client exits with an error code.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-321

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Logs are more verbose now, as output of the client is always printed.
