### PR TITLE
OP-326: Fix intermittent failures of integration tests in CI

### DIFF
--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -53,6 +53,13 @@ def three_node_network(docker_client_fixture):
         yield tnn
 
 
+@pytest.fixture(scope='module')
+def three_node_network_module_scope(docker_client_fixture):
+    with ThreeNodeNetwork(docker_client_fixture) as tnn:
+        tnn.create_cl_network()
+        yield tnn
+
+
 @pytest.fixture()
 def star_network(docker_client_fixture):
     with CustomConnectionNetwork(docker_client_fixture) as ccn:

--- a/integration-testing/test/test_call_contracts_one_another.py
+++ b/integration-testing/test/test_call_contracts_one_another.py
@@ -6,9 +6,9 @@ from .cl_node.wait import wait_for_blocks_count_at_least
 
 
 class BlockPropagatedToAllNodesChecker:
-    def __init__(self, docker_nodes, number_of_blocks):
+    def __init__(self, docker_nodes, initial_number_of_blocks):
         self.docker_nodes = docker_nodes
-        self.number_of_blocks = number_of_blocks
+        self.number_of_blocks = initial_number_of_blocks
 
     def __call__(self):
         self.number_of_blocks += 1

--- a/integration-testing/test/test_call_contracts_one_another.py
+++ b/integration-testing/test/test_call_contracts_one_another.py
@@ -1,77 +1,77 @@
 import time
 from itertools import count
-from .cl_node.casperlabsnode import (
-    COMBINED_CONTRACT,
-    COUNTER_CALL,
-    HELLO_WORLD,
-    MAILING_LIST_CALL,
-    get_contract_state,
-)
+import pytest
+from .cl_node.casperlabsnode import ( COMBINED_CONTRACT, COUNTER_CALL, HELLO_WORLD, MAILING_LIST_CALL, get_contract_state)
 from .cl_node.wait import wait_for_blocks_count_at_least
 
 
-def test_call_contracts_one_another(three_node_network):
+class BlockPropagatedToAllNodesChecker:
+    def __init__(self, docker_nodes, number_of_blocks):
+        self.docker_nodes = docker_nodes
+        self.number_of_blocks = number_of_blocks
+
+    def __call__(self):
+        self.number_of_blocks += 1
+        for n in self.docker_nodes:
+            wait_for_blocks_count_at_least(n, self.number_of_blocks, self.number_of_blocks, n.timeout)
+        
+
+@pytest.fixture(scope='module')
+def three_node_network_with_combined_contract(three_node_network_module_scope):
+    tnn = three_node_network_module_scope
+    bootstrap, node1, node2 = tnn.docker_nodes
+
+    bootstrap.deploy_and_propose(session_contract = COMBINED_CONTRACT, payment_contract = COMBINED_CONTRACT)
+
+    BlockPropagatedToAllNodesChecker(tnn.docker_nodes, 1)()
+
+    return tnn
+
+
+@pytest.fixture(scope='module')
+def nodes(three_node_network_with_combined_contract):
+    return three_node_network_with_combined_contract.docker_nodes
+
+
+@pytest.fixture(scope='module')
+def generated_hashes(nodes):
+    check_block_propagated = BlockPropagatedToAllNodesChecker(nodes, 2)
+
+    def deploy_and_propose(node, contract):
+        block_hash = node.deploy_and_propose(session_contract=contract, payment_contract=contract)
+        check_block_propagated()
+        return block_hash
+
+    return { contract_name: [deploy_and_propose(node, contract_name) for node in nodes]
+             for contract_name in (COUNTER_CALL, MAILING_LIST_CALL, HELLO_WORLD) }
+
+
+@pytest.fixture(scope='module')
+def docker_client(three_node_network_with_combined_contract):
+    return three_node_network_with_combined_contract.docker_client
+
+
+expected_result = count(1)
+test_parameters = [
+    (COUNTER_CALL, "counter/count", lambda: bytes(f'int_value: {next(expected_result)}\n\n', 'utf-8')),
+    (MAILING_LIST_CALL, "mailing/list", lambda: bytes('string_list {\n  values: "CasperLabs"\n}\n\n', 'utf-8')),
+    (HELLO_WORLD, "helloworld", lambda: b'string_value: "Hello, World"\n\n'),
+]
+
+@pytest.mark.parametrize("contract, path, expected", test_parameters)
+def test_call_contracts_one_another(nodes, docker_client, generated_hashes, contract, path, expected):
     """
     Feature file: consensus.feature
     Scenario: Call contracts deployed on a node from another node.
     """
-    nonce = count(1)
-    tnn = three_node_network
-    bootstrap, node1, node2 = tnn.docker_nodes
-    bootstrap.deploy_and_propose(session_contract=COMBINED_CONTRACT, payment_contract=COMBINED_CONTRACT, nonce=next(nonce))
 
-    number_of_blocks = 2
-    for n in tnn.docker_nodes:
-        wait_for_blocks_count_at_least(n, number_of_blocks, number_of_blocks, n.timeout)
+    def state(node, path, block_hash):
+        return get_contract_state(docker_client = docker_client, port = 40401, _type = "address",
+                                  key = 3030303030303030303030303030303030303030303030303030303030303030,
+                                  network_name = node.network, target_host_name = node.name, path = path,
+                                  block_hash = block_hash)
 
-    generated_hashes = {}
-    for contract_name in (COUNTER_CALL, MAILING_LIST_CALL, HELLO_WORLD):
-        list_of_hashes = []
-        for node in tnn.docker_nodes:
-            block_hash = node.deploy_and_propose(session_contract=contract_name, payment_contract=contract_name, nonce=next(nonce))
-            list_of_hashes.append(block_hash)
 
-            number_of_blocks += 1
-            for n in tnn.docker_nodes:
-                wait_for_blocks_count_at_least(n, number_of_blocks, number_of_blocks, n.timeout)
-
-        generated_hashes[contract_name] = list_of_hashes
-    for index, counter_hash in enumerate(generated_hashes[COUNTER_CALL]):
-        expected_result = index + 1
-        output = get_contract_state(
-            docker_client=three_node_network.docker_client,
-            network_name=tnn.docker_nodes[index].network,
-            target_host_name=tnn.docker_nodes[index].name,
-            port=40401,
-            _type="address",
-            key=3030303030303030303030303030303030303030303030303030303030303030,
-            path="counter/count",
-            block_hash=counter_hash
-        )
-        assert bytes(f'int_value: {expected_result}\n\n', 'utf-8') == output
-
-    for index, mailing_list_hash in enumerate(generated_hashes[MAILING_LIST_CALL]):
-        output = get_contract_state(
-            docker_client=three_node_network.docker_client,
-            network_name=tnn.docker_nodes[index].network,
-            target_host_name=tnn.docker_nodes[index].name,
-            port=40401,
-            _type="address",
-            key=3030303030303030303030303030303030303030303030303030303030303030,
-            path="mailing/list",
-            block_hash=mailing_list_hash
-        )
-        assert bytes('string_list {\n  values: "CasperLabs"\n}\n\n', 'utf-8') == output
-
-    for index, hello_world_hash in enumerate(generated_hashes[HELLO_WORLD]):
-        output = get_contract_state(
-            docker_client=three_node_network.docker_client,
-            network_name=tnn.docker_nodes[index].network,
-            target_host_name=tnn.docker_nodes[index].name,
-            port=40401,
-            _type="address",
-            key=3030303030303030303030303030303030303030303030303030303030303030,
-            path="helloworld",
-            block_hash=hello_world_hash
-        )
-        assert b'string_value: "Hello, World"\n\n' == output
+    for node, block_hash in zip(nodes, generated_hashes[contract]):
+        output = state(node, path, block_hash)
+        assert expected() == output

--- a/integration-testing/test/test_call_contracts_one_another.py
+++ b/integration-testing/test/test_call_contracts_one_another.py
@@ -18,6 +18,10 @@ class BlockPropagatedToAllNodesChecker:
 
 @pytest.fixture(scope='module')
 def three_node_network_with_combined_contract(three_node_network_module_scope):
+    """
+    Fixture of a network with deployed combined definitions contract,
+    use later by tests in this module.
+    """
     tnn = three_node_network_module_scope
     bootstrap, node1, node2 = tnn.docker_nodes
 
@@ -35,6 +39,15 @@ def nodes(three_node_network_with_combined_contract):
 
 @pytest.fixture(scope='module')
 def generated_hashes(nodes):
+    """
+    This fixture deploys & proposes test contracts on all nodes.
+    Note, this happens when the combined contract definition is already deployed
+    as part of the fixture three_node_network_with_combined_contract
+    (via nodes)
+
+    Returns dictionary mapping contract names to list of deployed block hashes
+    on all nodes.
+    """
     check_block_propagated = BlockPropagatedToAllNodesChecker(nodes, 2)
 
     def deploy_and_propose(node, contract):
@@ -52,6 +65,7 @@ def docker_client(three_node_network_with_combined_contract):
 
 
 expected_result = count(1)
+
 test_parameters = [
     (COUNTER_CALL, "counter/count", lambda: bytes(f'int_value: {next(expected_result)}\n\n', 'utf-8')),
     (MAILING_LIST_CALL, "mailing/list", lambda: bytes('string_list {\n  values: "CasperLabs"\n}\n\n', 'utf-8')),


### PR DESCRIPTION

### Overview
This PR fixes intermittent failures of integration tests in CI.

Some tests modify structure of test networks by adding or removing nodes and inter-node connections, these could fail occasionally due to implemenation of these operations not being thread safe.

Fixed thread safety of network by protecting structure changing operations with a lock.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-326

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
NA
