### PR TITLE
EE-371: Validate deploy's authorization keys & validate deployment threshold.

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -738,6 +738,9 @@ impl From<ExecutionResult> for ipc::DeployResult {
                         execution_error(storage_err.to_string(), cost, effect)
                     }
                     EngineError::PreprocessingError(error_msg) => precondition_failure(error_msg),
+                    authorization_failure @ EngineError::AuthorizationFailure => {
+                        precondition_failure(authorization_failure.to_string())
+                    }
                     EngineError::ExecError(exec_error) => match exec_error {
                         ExecutionError::GasLimit => {
                             let mut deploy_result = ipc::DeployResult::new();

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -310,13 +310,10 @@ impl Account {
     }
 
     /// Checks whether all authorization keys are associated with this account.
-    pub fn validate_authorization_keys<I: IntoIterator<Item = PublicKey>>(
-        &self,
-        authorization_keys: I,
-    ) -> bool {
+    pub fn validate_authorization_keys(&self, authorization_keys: &[PublicKey]) -> bool {
         authorization_keys
             .into_iter()
-            .all(|key| self.associated_keys.contains(&key))
+            .all(|key| self.associated_keys.contains(key))
     }
 }
 

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -225,6 +225,10 @@ impl AssociatedKeys {
     pub fn get_all(&self) -> &BTreeMap<PublicKey, Weight> {
         &self.0
     }
+
+    pub fn contains(&self, key: &PublicKey) -> bool {
+        self.0.contains_key(key)
+    }
 }
 
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -303,6 +307,16 @@ impl Account {
     /// with old contents but with nonce increased by 1.
     pub fn increment_nonce(&mut self) {
         self.nonce += 1;
+    }
+
+    /// Checks whether all authorization keys are associated with this account.
+    pub fn validate_authorization_keys<I: IntoIterator<Item = PublicKey>>(
+        &self,
+        authorization_keys: I,
+    ) -> bool {
+        authorization_keys
+            .into_iter()
+            .all(|key| self.associated_keys.contains(&key))
     }
 }
 

--- a/execution-engine/engine/src/engine_state/error.rs
+++ b/execution-engine/engine/src/engine_state/error.rs
@@ -6,6 +6,8 @@ use shared::newtypes::Blake2bHash;
 pub enum Error {
     #[fail(display = "{}", _0)]
     PreprocessingError(String),
+    #[fail(display = "Authorization failure: Keys do not belong to an account.")]
+    AuthorizationFailure,
     #[fail(display = "Execution error")]
     ExecError(::execution::Error),
     #[fail(display = "Storage error")]

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -17,6 +17,7 @@ use wasm_prep::Preprocessor;
 
 use self::error::{Error, RootNotFound};
 use self::execution_result::ExecutionResult;
+use common::value::account::PublicKey;
 use execution::{self, Executor};
 use tracking_copy::TrackingCopy;
 
@@ -60,6 +61,7 @@ where
         prestate_hash: Blake2bHash,
         gas_limit: u64,
         protocol_version: u64,
+        authorization_keys: Vec<PublicKey>,
         correlation_id: CorrelationId,
         executor: &E,
         preprocessor: &P,
@@ -84,6 +86,7 @@ where
             nonce,
             gas_limit,
             protocol_version,
+            authorization_keys,
             correlation_id,
             tracking_copy,
             self.nonce_check,

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -877,7 +877,7 @@ impl Executor<Module> for WasmiExecutor {
             }
         };
 
-        if authorization_keys.is_empty() || !account.validate_authorization_keys(authorization_keys)
+        if authorization_keys.is_empty() || !account.validate_authorization_keys(&authorization_keys)
         {
             return ExecutionResult::precondition_failure(
                 ::engine_state::error::Error::AuthorizationFailure,

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -865,8 +865,9 @@ impl Executor<Module> for WasmiExecutor {
             Value::Account(a) => a,
             other => {
                 return ExecutionResult::precondition_failure(
-                    ::engine_state::error::Error::ExecError(Error::TypeMismatch(
-                        TypeMismatch::new("Account".to_string(), other.type_string()),
+                    ::engine_state::error::Error::PreprocessingError(format!(
+                        "{} does not point at Account value but {}.",
+                        acct_key, other.type_string()
                     )),
                 )
             }

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -226,6 +226,7 @@ fn main() {
             state_hash,
             gas_limit,
             protocol_version,
+            Vec::new(),
             correlation_id,
             &wasmi_executor,
             &wasmi_preprocessor,

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -10,7 +10,7 @@ use rand_chacha::ChaChaRng;
 use common::bytesrepr::{deserialize, ToBytes};
 use common::key::{Key, LOCAL_SEED_SIZE};
 use common::uref::{AccessRights, URef};
-use common::value::account::Account;
+use common::value::account::{Account, PublicKey};
 use common::value::Value;
 use shared::newtypes::{Blake2bHash, CorrelationId, Validated};
 use storage::global_state::StateReader;
@@ -29,6 +29,7 @@ pub struct RuntimeContext<'a, R> {
     known_urefs: HashMap<URefAddr, HashSet<AccessRights>>,
     account: &'a Account,
     args: Vec<Vec<u8>>,
+    authorization_keys: Vec<PublicKey>,
     // Key pointing to the entity we are currently running
     //(could point at an account or contract in the global state)
     base_key: Key,
@@ -50,6 +51,7 @@ where
         uref_lookup: &'a mut BTreeMap<String, Key>,
         known_urefs: HashMap<URefAddr, HashSet<AccessRights>>,
         args: Vec<Vec<u8>>,
+        authorization_keys: Vec<PublicKey>,
         account: &'a Account,
         base_key: Key,
         gas_limit: u64,
@@ -64,6 +66,7 @@ where
             uref_lookup,
             known_urefs,
             args,
+            authorization_keys,
             account,
             base_key,
             gas_limit,
@@ -93,6 +96,10 @@ where
 
     pub fn account(&self) -> &'a Account {
         self.account
+    }
+
+    pub fn authorization_keys(&self) -> &Vec<PublicKey> {
+        &self.authorization_keys
     }
 
     pub fn args(&self) -> &Vec<Vec<u8>> {
@@ -482,6 +489,7 @@ mod tests {
             uref_map,
             known_urefs,
             Vec::new(),
+            Vec::new(),
             &account,
             base_key,
             0,
@@ -772,6 +780,7 @@ mod tests {
             &mut uref_map,
             known_urefs,
             Vec::new(),
+            Vec::new(),
             &account,
             contract_key,
             0,
@@ -822,6 +831,7 @@ mod tests {
             Rc::clone(&tc),
             &mut uref_map,
             known_urefs,
+            Vec::new(),
             Vec::new(),
             &account,
             other_contract_key,


### PR DESCRIPTION
### Overview
Adds a validation step that checks whether all of the deploy's authorization keys are associated with the account. Also, checks whether authorization keys' total weight meets the deployment threshold before executing the deploy.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-371

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
n/a