### PR TITLE
NODE-579: Don't start the initial sync before the genesis is approved.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -82,33 +82,36 @@ package object gossiping {
       genesisApprover <- makeGenesisApprover(conf, connectToGossip, downloadManager)
 
       // Make sure MultiParentCasperRef is set before the synchronizer is resumed.
-      awaitApproval = genesisApprover.awaitApproval >>= { genesisBlockHash =>
-        for {
-          maybeGenesis <- BlockStore[F].get(genesisBlockHash)
-          genesisStore <- MonadThrowable[F].fromOption(
-                           maybeGenesis,
-                           NotFound(s"Cannot retrieve Genesis ${show(genesisBlockHash)}")
-                         )
-          validatorId <- ValidatorIdentity.fromConfig[F](conf.casper)
-          genesis     = genesisStore.getBlockMessage
-          prestate    = ProtoUtil.preStateHash(genesis)
-          transforms  = genesisStore.transformEntry
-          casper <- MultiParentCasper.fromGossipServices(
-                     validatorId,
-                     genesis,
-                     prestate,
-                     transforms,
-                     conf.casper.chainId,
-                     relaying
-                   )
-          _ <- MultiParentCasperRef[F].set(casper)
-          _ <- Log[F].info("Making the transition to block processing.")
-        } yield ()
-      }
+      awaitApproval <- makeFiberResource {
+                        genesisApprover.awaitApproval >>= { genesisBlockHash =>
+                          for {
+                            maybeGenesis <- BlockStore[F].get(genesisBlockHash)
+                            genesisStore <- MonadThrowable[F].fromOption(
+                                             maybeGenesis,
+                                             NotFound(
+                                               s"Cannot retrieve Genesis ${show(genesisBlockHash)}"
+                                             )
+                                           )
+                            validatorId <- ValidatorIdentity.fromConfig[F](conf.casper)
+                            genesis     = genesisStore.getBlockMessage
+                            prestate    = ProtoUtil.preStateHash(genesis)
+                            transforms  = genesisStore.transformEntry
+                            casper <- MultiParentCasper.fromGossipServices(
+                                       validatorId,
+                                       genesis,
+                                       prestate,
+                                       transforms,
+                                       conf.casper.chainId,
+                                       relaying
+                                     )
+                            _ <- MultiParentCasperRef[F].set(casper)
+                            _ <- Log[F].info("Making the transition to block processing.")
+                          } yield ()
+                        }
+                      }
 
-      // The StashingSynchronizer will start a fiber to await on the above.
       isInitialRef <- Resource.liftF(Ref.of[F, Boolean](true))
-      synchronizer <- makeSynchronizer(conf, connectToGossip, awaitApproval, isInitialRef)
+      synchronizer <- makeSynchronizer(conf, connectToGossip, awaitApproval.join, isInitialRef)
 
       gossipServiceServer <- makeGossipServiceServer(
                               port,
@@ -121,7 +124,13 @@ package object gossiping {
                             )
 
       // Start syncing with the bootstrap in the background.
-      _ <- makeInitialSynchronization(conf, gossipServiceServer, connectToGossip, isInitialRef)
+      _ <- makeInitialSynchronization(
+            conf,
+            gossipServiceServer,
+            connectToGossip,
+            awaitApproval.join,
+            isInitialRef
+          )
 
       // Start a loop to periodically print peer count, new and disconnected peers, based on NodeDiscovery.
       _ <- makePeerCountPrinter
@@ -644,6 +653,7 @@ package object gossiping {
       conf: Configuration,
       gossipServiceServer: GossipServiceServer[F],
       connectToGossip: GossipService.Connector[F],
+      awaitApproved: F[Unit],
       isInitialRef: Ref[F, Boolean]
   ): Resource[F, Unit] =
     for {
@@ -659,7 +669,9 @@ package object gossiping {
                         connector = connectToGossip
                       )
                     }
-      _ <- makeFiberResource(initialSync.sync() >> isInitialRef.set(false))
+      _ <- makeFiberResource {
+            awaitApproved >> initialSync.sync() >> isInitialRef.set(false)
+          }
     } yield ()
 
   /** The TransportLayer setup prints the number of peers now and then which integration tests


### PR DESCRIPTION
### Overview
While debugging a connectivity issue with @TomVasile I noticed that the node was trying to get the genesis candidate and do the initial synchronization at the same time. While this doesn't necessarily lead to problems, it's not nice. This PR makes syncing wait until the approval is finished.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-579

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
