### PR TITLE
NODE-557: Handle missing or invalid bonds.txt

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -265,14 +265,17 @@ object Genesis {
                       case Success(bonds) =>
                         bonds.pure[F]
                       case Failure(_) =>
-                        Log[F].warn(s"Bonds file ${file.getPath} cannot be parsed.") *> Map
-                          .empty[PublicKey, Long]
-                          .pure[F]
+                        val message = s"Bonds file ${file.getPath} cannot be parsed."
+                        Log[F].error(message) *> Sync[F].raiseError[Map[PublicKey, Long]](
+                          new IllegalArgumentException(message) with NoStackTrace
+                        )
                     }
                 case None =>
-                  Log[F].warn(s"Specified bonds file $bondsFile does not exist.") *> Map
-                    .empty[PublicKey, Long]
-                    .pure[F]
+                  val message = s"Specified bonds file $bonds does not exist."
+                  Log[F].error(message) *> Sync[F]
+                    .raiseError[Map[PublicKey, Long]](
+                      new IllegalArgumentException(message) with NoStackTrace
+                    )
               }
     } yield bonds
 }

--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -22,6 +22,7 @@ import io.casperlabs.storage.BlockMsgWithTransform
 
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
+import scala.util.control.NoStackTrace
 
 object Genesis {
 
@@ -240,7 +241,6 @@ object Genesis {
     }
 
   def getBonds[F[_]: Sync: Log](
-      genesisPath: Path,
       bonds: Path,
       numValidators: Int
   ): F[Map[PublicKey, Long]] =

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
@@ -100,7 +100,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     for {
       _ <- Log[F].info("Starting in default mode")
       // FIXME: The bonds should probably be taken from the approved block, but that's not implemented.
-      bonds       <- Genesis.getBonds[F](conf.genesisPath, conf.bondsFile, conf.numValidators)
+      bonds       <- Genesis.getBonds[F](conf.bondsFile, conf.numValidators)
       validators  <- CasperConf.parseValidatorsFile[F](conf.knownValidatorsFile)
       validatorId <- ValidatorIdentity.fromConfig[F](conf)
       _           <- ExecutionEngineService[F].setBonds(bonds)
@@ -127,7 +127,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
   )(implicit scheduler: Scheduler): F[CasperPacketHandler[F]] =
     for {
       _     <- Log[F].info("Starting in create genesis mode")
-      bonds <- Genesis.getBonds[F](conf.genesisPath, conf.bondsFile, conf.numValidators)
+      bonds <- Genesis.getBonds[F](conf.bondsFile, conf.numValidators)
       _     <- ExecutionEngineService[F].setBonds(bonds)
       genesis <- Genesis[F](
                   conf.walletsFile,
@@ -177,7 +177,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       _           <- Log[F].info("Starting in approve genesis mode")
       timestamp   <- conf.deployTimestamp.fold(Time[F].currentMillis)(_.pure[F])
       wallets     <- Genesis.getWallets[F](conf.walletsFile)
-      bonds       <- Genesis.getBonds[F](conf.genesisPath, conf.bondsFile, conf.numValidators)
+      bonds       <- Genesis.getBonds[F](conf.bondsFile, conf.numValidators)
       _           <- ExecutionEngineService[F].setBonds(bonds)
       validatorId <- ValidatorIdentity.fromConfig[F](conf)
       bap = new BlockApproverProtocol(
@@ -208,7 +208,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     val genesis = LegacyConversions.toBlock(approvedBlock.candidate.flatMap(_.block).get)
     for {
       // FIXME: The bonds should probably be taken from the approved block, but that's not implemented.
-      bonds       <- Genesis.getBonds[F](conf.genesisPath, conf.bondsFile, conf.numValidators)
+      bonds       <- Genesis.getBonds[F](conf.bondsFile, conf.numValidators)
       _           <- ExecutionEngineService[F].setBonds(bonds)
       validatorId <- ValidatorIdentity.fromConfig[F](conf)
       casper <- MultiParentCasper.fromTransportLayer(

--- a/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
@@ -106,7 +106,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
       pw.close()
 
       for {
-        _ <- fromBondsFile(genesisPath, badBondsFile)(
+        _ <- fromBondsFile(badBondsFile)(
               executionEngineService,
               log,
               time
@@ -131,7 +131,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
       printBonds(bondsFile.toString)
 
       for {
-        genesisWithTransform <- fromBondsFile(genesisPath, bondsFile)(
+        genesisWithTransform <- fromBondsFile(bondsFile)(
                                  executionEngineService,
                                  log,
                                  time
@@ -163,7 +163,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
           implicit val logEff                    = log
           implicit val executionEngineServiceEff = executionEngineService
           for {
-            genesisWithTransform <- fromBondsFile(genesisPath, bondsFile)(
+            genesisWithTransform <- fromBondsFile(bondsFile)(
                                      executionEngineService,
                                      log,
                                      time
@@ -215,16 +215,13 @@ object GenesisTest {
   val numValidators     = 5
   val casperlabsChainId = "casperlabs"
 
-  def fromBondsFile(
-      genesisPath: Path,
-      bondsPath: Path = nonExistentPath
-  )(
+  def fromBondsFile(bondsPath: Path)(
       implicit executionEngineService: ExecutionEngineService[Task],
       log: LogStub[Task],
       time: LogicalTime[Task]
   ): Task[BlockMsgWithTransform] =
     for {
-      bonds <- Genesis.getBonds[Task](genesisPath, bondsPath, numValidators)
+      bonds <- Genesis.getBonds[Task](bondsPath, numValidators)
       _     <- ExecutionEngineService[Task].setBonds(bonds)
       genesis <- Genesis[Task](
                   walletsPath = nonExistentPath,

--- a/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
@@ -56,7 +56,7 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
     pw.close()
   }
 
-  "Genesis.getBonds" should "generate random validators when no bonds file is given" in withGenResources {
+  it should "throw exception when bonds file does not exist" in withGenResources {
     (
         executionEngineService: ExecutionEngineService[Task],
         genesisPath: Path,
@@ -64,35 +64,23 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
         time: LogicalTime[Task]
     ) =>
       for {
-        _      <- fromBondsFile(genesisPath)(executionEngineService, log, time)
-        _      = log.warns.find(_.contains("bonds")) should be(None)
-        result = log.infos.count(_.contains("Created validator")) should be(numValidators)
-      } yield result
-  }
-
-  it should "generate random validators, with a warning, when bonds file does not exist" in withGenResources {
-    (
-        executionEngineService: ExecutionEngineService[Task],
-        genesisPath: Path,
-        log: LogStub[Task],
-        time: LogicalTime[Task]
-    ) =>
-      for {
-        _ <- fromBondsFile(genesisPath)(
+        r <- fromBondsFile(nonExistentPath)(
               executionEngineService,
               log,
               time
-            )
-        _ = log.warns.count(
-          _.contains("does not exist. Falling back on generating random validators.")
+            ).attempt
+      } yield {
+        log.errors.count(
+          _.contains(s"Specified bonds file ${nonExistentPath} does not exist.")
         ) should be(
           1
         )
-        result = log.infos.count(_.contains("Created validator")) should be(numValidators)
-      } yield result
+        r.isLeft shouldBe true
+        r.left.get shouldBe an[IllegalArgumentException]
+      }
   }
 
-  it should "generate random validators, with a warning, when bonds file cannot be parsed" in withGenResources {
+  it should "throw exception when bonds file cannot be parsed" in withGenResources {
     (
         executionEngineService: ExecutionEngineService[Task],
         genesisPath: Path,
@@ -106,18 +94,20 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
       pw.close()
 
       for {
-        _ <- fromBondsFile(badBondsFile)(
+        r <- fromBondsFile(badBondsFile)(
               executionEngineService,
               log,
               time
-            )
-        _ = log.warns.count(
-          _.contains("cannot be parsed. Falling back on generating random validators.")
+            ).attempt
+      } yield {
+        log.errors.count(
+          _.contains(s"Bonds file ${badBondsFile} cannot be parsed.")
         ) should be(
           1
         )
-        result = log.infos.count(_.contains("Created validator")) should be(numValidators)
-      } yield result
+        r.isLeft shouldBe true
+        r.left.get shouldBe an[IllegalArgumentException]
+      }
   }
 
   it should "create a genesis block with the right bonds when a proper bonds file is given" in withGenResources {
@@ -138,72 +128,47 @@ class GenesisTest extends FlatSpec with Matchers with BlockDagStorageFixture {
                                )
         BlockMsgWithTransform(Some(genesis), _) = genesisWithTransform
         bonds                                   = ProtoUtil.bonds(genesis)
-        _                                       = log.infos.isEmpty should be(true)
-        result = validators
-          .map {
-            case (v, i) => Bond(ByteString.copyFrom(Base64.getDecoder.decode(v)), i.toLong)
-          }
-          .forall(
-            bonds.contains(_)
-          ) should be(true)
-      } yield result
+      } yield {
+        val fromGenesis =
+          bonds.map(
+            b => (Base64.getEncoder().encodeToString(b.validatorPublicKey.toByteArray()), b.stake)
+          )
+        fromGenesis should contain theSameElementsAs validators
+      }
   }
 
   it should "create a valid genesis block" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
-      withGenResources {
-        (
-            executionEngineService: ExecutionEngineService[Task],
-            genesisPath: Path,
-            log: LogStub[Task],
-            time: LogicalTime[Task]
-        ) =>
-          val bondsFile = genesisPath.resolve("bonds.txt")
-          printBonds(bondsFile.toString)
-          implicit val logEff                    = log
-          implicit val executionEngineServiceEff = executionEngineService
-          for {
-            genesisWithTransform <- fromBondsFile(bondsFile)(
-                                     executionEngineService,
-                                     log,
-                                     time
-                                   )
-            BlockMsgWithTransform(Some(genesis), transforms) = genesisWithTransform
-            _ <- BlockStore[Task]
-                  .put(genesis.blockHash, genesis, transforms)
-            dag <- blockDagStorage.getRepresentation
-            maybePostGenesisStateHash <- ExecutionEngineServiceStub
-                                          .validateBlockCheckpoint[Task](
-                                            genesis,
-                                            dag
-                                          )
-          } yield maybePostGenesisStateHash shouldBe 'right
-      }
-  }
-
-  it should "detect an existing bonds file in the default location" in withGenResources {
-    (
-        executionEngineService: ExecutionEngineService[Task],
-        genesisPath: Path,
-        log: LogStub[Task],
-        time: LogicalTime[Task]
-    ) =>
-      val bondsFile = genesisPath.resolve("bonds.txt").toString
-      printBonds(bondsFile)
-
-      for {
-        genesisWithTransform                    <- fromBondsFile(genesisPath)(executionEngineService, log, time)
-        BlockMsgWithTransform(Some(genesis), _) = genesisWithTransform
-        bonds                                   = ProtoUtil.bonds(genesis)
-        _                                       = log.infos.length should be(1)
-        result = validators
-          .map {
-            case (v, i) => Bond(ByteString.copyFrom(Base64.getDecoder.decode(v)), i.toLong)
-          }
-          .forall(
-            bonds.contains(_)
-          ) should be(true)
-      } yield result
+      Task.delay(
+        withGenResources {
+          (
+              executionEngineService: ExecutionEngineService[Task],
+              genesisPath: Path,
+              log: LogStub[Task],
+              time: LogicalTime[Task]
+          ) =>
+            val bondsFile = genesisPath.resolve("bonds.txt")
+            printBonds(bondsFile.toString)
+            implicit val logEff                    = log
+            implicit val executionEngineServiceEff = executionEngineService
+            for {
+              genesisWithTransform <- fromBondsFile(bondsFile)(
+                                       executionEngineService,
+                                       log,
+                                       time
+                                     )
+              BlockMsgWithTransform(Some(genesis), transforms) = genesisWithTransform
+              _ <- BlockStore[Task]
+                    .put(genesis.blockHash, genesis, transforms)
+              dag <- blockDagStorage.getRepresentation
+              maybePostGenesisStateHash <- ExecutionEngineServiceStub
+                                            .validateBlockCheckpoint[Task](
+                                              genesis,
+                                              dag
+                                            )
+            } yield maybePostGenesisStateHash shouldBe 'right
+        }
+      )
   }
 }
 
@@ -235,17 +200,21 @@ object GenesisTest {
 
   def withGenResources(
       body: (ExecutionEngineService[Task], Path, LogStub[Task], LogicalTime[Task]) => Task[Unit]
-  ): Task[Unit] = {
+  ): Unit = {
     val storagePath             = mkStoragePath
     val genesisPath             = mkGenesisPath
     val casperSmartContractsApi = HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
     val log                     = new LogStub[Task]
     val time                    = new LogicalTime[Task]
 
-    for {
+    val task = for {
       result <- body(casperSmartContractsApi, genesisPath, log, time)
       _      <- Sync[Task].delay { storagePath.recursivelyDelete() }
       _      <- Sync[Task].delay { genesisPath.recursivelyDelete() }
     } yield result
+    import monix.execution.Scheduler.Implicits.global
+    import monix.execution.schedulers.CanBlock.permit
+    import scala.concurrent.duration._
+    task.runSyncUnsafe(15.seconds)
   }
 }

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -356,7 +356,6 @@ package object gossiping {
         for {
           _ <- Log[F].info("Taking bonds from file.")
           bonds <- Genesis.getBonds[F](
-                    conf.casper.genesisPath,
                     conf.casper.bondsFile,
                     conf.casper.numValidators
                   )


### PR DESCRIPTION
### Overview
Previously node was failing with the following exception if it was expecting the `bonds.txt` file which didn't exist:
```console
21:38:51.625 [main] ERROR io.casperlabs.node.Main$ - requirement failed
java.lang.IllegalArgumentException: requirement failed
	at scala.Predef$.require(Predef.scala:268)
	at io.casperlabs.casper.genesis.contracts.ProofOfStakeParams.<init>(ProofOfStake.scala:13)
	at io.casperlabs.casper.genesis.Genesis$.$anonfun$apply$6(Genesis.scala:160)
	at io.casperlabs.casper.genesis.Genesis$.$anonfun$apply$6$adapted(Genesis.scala:149)
	at cats.data.EitherT.$anonfun$flatMap$1(EitherT.scala:99)
	at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:147)
	at monix.eval.internal.TaskRestartCallback.syncOnSuccess(TaskRestartCallback.scala:108)
	at monix.eval.internal.TaskRestartCallback$$anon$1.run(TaskRestartCallback.scala:128)
	at monix.execution.internal.Trampoline.monix$execution$internal$Trampoline$$immediateLoop(Trampoline.scala:66)
	at monix.execution.internal.Trampoline.startLoop(Trampoline.scala:32)
	at monix.execution.schedulers.TrampolineExecutionContext$JVMOptimalTrampoline.startLoop(TrampolineExecutionContext.scala:146)
	at monix.execution.internal.Trampoline.execute(Trampoline.scala:39)
	at monix.execution.schedulers.TrampolineExecutionContext.execute(TrampolineExecutionContext.scala:65)
	at monix.execution.schedulers.BatchingScheduler.execute(BatchingScheduler.scala:50)
	at monix.execution.schedulers.BatchingScheduler.execute$(BatchingScheduler.scala:47)
	at monix.execution.schedulers.ExecutorScheduler.execute(ExecutorScheduler.scala:34)
	at monix.eval.internal.TaskRestartCallback.start(TaskRestartCallback.scala:56)
	at monix.eval.internal.TaskRunLoop$.executeAsyncTask(TaskRunLoop.scala:564)
	at monix.eval.internal.TaskRunSyncUnsafe$.blockForResult(TaskRunSyncUnsafe.scala:143)
	at monix.eval.internal.TaskRunSyncUnsafe$.apply(TaskRunSyncUnsafe.scala:102)
	at monix.eval.Task.runSyncUnsafe(Task.scala:1043)
	at io.casperlabs.node.Main$.main(Main.scala:40)
	at io.casperlabs.node.Main.main(Main.scala)
```

This PR makes it more readable:
```console
21:40:04.893 [main] ERROR io.casperlabs.node.Main$ - Specified bonds file /Users/igorramazanov/.casperlabs/genesis/bonds.txt does not exist.
io.casperlabs.casper.genesis.Genesis$$anon$1: Specified bonds file /Users/igorramazanov/.casperlabs/genesis/bonds.txt does not exist.
```
and
```console
22:46:41.346 [main] ERROR io.casperlabs.node.Main$ - Bonds file /Users/igorramazanov/.casperlabs/genesis/bonds.txt cannot be parsed.
io.casperlabs.casper.genesis.Genesis$$anon$1: Bonds file /Users/igorramazanov/.casperlabs/genesis/bonds.txt cannot be parsed.
```
### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-557

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._