### PR TITLE
OP-336: Add integration test for account state retrieval with query-state

### DIFF
--- a/integration-testing/test/cl_node/casperlabsnode.py
+++ b/integration-testing/test/cl_node/casperlabsnode.py
@@ -67,33 +67,3 @@ def extract_block_hash_from_propose_output(propose_output: str):
         raise UnexpectedProposeOutputFormatError(propose_output)
     return match.group(1)
 
-
-def make_get_state_client_name() -> str:
-    return f"get_state.{random_string(5)}"
-
-
-def get_contract_state(
-    *,
-    docker_client: "DockerClient",
-    network_name: str,
-    target_host_name: str,
-    port: int,
-    _type: str,
-    key: str,
-    path: str,
-    block_hash: str,
-    image: str = DEFAULT_CLIENT_IMAGE
-):
-    name = make_get_state_client_name()
-    command = f'--host {target_host_name} --port {port} query-state -t {_type} -k {key} -p "{path}" -b {block_hash}'
-    logging.info(command)
-    output = docker_client.containers.run(
-        image,
-        name=name,
-        user='root',
-        auto_remove=True,
-        command=command,
-        network=network_name,
-        hostname=name
-    )
-    return output

--- a/integration-testing/test/cl_node/client_base.py
+++ b/integration-testing/test/cl_node/client_base.py
@@ -32,7 +32,7 @@ class CasperLabsClient(ABC):
         pass
 
     @abstractmethod
-    def queryState(self, blockHash: str, key: str, path: str, keyType: str):
+    def query_state(self, block_hash: str, key: str, path: str, key_type: str):
         pass
 
     @abstractmethod

--- a/integration-testing/test/cl_node/client_parser.py
+++ b/integration-testing/test/cl_node/client_parser.py
@@ -77,7 +77,12 @@ def _parse(tokens):
         if next_token == '{':
             d[token].append(_parse(tokens))
         else:
-            d[token] = next_token
+            if token not in d:
+                d[token] = next_token
+            elif isinstance(d[token], list):
+                d[token].append(next_token)
+            else:
+                d[token] = [d[token], next_token]
 
     raise Exception("Missing closing bracket '}'")
 

--- a/integration-testing/test/cl_node/client_parser.py
+++ b/integration-testing/test/cl_node/client_parser.py
@@ -46,7 +46,7 @@ def value(s, line_number):
             elif s[0] == '"' and s[-1] == '"':
                 return s[1:-1], line_number
             else:
-                # This must be a const or enum, for example: READ_ADD_WRITE
+                # This must be an enum, for example: READ_ADD_WRITE
                 return s, line_number
 
 

--- a/integration-testing/test/cl_node/client_parser.py
+++ b/integration-testing/test/cl_node/client_parser.py
@@ -34,19 +34,20 @@ def attribute_name(s, line_number):
 
 def value(s, line_number):
     try:
-        return (int(s), line_number)
+        return int(s), line_number
     except ValueError:
         try:
-            return (float(s), line_number)
+            return float(s), line_number
         except ValueError:
             if s == 'true':
-                return (True, line_number)
+                return True, line_number
             elif s == 'false':
-                return (False, line_number)
+                return False, line_number
             elif s[0] == '"' and s[-1] == '"':
-                return (s[1:-1], line_number)
+                return s[1:-1], line_number
             else:
-                raise Exception(f'Could not parse "{s}" at line {line_number}')
+                # This must be a const or enum, for example: READ_ADD_WRITE
+                return s, line_number
 
 
 def lexer(s):

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -123,7 +123,7 @@ class DockerClient(CasperLabsClient):
         just_text = '--show-justification-lines' if show_justification_lines else ''
         return self.invoke_client(f'vdag --depth {depth} {just_text}')
 
-    def queryState(self, blockHash: str, key: str, path: str, keyType: str):
+    def query_state(self, block_hash: str, key: str, path: str, key_type: str):
         """
         Subcommand: query-state - Query a value in the global state.
           -b, --block-hash  <arg>   Hash of the block to query the state of
@@ -136,10 +136,10 @@ class DockerClient(CasperLabsClient):
 
         """
         return parse(self.invoke_client(f'query-state '
-                                        f' --block-hash "{blockHash}"'
+                                        f' --block-hash "{block_hash}"'
                                         f' --key "{key}"'
                                         f' --path "{path}"'
-                                        f' --type "{keyType}"'))
+                                        f' --type "{key_type}"'))
 
 
     def show_deploys(self, hash: str):

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -135,11 +135,11 @@ class DockerClient(CasperLabsClient):
           -h, --help                Show help message
 
         """
-        return self.invoke_client(f'query-state '
-                                  f' --block-hash "{blockHash}"'
-                                  f' --key "{key}"'
-                                  f' --path "{path}"'
-                                  f' --type "{keyType}"')
+        return parse(self.invoke_client(f'query-state '
+                                        f' --block-hash "{blockHash}"'
+                                        f' --key "{key}"'
+                                        f' --path "{path}"'
+                                        f' --type "{keyType}"'))
 
 
     def show_deploys(self, hash: str):

--- a/integration-testing/test/cl_node/python_client.py
+++ b/integration-testing/test/cl_node/python_client.py
@@ -46,8 +46,8 @@ class PythonClient(CasperLabsClient):
         logging.info(f'PY_CLIENT.propose() for {self.node.container_name}')
         return self.client.propose()
 
-    def queryState(self, blockHash: str, key: str, path: str, keyType: str):
-        return self.client.queryState(blockHash, key, path, keyType)
+    def query_state(self, block_hash: str, key: str, path: str, key_type: str):
+        return self.client.queryState(block_hash, key, path, key_type)
 
     def show_block(self, block_hash: str) -> str:
         # TODO:

--- a/integration-testing/test/test_account_state.py
+++ b/integration-testing/test/test_account_state.py
@@ -1,0 +1,53 @@
+import pytest
+
+"""
+Test account state retrieval with query-state.
+
+Example output of the Scala client:
+
+account {
+  public_key: "3030303030303030303030303030303030303030303030303030303030303030"
+  nonce: 1
+  purse_id {
+    uref: "0000000000000000000000000000000000000000000000000000000000000000"
+    access_rights: READ_ADD_WRITE
+  }
+  associated_keys {
+    public_key: "3030303030303030303030303030303030303030303030303030303030303030"
+    weight: 1
+  }
+  action_thresholds {
+    deployment_threshold: 1
+    key_management_threshold: 1
+  }
+  account_activity {
+    key_management_last_used: 0
+    deployment_last_used: 0
+    inactivity_period_limit: 100
+  }
+}
+
+"""
+
+ACCOUNT = '30' * 32
+assert ACCOUNT == "3030303030303030303030303030303030303030303030303030303030303030"
+
+
+@pytest.fixture(scope='module')
+def node(one_node_network_module_scope):
+    return one_node_network_module_scope.docker_nodes[0]
+
+
+def test_query_state_account(node):
+    def account_state():
+        return node.d_client.queryState(blockHash = '', keyType = 'address', key = ACCOUNT, path = '')
+
+    response = account_state()
+    assert response.account.public_key == ACCOUNT
+    assert response.account.nonce == 0
+
+    node.deploy_and_propose()
+
+    response = account_state()
+    assert response.account.nonce == 1
+

--- a/integration-testing/test/test_account_state.py
+++ b/integration-testing/test/test_account_state.py
@@ -43,7 +43,7 @@ def node(one_node_network_module_scope):
 def test_account_state(node):
 
     def account_state(block_hash):
-        return node.d_client.queryState(blockHash = block_hash, keyType = 'address', key = ACCOUNT, path = '')
+        return node.d_client.query_state(block_hash = block_hash, key_type = 'address', key = ACCOUNT, path = '')
     
     blocks = parse_show_blocks(node.d_client.show_blocks(1000)) 
     assert len(blocks) == 1  # There should be only one block, the genesis block

--- a/integration-testing/test/test_account_state.py
+++ b/integration-testing/test/test_account_state.py
@@ -1,5 +1,5 @@
 import pytest
-from .cl_node.wait import wait_for_blocks_count_at_least
+from .cl_node.client_parser import parse_show_blocks
 
 """
 Test account state retrieval with query-state.
@@ -33,34 +33,31 @@ account {
 ACCOUNT = '30' * 32
 assert ACCOUNT == "3030303030303030303030303030303030303030303030303030303030303030"
 
-# Note: calls to wait_for_blocks_count_at_least should not really be needed in this test.
-# The test network is just one node, we deploy and propose to this single node.
-# Also, passing nonce explicitly is not really needed, as the test framework would pass a correct
-# nonce for us, it's just to make it totally clear what's happenning.
-
 
 @pytest.fixture(scope='module')
 def node(one_node_network_module_scope):
     n = one_node_network_module_scope.docker_nodes[0]
-    wait_for_blocks_count_at_least(n, 1, 1, n.timeout)
     return n
 
 
 def test_account_state(node):
-    def account_state():
-        return node.d_client.queryState(blockHash = '', keyType = 'address', key = ACCOUNT, path = '')
 
-    response = account_state()
+    def account_state(block_hash):
+        return node.d_client.queryState(blockHash = block_hash, keyType = 'address', key = ACCOUNT, path = '')
+    
+    blocks = parse_show_blocks(node.d_client.show_blocks(1000)) 
+    assert len(blocks) == 1  # There should be only one block, the genesis block
+
+    response = account_state(blocks[0].summary.block_hash)
     assert response.account.public_key == ACCOUNT
     assert response.account.nonce == 0
 
-    node.deploy_and_propose(session_contract="test_counterdefine.wasm", nonce = 1)
-    response = account_state()
+    block_hash = node.deploy_and_propose(session_contract = "test_counterdefine.wasm", nonce = 1)
+    response = account_state(block_hash)
     assert response.account.nonce == 1
 
-    for nonce in range(2,10):
-        node.deploy_and_propose(session_contract="test_countercall.wasm", nonce = nonce)
-        wait_for_blocks_count_at_least(node, nonce + 1, nonce + 1, node.timeout)
-        response = account_state()
+    for nonce in range(2, 5):
+        block_hash = node.deploy_and_propose(session_contract="test_countercall.wasm", nonce = nonce)
+        response = account_state(block_hash)
         assert response.account.nonce == nonce
 

--- a/integration-testing/test/test_client_parser.py
+++ b/integration-testing/test/test_client_parser.py
@@ -1,8 +1,8 @@
-from test.cl_node.client_parser import parse
+from test.cl_node.client_parser import parse, parse_show_blocks
 
 
 
-SUMMARY = """
+SHOW_BLOCKS = """
 ------------- block @ 0 ---------------
 summary {
   block_hash: "295868cb6edc0636760a855341e66473708127194d0588c7654569d41818be13"
@@ -74,8 +74,8 @@ count: 3
 """
 
 
-def test_client_parser():
-    r = parse(SUMMARY)
+def test_client_parser_show_blocks():
+    r = parse_show_blocks(SHOW_BLOCKS)[0]
     bonds = r.summary.header.state.bonds
     assert len(bonds) == 10
     assert sum(bond.stake for bond in bonds) == 190
@@ -214,6 +214,15 @@ processing_results {
 
 """
 
-def test_client_parser():
+def test_client_parser_deploy():
     r = parse(DEPLOY)
     assert len (r.processing_results.block_info.summary.header.justifications) == 10
+
+
+def test_client_parser_list_of_values_of_primitive_types():
+    r = parse("""
+    values: 0
+    values: 1
+    """)
+
+    assert r.values == [0, 1]

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -50,6 +50,6 @@ def test_query_state_error(client, block_hash, query, expected):
         query['block_hash'] = block_hash
 
     with pytest.raises(NonZeroExitCodeError) as excinfo:
-        response = client.queryState(**query)
+        response = client.query_state(**query)
     assert expected in excinfo.value.output
 

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -1,10 +1,6 @@
-from .cl_node.wait import wait_for_blocks_count_at_least
-from .cl_node.casperlabsnode import get_contract_state
 from .cl_node.errors import NonZeroExitCodeError
 
-
 import pytest
-
 
 # Examples of query-state executed with the Scala client that result in errors:
 

--- a/integration-testing/test/test_query_state_error_handling.py
+++ b/integration-testing/test/test_query_state_error_handling.py
@@ -34,20 +34,20 @@ def block_hash(node):
     return node.deploy_and_propose()
 
 block_hash_queries = [
-    ({'blockHash': "9d", 'key': "a91208047c", 'path': "file.xxx", 'keyType': "hash"},
+    ({'block_hash': "9d", 'key': "a91208047c", 'path': "file.xxx", 'key_type': "hash"},
      "NOT_FOUND: Cannot find block matching"),
 
-    ({                   'key': "a91208047c", 'path': "file.xxx", 'keyType': "hash"},
+    ({                   'key': "a91208047c", 'path': "file.xxx", 'key_type': "hash"},
      "INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes"),
 
-    ({                   'key': KEY,          'path': "file.xxx", 'keyType': "hash"},
+    ({                   'key': KEY,          'path': "file.xxx", 'key_type': "hash"},
      "INVALID_ARGUMENT: Value not found"),
 ]
 
 @pytest.mark.parametrize("query, expected", block_hash_queries)
 def test_query_state_error(client, block_hash, query, expected):
-    if not 'blockHash' in query:
-        query['blockHash'] = block_hash
+    if not 'block_hash' in query:
+        query['block_hash'] = block_hash
 
     with pytest.raises(NonZeroExitCodeError) as excinfo:
         response = client.queryState(**query)


### PR DESCRIPTION

### Overview
This PR adds integration test for retrieval of account state with `query-state`. This is useful, for example, to retrieve current account's nonce.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-336

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
NA
