### PR TITLE
NODE-558: Reject already processed deploys

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -76,7 +76,7 @@ trait MultiParentCasper[F[_]] extends Casper[F, IndexedSeq[BlockHash]] {
   // this initial fault weight combined with our fault tolerance threshold t.
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float]
   def lastFinalizedBlock: F[Block]
-  def faultToleranceThreshold: Float = 0f
+  def faultToleranceThreshold: Float
 }
 
 object MultiParentCasper extends MultiParentCasperInstances {

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -55,7 +55,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
     genesis: Block,
     chainId: String,
     blockProcessingLock: Semaphore[F],
-    faultToleranceThreshold: Float = 0f
+    val faultToleranceThreshold: Float = 0f
 )(implicit state: Cell[F, CasperState])
     extends MultiParentCasper[F] {
 

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -231,7 +231,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
 
         EitherT(req)
           .leftMap(c => new IllegalArgumentException(s"Contract verification failed: $c"))
-          .flatMapF(_ => addDeploy(deploy) map (_.asRight[Throwable]))
+          .flatMapF(_ => addDeploy(deploy))
           .value
       // TODO: Genesis doesn't have payment code; does it come here?
       case (None, _) | (_, None) =>
@@ -244,10 +244,27 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Time: SafetyOracle: BlockStore: Blo
     }
 
   /** Add a deploy to the buffer, to be executed later. */
-  private def addDeploy(deploy: Deploy): F[Unit] =
-    Cell[F, CasperState].modify { s =>
-      s.copy(deployBuffer = s.deployBuffer.add(deploy))
-    } *> Log[F].info(s"Received ${PrettyPrinter.buildString(deploy)}")
+  private def addDeploy(deploy: Deploy): F[Either[Throwable, Unit]] = {
+    def show(d: Deploy) = PrettyPrinter.buildString(d)
+    (for {
+      s <- Cell[F, CasperState].read
+      _ <- s.deployBuffer.processedDeploys.values.find { d =>
+            d.getHeader.accountPublicKey == deploy.getHeader.accountPublicKey &&
+            d.getHeader.nonce >= deploy.getHeader.nonce &&
+            d.deployHash != deploy.deployHash
+          } map { d =>
+            Sync[F].raiseError(
+              new IllegalArgumentException(
+                s"${show(d)} supersedes ${show(deploy)}."
+              )
+            )
+          } getOrElse ().pure[F]
+      _ <- Cell[F, CasperState].modify { s =>
+            s.copy(deployBuffer = s.deployBuffer.add(deploy))
+          }
+      _ <- Log[F].info(s"Received ${show(deploy)}")
+    } yield ()).attempt
+  }
 
   /** Return the list of tips. */
   def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =

--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -87,7 +87,7 @@ object PrettyPrinter {
         s"-- Sender ID ${buildString(header.validatorPublicKey)} " +
         s"-- M Parent Hash ${buildString(mainParent)} " +
         s"-- Contents ${buildString(postState.postStateHash)}" +
-        s"-- Shard ID ${limit(header.chainId, 10)}"
+        s"-- Chain ID ${limit(header.chainId, 10)}"
     blockString match {
       case Some(str) => str
       case None      => s"Block with missing elements (${buildString(b.blockHash)})"

--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -134,7 +134,7 @@ object PrettyPrinter {
     s"Last deploy: ${ac.deploymentLastUsed}, last key management change: ${ac.keyManagementLastUsed}, inactivity period limit: ${ac.inactivityPeriodLimit}"
 
   def buildString(d: consensus.Deploy): String =
-    s"Deploy #${d.getHeader.timestamp}"
+    s"Deploy ${buildStringNoLimit(d.deployHash)} (${buildStringNoLimit(d.getHeader.accountPublicKey)} / ${d.getHeader.nonce})"
 
   def buildString(d: DeployData): String =
     s"Deploy #${d.timestamp}"

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -196,5 +196,6 @@ object AutoProposerTest {
     override def fetchDependencies: F[Unit]                                           = ???
     override def normalizedInitialFault(weights: Map[ByteString, Long]): F[Float]     = ???
     override def lastFinalizedBlock: F[Block]                                         = ???
+    override def faultToleranceThreshold                                              = 0f
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -29,8 +29,8 @@ class CreateBlockAPITest extends FlatSpec with Matchers with TransportLayerCaspe
   import HashSetCasperTest._
   import HashSetCasperTestNode.Effect
 
-  private implicit val scheduler: Scheduler = Scheduler.fixedPool("create-block-api-test", 4)
-  implicit val metrics                      = new Metrics.MetricsNOP[Task]
+  implicit val scheduler: Scheduler = Scheduler.fixedPool("create-block-api-test", 4)
+  implicit val metrics              = new Metrics.MetricsNOP[Task]
 
   private val (validatorKeys, validators)                      = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
   private val bonds                                            = createBonds(validators)
@@ -52,7 +52,11 @@ class CreateBlockAPITest extends FlatSpec with Matchers with TransportLayerCaspe
     ).zipWithIndex.map {
       case (deploy, nonce) =>
         ProtoUtil
-          .basicDeploy(System.currentTimeMillis(), ByteString.copyFromUtf8(deploy), nonce + 1)
+          .basicDeploy(
+            System.currentTimeMillis(),
+            ByteString.copyFromUtf8(deploy),
+            nonce.toLong + 1
+          )
     }
 
     implicit val logEff       = new LogStub[Effect]
@@ -73,18 +77,61 @@ class CreateBlockAPITest extends FlatSpec with Matchers with TransportLayerCaspe
       } yield (r1.right.get, r2.right.get)
     )
 
-    val (response1, response2) = (for {
-      casperRef    <- MultiParentCasperRef.of[Effect]
-      _            <- casperRef.set(casper)
-      blockApiLock <- Semaphore[Effect](1)
-      result       <- testProgram(blockApiLock)(casperRef)
-    } yield result).value.unsafeRunSync.right.get
+    try {
+      val (response1, response2) = (for {
+        casperRef    <- MultiParentCasperRef.of[Effect]
+        _            <- casperRef.set(casper)
+        blockApiLock <- Semaphore[Effect](1)
+        result       <- testProgram(blockApiLock)(casperRef)
+      } yield result).value.unsafeRunSync.right.get
 
-    response1.success shouldBe true
-    response2.success shouldBe false
-    response2.message shouldBe "Error: There is another propose in progress."
+      response1.success shouldBe true
+      response2.success shouldBe false
+      response2.message shouldBe "Error: There is another propose in progress."
+    } finally {
+      node.tearDown()
+    }
+  }
 
-    node.tearDown()
+  "deploy" should "reject replayed deploys" in {
+    implicit val time = new Time[Task] {
+      private val timer                               = Task.timer
+      def currentMillis: Task[Long]                   = timer.clock.realTime(MILLISECONDS)
+      def nanoTime: Task[Long]                        = timer.clock.monotonic(NANOSECONDS)
+      def sleep(duration: FiniteDuration): Task[Unit] = timer.sleep(duration)
+    }
+
+    // Create the node with low fault tolerance threshold so it finalizes the blocks as soon as they are made.
+    val node =
+      standaloneEff(genesis, transforms, validatorKeys.head, faultToleranceThreshold = -2.0f)
+
+    implicit val logEff       = new LogStub[Effect]
+    implicit val blockStore   = node.blockStore
+    implicit val safetyOracle = node.safetyOracleEff
+
+    def testProgram(blockApiLock: Semaphore[Effect])(
+        implicit casperRef: MultiParentCasperRef[Effect]
+    ): Effect[Unit] =
+      for {
+        d <- ProtoUtil.basicDeploy[Effect](1)
+        _ <- BlockAPI.deploy[Effect](d, ignoreDeploySignature = true)
+        _ <- BlockAPI.createBlock[Effect](blockApiLock)
+        _ <- BlockAPI.deploy[Effect](d, ignoreDeploySignature = true)
+      } yield ()
+
+    try {
+      (for {
+        casperRef    <- MultiParentCasperRef.of[Effect]
+        _            <- casperRef.set(node.casperEff)
+        blockApiLock <- Semaphore[Effect](1)
+        result       <- testProgram(blockApiLock)(casperRef)
+      } yield result).value.unsafeRunSync
+    } catch {
+      case ex: io.grpc.StatusRuntimeException =>
+        ex.getMessage should include("already contains")
+    } finally {
+      node.tearDown()
+    }
   }
 }
 
@@ -101,6 +148,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def lastFinalizedBlock: F[Block] = underlying.lastFinalizedBlock
   def fetchDependencies: F[Unit]   = underlying.fetchDependencies
   def bufferedDeploys              = underlying.bufferedDeploys
+  def faultToleranceThreshold      = underlying.faultToleranceThreshold
 
   override def createBlock: F[CreateBlockStatus] =
     for {

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -55,7 +55,10 @@ class CreateBlockAPITest extends FlatSpec with Matchers with TransportLayerCaspe
           .basicDeploy(System.currentTimeMillis(), ByteString.copyFromUtf8(deploy), nonce + 1)
     }
 
-    implicit val logEff = new LogStub[Effect]
+    implicit val logEff       = new LogStub[Effect]
+    implicit val blockStore   = node.blockStore
+    implicit val safetyOracle = node.safetyOracleEff
+
     def testProgram(blockApiLock: Semaphore[Effect])(
         implicit casperRef: MultiParentCasperRef[Effect]
     ): Effect[(DeployServiceResponse, DeployServiceResponse)] = EitherT.liftF(

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -56,7 +56,7 @@ class GossipServiceCasperTestNode[F[_]](
       validateNonces
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
-  implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]
+  implicit val safetyOracleEff: SafetyOracle[F] = SafetyOracle.cliqueOracle[F]
 
   //val defaultTimeout = FiniteDuration(1000, MILLISECONDS)
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -54,6 +54,7 @@ abstract class HashSetCasperTestNode[F[_]](
   implicit val logEff: LogStub[F]
 
   implicit val casperEff: MultiParentCasperImpl[F]
+  implicit val safetyOracleEff: SafetyOracle[F]
 
   val validatorId = ValidatorIdentity(Ed25519.tryToPublic(sk).get, sk, Ed25519)
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -38,6 +38,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def lastFinalizedBlock: F[Block]                                    = Block().pure[F]
   def fetchDependencies: F[Unit]                                      = ().pure[F]
   def bufferedDeploys: F[DeployBuffer]                                = DeployBuffer.empty.pure[F]
+  def faultToleranceThreshold                                         = 0f
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -67,8 +67,9 @@ class TransportLayerCasperTestNode[F[_]](
   implicit val logEff: LogStub[F] = new LogStub[F](local.host, printEnabled = false)
   implicit val connectionsCell    = Cell.unsafe[F, Connections](Connect.Connections.empty)
   implicit val transportLayerEff  = tle
-  implicit val cliqueOracleEffect = SafetyOracle.cliqueOracle[F]
   implicit val rpConfAsk          = createRPConfAsk[F](local)
+
+  implicit val safetyOracleEff: SafetyOracle[F] = SafetyOracle.cliqueOracle[F]
 
   val defaultTimeout = FiniteDuration(1000, MILLISECONDS)
 

--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -124,6 +124,7 @@ object ServiceError {
   // NOTE: See https://github.com/grpc/grpc/blob/master/doc/statuscodes.md about when to use which one.
 
   object Aborted            extends StatusError(Status.ABORTED)
+  object AlreadyExists      extends StatusError(Status.ALREADY_EXISTS)
   object DeadlineExceeded   extends StatusError(Status.DEADLINE_EXCEEDED)
   object FailedPrecondition extends StatusError(Status.FAILED_PRECONDITION)
   object Internal           extends StatusError(Status.INTERNAL)


### PR DESCRIPTION
### Overview
Provides some protection against replay errors stalling the processing of deploys by rejecting deploys that have the same or lower nonces then the deploys waiting for finalization, or deploys we have actually already finalized.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-558

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
