### PR TITLE
NODE-581: Fix secondary block parent ordering (against release branch)

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -473,7 +473,7 @@ class ValidateTest
         b2  <- createValidatorBlock[Task](Seq(b0), Seq.empty, 1)
         b3  <- createValidatorBlock[Task](Seq(b0), Seq.empty, 2)
         b4  <- createValidatorBlock[Task](Seq(b1), Seq(b1), 0)
-        b5  <- createValidatorBlock[Task](Seq(b3, b1, b2), Seq(b1, b2, b3), 1)
+        b5  <- createValidatorBlock[Task](Seq(b3, b2, b1), Seq(b1, b2, b3), 1)
         b6  <- createValidatorBlock[Task](Seq(b5, b4), Seq(b1, b4, b5), 0)
         b7  <- createValidatorBlock[Task](Seq(b4), Seq(b1, b4, b5), 1) //not highest score parent
         b8  <- createValidatorBlock[Task](Seq(b1, b2, b3), Seq(b1, b2, b3), 2) //parents wrong order


### PR DESCRIPTION
### Overview
Cherry pick commits from branch `abner/NODE-581` to make a release patch. The link of original PR against `dev` branch is [here](https://github.com/CasperLabs/CasperLabs/pull/649).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-581

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
