### PR TITLE
EE-389: Add `list_known_urefs` method to the API.

### DIFF
--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -159,6 +159,16 @@ fn fn_bytes_by_name(name: &str) -> Vec<u8> {
     }
 }
 
+pub fn list_known_urefs() -> BTreeMap<String, Key> {
+    let bytes_size = unsafe { ext_ffi::serialize_known_urefs() };
+    let dest_ptr = alloc_bytes(bytes_size);
+    let bytes = unsafe {
+        ext_ffi::list_known_urefs(dest_ptr);
+        Vec::from_raw_parts(dest_ptr, bytes_size, bytes_size)
+    };
+    deserialize(&bytes).unwrap()
+}
+
 // TODO: fn_by_name, fn_bytes_by_name and ext_ffi::serialize_function should be removed.
 // Functions shouldn't be serialized and returned back to the contract because they're never used there.
 // Host should read the function pointer (and correct number of bytes) and persist it on the host side.

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -58,6 +58,9 @@ mod ext_ffi {
             extra_urefs_size: usize,
             hash_ptr: *const u8,
         );
+        pub fn serialize_known_urefs() -> usize;
+        // Can only be called after `serialize_known_urefs`.
+        pub fn list_known_urefs(dest_ptr: *mut u8);
         pub fn load_arg(i: u32) -> usize;
         pub fn get_arg(dest: *mut u8); //can only be called after `load_arg`
         pub fn ret(

--- a/execution-engine/engine/src/function_index.rs
+++ b/execution-engine/engine/src/function_index.rs
@@ -29,6 +29,8 @@ pub enum FunctionIndex {
     AddAssociatedKeyFuncIndex = 22,
     RemoveAssociatedKeyFuncIndex = 23,
     SetActionThresholdFuncIndex = 24,
+    SerKnownURefs = 25,
+    ListKnownURefsIndex = 26,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -53,6 +53,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::SerFnFuncIndex.into(),
             ),
+            "serialize_known_urefs" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 0][..], Some(ValueType::I32)),
+                FunctionIndex::SerKnownURefs.into(),
+            ),
             "write" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 FunctionIndex::WriteFuncIndex.into(),
@@ -140,6 +144,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
             "set_action_threshold" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::SetActionThresholdFuncIndex.into(),
+            ),
+            "list_known_urefs" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                FunctionIndex::ListKnownURefsIndex.into(),
             ),
             _ => {
                 return Err(InterpreterError::Function(format!(

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -84,6 +84,10 @@ where
         self.uref_lookup.get(name)
     }
 
+    pub fn list_known_urefs(&self) -> &BTreeMap<String, Key> {
+        &self.uref_lookup
+    }
+
     pub fn fn_store_id(&self) -> u32 {
         self.fn_store_id
     }


### PR DESCRIPTION
### Overview
As in the title. For more context see JIRA ticket.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-389

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
There is a supporting PR in the `contract-examples` repository that adds contracts to test new endpoint: https://github.com/CasperLabs/contract-examples/pull/21
