### PR TITLE
NODE-561: Reduce amount of full Kademlia Node Discovery round trips

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
@@ -1,22 +1,20 @@
 package io.casperlabs.casper
 
-import cats._
-import cats.implicits._
 import cats.effect._
 import cats.effect.concurrent._
+import cats.implicits._
 import com.google.protobuf.ByteString
-import io.casperlabs.casper.api.BlockAPI
-import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
-import io.casperlabs.shared.Time
-import io.casperlabs.shared.Log
+import io.casperlabs.casper.api.BlockAPI
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.shared.{Log, Time}
+
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
 /** Propose a block automatically whenever a timespan has elapsed or
   * we have more than a certain number of new deploys in the buffer. */
-class AutoProposer[F[_]: Concurrent: Time: Log: Metrics: MultiParentCasperRef](
+class AutoProposer[F[_]: Bracket[?[_], Throwable]: Time: Log: Metrics: MultiParentCasperRef](
     checkInterval: FiniteDuration,
     maxInterval: FiniteDuration,
     maxCount: Int,

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -109,7 +109,8 @@ sealed abstract class MultiParentCasperInstances {
     for {
       dag <- BlockDagStorage[F].getRepresentation
       _ <- {
-        implicit val functorRaiseInvalidBlock = Validate.raiseValidateErrorThroughSync[F]
+        implicit val functorRaiseInvalidBlock =
+          Validate.raiseValidateErrorThroughApplicativeError[F]
         Validate.transactions[F](genesis, dag, genesisPreState, genesisEffects)
       }
       blockProcessingLock <- Semaphore[F](1)

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -2,7 +2,7 @@ package io.casperlabs.casper.api
 
 import cats.Monad
 import cats.effect.concurrent.Semaphore
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Bracket, Concurrent, Resource}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockDagRepresentation, BlockStore, StorageError}
@@ -164,14 +164,14 @@ object BlockAPI {
         DeployServiceResponse(success = false, s"Error: Could not create block.")
     }
 
-  def propose[F[_]: Sync: MultiParentCasperRef: Log: Metrics](
+  def propose[F[_]: Bracket[?[_], Throwable]: MultiParentCasperRef: Log: Metrics](
       blockApiLock: Semaphore[F]
   ): F[ByteString] = {
     def raise[A](ex: ServiceError.Exception): F[ByteString] =
       MonadThrowable[F].raiseError(ex)
 
     unsafeWithCasper[F, ByteString]("Could not create block.") { implicit casper =>
-      Sync[F].bracket[Boolean, ByteString](blockApiLock.tryAcquire) {
+      Resource.make(blockApiLock.tryAcquire)(blockApiLock.release.whenA).use {
         case true =>
           for {
             _          <- Metrics[F].incrementCounter("create-blocks")
@@ -210,7 +210,7 @@ object BlockAPI {
 
         case false =>
           raise(Aborted("There is another propose in progress."))
-      }(blockApiLock.release.whenA(_))
+      }
     }
   }
 

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -179,7 +179,7 @@ object ExecEngineUtil {
     * @param dag Representation of the DAG.
     * @return Effects of running deploys from the block.
     */
-  def effectsForBlock[F[_]: Sync: BlockStore: ExecutionEngineService](
+  def effectsForBlock[F[_]: MonadThrowable: BlockStore: ExecutionEngineService](
       block: Block,
       prestate: StateHash,
       dag: BlockDagRepresentation[F]

--- a/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidateTest.scala
@@ -45,7 +45,7 @@ class ValidateTest
     with BlockDagStorageFixture
     with ArbitraryConsensus {
   implicit val log              = new LogStub[Task]
-  implicit val raiseValidateErr = Validate.raiseValidateErrorThroughSync[Task]
+  implicit val raiseValidateErr = Validate.raiseValidateErrorThroughApplicativeError[Task]
   // Necessary because errors are returned via Sync which has an error type fixed to _ <: Throwable.
   // When raise errors we wrap them with Throwable so we need to do the same here.
   implicit def wrapWithThrowable[A <: InvalidBlock](err: A): Throwable =

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -261,9 +261,9 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
 
 object GossipServiceCasperTestNodeFactory {
   class TestNodeDiscovery[F[_]: Applicative](peers: List[Node]) extends NodeDiscovery[F] {
-    def discover: F[Unit]                           = ???
-    def lookup(id: NodeIdentifier): F[Option[Node]] = ???
-    def alivePeersAscendingDistance: F[List[Node]]  = peers.pure[F]
+    def discover: F[Unit]                                  = ???
+    def lookup(id: NodeIdentifier): F[Option[Node]]        = ???
+    def recentlyAlivePeersAscendingDistance: F[List[Node]] = peers.pure[F]
   }
 
   def makeNodeAsk[F[_]](node: Node)(implicit ev: Applicative[F]) =

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -362,7 +362,8 @@ object GossipServiceCasperTestNodeFactory {
               } yield latest.values.toList
 
             override def validate(blockSummary: consensus.BlockSummary): F[Unit] = {
-              implicit val functorRaiseInvalidBlock = Validate.raiseValidateErrorThroughSync[F]
+              implicit val functorRaiseInvalidBlock =
+                Validate.raiseValidateErrorThroughApplicativeError[F]
               for {
                 dag <- casper.blockDag
                 _ <- Log[F].debug(

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecutionEngineServiceStub.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecutionEngineServiceStub.scala
@@ -21,7 +21,8 @@ import scala.util.Either
 object ExecutionEngineServiceStub {
   type Bonds = Map[PublicKey, Long]
 
-  implicit def functorRaiseInvalidBlock[F[_]: Sync] = Validate.raiseValidateErrorThroughSync[F]
+  implicit def functorRaiseInvalidBlock[F[_]: Sync] =
+    Validate.raiseValidateErrorThroughApplicativeError[F]
 
   def validateBlockCheckpoint[F[_]: Sync: Log: BlockStore: ExecutionEngineService](
       b: Block,

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
@@ -13,8 +13,8 @@ trait NodeDiscovery[F[_]] {
   /** Iteratively try to find a peer. */
   def lookup(id: NodeIdentifier): F[Option[Node]]
 
-  /** Return the currently active peers. */
-  def alivePeersAscendingDistance: F[List[Node]]
+  /** Return the recently active peers. */
+  def recentlyAlivePeersAscendingDistance: F[List[Node]]
 }
 
 object NodeDiscovery extends NodeDiscoveryInstances {
@@ -26,7 +26,8 @@ object NodeDiscovery extends NodeDiscoveryInstances {
     new NodeDiscovery[T[F, ?]] {
       def discover: T[F, Unit]                           = C.discover.liftM[T]
       def lookup(id: NodeIdentifier): T[F, Option[Node]] = C.lookup(id).liftM[T]
-      def alivePeersAscendingDistance: T[F, List[Node]]  = C.alivePeersAscendingDistance.liftM[T]
+      def recentlyAlivePeersAscendingDistance: T[F, List[Node]] =
+        C.recentlyAlivePeersAscendingDistance.liftM[T]
     }
 }
 

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -112,9 +112,9 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
     /* Threshold to start gradually pinging peers to fill cache */
     alivePeersCacheMinThreshold: Int = 10,
     /* Period to re-fill cache */
-    alivePeersCacheExpirationPeriod: FiniteDuration = 10.minutes,
+    alivePeersCacheExpirationPeriod: FiniteDuration = 5.minutes,
     /* Period to update the cache */
-    alivePeersCacheUpdatePeriod: FiniteDuration = 1.minute,
+    alivePeersCacheUpdatePeriod: FiniteDuration = 15.seconds,
     /* Batches pinged in parallel */
     alivePeersCachePingsBatchSize: Int = 10
 ) extends NodeDiscovery[F] {

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -234,6 +234,8 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Sync: Log: Time: Timer: Metrics
       Timer[F].sleep(alivePeersCacheUpdatePeriod) >>
       schedulePeriodicRecentlyAlivePeersCacheUpdate
 
+  // TODO: The logic might be too complex here
+  // Possible simplification would be pinging all known peers in some period and cache responded ones
   def updateRecentlyAlivePeers: F[Unit] =
     for {
       (recentlyAlivePeers, lastTimeAccess) <- recentlyAlivePeersRef.get

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -181,7 +181,9 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Sync: Log: Time: Metrics: Kadem
                         } yield if (oldEnough) newAlivePeers else newAlivePeers ++ alivePeers
                       else
                         alivePeers.pure[F]
-      _ <- recentlyAlivePeersRef.set((newAlivePeers.toSet, currentTime))
+      _ <- recentlyAlivePeersRef.set(
+            (newAlivePeers.toSet, if (oldEnough) currentTime else lastTimeAccess)
+          )
     } yield PeerTable.sort(newAlivePeers, id)(_.id)
 
   def filterAlive(peers: List[Node]): F[List[Node]] =

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -217,7 +217,7 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Sync: Log: Time: Timer: Metrics
     } yield closestNode
   }
 
-  override def alivePeersAscendingDistance: F[List[Node]] =
+  override def recentlyAlivePeersAscendingDistance: F[List[Node]] =
     if (gossipingEnabled)
       recentlyAlivePeersRef.get.map {
         case (recentlyAlivePeers, _) => PeerTable.sort(recentlyAlivePeers.toList, id)(_.id)

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/PeerTable.scala
@@ -11,7 +11,7 @@ import io.casperlabs.comm.discovery.PeerTable.Entry
 import scala.annotation.tailrec
 import scala.util.Sorting
 
-object PeerTable {
+private[discovery] object PeerTable {
   final case class Entry(node: Node, pinging: Boolean = false) {
     override def toString = s"#{PeerTableEntry $node}"
   }
@@ -46,7 +46,7 @@ object PeerTable {
     * @return `Some(Int)` if `a` and `b` are comparable in this table,
     * `None` otherwise.
     */
-  private[discovery] def longestCommonBitPrefix(a: NodeIdentifier, b: NodeIdentifier): Int = {
+  def longestCommonBitPrefix(a: NodeIdentifier, b: NodeIdentifier): Int = {
     @tailrec
     def highBit(idx: Int): Int =
       if (idx === a.key.length) 8 * a.key.length
@@ -58,31 +58,44 @@ object PeerTable {
     highBit(0)
   }
 
-  private[discovery] def xorDistance(a: NodeIdentifier, b: NodeIdentifier): BigInt =
+  def xorDistance(a: NodeIdentifier, b: NodeIdentifier): BigInt =
     BigInt(a.key.zip(b.key).map { case (l, r) => (l ^ r).toByte }.toArray).abs
 
-  private[discovery] def xorDistance(a: ByteString, b: ByteString): BigInt =
+  def xorDistance(a: ByteString, b: ByteString): BigInt =
     xorDistance(NodeIdentifier(a), NodeIdentifier(b))
+
+  def sort[A](entries: List[A], target: NodeIdentifier)(
+      extractId: A => ByteString
+  ): List[A] =
+    entries.sorted(
+      (x: A, y: A) =>
+        Ordering[BigInt].compare(
+          PeerTable.xorDistance(target.asByteString, extractId(x)),
+          PeerTable.xorDistance(target.asByteString, extractId(y))
+        )
+    )
 }
 
 /** `PeerTable` implements the routing table used in the Kademlia
   * network discovery and routing protocol.
   *
   */
-final class PeerTable[F[_]: Monad](
+private[discovery] final class PeerTable[F[_]: Monad](
     local: NodeIdentifier,
-    private[discovery] val k: Int,
-    private[discovery] val tableRef: Ref[F, Vector[List[Entry]]]
+    val k: Int,
+    val tableRef: Ref[F, Vector[List[Entry]]]
 ) {
+  import PeerTable.sort
+
   private implicit def arrayEq[A]: Eq[Array[A]] = Eq.instance[Array[A]]((a, b) => a.sameElements(b))
   private implicit val bytestringEq: Eq[ByteString] =
     Eq.instance[ByteString]((a, b) => a.toByteArray === b.toByteArray)
 
-  private[discovery] val width = local.key.length // in bytes
+  val width = local.key.length // in bytes
 
-  private[discovery] def longestCommonBitPrefix(other: Node): Int =
+  def longestCommonBitPrefix(other: Node): Int =
     PeerTable.longestCommonBitPrefix(local, NodeIdentifier(other.id))
-  private[discovery] def longestCommonBitPrefix(other: NodeIdentifier): Int =
+  def longestCommonBitPrefix(other: NodeIdentifier): Int =
     PeerTable.longestCommonBitPrefix(local, other)
 
   def updateLastSeen(peer: Node)(implicit K: KademliaService[F]): F[Unit] = {
@@ -131,7 +144,7 @@ final class PeerTable[F[_]: Monad](
 
   def lookup(toLookup: NodeIdentifier): F[Seq[Node]] =
     tableRef.get.map { table =>
-      sort(table.flatten.toList, toLookup).take(k).map(_.node)
+      sort(table.flatten.toList, toLookup)(_.node.id).take(k).map(_.node)
     }
 
   def find(toFind: NodeIdentifier): F[Option[Node]] =
@@ -142,7 +155,7 @@ final class PeerTable[F[_]: Monad](
     )
 
   def peersAscendingDistance: F[List[Node]] = tableRef.get.map { table =>
-    sort(table.flatten.toList, local).map(_.node).toList
+    sort(table.flatten.toList, local)(_.node.id).map(_.node)
   }
 
   def sparseness: F[Seq[Int]] =
@@ -152,14 +165,5 @@ final class PeerTable[F[_]: Monad](
           case ((bucketA, _), (bucketB, _)) => bucketA.size < bucketB.size
         }
         .map(_._2)
-    )
-
-  private def sort(entries: Seq[Entry], target: NodeIdentifier): Seq[Entry] =
-    entries.sorted(
-      (x: Entry, y: Entry) =>
-        Ordering[BigInt].compare(
-          PeerTable.xorDistance(target.asByteString, x.node.id),
-          PeerTable.xorDistance(target.asByteString, y.node.id)
-        )
     )
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
@@ -341,7 +341,7 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
           Log[F].debug(s"Relayed an approval for $id to $relayed peers.")
       }
 
-    nodeDiscovery.alivePeersAscendingDistance.flatMap { peers =>
+    nodeDiscovery.recentlyAlivePeersAscendingDistance.flatMap { peers =>
       loop(Random.shuffle(peers), 0)
     }
   }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/InitialSynchronization.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/InitialSynchronization.scala
@@ -82,7 +82,7 @@ class InitialSynchronizationImpl[F[_]: Concurrent: Par: Log: Timer](
                   if (memoizeNodes) {
                     (if (skipFailedNodesInNextRounds) successful else nodes).pure[F]
                   } else {
-                    nodeDiscovery.alivePeersAscendingDistance.map { peers =>
+                    nodeDiscovery.recentlyAlivePeersAscendingDistance.map { peers =>
                       val nodes = selectNodes(peers)
                       if (skipFailedNodesInNextRounds) {
                         nodes.filterNot(newFailed)
@@ -101,7 +101,7 @@ class InitialSynchronizationImpl[F[_]: Concurrent: Par: Log: Timer](
             }
       }
 
-    nodeDiscovery.alivePeersAscendingDistance
+    nodeDiscovery.recentlyAlivePeersAscendingDistance
       .flatMap { peers =>
         val nodesToSyncWith = selectNodes(peers)
         loop(nodesToSyncWith, Set.empty)

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Relaying.scala
@@ -71,7 +71,7 @@ class RelayingImpl[F[_]: Sync: Par: Log: Metrics: NodeAsk](
     }
 
     for {
-      peers <- nd.alivePeersAscendingDistance
+      peers <- nd.recentlyAlivePeersAscendingDistance
       _     <- hashes.parTraverse(hash => loop(hash, Random.shuffle(peers), 0, 0))
     } yield ()
   }

--- a/comm/src/main/scala/io/casperlabs/comm/rp/Connect.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/rp/Connect.scala
@@ -127,7 +127,7 @@ object Connect {
     for {
       connections <- ConnectionsCell[F].read
       tout        <- RPConfAsk[F].reader(_.defaultTimeout)
-      peers <- NodeDiscovery[F].alivePeersAscendingDistance
+      peers <- NodeDiscovery[F].recentlyAlivePeersAscendingDistance
                 .map(p => (p.toSet -- connections).toList)
       connected <- peers.traverseFilter { peer =>
                     ErrorHandler[F].attempt(conn(peer, tout)).flatMap {

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -473,6 +473,7 @@ object NodeDiscoverySpec {
           recentlyAlivePeersRef,
           alpha,
           k,
+          true,
           alivePeersCacheSize,
           alivePeersCacheMinThreshold,
           alivePeersCacheExpirationPeriod,

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -303,12 +303,13 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
           for {
             // fills up cache
             _  <- nd.updateRecentlyAlivePeers
-            r1 <- nd.alivePeersAscendingDistance
+            r1 <- nd.recentlyAlivePeersAscendingDistance
             // each request should cause re-pinging all peers
             // firstly only alive peers from previous request
             // then rest of all known peers trying to fill up cache
-            n  = nextInt(1, 5)
-            r2 <- (nd.updateRecentlyAlivePeers >> nd.alivePeersAscendingDistance).replicateA(n)
+            n = nextInt(1, 5)
+            r2 <- (nd.updateRecentlyAlivePeers >> nd.recentlyAlivePeersAscendingDistance)
+                   .replicateA(n)
           } yield {
             kademlia.totalPings shouldBe (totalN(peers) * (n + 1))
             r1 should contain theSameElementsInOrderAs ascendingDistance(alive)
@@ -339,10 +340,10 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
           for {
             // fills up cache
             _  <- nd.updateRecentlyAlivePeers
-            r1 <- nd.alivePeersAscendingDistance
+            r1 <- nd.recentlyAlivePeersAscendingDistance
             // pings alive peers from previous query
             _  <- nd.updateRecentlyAlivePeers
-            r2 <- nd.alivePeersAscendingDistance
+            r2 <- nd.recentlyAlivePeersAscendingDistance
           } yield {
             kademlia.totalPings shouldBe (all.size + alive.size)
             r1 should contain theSameElementsInOrderAs ascendingDistance(alive)
@@ -366,10 +367,10 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
         ) { (kademlia, nd, _) =>
           for {
             _  <- nd.updateRecentlyAlivePeers
-            r1 <- nd.alivePeersAscendingDistance
+            r1 <- nd.recentlyAlivePeersAscendingDistance
             _  <- Task.sleep(200.milliseconds)
             _  <- nd.updateRecentlyAlivePeers
-            r2 <- nd.alivePeersAscendingDistance
+            r2 <- nd.recentlyAlivePeersAscendingDistance
           } yield {
             // 1st => to fill up cache
             // 2nd => to check alive peers from cache
@@ -394,7 +395,7 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
           ) { (kademlia, nd, _) =>
             for {
               _ <- nd.updateRecentlyAlivePeers
-              _ <- nd.alivePeersAscendingDistance
+              _ <- nd.recentlyAlivePeersAscendingDistance
             } yield {
               kademlia.totalPings shouldBe 1
             }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -471,9 +471,9 @@ object GenesisApproverSpec extends ArbitraryConsensus {
     .withApproverPublicKey(genesis.getHeader.getState.bonds.last.validatorPublicKey)
 
   class MockNodeDiscovery(peers: List[Node]) extends NodeDiscovery[Task] {
-    override def discover                    = ???
-    override def lookup(id: NodeIdentifier)  = ???
-    override def alivePeersAscendingDistance = Task.now(peers)
+    override def discover                            = ???
+    override def lookup(id: NodeIdentifier)          = ???
+    override def recentlyAlivePeersAscendingDistance = Task.now(peers)
   }
 
   class MockGossipService extends GossipService[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -203,9 +203,9 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
   implicit val metris  = new Metrics.MetricsNOP[Task]
 
   class MockNodeDiscovery(nodes: List[Node]) extends NodeDiscovery[Task] {
-    def discover                    = ???
-    def lookup(id: NodeIdentifier)  = ???
-    def alivePeersAscendingDistance = Task.now(nodes)
+    def discover                            = ???
+    def lookup(id: NodeIdentifier)          = ???
+    def recentlyAlivePeersAscendingDistance = Task.now(nodes)
   }
 
   object MockBackend extends GossipServiceServer.Backend[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -143,9 +143,9 @@ object RelayingSpec {
         log: Log[Task] = noOpLog
     )(test: (Relaying[Task], AtomicInt, AtomicInt) => Task[Unit]): Unit = {
       val nd = new NodeDiscovery[Task] {
-        override def discover: Task[Unit]                           = ???
-        override def lookup(id: NodeIdentifier): Task[Option[Node]] = ???
-        override def alivePeersAscendingDistance: Task[List[Node]]  = Task.now(peers)
+        override def discover: Task[Unit]                                  = ???
+        override def lookup(id: NodeIdentifier): Task[Option[Node]]        = ???
+        override def recentlyAlivePeersAscendingDistance: Task[List[Node]] = Task.now(peers)
       }
       val asked                 = AtomicInt(0)
       val concurrency           = AtomicInt(0)

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -39,7 +39,7 @@ object EffectsTestInstances {
     var nodes: List[Node] = List.empty[Node]
     def reset(): Unit =
       nodes = List.empty[Node]
-    def alivePeersAscendingDistance: F[List[Node]] = Sync[F].delay {
+    def recentlyAlivePeersAscendingDistance: F[List[Node]] = Sync[F].delay {
       nodes
     }
     def discover: F[Unit]                                          = ???

--- a/integration-testing/test/cl_node/docker_base.py
+++ b/integration-testing/test/cl_node/docker_base.py
@@ -79,7 +79,7 @@ class DockerConfig:
         if self.node_env is None:
             self.node_env = {
                 'RUST_BACKTRACE': 'full',
-                'CL_LOG_LEVEL': 'DEBUG',
+                'CL_LOG_LEVEL': os.environ.get("CL_LOG_LEVEL", "INFO"),
                 'CL_CASPER_IGNORE_DEPLOY_SIGNATURE': 'true',
                 'CL_SERVER_NO_UPNP': 'true'
             }

--- a/integration-testing/test/cl_node/docker_node.py
+++ b/integration-testing/test/cl_node/docker_node.py
@@ -230,6 +230,15 @@ class DockerNode(LoggingDockerBase):
         logging.info(f"The block hash: {block_hash} generated for {self.container.name}")
         return block_hash
 
+    def deploy_and_propose_with_retry(self, max_attempts: int, retry_seconds: int, **deploy_kwargs) -> str:
+        deploy_output = self.client.deploy(**deploy_kwargs)
+        assert 'Success!' in deploy_output
+        block_hash_output_string = self.client.propose_with_retry(max_attempts, retry_seconds)
+        block_hash = extract_block_hash_from_propose_output(block_hash_output_string)
+        assert block_hash is not None
+        logging.info(f"The block hash: {block_hash} generated for {self.container.name}")
+        return block_hash
+
     def show_blocks(self) -> Tuple[int, str]:
         return self.exec_run(f'{self.CL_NODE_BINARY} show-blocks')
 

--- a/integration-testing/test/cl_node/wait.py
+++ b/integration-testing/test/cl_node/wait.py
@@ -268,7 +268,7 @@ def wait_for_new_fork_choice_tip_block(node: 'Node', block: str, timeout_seconds
     wait_on_using_wall_clock_time(predicate, timeout_seconds)
 
 
-def wait_for_blocks_count_at_least(node: 'Node', expected_blocks_count: int, max_retrieved_blocks: int, timeout_seconds: int = 10):
+def wait_for_blocks_count_at_least(node: 'Node', expected_blocks_count: int, max_retrieved_blocks: int, timeout_seconds: int = 60):
     predicate = BlocksCountAtLeast(node, expected_blocks_count, max_retrieved_blocks)
     wait_using_wall_clock_time_or_fail(predicate, timeout_seconds)
 

--- a/integration-testing/test/test_block_propagation.py
+++ b/integration-testing/test/test_block_propagation.py
@@ -7,18 +7,20 @@ import pytest
 import logging
 
 from . import conftest
-from .cl_node.casperlabs_network import ThreeNodeNetwork, CustomConnectionNetwork
+from .cl_node.casperlabs_network import ThreeNodeNetwork, \
+    CustomConnectionNetwork
 from .cl_node.casperlabsnode import extract_block_hash_from_propose_output
 from .cl_node.common import random_string
-from .cl_node.wait import wait_for_blocks_count_at_least, wait_for_peers_count_at_least
+from .cl_node.wait import wait_for_blocks_count_at_least, \
+    wait_for_peers_count_at_least
 
 
 class DeployThread(threading.Thread):
     def __init__(self,
-            node: DockerNode,
-            batches_of_contracts: List[List[str]],
-            max_attempts: int,
-            retry_seconds: int) -> None:
+                 node: DockerNode,
+                 batches_of_contracts: List[List[str]],
+                 max_attempts: int,
+                 retry_seconds: int) -> None:
         threading.Thread.__init__(self)
         self.node = node
         self.batches_of_contracts = batches_of_contracts
@@ -29,12 +31,14 @@ class DeployThread(threading.Thread):
     def run(self) -> None:
         for batch in self.batches_of_contracts:
             for contract in batch:
-                assert 'Success' in self.node.client.deploy(session_contract = contract,
-                                                            payment_contract = contract,
-                                                            private_key="validator-0-private.pem",
-                                                            public_key="validator-0-public.pem")
+                assert 'Success' in self.node.client.deploy(
+                    session_contract=contract,
+                    payment_contract=contract,
+                    private_key="validator-0-private.pem",
+                    public_key="validator-0-public.pem")
 
-            propose_output = self.node.client.propose_with_retry(self.max_attempts, self.retry_seconds)
+            propose_output = self.node.client.propose_with_retry(
+                self.max_attempts, self.retry_seconds)
             block_hash = extract_block_hash_from_propose_output(propose_output)
             self.deployed_blocks_hashes.add(block_hash)
 
@@ -49,10 +53,9 @@ def nodes(docker_client_fixture):
         yield network.docker_nodes
 
 
-
 @pytest.mark.parametrize("contract_paths, expected_number_of_blocks", [
-                         ([['test_helloname.wasm'],['test_helloworld.wasm']], 7),
-                         ])
+    ([['test_helloname.wasm'], ['test_helloworld.wasm']], 7),
+])
 def test_block_propagation(nodes,
                            contract_paths: List[List[str]],
                            expected_number_of_blocks):
@@ -61,7 +64,9 @@ def test_block_propagation(nodes,
     Scenario: test_helloworld.wasm deploy and propose by all nodes and stored in all nodes blockstores
     """
 
-    deploy_threads = [DeployThread(node, contract_paths, max_attempts = 5, retry_seconds = 3) for node in nodes]
+    deploy_threads = [
+        DeployThread(node, contract_paths, max_attempts=5, retry_seconds=3) for
+        node in nodes]
 
     for t in deploy_threads:
         t.start()
@@ -70,24 +75,26 @@ def test_block_propagation(nodes,
         t.join()
 
     for node in nodes:
-        wait_for_blocks_count_at_least(node, expected_number_of_blocks, expected_number_of_blocks * 2, node.timeout)
+        wait_for_blocks_count_at_least(node, expected_number_of_blocks,
+                                       expected_number_of_blocks * 2,
+                                       node.timeout)
 
     for node in nodes:
-        blocks = parse_show_blocks(node.client.show_blocks(expected_number_of_blocks * 100))
+        blocks = parse_show_blocks(
+            node.client.show_blocks(expected_number_of_blocks * 100))
         # What propose returns is first 10 characters of block hash, so we can compare only first 10 charcters.
         blocks_hashes = set([b.summary.block_hash[:10] for b in blocks])
         for t in deploy_threads:
             assert t.deployed_blocks_hashes.issubset(blocks_hashes), \
-                   f"Not all blocks deployed and proposed on {t.node.container_name} were propagated to {node.container_name}"
-
+                f"Not all blocks deployed and proposed on {t.node.container_name} were propagated to {node.container_name}"
 
 
 def deploy_and_propose(node, contract, nonce=None):
-    assert 'Success' in node.client.deploy(session_contract = contract,
-                                           payment_contract = contract,
+    assert 'Success' in node.client.deploy(session_contract=contract,
+                                           payment_contract=contract,
                                            private_key="validator-0-private.pem",
                                            public_key="validator-0-public.pem",
-                                           nonce = nonce)
+                                           nonce=nonce)
     propose_output = node.client.propose()
     return extract_block_hash_from_propose_output(propose_output)
 
@@ -113,7 +120,8 @@ def test_blocks_infect_network(not_all_connected_directly_nodes):
     Feature file: block_gossiping.feature
     Scenario: Blocks 'infect' the network and nodes 'closest' to the propose see the blocks first.
     """
-    first, last = not_all_connected_directly_nodes[0], not_all_connected_directly_nodes[-1]
+    first, last = not_all_connected_directly_nodes[0], \
+                  not_all_connected_directly_nodes[-1]
 
     block_hash = deploy_and_propose(first, 'test_helloname.wasm')
     wait_for_blocks_count_at_least(last, 2, 2)
@@ -125,9 +133,10 @@ def test_blocks_infect_network(not_all_connected_directly_nodes):
 @pytest.fixture()
 def four_nodes_network(docker_client_fixture):
     with CustomConnectionNetwork(docker_client_fixture) as network:
-
         # Initially all nodes are connected to each other
-        network.create_cl_network(4, [(i, j) for i in range(4) for j in range(4) if i != j and i < j])
+        network.create_cl_network(4,
+                                  [(i, j) for i in range(4) for j in range(4) if
+                                   i != j and i < j])
 
         # Wait till all nodes have the genesis block.
         for node in network.docker_nodes:
@@ -135,7 +144,10 @@ def four_nodes_network(docker_client_fixture):
 
         yield network
 
-C = ["test_helloname.wasm", "test_mailinglistdefine.wasm", "test_helloworld.wasm"]
+
+C = ["test_helloname.wasm", "test_mailinglistdefine.wasm",
+     "test_helloworld.wasm"]
+
 
 def test_network_partition_and_rejoin(four_nodes_network):
     """
@@ -143,54 +155,52 @@ def test_network_partition_and_rejoin(four_nodes_network):
     Scenario: Network partition occurs and rejoin occurs
     """
     # Partition the network so node0 connected to node1 and node2 connected to node3 only.
-    connections_between_partitions = [(i, j) for i in (0,1) for j in (2,3)]
+    connections_between_partitions = [(i, j) for i in (0, 1) for j in (2, 3)]
+    logging.info("PARTITIONS: {}".format(connections_between_partitions))
 
     logging.info("DISCONNECT PARTITIONS")
     for connection in connections_between_partitions:
+        logging.info("DISCONNECTING PARTITION: {}".format(connection))
         four_nodes_network.disconnect(connection)
 
     nodes = four_nodes_network.docker_nodes
     n = len(nodes)
-    partitions = nodes[:int(n/2)], nodes[int(n/2):]
+    partitions = nodes[:int(n / 2)], nodes[int(n / 2):]
+    logging.info("PARTITIONS: {}".format(partitions))
 
     # Propose separately in each partition. They should not see each others' blocks,
     # so everyone has the genesis plus the 1 block proposed in its partition.
     # Using the same nonce in both partitions because otherwise one of them will
     # sit there unable to propose; should use separate accounts really.
-    deploy_and_propose(partitions[0][0], C[0], nonce = 1)
-    deploy_and_propose(partitions[1][0], C[1], nonce = 1)
+    deploy_and_propose(partitions[0][0], C[0], nonce=1)
+    deploy_and_propose(partitions[1][0], C[1], nonce=1)
 
     for node in nodes:
         wait_for_blocks_count_at_least(node, 2, 2, node.timeout * 2)
 
     logging.info("CONNECT PARTITIONS")
     for connection in connections_between_partitions:
+        logging.info("CONNECTING PARTITIONS: {}".format(connection))
         four_nodes_network.connect(connection)
 
     logging.info("PARTITIONS CONNECTED")
 
-    # NOTE: Currently `NodeDiscoveryImpl.alivePeersInAscendingDistance` pings the peers
-    # before returning a list, from which we take a random subset for gossiping,
-    # so when we do a deploy the node will see the peers it previously knew about
-    # as alive as soon as the network is re-established.
-    # However, NODE-561 may change this and push pinging into the background in
-    # which case it may take a bit longer for the peers to pick up each outhers's presence.
+    # Node updates its list of alive peers in background with a certain period
+    # So we need to wait here for nodes to re-connect partitioned peers
+    for node in nodes:
+        wait_for_peers_count_at_least(node, len(nodes) - 1, 60)
 
     # When we propose a node in partition[0] it should propagate to partition[1],
     # however, nodes in partition[0] will still not see blocks from partition[1]
     # until they also propose a new one on top of the block the created during
     # the network outage.
-    deploy_and_propose(nodes[0], C[2], nonce = 2)
-
-    # NOTE: Currently the node closes the channel only after it has detected a failure,
-    # but the syncing will not retry it. A second attempt will create a new channel though.
-    deploy_and_propose(nodes[0], C[2], nonce = 3)
+    deploy_and_propose(nodes[0], C[2], nonce=2)
 
     for node in partitions[0]:
         logging.info(f"CHECK {node} HAS ALL BLOCKS CREATED IN PARTITION 1")
-        wait_for_blocks_count_at_least(node, 4, 4, node.timeout * 2)
+        wait_for_blocks_count_at_least(node, 3, 3, node.timeout * 2)
 
     for node in partitions[1]:
-        logging.info(f"CHECK {node} HAS ALL BLOCKS CREATED IN PARTITION 1 and 2")
-        wait_for_blocks_count_at_least(node, 5, 5, node.timeout * 2)
-
+        logging.info(
+            f"CHECK {node} HAS ALL BLOCKS CREATED IN PARTITION 1 and 2")
+        wait_for_blocks_count_at_least(node, 4, 4, node.timeout * 2)

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -125,7 +125,6 @@ class NodeRuntime private[node] (
                                                           blockingScheduler,
                                                           effects.peerNodeAsk,
                                                           log,
-                                                          effects.time,
                                                           metrics
                                                         )
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -115,7 +115,10 @@ class NodeRuntime private[node] (
         implicit0(nodeDiscovery: NodeDiscovery[Task]) <- effects.nodeDiscovery(
                                                           id,
                                                           kademliaPort,
-                                                          conf.server.defaultTimeout
+                                                          conf.server.defaultTimeout,
+                                                          conf.server.useGossiping,
+                                                          conf.server.relayFactor,
+                                                          conf.server.relaySaturation
                                                         )(
                                                           maybeBootstrap
                                                         )(

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcControlService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcControlService.scala
@@ -1,19 +1,17 @@
 package io.casperlabs.node.api
 
-import cats.implicits._
 import cats.effect._
 import cats.effect.concurrent._
-import com.google.protobuf.empty.Empty
+import cats.implicits._
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.api.BlockAPI
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.shared.Log
 import io.casperlabs.node.api.control._
-import monix.execution.Scheduler
+import io.casperlabs.shared.Log
 import monix.eval.{Task, TaskLike}
 
 object GrpcControlService {
-  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef](
+  def apply[F[_]: Sync: TaskLike: Log: Metrics: MultiParentCasperRef](
       blockApiLock: Semaphore[F]
   ): F[ControlGrpcMonix.ControlService] =
     BlockAPI.establishMetrics[F] *> Sync[F].delay {

--- a/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
@@ -20,7 +20,7 @@ object StatusInfo {
     for {
       version <- Sync[F].delay(VersionInfo.get)
       peers   <- ConnectionsCell[F].read
-      nodes   <- NodeDiscovery[F].alivePeersAscendingDistance
+      nodes   <- NodeDiscovery[F].recentlyAlivePeersAscendingDistance
     } yield Status(version, peers.length, nodes.length)
 
   def service[F[_]: Sync: ConnectionsCell: NodeDiscovery]: HttpRoutes[F] = {

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -160,7 +160,7 @@ package object gossiping {
           for {
             _           <- Log[F].info(s"Validating genesis-like block ${show(block.blockHash)}...")
             state       <- Cell.mvarCell[F, CasperState](CasperState())
-            executor    = new MultiParentCasperImpl.StatelessExecutor(chainId)
+            executor    = new MultiParentCasperImpl.StatelessExecutor[F](chainId)
             dag         <- BlockDagStorage[F].getRepresentation
             result      <- executor.validateAndAddBlock(None, dag, block)(state)
             (status, _) = result
@@ -495,7 +495,7 @@ package object gossiping {
       awaitApproved: F[Unit],
       isInitialRef: Ref[F, Boolean]
   ): Resource[F, Synchronizer[F]] = Resource.liftF {
-    implicit val functorRaiseInvalidBlock = Validate.raiseValidateErrorThroughSync[F]
+    implicit val functorRaiseInvalidBlock = Validate.raiseValidateErrorThroughApplicativeError[F]
 
     for {
       _ <- SynchronizerImpl.establishMetrics[F]

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -668,7 +668,7 @@ package object gossiping {
     def loop(prevPeers: Set[Node]): F[Unit] = {
       // Based on Connecttions.removeConn
       val newPeers = for {
-        peers <- NodeDiscovery[F].alivePeersAscendingDistance.map(_.toSet)
+        peers <- NodeDiscovery[F].recentlyAlivePeersAscendingDistance.map(_.toSet)
         _     <- Log[F].info(s"Peers: ${peers.size}").whenA(peers.size != prevPeers.size)
         _ <- (prevPeers diff peers).toList.traverse { peer =>
               Log[F].info(s"Disconnected from ${peer.show}")

--- a/node/src/main/scala/io/casperlabs/node/diagnostics/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/diagnostics/effects/package.scala
@@ -242,7 +242,7 @@ package object effects {
         }
 
       def listDiscoveredPeers(request: Empty): Task[Peers] =
-        nodeDiscovery.alivePeersAscendingDistance.map { ps =>
+        nodeDiscovery.recentlyAlivePeersAscendingDistance.map { ps =>
           Peers(
             ps.map(
               p => Peer(p.host, p.protocolPort, p.id)

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -37,7 +37,6 @@ package object effects {
       scheduler: Scheduler,
       peerNodeAsk: NodeAsk[Task],
       log: Log[Task],
-      time: Time[Task],
       metrics: Metrics[Task]
   ): Resource[Effect, NodeDiscovery[Task]] =
     NodeDiscoveryImpl

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -25,7 +25,14 @@ package object effects {
 
   def log: Log[Task] = Log.log
 
-  def nodeDiscovery(id: NodeIdentifier, port: Int, timeout: FiniteDuration)(init: Option[Node])(
+  def nodeDiscovery(
+      id: NodeIdentifier,
+      port: Int,
+      timeout: FiniteDuration,
+      gossipingEnabled: Boolean,
+      gossipingRelayFactor: Int,
+      gossipingRelaySaturation: Int
+  )(init: Option[Node])(
       implicit
       scheduler: Scheduler,
       peerNodeAsk: NodeAsk[Task],
@@ -34,7 +41,14 @@ package object effects {
       metrics: Metrics[Task]
   ): Resource[Effect, NodeDiscovery[Task]] =
     NodeDiscoveryImpl
-      .create[Task](id, port, timeout)(init)
+      .create[Task](
+        id,
+        port,
+        timeout,
+        gossipingEnabled,
+        gossipingRelayFactor,
+        gossipingRelaySaturation
+      )(init)
       .toEffect
 
   def time(implicit timer: Timer[Task]): Time[Task] =


### PR DESCRIPTION
### Overview
Instead of making full round trip pinging all known nodes (there are can be thousands of them) on each `alivePeersAscendingDistance` try to cache previous results and reuse them.
The cache fully cleaned up with some period.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-561

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._