### PR TITLE
NODE-571: Add keys generator Docker image to CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -182,7 +182,7 @@ pipeline:
       - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
       - "make docker-build/execution-engine"
       - "make docker-build/integration-testing"
-      - "make docker-build/keys-generator"
+      - "make docker-build/key-generator"
     environment:
       - "_JAVA_OPTIONS=-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
     image: "casperlabs/buildenv:latest"
@@ -260,7 +260,7 @@ pipeline:
   docker-key-gen-merge:
     commands:
       - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
-      - "make docker-build/keys-generator"
+      - "make docker-build/key-generator"
     image: "casperlabs/buildenv:latest"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -359,20 +359,20 @@ pipeline:
       docker tag casperlabs/node:DRONE-${DRONE_BUILD_NUMBER} casperlabs/node:"$REF"
       docker tag casperlabs/client:DRONE-${DRONE_BUILD_NUMBER} casperlabs/client:"$REF"
       docker tag casperlabs/execution-engine:DRONE-${DRONE_BUILD_NUMBER} casperlabs/execution-engine:"$REF"
-      docker tag casperlabs/keys-generator:DRONE-${DRONE_BUILD_NUMBER} casperlabs/keys-generator:"$REF"
+      docker tag casperlabs/key-generator:DRONE-${DRONE_BUILD_NUMBER} casperlabs/key-generator:"$REF"
       docker push casperlabs/node:"$REF"
       docker push casperlabs/client:"$REF"
       docker push casperlabs/execution-engine:"$REF"
-      docker push casperlabs/keys-generator:"$REF"
+      docker push casperlabs/key-generator:"$REF"
       if [ "${DRONE_BRANCH}" = "master" ]; then
         docker tag casperlabs/node:DRONE-${DRONE_BUILD_NUMBER} casperlabs/node:latest
         docker tag casperlabs/client:DRONE-${DRONE_BUILD_NUMBER} casperlabs/client:latest
         docker tag casperlabs/execution-engine:DRONE-${DRONE_BUILD_NUMBER} casperlabs/execution-engine:latest
-        docker tag casperlabs/keys-generator:DRONE-${DRONE_BUILD_NUMBER} casperlabs/keys-generator:latest
+        docker tag casperlabs/key-generator:DRONE-${DRONE_BUILD_NUMBER} casperlabs/key-generator:latest
         docker push casperlabs/node:latest
         docker push casperlabs/client:latest
         docker push casperlabs/execution-engine:latest
-        docker push casperlabs/keys-generator:latest
+        docker push casperlabs/key-generator:latest
       fi
       echo "done"
     image: "casperlabs/buildenv:latest"

--- a/.drone.yml
+++ b/.drone.yml
@@ -182,8 +182,22 @@ pipeline:
       - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
       - "make docker-build/execution-engine"
       - "make docker-build/integration-testing"
+      - "make docker-build/keys-generator"
     environment:
       - "_JAVA_OPTIONS=-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+    image: "casperlabs/buildenv:latest"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    when:
+      branch:
+        - staging
+        - trying
+
+  docker-keys-gen-test-bors:
+    commands:
+      - "cd hack/key-management"
+      - "mkdir test"
+      - "./docker-gen-keys.sh test --test"
     image: "casperlabs/buildenv:latest"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -231,6 +245,22 @@ pipeline:
       - "make docker-build/execution-engine"
     environment:
       - "_JAVA_OPTIONS=-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+    image: "casperlabs/buildenv:latest"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock"
+    when:
+      branch:
+        - dev
+        - release-*
+        - master
+      event:
+        - push
+        - tag
+
+  docker-key-gen-merge:
+    commands:
+      - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
+      - "make docker-build/keys-generator"
     image: "casperlabs/buildenv:latest"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -329,16 +359,20 @@ pipeline:
       docker tag casperlabs/node:DRONE-${DRONE_BUILD_NUMBER} casperlabs/node:"$REF"
       docker tag casperlabs/client:DRONE-${DRONE_BUILD_NUMBER} casperlabs/client:"$REF"
       docker tag casperlabs/execution-engine:DRONE-${DRONE_BUILD_NUMBER} casperlabs/execution-engine:"$REF"
+      docker tag casperlabs/keys-generator:DRONE-${DRONE_BUILD_NUMBER} casperlabs/keys-generator:"$REF"
       docker push casperlabs/node:"$REF"
       docker push casperlabs/client:"$REF"
       docker push casperlabs/execution-engine:"$REF"
+      docker push casperlabs/keys-generator:"$REF"
       if [ "${DRONE_BRANCH}" = "master" ]; then
         docker tag casperlabs/node:DRONE-${DRONE_BUILD_NUMBER} casperlabs/node:latest
         docker tag casperlabs/client:DRONE-${DRONE_BUILD_NUMBER} casperlabs/client:latest
         docker tag casperlabs/execution-engine:DRONE-${DRONE_BUILD_NUMBER} casperlabs/execution-engine:latest
+        docker tag casperlabs/keys-generator:DRONE-${DRONE_BUILD_NUMBER} casperlabs/keys-generator:latest
         docker push casperlabs/node:latest
         docker push casperlabs/client:latest
         docker push casperlabs/execution-engine:latest
+        docker push casperlabs/keys-generator:latest
       fi
       echo "done"
     image: "casperlabs/buildenv:latest"

--- a/.drone.yml
+++ b/.drone.yml
@@ -195,12 +195,13 @@ pipeline:
 
   docker-keys-gen-test-bors:
     commands:
-      - "cd hack/key-management"
-      - "mkdir test"
-      - "./docker-gen-keys.sh test --test"
+      - "mkdir /tmp/keys-DRONE-${DRONE_BUILD_NUMBER}"
+      - "./hack/key-management/docker-gen-keys.sh /tmp/keys-DRONE-${DRONE_BUILD_NUMBER} --test"
+      - "rm -rf /tmp/keys-DRONE-${DRONE_BUILD_NUMBER}"
     image: "casperlabs/buildenv:latest"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
+      - "/tmp:/tmp"
     when:
       branch:
         - staging

--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,19 @@ docker-build-all: \
 	docker-build/client \
 	docker-build/execution-engine \
 	docker-build/integration-testing \
-	docker-build/keys-generator
+	docker-build/key-generator
 
 docker-push-all: \
 	docker-push/node \
 	docker-push/client \
 	docker-push/execution-engine \
-	docker-push/keys-generator
+	docker-push/key-generator
 
 docker-build/node: .make/docker-build/universal/node .make/docker-build/test/node
 docker-build/client: .make/docker-build/universal/client .make/docker-build/test/client
 docker-build/execution-engine: .make/docker-build/execution-engine .make/docker-build/test/execution-engine
 docker-build/integration-testing: .make/docker-build/integration-testing .make/docker-build/test/integration-testing
-docker-build/keys-generator: .make/docker-build/keys-generator
+docker-build/key-generator: .make/docker-build/key-generator
 
 # Tag the `latest` build with the version from git and push it.
 # Call it like `DOCKER_PUSH_LATEST=true make docker-push/node`
@@ -156,10 +156,10 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 	mkdir -p $(dir $@) && touch $@
 
 # Make an image for keys generation
-.make/docker-build/keys-generator: \
+.make/docker-build/key-generator: \
 	hack/key-management/Dockerfile \
 	hack/key-management/gen-keys.sh
-	docker build -f hack/key-management/Dockerfile -t $(DOCKER_USERNAME)/keys-generator:$(DOCKER_LATEST_TAG) hack/key-management
+	docker build -f hack/key-management/Dockerfile -t $(DOCKER_USERNAME)/key-generator:$(DOCKER_LATEST_TAG) hack/key-management
 	mkdir -p $(dir $@) && touch $@
 
 # Refresh Scala build artifacts if source was changed.

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -1,21 +1,37 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 # Generates all necessary keys for a node using Docker image
 # Usage:
-# ./docker-gen-keys.sh <directory where to put keys>
+# ./docker-gen-keys.sh <directory where to put keys> [--test]
 
 if [[ "$1" == /* ]] || [[ "$1" == ~* ]]; then
-	OUTPUT_DIR="$1"
+    OUTPUT_DIR="$1"
 else
-	OUTPUT_DIR="$(PWD)/$1"	
+    OUTPUT_DIR="$(PWD)/$1"
 fi
 
 if [[ ! -d "$OUTPUT_DIR" ]]; then
     echo "ERROR: output dir doesn't exist"
     echo "usage: ./docker-gen-keys.sh <dir>"
-    exit 1
+    exit "1"
 fi
 
-docker pull casperlabs/keys-generator
+shift
+
+docker pull casperlabs/keys-generator:latest || true
 docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/keys-generator /keys
+
+if [[ "$1" == "--test" ]]; then
+    if [[ -f "$OUTPUT_DIR/node-id" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-id" ]] && \
+       [[ -f "$OUTPUT_DIR/node.key.pem" ]] && \
+       [[ -f "$OUTPUT_DIR/node.certificate.pem" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-private.pem" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-public.pem" ]]; then
+        exit "0"
+    else
+        echo "ERROR: Some of required files haven't created"
+        exit "1"
+    fi
+fi

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -8,7 +8,7 @@ set -eo pipefail
 if [[ "$1" == /* ]] || [[ "$1" == ~* ]]; then
     OUTPUT_DIR="$1"
 else
-    OUTPUT_DIR="$(PWD)/$1"
+    OUTPUT_DIR="$PWD/$1"
 fi
 
 if [[ ! -d "$OUTPUT_DIR" ]]; then
@@ -19,8 +19,8 @@ fi
 
 shift
 
-docker pull casperlabs/keys-generator:latest || true
-docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/keys-generator /keys
+docker pull casperlabs/key-generator:latest || true
+docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/key-generator /keys
 
 if [[ "$1" == "--test" ]]; then
     if [[ -f "$OUTPUT_DIR/node-id" ]] && \

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -22,10 +22,10 @@ shift
 
 docker pull casperlabs/key-generator:latest || true
 
-if [[ -z "$DRONE" ]]; then
-    docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/key-generator /keys
+if [[ -z "$DRONE_BUILD_NUMBER" ]]; then
+    docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/key-generator:latest /keys
 else
-    docker run --rm -v "$OUTPUT_DIR":/keys casperlabs/key-generator /keys
+    docker run --rm -v "$OUTPUT_DIR":/keys casperlabs/key-generator:DRONE-"$DRONE_BUILD_NUMBER" /keys
 fi
 
 

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 # Generates all necessary keys for a node using Docker image
 # Usage:
 # ./docker-gen-keys.sh <directory where to put keys> [--test]
+#   --test  tests if all the required keys have been created
 
 if [[ "$1" == /* ]] || [[ "$1" == ~* ]]; then
     OUTPUT_DIR="$1"
@@ -20,7 +21,13 @@ fi
 shift
 
 docker pull casperlabs/key-generator:latest || true
-docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/key-generator /keys
+
+if [[ -z "$DRONE" ]]; then
+    docker run --rm -it -v "$OUTPUT_DIR":/keys casperlabs/key-generator /keys
+else
+    docker run --rm -v "$OUTPUT_DIR":/keys casperlabs/key-generator /keys
+fi
+
 
 if [[ "$1" == "--test" ]]; then
     if [[ -f "$OUTPUT_DIR/node-id" ]] && \


### PR DESCRIPTION
### Overview
Adds [the new Docker image for keys generation](https://github.com/CasperLabs/CasperLabs/pull/663) to the CI.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-571 (I forgot including this work into the original PR)

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._