### PR TITLE
NODE-526 Gas processing metrics

### DIFF
--- a/docker/monitoring/grafana/dashboards/gas-processing.json
+++ b/docker/monitoring/grafana/dashboards/gas-processing.json
@@ -1,0 +1,231 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(casperlabs_engine_gas_spent_total[5s])",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Gas processing rate per 5 seconds",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "casperlabs_engine_gas_spent_total",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Total gas spent",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Gas processing",
+  "uid": "EL38q0nZz",
+  "version": 4
+}

--- a/hack/docker/monitoring/grafana/dashboards/block-gossiping.json
+++ b/hack/docker/monitoring/grafana/dashboards/block-gossiping.json
@@ -658,6 +658,7 @@
       }
     }
   ],
+  "refresh": "5s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [],

--- a/hack/docker/monitoring/prometheus/prometheus.yml
+++ b/hack/docker/monitoring/prometheus/prometheus.yml
@@ -1,9 +1,9 @@
 scrape_configs:
 - job_name: node
-  scrape_interval: 5s
+  scrape_interval: 750ms
   # Timeout can't be higher than the interval.
   # If we slow down the network too much we can't gather metrics.
-  scrape_timeout: 5s
+  scrape_timeout: 750ms
   file_sd_configs:
   - files:
     - /etc/prometheus/targets.yml

--- a/hack/docker/monitoring/prometheus/prometheus.yml
+++ b/hack/docker/monitoring/prometheus/prometheus.yml
@@ -1,9 +1,9 @@
 scrape_configs:
 - job_name: node
-  scrape_interval: 750ms
+  scrape_interval: 5s
   # Timeout can't be higher than the interval.
   # If we slow down the network too much we can't gather metrics.
-  scrape_timeout: 750ms
+  scrape_timeout: 5s
   file_sd_configs:
   - files:
     - /etc/prometheus/targets.yml

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -87,11 +87,9 @@ class NodeRuntime private[node] (
       implicit val metricsEff: Metrics[Effect] =
         Metrics.eitherT[CommError, Task](Monad[Task], metrics)
       val resources = for {
-        implicit0(filesApi: FilesAPI[Task]) <- Resource.liftF(FilesAPI.create[Task].toEffect)
         implicit0(executionEngineService: ExecutionEngineService[Effect]) <- GrpcExecutionEngineService[
                                                                               Effect
                                                                             ](
-                                                                              conf.server.dataDir,
                                                                               conf.grpc.socket,
                                                                               conf.server.maxMessageSize,
                                                                               initBonds = Map.empty

--- a/shared/src/main/scala/io/casperlabs/shared/FilesAPI.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/FilesAPI.scala
@@ -1,0 +1,107 @@
+package io.casperlabs.shared
+
+import java.nio.charset.Charset
+import java.nio.file.{Files, OpenOption, Path}
+
+import cats.Monad
+import cats.data.EitherT
+import cats.effect.Sync
+import cats.implicits._
+import io.casperlabs.catscontrib.Catscontrib._
+import simulacrum.typeclass
+
+@typeclass trait FilesAPI[F[_]] {
+  def readBytes(path: Path): F[Option[Array[Byte]]]
+  def readString(path: Path, charset: Charset = Charset.defaultCharset()): F[Option[String]]
+
+  /* If `path` doesn't exist then will try to create it with all non-existent parent directories */
+  def writeBytes(path: Path, data: Array[Byte], options: List[OpenOption] = Nil): F[Unit]
+
+  /* If `path` doesn't exist then will try to create it with all non-existent parent directories */
+  def writeString(
+      path: Path,
+      data: String,
+      charset: Charset = Charset.defaultCharset(),
+      options: List[OpenOption] = Nil
+  ): F[Unit]
+}
+
+object FilesAPI {
+  private implicit val logSource: LogSource = LogSource(this.getClass)
+
+  def create[F[_]: Sync: Log]: F[FilesAPI[F]] = Sync[F].delay {
+    new FilesAPI[F] {
+      override def readBytes(path: Path): F[Option[Array[Byte]]] =
+        Sync[F]
+          .delay {
+            Files.readAllBytes(path).some
+          }
+          .handleErrorWith { e =>
+            Log[F].warn(s"Failed to read a file: $path, ${e.getMessage}") *> none[Array[Byte]]
+              .pure[F]
+          }
+
+      override def readString(
+          path: Path,
+          charset: Charset = Charset.defaultCharset()
+      ): F[Option[String]] =
+        readBytes(path).map(_.map(array => new String(array, charset)))
+
+      override def writeBytes(
+          path: Path,
+          data: Array[Byte],
+          options: List[OpenOption] = Nil
+      ): F[Unit] =
+        (for {
+          _ <- Sync[F]
+                .delay(Files.createDirectories(path.getParent))
+                .whenA(!path.getParent.toFile.exists())
+          _ <- Sync[F]
+                .delay {
+                  Files.write(path, data, options: _*)
+                }
+        } yield ()).handleErrorWith { e =>
+          Log[F].error(s"Failed to write data to file: $path", e)
+        }
+
+      override def writeString(
+          path: Path,
+          data: String,
+          charset: Charset = Charset.defaultCharset(),
+          options: List[OpenOption] = Nil
+      ): F[Unit] = writeBytes(path, data.getBytes(charset), options)
+    }
+  }
+
+  implicit def eitherTFilesApi[E, F[_]: Monad: FilesAPI]: FilesAPI[EitherT[F, E, ?]] =
+    new FilesAPI[EitherT[F, E, ?]] {
+      override def readBytes(path: Path): EitherT[F, E, Option[Array[Byte]]] =
+        FilesAPI[F].readBytes(path).liftM[EitherT[?[_], E, ?]]
+
+      override def readString(
+          path: Path,
+          charset: Charset = Charset.defaultCharset()
+      ): EitherT[F, E, Option[String]] =
+        FilesAPI[F]
+          .readString(
+            path,
+            charset
+          )
+          .liftM[EitherT[?[_], E, ?]]
+
+      override def writeBytes(
+          path: Path,
+          data: Array[Byte],
+          options: List[OpenOption] = Nil
+      ): EitherT[F, E, Unit] =
+        FilesAPI[F].writeBytes(path, data, options).liftM[EitherT[?[_], E, ?]]
+
+      override def writeString(
+          path: Path,
+          data: String,
+          charset: Charset = Charset.defaultCharset(),
+          options: List[OpenOption] = Nil
+      ): EitherT[F, E, Unit] =
+        FilesAPI[F].writeString(path, data, charset, options).liftM[EitherT[?[_], E, ?]]
+    }
+}

--- a/shared/src/main/scala/io/casperlabs/shared/FilesAPI.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/FilesAPI.scala
@@ -31,7 +31,7 @@ import simulacrum.typeclass
 object FilesAPI {
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  def create[F[_]: Sync: Log]: F[FilesAPI[F]] = Sync[F].delay {
+  def create[F[_]: Sync: Log]: FilesAPI[F] =
     new FilesAPI[F] {
       override def readBytes(path: Path): F[Array[Byte]] =
         Sync[F]
@@ -70,7 +70,6 @@ object FilesAPI {
           options: List[OpenOption] = Nil
       ): F[Unit] = writeBytes(path, data.getBytes(charset), options)
     }
-  }
 
   implicit def eitherTFilesApi[E, F[_]: Monad: FilesAPI]: FilesAPI[EitherT[F, E, ?]] =
     new FilesAPI[EitherT[F, E, ?]] {

--- a/shared/src/test/scala/io/casperlabs/shared/FilesAPISuite.scala
+++ b/shared/src/test/scala/io/casperlabs/shared/FilesAPISuite.scala
@@ -1,0 +1,142 @@
+package io.casperlabs.shared
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+import java.util.UUID
+
+import cats.effect.SyncIO
+import io.casperlabs.shared.Log.NOPLog
+import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+
+import scala.util.Try
+
+class FilesAPISuite extends WordSpec with Matchers with BeforeAndAfterEach {
+
+  import FilesAPISuite.TestFixture
+  val nonExistentFile: Path = Paths.get(s"/tmp/$random.txt")
+  val nonExistentFileWithParents: Path = Paths.get(
+    s"/tmp/$random/$random/$random.txt"
+  )
+  val existingFile: Path       = Paths.get(s"/tmp/$random.txt")
+  val existingFileData: String = random
+
+  override protected def beforeEach(): Unit = {
+    Try(Files.delete(nonExistentFile))
+    Try(Files.delete(nonExistentFileWithParents))
+    Try(Files.delete(nonExistentFileWithParents.getParent))
+    Try(Files.delete(nonExistentFileWithParents.getParent.getParent))
+    Try(Files.delete(existingFile))
+    Try(Files.write(existingFile, existingFileData.getBytes()))
+  }
+
+  override protected def afterEach(): Unit = {
+    Try(Files.delete(existingFile))
+    Try(Files.delete(nonExistentFile))
+    Try(Files.delete(nonExistentFileWithParents))
+    Try(Files.delete(nonExistentFileWithParents.getParent))
+    Try(Files.delete(nonExistentFileWithParents.getParent.getParent))
+  }
+
+  def random: String = UUID.randomUUID().toString
+
+  "FilesAPI implementation" when {
+    "file doesn't exist" should {
+
+      "return None when readBytes" in TestFixture { api =>
+        for {
+          maybeData <- api.readBytes(nonExistentFile)
+        } yield {
+          maybeData shouldBe None
+        }
+      }
+      "return None when readString" in TestFixture { api =>
+        for {
+          maybeData <- api.readString(nonExistentFile, StandardCharsets.UTF_8)
+        } yield {
+          maybeData shouldBe None
+        }
+      }
+      "create file when writeBytes" in TestFixture { api =>
+        for {
+          _ <- api.writeBytes(nonExistentFile, "Hello".getBytes(StandardCharsets.UTF_8))
+        } yield {
+          Files.exists(nonExistentFile) shouldBe true
+        }
+      }
+      "create file when writeString" in TestFixture { api =>
+        for {
+          _ <- api.writeString(nonExistentFile, "Hello")
+        } yield {
+          Files.exists(nonExistentFile) shouldBe true
+        }
+      }
+    }
+
+    "file and parent directories don't exist" should {
+      "create parents directories and file when writeBytes" in TestFixture { api =>
+        for {
+          _ <- api.writeBytes(nonExistentFileWithParents, "Hello".getBytes(StandardCharsets.UTF_8))
+        } yield {
+          Files.exists(nonExistentFileWithParents) shouldBe true
+        }
+      }
+
+      "create parents directories and file when writeString" in TestFixture { api =>
+        for {
+          _ <- api.writeString(nonExistentFileWithParents, "Hello")
+        } yield {
+          Files.exists(nonExistentFileWithParents) shouldBe true
+        }
+      }
+    }
+
+    "file exists" should {
+      "return Some when readBytes" in TestFixture { api =>
+        for {
+          maybeData <- api.readBytes(existingFile)
+        } yield {
+          maybeData shouldBe an[Some[_]]
+        }
+      }
+      "return Some when readString" in TestFixture { api =>
+        for {
+          maybeData <- api.readString(existingFile)
+        } yield {
+          maybeData shouldBe an[Some[_]]
+        }
+      }
+      "override file when writeBytes if called without additional options" in TestFixture { api =>
+        val newData = random.getBytes(StandardCharsets.UTF_8)
+        for {
+          _ <- api.writeBytes(existingFile, newData)
+        } yield {
+          Files
+            .readAllBytes(existingFile)
+            .toList should contain theSameElementsInOrderAs newData.toList
+        }
+      }
+      "override file when writeString if called without additional options" in TestFixture { api =>
+        val newData = random
+        for {
+          _ <- api.writeString(existingFile, newData)
+        } yield {
+          import scala.collection.JavaConverters._
+          Files
+            .readAllLines(existingFile)
+            .asScala
+            .mkString
+            .trim shouldBe newData
+        }
+      }
+    }
+  }
+}
+
+object FilesAPISuite {
+  private implicit val NOPLog: NOPLog[SyncIO] = new NOPLog[SyncIO]
+
+  object TestFixture {
+    def apply(test: FilesAPI[SyncIO] => SyncIO[Unit]): Unit =
+      FilesAPI.create[SyncIO].flatMap(test).unsafeRunSync()
+  }
+}

--- a/shared/src/test/scala/io/casperlabs/shared/FilesAPISuite.scala
+++ b/shared/src/test/scala/io/casperlabs/shared/FilesAPISuite.scala
@@ -141,6 +141,6 @@ object FilesAPISuite {
 
   object TestFixture {
     def apply(test: FilesAPI[SyncIO] => SyncIO[Unit]): Unit =
-      FilesAPI.create[SyncIO].flatMap(test).unsafeRunSync()
+      test(FilesAPI.create[SyncIO]).unsafeRunSync()
   }
 }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineConf.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineConf.scala
@@ -20,7 +20,6 @@ import io.netty.channel.unix.DomainSocketAddress
 import monix.eval.TaskLift
 
 class ExecutionEngineConf[F[_]: Sync: Log: TaskLift: Metrics](
-    gasSpentRef: Ref[F, Long],
     addr: Path,
     maxMessageSize: Int,
     initBonds: Map[Array[Byte], Long]
@@ -64,7 +63,7 @@ class ExecutionEngineConf[F[_]: Sync: Log: TaskLift: Metrics](
       stub    <- Sync[F].delay(IpcGrpcMonix.stub(channel))
     } yield Resource.make(
       Sync[F].delay(
-        new GrpcExecutionEngineService[F](addr, maxMessageSize, initBonds, stub, gasSpentRef)
+        new GrpcExecutionEngineService[F](addr, maxMessageSize, initBonds, stub)
       )
     )(_ => stop(channel))
 

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineConf.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineConf.scala
@@ -3,12 +3,14 @@ package io.casperlabs.smartcontracts
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
+import cats.effect.concurrent.Ref
 import cats.effect.{Resource, Sync}
 import cats.syntax.applicative._
 import cats.syntax.functor._
 import cats.syntax.flatMap._
 import cats.syntax.apply._
 import io.casperlabs.ipc.IpcGrpcMonix
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared.Log
 import io.grpc.ManagedChannel
 import io.grpc.netty.NettyChannelBuilder
@@ -17,7 +19,8 @@ import io.netty.channel.kqueue.{KQueueDomainSocketChannel, KQueueEventLoopGroup}
 import io.netty.channel.unix.DomainSocketAddress
 import monix.eval.TaskLift
 
-class ExecutionEngineConf[F[_]: Sync: Log: TaskLift](
+class ExecutionEngineConf[F[_]: Sync: Log: TaskLift: Metrics](
+    gasSpentRef: Ref[F, Long],
     addr: Path,
     maxMessageSize: Int,
     initBonds: Map[Array[Byte], Long]
@@ -60,7 +63,9 @@ class ExecutionEngineConf[F[_]: Sync: Log: TaskLift](
       channel <- channelF
       stub    <- Sync[F].delay(IpcGrpcMonix.stub(channel))
     } yield Resource.make(
-      Sync[F].delay(new GrpcExecutionEngineService[F](addr, maxMessageSize, initBonds, stub))
+      Sync[F].delay(
+        new GrpcExecutionEngineService[F](addr, maxMessageSize, initBonds, stub, gasSpentRef)
+      )
     )(_ => stop(channel))
 
     Resource.suspend(res)


### PR DESCRIPTION
### Overview
* Adds new `casperlabs_engine_gas_spent` Prometheus metric which is persisted between restarts.
* Also adds new `FilesAPI` tagless final algebra which we can use in the future making the codebase cleaner and more testable.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-526

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
The ticket has the requirement for having gas processing rate per 1 second. I decided to move the responsibility of calculating it to the Prometheus. We can use Prometheus queries like `rate(casperlabs_engine_gas_spent[10s])` to calculate a rate for some period of time. If we want to calculate gas processing rate per 1 second then we'll have to specify `scraping_interval` to be 500ms-1s. Intuitively for me, it looks suspicious, because feels like 500ms-1s scraping interval is too low, but it worked fine locally. Please, share your thought about it.