### PR TITLE
NO-TICKET: Fix standalone engine runtime panic.

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -76,6 +76,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "binascii"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "bit-set"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +320,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "execution-engine"
 version = "0.1.0"
 dependencies = [
+ "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "casperlabs-contract-ffi 0.8.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1825,6 +1831,7 @@ dependencies = [
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5d608a38535c371b2a9149159f6dd2259af379f71e50c24d54a842de44bc5b19"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
+"checksum binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc96c09fe0e8441b8e0e8afa1a64f11a1994f3f146008175eccdfe67f7c0330"
 "checksum bit-set 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e84c238982c4b1e1ee668d136c510c67a13465279c0cb367ea6baf6310620a80"
 "checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"

--- a/execution-engine/engine/Cargo.toml
+++ b/execution-engine/engine/Cargo.toml
@@ -22,6 +22,7 @@ wasmi = "0.4.2"
 wasm-prep = { path = "../wasm-prep" }
 num-derive = "0.2.5"
 num-traits = "0.2.8"
+binascii = "0.1.2"
 
 [dev-dependencies]
 matches = "0.1.8"


### PR DESCRIPTION
Passed `address` parameter wasn't decoded from base16. Standalone engine failed at
`copy_from_slice` where `DEFAULT_ADDRESS` is 64 bytes (an address in base16), but the result
address array is 32 bytes (bytes).

Without this fix I was unable to run standalone engine because it failed at boot time while parsing `address` parameter.

It takes inspiration from #627 where it depends on a `binascii` to do the decoding

### Overview
_Provide a brief description of what this PR does, and why it's needed._

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
