### PR TITLE
NODE-591: Requeue orphaned deploys

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,3 +7,4 @@ rewrite.rules = [PreferCurlyFors, RedundantBraces, SortImports]
 align = most
 maxColumn = 100
 version = 2.0.0-RC8
+docstrings = ScalaDoc

--- a/casper/src/main/scala/io/casperlabs/casper/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/package.scala
@@ -1,7 +1,9 @@
 package io.casperlabs
 
+import com.google.protobuf.ByteString
 import io.casperlabs.metrics.Metrics
 
 package object casper {
   val CasperMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "casper")
+  type DeployHash = ByteString
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -34,6 +34,7 @@ class GossipServiceCasperTestNode[F[_]](
     blockProcessingLock: Semaphore[F],
     faultToleranceThreshold: Float = 0f,
     validateNonces: Boolean = true,
+    maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None,
     chainId: String = "casperlabs",
     relaying: Relaying[F],
     gossipService: GossipServiceCasperTestNodeFactory.TestGossipService[F],
@@ -53,7 +54,8 @@ class GossipServiceCasperTestNode[F[_]](
       genesis,
       blockDagDir,
       blockStoreDir,
-      validateNonces
+      validateNonces,
+      maybeMakeEE
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
   implicit val safetyOracleEff: SafetyOracle[F] = SafetyOracle.cliqueOracle[F]
@@ -163,7 +165,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
       transforms: Seq[TransformEntry],
       storageSize: Long = 1024L * 1024 * 10,
       faultToleranceThreshold: Float = 0f,
-      validateNonces: Boolean = true
+      validateNonces: Boolean = true,
+      maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None
   )(
       implicit errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
@@ -228,7 +231,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                   relaying = relaying,
                   gossipService = gossipService,
                   validatorToNode = validatorToNode,
-                  validateNonces = validateNonces
+                  validateNonces = validateNonces,
+                  maybeMakeEE = maybeMakeEE
                 )(
                   concurrentF,
                   blockStore,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -11,6 +11,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage._
 import io.casperlabs.casper._
 import io.casperlabs.casper.consensus.{Block, Bond}
+import io.casperlabs.casper.consensus.state
 import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.catscontrib._
@@ -35,6 +36,7 @@ import monix.execution.Scheduler
 
 import scala.collection.mutable.{Map => MutMap}
 import scala.util.Random
+import io.casperlabs.crypto.Keys
 
 /** Base class for test nodes with fields used by tests exposed as public. */
 abstract class HashSetCasperTestNode[F[_]](
@@ -43,7 +45,8 @@ abstract class HashSetCasperTestNode[F[_]](
     val genesis: Block,
     val blockDagDir: Path,
     val blockStoreDir: Path,
-    val validateNonces: Boolean
+    val validateNonces: Boolean,
+    maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]]
 )(
     implicit
     concurrentF: Concurrent[F],
@@ -63,7 +66,9 @@ abstract class HashSetCasperTestNode[F[_]](
     .map(b => PublicKey(b.validatorPublicKey.toByteArray) -> b.stake)
     .toMap
 
-  implicit val casperSmartContractsApi = HashSetCasperTestNode.simpleEEApi[F](bonds, validateNonces)
+  implicit val casperSmartContractsApi =
+    maybeMakeEE.map(_(bonds, validateNonces)) getOrElse
+      HashSetCasperTestNode.simpleEEApi[F](bonds, validateNonces)
 
   /** Handle one message. */
   def receive(): F[Unit]
@@ -140,7 +145,8 @@ trait HashSetCasperTestNodeFactory {
       transforms: Seq[TransformEntry],
       storageSize: Long = 1024L * 1024 * 10,
       faultToleranceThreshold: Float = 0f,
-      validateNonces: Boolean = true
+      validateNonces: Boolean = true,
+      maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None
   )(
       implicit errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
@@ -154,7 +160,8 @@ trait HashSetCasperTestNodeFactory {
       transforms: Seq[TransformEntry],
       storageSize: Long = 1024L * 1024 * 10,
       faultToleranceThreshold: Float = 0f,
-      validateNonces: Boolean = true
+      validateNonces: Boolean = true,
+      maybeMakeEE: Option[MakeExecutionEngineService[Effect]] = None
   ): Effect[IndexedSeq[TestNode[Effect]]] =
     networkF[Effect](
       sks,
@@ -162,7 +169,8 @@ trait HashSetCasperTestNodeFactory {
       transforms,
       storageSize,
       faultToleranceThreshold,
-      validateNonces
+      validateNonces,
+      maybeMakeEE
     )(
       ApplicativeError_[Effect, CommError],
       Concurrent[Effect],
@@ -185,7 +193,9 @@ trait HashSetCasperTestNodeFactory {
 }
 
 object HashSetCasperTestNode {
-  type Effect[A] = EitherT[Task, CommError, A]
+  type Effect[A]                        = EitherT[Task, CommError, A]
+  type Bonds                            = Map[Keys.PublicKey, Long]
+  type MakeExecutionEngineService[F[_]] = (Bonds, Boolean) => ExecutionEngineService[F]
 
   val appErrId = new ApplicativeError[Id, CommError] {
     def ap[A, B](ff: Id[A => B])(fa: Id[A]): Id[B] = Applicative[Id].ap[A, B](ff)(fa)
@@ -255,7 +265,8 @@ object HashSetCasperTestNode {
   //TODO: Give a better implementation for use in testing; this one is too simplistic.
   def simpleEEApi[F[_]: Defer: Applicative](
       initialBonds: Map[PublicKey, Long],
-      validateNonces: Boolean = true
+      validateNonces: Boolean = true,
+      generateConflict: Boolean = false
   ): ExecutionEngineService[F] =
     new ExecutionEngineService[F] {
       import ipc._
@@ -275,8 +286,19 @@ object HashSetCasperTestNode {
         val key = Key(
           Key.Value.Hash(Key.Hash(deploy.session.fold(ByteString.EMPTY)(_.code)))
         )
-        val transform     = Transform(Transform.TransformInstance.Identity(TransformIdentity()))
-        val op            = Op(Op.OpInstance.Read(ReadOp()))
+        val (op, transform) = if (!generateConflict) {
+          Op(Op.OpInstance.Read(ReadOp())) ->
+            Transform(Transform.TransformInstance.Identity(TransformIdentity()))
+        } else {
+          Op(Op.OpInstance.Write(WriteOp())) ->
+            Transform(
+              Transform.TransformInstance.Write(
+                TransformWrite(
+                  state.Value(state.Value.Value.IntValue(0)).some
+                )
+              )
+            )
+        }
         val transforEntry = TransformEntry(Some(key), Some(transform))
         val opEntry       = OpEntry(Some(key), Some(op))
         ExecutionEffect(Seq(opEntry), Seq(transforEntry))

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -45,7 +45,8 @@ class TransportLayerCasperTestNode[F[_]](
     blockProcessingLock: Semaphore[F],
     faultToleranceThreshold: Float = 0f,
     chainId: String = "casperlabs",
-    validateNonces: Boolean = true
+    validateNonces: Boolean = true,
+    maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None
 )(
     implicit
     concurrentF: Concurrent[F],
@@ -61,7 +62,8 @@ class TransportLayerCasperTestNode[F[_]](
       genesis,
       blockDagDir,
       blockStoreDir,
-      validateNonces
+      validateNonces,
+      maybeMakeEE
     )(concurrentF, blockStore, blockDagStorage, metricEff, casperState) {
 
   implicit val logEff: LogStub[F] = new LogStub[F](local.host, printEnabled = false)
@@ -175,7 +177,8 @@ trait TransportLayerCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
       transforms: Seq[TransformEntry],
       storageSize: Long = 1024L * 1024 * 10,
       faultToleranceThreshold: Float = 0f,
-      validateNonces: Boolean = true
+      validateNonces: Boolean = true,
+      maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None
   )(
       implicit errorHandler: ErrorHandler[F],
       concurrentF: Concurrent[F],
@@ -218,7 +221,8 @@ trait TransportLayerCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                     blockStoreDir,
                     semaphore,
                     faultToleranceThreshold,
-                    validateNonces = validateNonces
+                    validateNonces = validateNonces,
+                    maybeMakeEE = maybeMakeEE
                   )(
                     concurrentF,
                     blockStore,


### PR DESCRIPTION
### Overview
This is to prevent the OOM error which came up with the long term testing which (I think) arises from the fact that all nodes use the same account and thus produce orphans, then pile on more deploys. The PR adds `MultiParentCasperImpl.requeueOrphanedDeploys` which runs as a part of `addBlock` to check if any unfinalized deploys still in the buffer just became orphans. If so, it puts them back to be pending so that it can be picked up by `AutoProposer` and proposed again.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-591

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
This should not cause an infinite loop: a node that just proposed a block will see that block be the tip, so it won't instantly be an orphan, otherwise, with a correct implementation, it should have been build on top of some other block to begin with.

There's a risk that with many nodes A produces a block, B trumps it, A proposes again, C trumps it, A proposes again, but at least it's not sitting there. Hopefully with some tweaks like the timeout from the auto-proposer this isn't going to be turned into a busy block factory.
