### PR TITLE
NODE-588: Remove finalized deploys as a separate step.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -15,6 +15,7 @@ import io.casperlabs.comm.CommError.ErrorHandler
 import io.casperlabs.comm.gossiping
 import io.casperlabs.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import io.casperlabs.comm.transport.TransportLayer
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 
@@ -117,7 +118,7 @@ sealed abstract class MultiParentCasperInstances {
                     )
     } yield (blockProcessingLock, casperState)
 
-  def fromTransportLayer[F[_]: Concurrent: ConnectionsCell: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
+  def fromTransportLayer[F[_]: Concurrent: ConnectionsCell: TransportLayer: Log: Time: Metrics: ErrorHandler: SafetyOracle: BlockStore: RPConfAsk: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
       validatorId: Option[ValidatorIdentity],
       genesis: Block,
       genesisPreState: StateHash,
@@ -138,7 +139,7 @@ sealed abstract class MultiParentCasperInstances {
     }
 
   /** Create a MultiParentCasper instance from the new RPC style gossiping. */
-  def fromGossipServices[F[_]: Concurrent: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
+  def fromGossipServices[F[_]: Concurrent: Log: Time: Metrics: SafetyOracle: BlockStore: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
       validatorId: Option[ValidatorIdentity],
       genesis: Block,
       genesisPreState: StateHash,

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -12,24 +12,47 @@ import io.casperlabs.shared.StreamT
 import scala.annotation.tailrec
 import scala.collection.immutable.{BitSet, HashSet, Queue}
 import scala.collection.mutable
+import simulacrum.typeclass
 
 object DagOperations {
 
-  def bfTraverseF[F[_]: Monad, A](start: List[A])(neighbours: A => F[List[A]]): StreamT[F, A] = {
-    def build(q: Queue[A], prevVisited: HashSet[A]): F[StreamT[F, A]] =
+  /** Some traversals take so long that tracking the visited nodes can fill the memory.
+    * Key should reduce the data we are traversing to a small identifier.
+    */
+  @typeclass
+  trait Key[A] {
+    type K
+    def key(a: A): K
+  }
+  object Key {
+    def instance[A, B](k: A => B) = new Key[A] {
+      type K = B
+      def key(a: A) = k(a)
+    }
+    def identity[A]           = instance[A, A](a => a)
+    implicit val blockKey     = instance[Block, BlockHash](_.blockHash)
+    implicit val blockHashKey = identity[BlockHash]
+  }
+
+  def bfTraverseF[F[_]: Monad, A](
+      start: List[A]
+  )(neighbours: A => F[List[A]])(
+      implicit k: Key[A]
+  ): StreamT[F, A] = {
+    def build(q: Queue[A], prevVisited: HashSet[k.K]): F[StreamT[F, A]] =
       if (q.isEmpty) StreamT.empty[F, A].pure[F]
       else {
         val (curr, rest) = q.dequeue
-        if (prevVisited(curr)) build(rest, prevVisited)
+        if (prevVisited(k.key(curr))) build(rest, prevVisited)
         else
           for {
             ns      <- neighbours(curr)
-            visited = prevVisited + curr
-            newQ    = rest.enqueue[A](ns.filterNot(visited))
+            visited = prevVisited + k.key(curr)
+            newQ    = rest.enqueue[A](ns.filterNot(n => visited(k.key(n))))
           } yield StreamT.cons(curr, Eval.always(build(newQ, visited)))
       }
 
-    StreamT.delay(Eval.now(build(Queue.empty[A].enqueue[A](start), HashSet.empty[A])))
+    StreamT.delay(Eval.now(build(Queue.empty[A].enqueue[A](start), HashSet.empty[k.K])))
   }
 
   /**
@@ -197,6 +220,7 @@ object DagOperations {
   //Conceptually, the GCA is the first point at which the histories of b1 and b2 diverge.
   //Based on that, we compute by finding the first block from genesis for which there
   //exists a child of that block which is an ancestor of b1 or b2 but not both.
+  @deprecated("Use uncommonAncestors", "0.1")
   def greatestCommonAncestorF[F[_]: MonadThrowable: BlockStore](
       b1: Block,
       b2: Block,
@@ -221,20 +245,19 @@ object DagOperations {
         b1Ancestors     <- bfTraverseF[F, Block](List(b1))(ProtoUtil.unsafeGetParents[F]).toSet
         b2Ancestors     <- bfTraverseF[F, Block](List(b2))(ProtoUtil.unsafeGetParents[F]).toSet
         commonAncestors = b1Ancestors.intersect(b2Ancestors)
-        gca <- bfTraverseF[F, Block](List(genesis))(commonAncestorChild(_, commonAncestors))
-                .findF(
-                  b =>
-                    for {
-                      childrenOpt <- dag.children(b.blockHash)
-                      children    = childrenOpt.getOrElse(Set.empty[BlockHash]).toList
-                      result <- children.existsM(
-                                 hash =>
-                                   for {
-                                     c <- ProtoUtil.unsafeGetBlock[F](hash)
-                                   } yield b1Ancestors(c) ^ b2Ancestors(c)
-                               )
-                    } yield result
-                )
+        gca <- bfTraverseF[F, Block](List(genesis))(commonAncestorChild(_, commonAncestors)).findF(
+                b =>
+                  for {
+                    childrenOpt <- dag.children(b.blockHash)
+                    children    = childrenOpt.getOrElse(Set.empty[BlockHash]).toList
+                    result <- children.existsM(
+                               hash =>
+                                 for {
+                                   c <- ProtoUtil.unsafeGetBlock[F](hash)
+                                 } yield b1Ancestors(c) ^ b2Ancestors(c)
+                             )
+                  } yield result
+              )
       } yield gca.get
     }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CasperPacketHandler.scala
@@ -251,7 +251,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     *
     * When in this state node can't handle any other message type so it will return `F[None]`
     **/
-  private[comm] class GenesisValidatorHandler[F[_]: Sync: Concurrent: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
+  private[comm] class GenesisValidatorHandler[F[_]: Sync: Concurrent: ConnectionsCell: NodeDiscovery: TransportLayer: Log: Time: Metrics: SafetyOracle: ErrorHandler: RPConfAsk: BlockStore: LastApprovedBlock: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
       validatorId: ValidatorIdentity,
       shardId: String,
       blockApprover: BlockApproverProtocol
@@ -379,7 +379,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
     * and will wait for the [[ApprovedBlock]] message to arrive. Until then  it will respond with
     * `F[None]` to all other message types.
     **/
-  private[comm] class BootstrapCasperHandler[F[_]: Concurrent: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
+  private[comm] class BootstrapCasperHandler[F[_]: Concurrent: ConnectionsCell: NodeDiscovery: BlockStore: TransportLayer: Log: Time: Metrics: ErrorHandler: SafetyOracle: RPConfAsk: LastApprovedBlock: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
       shardId: String,
       validatorId: Option[ValidatorIdentity],
       validators: Set[PublicKeyBS]
@@ -651,7 +651,7 @@ object CasperPacketHandler extends CasperPacketHandlerInstances {
       Try(NoApprovedBlockAvailable.parseFrom(msg.content.toByteArray)).toOption
     else None
 
-  private def onApprovedBlockTransition[F[_]: Concurrent: Time: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: ConnectionsCell: Log: BlockStore: LastApprovedBlock: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
+  private def onApprovedBlockTransition[F[_]: Concurrent: Time: Metrics: ErrorHandler: SafetyOracle: RPConfAsk: TransportLayer: ConnectionsCell: Log: BlockStore: LastApprovedBlock: BlockDagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer](
       b: ApprovedBlock,
       validators: Set[PublicKeyBS],
       validatorId: Option[ValidatorIdentity],

--- a/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
@@ -18,7 +18,8 @@ class DagOperationsTest
     with BlockDagStorageFixture {
 
   "bfTraverseF" should "lazily breadth-first traverse a DAG with effectful neighbours" in {
-    val stream = DagOperations.bfTraverseF[Id, Int](List(1))(i => List(i * 2, i * 3))
+    implicit val intKey = DagOperations.Key.identity[Int]
+    val stream          = DagOperations.bfTraverseF[Id, Int](List(1))(i => List(i * 2, i * 3))
     stream.take(10).toList shouldBe List(1, 2, 3, 4, 6, 9, 8, 12, 18, 27)
   }
 


### PR DESCRIPTION
### Overview
It's just a hunch but I'm not sure the way finalized deploys are discarded doesn't have a chance to leave some blocks unvisited. The PR changes so that we can take the deploys we have in the buffer, find the blocks they are included in, see if they are final, and discard them if they are.

Another source of OOM we discovered was the way block proposal was looking for orphaned deploys by walking back the DAG towards Genesis: it accumulated all the blocks along the way, eventually filling up the memory. Replaced this with the inverted index based approach as well.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-588

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
