### PR TITLE
NO-TICKET: execution-engine: restructure comm integration tests

### DIFF
--- a/execution-engine/comm/Cargo.toml
+++ b/execution-engine/comm/Cargo.toml
@@ -32,6 +32,11 @@ parity-wasm = "0.31"
 [[bin]]
 name = "casperlabs-engine-grpc-server"
 path = "src/main.rs"
+
+[lib]
+name = "casperlabs_engine_grpc_server"
+path = "src/lib.rs"
+
 [package.metadata.rpm.cargo]
 buildflags = ["--release"]
 

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -3,6 +3,8 @@ mod uint;
 use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
 
+use protobuf::ProtobufEnum;
+
 use common::uref::URef;
 use common::value::account::{
     AccountActivity, ActionThresholds, AssociatedKeys, BlockTime, PublicKey, PurseId, Weight,
@@ -13,16 +15,15 @@ use execution_engine::engine_state::execution_result::ExecutionResult;
 use execution_engine::engine_state::op::Op;
 use execution_engine::execution::Error as ExecutionError;
 use execution_engine::utils;
-use ipc;
-use protobuf::ProtobufEnum;
 use shared::logging;
 use shared::logging::log_level;
 use shared::newtypes::Blake2bHash;
 use shared::transform::{self, TypeMismatch};
-use state;
 use std::fmt::Display;
 use std::string::ToString;
 use storage::global_state::{CommitResult, History};
+
+use engine_server::{ipc, state};
 
 /// Helper method for turning instances of Value into Transform::Write.
 fn transform_write(v: common::value::Value) -> Result<transform::Transform, ParsingError> {

--- a/execution-engine/comm/src/engine_server/mappings/uint.rs
+++ b/execution-engine/comm/src/engine_server/mappings/uint.rs
@@ -1,8 +1,11 @@
 //! Mappings for uint types (e.g. common::value::U512, ipc::RustBigInt)
 
-use super::{parse_error, state, ParsingError};
-use common::value::U512;
 use std::convert::TryFrom;
+
+use common::value::U512;
+
+use super::{parse_error, ParsingError};
+use engine_server::state;
 
 /// Map a result into the expected error for this module, while also
 /// converting the type into a Value. Use case: parsing U128, U256,

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -1,3 +1,8 @@
+pub mod ipc;
+pub mod ipc_grpc;
+pub mod mappings;
+pub mod state;
+
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::io::ErrorKind;
@@ -11,8 +16,6 @@ use execution_engine::engine_state::execution_result::ExecutionResult;
 use execution_engine::engine_state::{EngineState, GenesisResult};
 use execution_engine::execution::{Executor, WasmiExecutor};
 use execution_engine::tracking_copy::QueryResult;
-use ipc_grpc::ExecutionEngineService;
-use mappings::*;
 use shared::logging;
 use shared::logging::{log_duration, log_info};
 use shared::newtypes::{Blake2bHash, CorrelationId};
@@ -20,13 +23,8 @@ use storage::global_state::History;
 use wasm_prep::wasm_costs::WasmCosts;
 use wasm_prep::{Preprocessor, WasmiPreprocessor};
 
-pub mod ipc;
-pub mod ipc_grpc;
-pub mod mappings;
-pub mod state;
-
-#[cfg(test)]
-mod tests;
+use self::ipc_grpc::ExecutionEngineService;
+use self::mappings::*;
 
 const EXPECTED_PUBLIC_KEY_LENGTH: usize = 32;
 

--- a/execution-engine/comm/src/lib.rs
+++ b/execution-engine/comm/src/lib.rs
@@ -1,0 +1,15 @@
+extern crate common;
+extern crate execution_engine;
+extern crate grpc;
+extern crate lmdb;
+extern crate proptest;
+extern crate protobuf;
+extern crate shared;
+extern crate storage;
+extern crate wabt;
+extern crate wasm_prep;
+
+#[cfg(test)]
+extern crate parity_wasm;
+
+pub mod engine_server;

--- a/execution-engine/comm/src/main.rs
+++ b/execution-engine/comm/src/main.rs
@@ -1,22 +1,15 @@
 extern crate clap;
-extern crate common;
 extern crate ctrlc;
 extern crate dirs;
-extern crate execution_engine;
 extern crate grpc;
 #[macro_use]
 extern crate lazy_static;
 extern crate lmdb;
-#[cfg(test)]
-extern crate parity_wasm;
-extern crate proptest;
-extern crate protobuf;
+
+extern crate casperlabs_engine_grpc_server;
+extern crate execution_engine;
 extern crate shared;
 extern crate storage;
-extern crate wabt;
-extern crate wasm_prep;
-
-pub mod engine_server;
 
 use std::collections::btree_map::BTreeMap;
 use std::fs;
@@ -28,7 +21,6 @@ use std::time::Duration;
 
 use clap::{App, Arg, ArgMatches};
 use dirs::home_dir;
-use engine_server::*;
 use execution_engine::engine_state::EngineState;
 use lmdb::DatabaseFlags;
 
@@ -39,6 +31,8 @@ use shared::os::get_page_size;
 use shared::{init, logging, socket};
 use storage::global_state::lmdb::LmdbGlobalState;
 use storage::trie_store::lmdb::{LmdbEnvironment, LmdbTrieStore};
+
+use casperlabs_engine_grpc_server::engine_server;
 
 // exe / proc
 const PROC_NAME: &str = "casperlabs-engine-grpc-server";

--- a/execution-engine/comm/tests/common.rs
+++ b/execution-engine/comm/tests/common.rs
@@ -1,0 +1,84 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate shared;
+
+use std::path::PathBuf;
+
+use shared::test_utils;
+
+use casperlabs_engine_grpc_server::engine_server::ipc::{Deploy, DeployCode, GenesisRequest};
+use casperlabs_engine_grpc_server::engine_server::state::{BigInt, ProtocolVersion};
+
+pub const MOCKED_ACCOUNT_ADDRESS: [u8; 32] = [48u8; 32];
+pub const COMPILED_WASM_PATH: &str = "../target/wasm32-unknown-unknown/debug";
+
+pub fn get_protocol_version() -> ProtocolVersion {
+    let mut protocol_version: ProtocolVersion = ProtocolVersion::new();
+    protocol_version.set_value(1);
+    protocol_version
+}
+
+pub fn get_mock_deploy() -> Deploy {
+    let mut deploy = Deploy::new();
+    deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
+    deploy.set_gas_limit(1000);
+    deploy.set_gas_price(1);
+    deploy.set_nonce(1);
+    deploy.set_timestamp(10);
+    let mut deploy_code = DeployCode::new();
+    deploy_code.set_code(test_utils::create_empty_wasm_module_bytes());
+    deploy.set_session(deploy_code);
+    deploy
+}
+
+fn get_compiled_wasm_path(contract_file: PathBuf) -> PathBuf {
+    let mut path = std::env::current_dir().expect("should get working directory");
+    path.push(PathBuf::from(COMPILED_WASM_PATH));
+    path.push(contract_file);
+    path
+}
+
+fn read_wasm_file_bytes(contract_file: &str) -> Vec<u8> {
+    let contract_file = PathBuf::from(contract_file);
+    let path = get_compiled_wasm_path(contract_file);
+    std::fs::read(path).expect("should read mint bytes from disk")
+}
+
+pub fn create_genesis_request() -> GenesisRequest {
+    let genesis_account_addr = [6u8; 32].to_vec();
+
+    let initial_tokens = {
+        let mut ret = BigInt::new();
+        ret.set_bit_width(512);
+        ret.set_value("1000000".to_string());
+        ret
+    };
+
+    let mint_code = {
+        let mut ret = DeployCode::new();
+        let contract_file = "mint_token.wasm";
+        let wasm_bytes = read_wasm_file_bytes(contract_file);
+        ret.set_code(wasm_bytes);
+        ret
+    };
+
+    let proof_of_stake_code = {
+        let mut ret = DeployCode::new();
+        let wasm_bytes = test_utils::create_empty_wasm_module_bytes();
+        ret.set_code(wasm_bytes);
+        ret
+    };
+
+    let protocol_version = {
+        let mut ret = ProtocolVersion::new();
+        ret.set_value(1);
+        ret
+    };
+
+    let mut ret = GenesisRequest::new();
+    ret.set_address(genesis_account_addr.to_vec());
+    ret.set_initial_tokens(initial_tokens);
+    ret.set_mint_code(mint_code);
+    ret.set_proof_of_stake_code(proof_of_stake_code);
+    ret.set_protocol_version(protocol_version);
+    ret
+}

--- a/execution-engine/comm/tests/tests.rs
+++ b/execution-engine/comm/tests/tests.rs
@@ -1,26 +1,54 @@
+extern crate grpc;
+#[macro_use]
+extern crate lazy_static;
+
+extern crate casperlabs_engine_grpc_server;
+extern crate execution_engine;
+extern crate shared;
+extern crate storage;
+
+mod common;
+
 use grpc::RequestOptions;
 
 use execution_engine::engine_state::EngineState;
 use shared::init::mocked_account;
 use shared::logging::log_level::LogLevel;
 use shared::logging::log_settings::{self, LogLevelFilter, LogSettings};
-use shared::logging::logger::initialize_buffered_logger;
-use shared::logging::logger::{LogBufferProvider, BUFFERED_LOGGER};
+use shared::logging::logger::{self, LogBufferProvider, BUFFERED_LOGGER};
 use shared::newtypes::CorrelationId;
 use shared::test_utils;
 use storage::global_state::in_memory::InMemoryGlobalState;
 
-use engine_server::ipc::{
+use casperlabs_engine_grpc_server::engine_server::ipc::{
     CommitRequest, Deploy, DeployCode, ExecRequest, GenesisRequest, QueryRequest, ValidateRequest,
 };
-use engine_server::ipc_grpc::ExecutionEngineService;
-use engine_server::state::{BigInt, Key, Key_Address, ProtocolVersion};
+use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
+use casperlabs_engine_grpc_server::engine_server::state::{
+    BigInt, Key, Key_Address, ProtocolVersion,
+};
+
+pub const PROC_NAME: &str = "ee-shared-lib-tests";
+
+pub fn get_log_settings(log_level: LogLevel) -> LogSettings {
+    let log_level_filter = LogLevelFilter::new(log_level);
+    LogSettings::new(PROC_NAME, log_level_filter)
+}
+
+fn setup() {
+    logger::initialize_buffered_logger();
+    log_settings::set_log_settings_provider(&*LOG_SETTINGS);
+}
+
+lazy_static! {
+    static ref LOG_SETTINGS: LogSettings = get_log_settings(LogLevel::Debug);
+}
 
 #[test]
 fn should_query_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
-    let mocked_account = mocked_account(MOCKED_ACCOUNT_ADDRESS);
+    let mocked_account = mocked_account(common::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let root_hash = global_state.root_hash.to_vec();
     let engine_state = EngineState::new(global_state, false);
@@ -29,7 +57,7 @@ fn should_query_with_metrics() {
     {
         let mut key = Key::new();
         let mut key_address = Key_Address::new();
-        key_address.set_account(MOCKED_ACCOUNT_ADDRESS.to_vec());
+        key_address.set_account(common::MOCKED_ACCOUNT_ADDRESS.to_vec());
         key.set_address(key_address);
 
         query_request.set_base_key(key);
@@ -72,7 +100,7 @@ fn should_query_with_metrics() {
 fn should_exec_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
-    let mocked_account = mocked_account(MOCKED_ACCOUNT_ADDRESS);
+    let mocked_account = mocked_account(common::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let root_hash = global_state.root_hash.to_vec();
     let engine_state = EngineState::new(global_state, false);
@@ -80,11 +108,11 @@ fn should_exec_with_metrics() {
     let mut exec_request = ExecRequest::new();
     {
         let mut deploys: protobuf::RepeatedField<Deploy> = <protobuf::RepeatedField<Deploy>>::new();
-        deploys.push(get_mock_deploy());
+        deploys.push(common::get_mock_deploy());
 
         exec_request.set_deploys(deploys);
         exec_request.set_parent_state_hash(root_hash);
-        exec_request.set_protocol_version(get_protocol_version());
+        exec_request.set_protocol_version(common::get_protocol_version());
     }
 
     let _exec_response_result = engine_state
@@ -122,7 +150,7 @@ fn should_exec_with_metrics() {
 fn should_commit_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
-    let mocked_account = mocked_account(MOCKED_ACCOUNT_ADDRESS);
+    let mocked_account = mocked_account(common::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let root_hash = global_state.root_hash.to_vec();
     let engine_state = EngineState::new(global_state, false);
@@ -169,7 +197,7 @@ fn should_commit_with_metrics() {
 fn should_validate_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
-    let mocked_account = mocked_account(MOCKED_ACCOUNT_ADDRESS);
+    let mocked_account = mocked_account(common::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let engine_state = EngineState::new(global_state, false);
 
@@ -273,39 +301,28 @@ fn should_run_genesis() {
     assert_eq!(state_root_hash.to_vec(), response_root_hash.to_vec());
 }
 
-lazy_static! {
-    static ref LOG_SETTINGS: LogSettings = get_log_settings(LogLevel::Debug);
-}
+#[ignore]
+#[test]
+fn should_run_genesis_with_mint_bytes() {
+    let global_state = InMemoryGlobalState::empty().expect("should create global state");
+    let engine_state = EngineState::new(global_state, false);
 
-const PROC_NAME: &str = "ee-shared-lib-tests";
-const MOCKED_ACCOUNT_ADDRESS: [u8; 32] = [48u8; 32];
+    let genesis_request = common::create_genesis_request();
 
-fn setup() {
-    initialize_buffered_logger();
-    log_settings::set_log_settings_provider(&*LOG_SETTINGS);
-}
+    let request_options = RequestOptions::new();
 
-fn get_log_settings(log_level: LogLevel) -> LogSettings {
-    let log_level_filter = LogLevelFilter::new(log_level);
+    let genesis_response = engine_state
+        .run_genesis(request_options, genesis_request)
+        .wait_drop_metadata();
 
-    LogSettings::new(PROC_NAME, log_level_filter)
-}
+    let response = genesis_response.unwrap();
 
-fn get_protocol_version() -> ProtocolVersion {
-    let mut protocol_version: ProtocolVersion = ProtocolVersion::new();
-    protocol_version.set_value(1);
-    protocol_version
-}
+    let state_handle = engine_state.state();
 
-fn get_mock_deploy() -> Deploy {
-    let mut deploy = Deploy::new();
-    deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
-    deploy.set_gas_limit(1000);
-    deploy.set_gas_price(1);
-    deploy.set_nonce(1);
-    deploy.set_timestamp(10);
-    let mut deploy_code = DeployCode::new();
-    deploy_code.set_code(test_utils::create_empty_wasm_module_bytes());
-    deploy.set_session(deploy_code);
-    deploy
+    let state_handle_guard = state_handle.lock();
+
+    let state_root_hash = state_handle_guard.root_hash;
+    let response_root_hash = response.get_success().get_poststate_hash();
+
+    assert_eq!(state_root_hash.to_vec(), response_root_hash.to_vec());
 }

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -2,7 +2,7 @@ pub mod error;
 pub mod execution_effect;
 pub mod execution_result;
 pub mod op;
-mod utils;
+pub mod utils;
 
 use std::cell::RefCell;
 use std::collections::btree_map::BTreeMap;

--- a/execution-engine/scripts/run-contract-tests.sh
+++ b/execution-engine/scripts/run-contract-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+cargo build -p mint-token --target wasm32-unknown-unknown
+
+cargo test -p casperlabs-engine-grpc-server -- --ignored


### PR DESCRIPTION
### Overview
This PR moves `casperlabs-engine-grpc-server`'s integration tests into a `tests` directory, a change suggested earlier by @mpapierski, which is a common practiced described [here](https://doc.rust-lang.org/stable/rust-by-example/testing/integration_testing.html).

This prepares us for writing more contract-based tests.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
