### PR TITLE
OP-266: Deploy with higher nonce and created block does not include previously deployed contract.

### DIFF
--- a/integration-testing/features/deploy.feature
+++ b/integration-testing/features/deploy.feature
@@ -73,6 +73,9 @@ Feature: Deploy Operation
        And: Propose of block deployed with nonce of 2 is successful
        And: Previous propose of block deployed with nonce of 4 is still a failure and deploy
             will stay in the deploy buffers.
+       And: Propose of block deployed with nonce of 3 is successful and this causes propose of block with
+            nonce of 4 becomes success finally.
+
 
   # Implemented: test_nonce.py : test_deploy_with_lower_nonce (first part of the test)
   Scenario: Deploy with correct nonce

--- a/integration-testing/features/deploy.feature
+++ b/integration-testing/features/deploy.feature
@@ -63,6 +63,17 @@ Feature: Deploy Operation
        And: Propose of block deployed with nonce of 2 is successful
        And: Subsequent propose of block deployed with nonce of 3 is successful
 
+  # Implemented: test_nonce.py : test_deploy_with_higher_nonce_does_not_include_previous_deploy
+  Scenario: Deploy with higher nonce and created block does not include previously deployed contract
+     Given: Single Node Network
+       And: Nonce is 1 for account
+      When: Deploy is performed with nonce of 4
+      Then: Propose will fail
+       And: Deploy with nonce of 2 is successful
+       And: Propose of block deployed with nonce of 2 is successful
+       And: Previous propose of block deployed with nonce of 4 is still a failure and deploy
+            will stay in the deploy buffers.
+
   # Implemented: test_nonce.py : test_deploy_with_lower_nonce (first part of the test)
   Scenario: Deploy with correct nonce
      Given: Single Node Network

--- a/integration-testing/test/test_nonce.py
+++ b/integration-testing/test/test_nonce.py
@@ -12,15 +12,6 @@ Feature file: ~/CasperLabs/integration-testing/features/deploy.feature
 """
 
 
-@pytest.fixture()
-def node(one_node_network):
-    with one_node_network as network:
-        # Wait for the genesis block reaching each node.
-        for node in network.docker_nodes:
-            wait_for_blocks_count_at_least(node, 1, 1, node.timeout)
-        yield network.docker_nodes[0]
-
-
 def deploy_and_propose(node, contract, nonce):
     node.client.deploy(session_contract=contract,
                        payment_contract=contract,

--- a/integration-testing/test/test_nonce.py
+++ b/integration-testing/test/test_nonce.py
@@ -75,3 +75,34 @@ def test_deploy_with_higher_nonce(node, contracts: List[str]):
     deploy_counts = [b.summary.header.deploy_count for b in blocks][:-1]
 
     assert sum(deploy_counts) == len(contracts)
+
+
+@pytest.mark.parametrize("contracts", [['test_helloname.wasm', 'test_helloworld.wasm', 'test_counterdefine.wasm']])
+def test_deploy_with_higher_nonce_does_not_include_previous_deploy(node, contracts: List[str]):
+    """
+    Feature file: deploy.feature
+
+    Scenario: Deploy with higher nonce and created block does not include previously deployed contract.
+    """
+    # Deploy successfully with nonce 1 => Nonce is 1 for account.
+    deploy_and_propose(node, contracts[0], 1)
+
+    # Now there should be the genesis block and the one we just deployed and proposed.
+    wait_for_blocks_count_at_least(node, 2, 2, node.timeout)
+
+    node.client.deploy(session_contract=contracts[1], payment_contract=contracts[1], nonce=4)
+
+    with pytest.raises(NonZeroExitCodeError):
+        node.client.propose()
+
+    node.client.deploy(session_contract=contracts[2], payment_contract=contracts[2], nonce=2)
+    # The deploy with nonce 4 cannot be proposed now.It will be in the deploy buffer but does not include
+    # in the new block created now.
+    node.client.propose()
+    wait_for_blocks_count_at_least(node, 3, 3, node.timeout)
+    blocks = parse_show_blocks(node.client.show_blocks(100))
+
+    # Deploy counts of all blocks except the genesis block.
+    deploy_counts = [b.summary.header.deploy_count for b in blocks][:-1]
+
+    assert sum(deploy_counts) == len(contracts) - 1


### PR DESCRIPTION

### Overview
OP-226: Deploy with higher nonce and created block does not include previously deployed contract.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-266
### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
