### PR TITLE
EE-385: include ExecutionEffect in GenesisResponse

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -667,18 +667,20 @@ impl From<(common::key::Key, transform::Transform)> for super::ipc::TransformEnt
 impl From<ExecutionEffect> for super::ipc::ExecutionEffect {
     fn from(ee: ExecutionEffect) -> super::ipc::ExecutionEffect {
         let mut eff = super::ipc::ExecutionEffect::new();
-        let ipc_ops: Vec<super::ipc::OpEntry> =
-            ee.0.iter()
-                .map(|(k, o)| {
-                    let mut op_entry = super::ipc::OpEntry::new();
-                    let ipc_key = k.into();
-                    let ipc_op = o.clone().into();
-                    op_entry.set_key(ipc_key);
-                    op_entry.set_operation(ipc_op);
-                    op_entry
-                })
-                .collect();
-        let ipc_tran: Vec<super::ipc::TransformEntry> = ee.1.into_iter().map(Into::into).collect();
+        let ipc_ops: Vec<super::ipc::OpEntry> = ee
+            .ops
+            .iter()
+            .map(|(k, o)| {
+                let mut op_entry = super::ipc::OpEntry::new();
+                let ipc_key = k.into();
+                let ipc_op = o.clone().into();
+                op_entry.set_key(ipc_key);
+                op_entry.set_operation(ipc_op);
+                op_entry
+            })
+            .collect();
+        let ipc_tran: Vec<super::ipc::TransformEntry> =
+            ee.transforms.into_iter().map(Into::into).collect();
         eff.set_op_map(protobuf::RepeatedField::from_vec(ipc_ops));
         eff.set_transform_map(protobuf::RepeatedField::from_vec(ipc_tran));
         eff
@@ -973,7 +975,7 @@ mod tests {
             tmp_map
         };
         let execution_effect: ExecutionEffect =
-            ExecutionEffect(HashMap::new(), input_transforms.clone());
+            ExecutionEffect::new(HashMap::new(), input_transforms.clone());
         let cost: u64 = 123;
         let execution_result: ExecutionResult = ExecutionResult::Success {
             effect: execution_effect,

--- a/execution-engine/engine/src/engine_state/execution_effect.rs
+++ b/execution-engine/engine/src/engine_state/execution_effect.rs
@@ -6,4 +6,13 @@ use shared::transform::Transform;
 use super::op::Op;
 
 #[derive(Debug, Default, PartialEq, Eq)]
-pub struct ExecutionEffect(pub HashMap<Key, Op>, pub HashMap<Key, Transform>);
+pub struct ExecutionEffect {
+    pub ops: HashMap<Key, Op>,
+    pub transforms: HashMap<Key, Transform>,
+}
+
+impl ExecutionEffect {
+    pub fn new(ops: HashMap<Key, Op>, transforms: HashMap<Key, Transform>) -> Self {
+        ExecutionEffect { ops, transforms }
+    }
+}

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -7,6 +7,7 @@ mod utils;
 use std::cell::RefCell;
 use std::collections::btree_map::BTreeMap;
 use std::collections::HashMap;
+use std::fmt;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -19,13 +20,15 @@ use common::value::account::PurseId;
 use common::value::{Contract, Value, U512};
 use shared::init;
 use shared::newtypes::{Blake2bHash, CorrelationId};
-use shared::transform::Transform;
+use shared::transform::{Transform, TypeMismatch};
 use storage::global_state::{CommitResult, History};
 use wasm_prep::wasm_costs::WasmCosts;
 use wasm_prep::Preprocessor;
 
 use self::error::{Error, RootNotFound};
 use self::execution_result::ExecutionResult;
+use engine_state::execution_effect::ExecutionEffect;
+use engine_state::op::Op;
 use engine_state::utils::WasmiBytes;
 use execution::{self, Executor};
 use tracking_copy::TrackingCopy;
@@ -43,8 +46,8 @@ pub fn create_genesis_effects(
     mint_code_bytes: WasmiBytes,
     _proof_of_stake_code_bytes: WasmiBytes,
     protocol_version: u64,
-) -> Result<HashMap<Key, Transform>, execution::Error> {
-    let mut ret: HashMap<Key, Value> = HashMap::new();
+) -> Result<ExecutionEffect, execution::Error> {
+    let mut tmp: HashMap<Key, Value> = HashMap::new();
     let mut rng = execution::create_rng(genesis_account_addr, 0, 0);
 
     // Create (public_uref, mint_contract_uref)
@@ -63,7 +66,7 @@ pub fn create_genesis_effects(
 
     // Store (public_uref, mint_contract_uref) in global state
 
-    ret.insert(
+    tmp.insert(
         Key::URef(public_uref),
         Value::Key(Key::URef(mint_contract_uref)),
     );
@@ -82,7 +85,7 @@ pub fn create_genesis_effects(
 
     // Store (genesis_account_addr, genesis_account) in global state
 
-    ret.insert(
+    tmp.insert(
         Key::Account(genesis_account_addr),
         Value::Account(genesis_account),
     );
@@ -108,7 +111,7 @@ pub fn create_genesis_effects(
 
     // Store (purse_id_local_key, balance_uref_key) in local state
 
-    ret.insert(purse_id_local_key, Value::Key(balance_uref_key));
+    tmp.insert(purse_id_local_key, Value::Key(balance_uref_key));
 
     // Create balance
 
@@ -116,7 +119,7 @@ pub fn create_genesis_effects(
 
     // Store (balance_uref_key, balance) in local state
 
-    ret.insert(balance_uref_key, balance);
+    tmp.insert(balance_uref_key, balance);
 
     // Create mint_contract
 
@@ -131,15 +134,59 @@ pub fn create_genesis_effects(
 
     // Store (mint_contract_uref, mint_contract) in global state
 
-    ret.insert(
+    tmp.insert(
         Key::URef(mint_contract_uref),
         Value::Contract(mint_contract),
     );
 
-    Ok(ret
-        .into_iter()
-        .map(|(k, v)| (k, Transform::Write(v)))
-        .collect())
+    let mut execution_effect: ExecutionEffect = Default::default();
+
+    for (k, v) in tmp.into_iter() {
+        execution_effect.ops.insert(k, Op::Write);
+        execution_effect.transforms.insert(k, Transform::Write(v));
+    }
+
+    Ok(execution_effect)
+}
+
+pub enum GenesisResult {
+    RootNotFound,
+    KeyNotFound(Key),
+    TypeMismatch(TypeMismatch),
+    Success {
+        post_state_hash: Blake2bHash,
+        effect: ExecutionEffect,
+    },
+}
+
+impl fmt::Display for GenesisResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            GenesisResult::RootNotFound => write!(f, "Root not found"),
+            GenesisResult::KeyNotFound(key) => write!(f, "Key not found: {}", key),
+            GenesisResult::TypeMismatch(type_mismatch) => {
+                write!(f, "Type mismatch: {:?}", type_mismatch)
+            }
+            GenesisResult::Success {
+                post_state_hash,
+                effect,
+            } => write!(f, "Success: {} {:?}", post_state_hash, effect),
+        }
+    }
+}
+
+impl GenesisResult {
+    fn from_commit_result(commit_result: CommitResult, effect: ExecutionEffect) -> Self {
+        match commit_result {
+            CommitResult::RootNotFound => GenesisResult::RootNotFound,
+            CommitResult::KeyNotFound(key) => GenesisResult::KeyNotFound(key),
+            CommitResult::TypeMismatch(type_mismatch) => GenesisResult::TypeMismatch(type_mismatch),
+            CommitResult::Success(post_state_hash) => GenesisResult::Success {
+                post_state_hash,
+                effect,
+            },
+        }
+    }
 }
 
 impl<H> EngineState<H>
@@ -161,7 +208,7 @@ where
         mint_code_bytes: &[u8],
         proof_of_stake_code_bytes: &[u8],
         protocol_version: u64,
-    ) -> Result<CommitResult, Error> {
+    ) -> Result<GenesisResult, Error> {
         let mint_code_bytes = WasmiBytes::new(mint_code_bytes, WasmCosts::free())?;
         let proof_of_stake_code_bytes =
             WasmiBytes::new(proof_of_stake_code_bytes, WasmCosts::free())?;
@@ -174,10 +221,13 @@ where
         )?;
         let mut state_guard = self.state.lock();
         let prestate_hash = state_guard.current_root();
-        let result = state_guard
-            .commit(correlation_id, prestate_hash, effects)
+        let commit_result = state_guard
+            .commit(correlation_id, prestate_hash, effects.transforms.to_owned())
             .map_err(Into::into)?;
-        Ok(result)
+
+        let genesis_result = GenesisResult::from_commit_result(commit_result, effects);
+
+        Ok(genesis_result)
     }
 
     pub fn state(&self) -> Arc<Mutex<H>> {
@@ -286,7 +336,7 @@ mod tests {
         WasmiBytes::new(raw_bytes.as_slice(), WasmCosts::free()).expect("should create wasmi bytes")
     }
 
-    fn get_genesis_effects() -> HashMap<Key, Transform> {
+    fn get_genesis_transforms() -> HashMap<Key, Transform> {
         let initial_tokens = get_initial_tokens(INITIAL_BALANCE);
 
         let mint_code_bytes = get_mint_code_bytes();
@@ -301,6 +351,7 @@ mod tests {
             PROTOCOL_VERSION,
         )
         .expect("should create effects")
+        .transforms
     }
 
     fn is_write(transform: &Transform) -> bool {
@@ -354,11 +405,11 @@ mod tests {
 
     #[test]
     fn create_genesis_effects_creates_expected_effects() {
-        let effects = get_genesis_effects();
+        let transforms = get_genesis_transforms();
 
-        assert_eq!(effects.len(), EXPECTED_GENESIS_TRANSFORM_COUNT);
+        assert_eq!(transforms.len(), EXPECTED_GENESIS_TRANSFORM_COUNT);
 
-        assert!(effects.iter().all(|(_, effect)| is_write(effect)));
+        assert!(transforms.iter().all(|(_, effect)| is_write(effect)));
     }
 
     #[test]
@@ -373,14 +424,14 @@ mod tests {
             Key::URef(URef::new(addr, AccessRights::READ_ADD_WRITE))
         };
 
-        let effects = get_genesis_effects();
+        let transforms = get_genesis_transforms();
 
         assert!(
-            effects.contains_key(&public_uref_key),
+            transforms.contains_key(&public_uref_key),
             "should have expected public_uref"
         );
 
-        let actual = extract_transform_key(effects, &public_uref_key)
+        let actual = extract_transform_key(transforms, &public_uref_key)
             .expect("transform was not a write of a key");
 
         let mint_contract_uref_key = {
@@ -409,9 +460,9 @@ mod tests {
             Key::URef(URef::new(addr, AccessRights::READ))
         };
 
-        let effects = get_genesis_effects();
+        let transforms = get_genesis_transforms();
 
-        let actual = extract_transform_contract_bytes(effects, &mint_contract_uref_key)
+        let actual = extract_transform_contract_bytes(transforms, &mint_contract_uref_key)
             .expect("transform was not a write of a key");
 
         let mint_code_bytes = get_mint_code_bytes();
@@ -469,14 +520,14 @@ mod tests {
             URef::new(addr, AccessRights::READ_ADD_WRITE)
         };
 
-        let effects = get_genesis_effects();
+        let transforms = get_genesis_transforms();
 
         assert!(
-            effects.contains_key(&purse_id_local_key),
-            "effects should contain purse_id_local_key"
+            transforms.contains_key(&purse_id_local_key),
+            "transforms should contain purse_id_local_key"
         );
 
-        let actual = extract_transform_key(effects, &purse_id_local_key)
+        let actual = extract_transform_key(transforms, &purse_id_local_key)
             .expect("transform was not a write of a key");
 
         // the value under the outer mint_contract_uref should be a key value pointing at
@@ -519,16 +570,16 @@ mod tests {
             URef::new(addr, AccessRights::READ_ADD_WRITE)
         };
 
-        let effects = get_genesis_effects();
+        let transforms = get_genesis_transforms();
 
         assert!(
-            effects.contains_key(&purse_id_local_key),
-            "effects should contain purse_id_local_key"
+            transforms.contains_key(&purse_id_local_key),
+            "transforms should contain purse_id_local_key"
         );
 
         let balance_uref_key = Key::URef(balance_uref);
 
-        let actual = extract_transform_u512(effects, &balance_uref_key)
+        let actual = extract_transform_u512(transforms, &balance_uref_key)
             .expect("transform was not a write of a key");
 
         let initial_tokens = get_initial_tokens(INITIAL_BALANCE);
@@ -541,10 +592,10 @@ mod tests {
     fn create_genesis_effects_stores_genesis_account_at_genesis_account_addr() {
         let account_key = Key::Account(GENESIS_ACCOUNT_ADDR);
 
-        let effects = get_genesis_effects();
+        let transforms = get_genesis_transforms();
 
         assert!(
-            effects.contains_key(&account_key),
+            transforms.contains_key(&account_key),
             "should have expected account key"
         );
 
@@ -560,7 +611,8 @@ mod tests {
         };
 
         let genesis_account = init::create_genesis_account(GENESIS_ACCOUNT_ADDR, purse_id);
-        let actual = extract_transform_account(effects, &account_key).expect("should have account");
+        let actual =
+            extract_transform_account(transforms, &account_key).expect("should have account");
 
         assert_eq!(actual, genesis_account, "invalid account indirection");
     }

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -1019,8 +1019,10 @@ mod tests {
             on_fail_charge!(input, 456, {
                 let mut effect = ExecutionEffect::default();
 
-                effect.0.insert(Key::Hash([42u8; 32]), Op::Read);
-                effect.1.insert(Key::Hash([42u8; 32]), Transform::Identity);
+                effect.ops.insert(Key::Hash([42u8; 32]), Op::Read);
+                effect
+                    .transforms
+                    .insert(Key::Hash([42u8; 32]), Transform::Identity);
 
                 effect
             });
@@ -1034,8 +1036,8 @@ mod tests {
             ExecutionResult::Failure { cost, effect, .. } => {
                 assert_eq!(cost, 456);
                 // Check if the containers are non-empty
-                assert_eq!(effect.0.len(), 1);
-                assert_eq!(effect.1.len(), 1);
+                assert_eq!(effect.ops.len(), 1);
+                assert_eq!(effect.transforms.len(), 1);
             }
         }
     }
@@ -1104,7 +1106,7 @@ mod tests {
                 effect,
                 cost,
             } => {
-                assert_eq!(effect, ExecutionEffect(HashMap::new(), HashMap::new()));
+                assert_eq!(effect, ExecutionEffect::new(HashMap::new(), HashMap::new()));
                 assert_eq!(cost, 0);
                 if let ::engine_state::error::Error::ExecError(Error::InvalidNonce {
                     deploy_nonce,

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -85,7 +85,7 @@ where
     H: History,
     H::Error: Into<execution_engine::execution::Error> + Debug,
 {
-    match engine_state.apply_effect(correlation_id, *pre_state_hash, effects.1) {
+    match engine_state.apply_effect(correlation_id, *pre_state_hash, effects.transforms) {
         Ok(CommitResult::RootNotFound) => {
             let mut properties: BTreeMap<String, String> = BTreeMap::new();
             let error_message = format!("root {:?} not found", pre_state_hash);
@@ -257,7 +257,10 @@ fn main() {
                 cost,
             }) => {
                 properties.insert("gas-cost".to_string(), format!("{:?}", cost));
-                properties.insert("effects".to_string(), format!("{:?}", effects.1.clone()));
+                properties.insert(
+                    "effects".to_string(),
+                    format!("{:?}", effects.transforms.clone()),
+                );
                 let (log_level, error_message, mut new_properties, new_state_hash) =
                     apply_effects(correlation_id, &engine_state, &state_hash, effects);
 

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -718,7 +718,11 @@ mod tests {
 
             let named_key_transform = Transform::AddKeys(once((uref_name.clone(), uref)).collect());
 
-            assert_eq!(*rc.effect().1.get(&base_key).unwrap(), named_key_transform);
+            assert_eq!(
+                *rc.effect().transforms.get(&base_key).unwrap(),
+                named_key_transform
+            );
+
             Ok(())
         });
 
@@ -806,7 +810,7 @@ mod tests {
             Contract::new(Vec::new(), once((uref_name, uref)).collect(), 1).into();
 
         assert_eq!(
-            *tc.borrow().effect().1.get(&contract_key).unwrap(),
+            *tc.borrow().effect().transforms.get(&contract_key).unwrap(),
             Transform::Write(updated_contract)
         );
     }

--- a/execution-engine/engine/src/tracking_copy.rs
+++ b/execution-engine/engine/src/tracking_copy.rs
@@ -190,7 +190,7 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     }
 
     pub fn effect(&self) -> ExecutionEffect {
-        ExecutionEffect(self.ops.clone(), self.fns.clone())
+        ExecutionEffect::new(self.ops.clone(), self.fns.clone())
     }
 
     pub fn query(

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -244,6 +244,7 @@ message GenesisRequest {
 
 message GenesisResult {
     bytes poststate_hash = 1;
+    ExecutionEffect effect = 2;
 }
 
 message GenesisDeployError {


### PR DESCRIPTION
### Overview
This PR:
- changes `engine_state::create_genesis_effects` to return an `ExecutionEffect`
- adds a `GenesisResult` enum which mirrors the structure of `CommitResult`, but also includes the `ExecutionEffect` value in the `Success` variant.
- changes `engine_state::commit_genesis` to return a `GenesisResult`.
- adds an `ExecutionEffect effect` field to the `GenesisResponse` ipc message
- destructs the successful results of calls to `engine_state::commit_genesis` and puts them in the `GenesisResponse` message. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-385

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
