### PR TITLE
EE-391: Add `remove_uref` API method.

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -291,8 +291,8 @@ impl From<common::value::account::Account> for super::state::Account {
             tmp.set_inactivity_period_limit(account.account_activity().inactivity_period_limit().0);
             tmp
         };
-        let account_urefs = account.get_urefs_lookup();
-        let account_urefs_lookup = URefMap(account_urefs);
+        let account_urefs = account.urefs_lookup();
+        let account_urefs_lookup = URefMap(account_urefs.clone());
         let ipc_urefs: Vec<super::state::NamedKey> = account_urefs_lookup.into();
         ipc_account.set_known_urefs(ipc_urefs.into());
         ipc_account.set_associated_keys(associated_keys.into());

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -159,6 +159,16 @@ fn fn_bytes_by_name(name: &str) -> Vec<u8> {
     }
 }
 
+pub fn list_known_urefs() -> BTreeMap<String, Key> {
+    let bytes_size = unsafe { ext_ffi::serialize_known_urefs() };
+    let dest_ptr = alloc_bytes(bytes_size);
+    let bytes = unsafe {
+        ext_ffi::list_known_urefs(dest_ptr);
+        Vec::from_raw_parts(dest_ptr, bytes_size, bytes_size)
+    };
+    deserialize(&bytes).unwrap()
+}
+
 // TODO: fn_by_name, fn_bytes_by_name and ext_ffi::serialize_function should be removed.
 // Functions shouldn't be serialized and returned back to the contract because they're never used there.
 // Host should read the function pointer (and correct number of bytes) and persist it on the host side.

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -245,6 +245,12 @@ pub fn add_uref(name: &str, key: &Key) {
     unsafe { ext_ffi::add_uref(name_ptr, name_size, key_ptr, key_size) };
 }
 
+/// Removes Key persisted under [name] in the current context's map.
+pub fn remove_uref(name: &str) {
+    let (name_ptr, name_size, _bytes) = str_ref_to_ptr(name);
+    unsafe { ext_ffi::remove_uref(name_ptr, name_size) }
+}
+
 /// Return `t` to the host, terminating the currently running module.
 /// Note this function is only relevent to contracts stored on chain which
 /// return a value to their caller. The return value of a directly deployed

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -89,6 +89,7 @@ mod ext_ffi {
         pub fn add_associated_key(public_key_ptr: *const u8, weight: i32) -> i32;
         pub fn remove_associated_key(public_key_ptr: *const u8) -> i32;
         pub fn set_action_threshold(permission_level: u32, threshold: i32) -> i32;
+        pub fn remove_uref(name_ptr: *const u8, name_size: usize);
     }
 }
 

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -58,6 +58,9 @@ mod ext_ffi {
             extra_urefs_size: usize,
             hash_ptr: *const u8,
         );
+        pub fn serialize_known_urefs() -> usize;
+        // Can only be called after `serialize_known_urefs`.
+        pub fn list_known_urefs(dest_ptr: *mut u8);
         pub fn load_arg(i: u32) -> usize;
         pub fn get_arg(dest: *mut u8); //can only be called after `load_arg`
         pub fn ret(

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -403,8 +403,8 @@ impl Account {
         &self.known_urefs
     }
 
-    pub fn get_urefs_lookup(self) -> BTreeMap<String, Key> {
-        self.known_urefs
+    pub fn get_urefs_lookup_mut(&mut self) -> &mut BTreeMap<String, Key> {
+        &mut self.known_urefs
     }
 
     pub fn pub_key(&self) -> &[u8; 32] {

--- a/execution-engine/common/src/value/contract.rs
+++ b/execution-engine/common/src/value/contract.rs
@@ -28,6 +28,10 @@ impl Contract {
         &self.known_urefs
     }
 
+    pub fn get_urefs_lookup_mut(&mut self) -> &mut BTreeMap<String, Key> {
+        &mut self.known_urefs
+    }
+
     pub fn destructure(self) -> (Vec<u8>, BTreeMap<String, Key>, u64) {
         (self.bytes, self.known_urefs, self.protocol_version)
     }

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -298,6 +298,12 @@ where
             .map_err(|e| Error::Interpreter(e).into())
     }
 
+    fn remove_uref(&mut self, name_ptr: u32, name_size: u32) -> Result<(), Trap> {
+        let name = self.string_from_mem(name_ptr, name_size)?;
+        self.context.remove_uref(&name)?;
+        Ok(())
+    }
+
     pub fn set_mem_from_buf(&mut self, dest_ptr: u32) -> Result<(), Trap> {
         self.memory
             .set(dest_ptr, &self.host_buf)
@@ -739,6 +745,14 @@ where
                 // args(0) = pointer to destination in Wasm memory
                 let ptr = Args::parse(args)?;
                 self.list_known_urefs(ptr)?;
+                Ok(None)
+            }
+
+            FunctionIndex::RemoveURef => {
+                // args(0) = pointer to uref name in Wasm memory
+                // args(1) = size of uref name
+                let (name_ptr, name_size) = Args::parse(args)?;
+                self.remove_uref(name_ptr, name_size)?;
                 Ok(None)
             }
 

--- a/execution-engine/engine/src/function_index.rs
+++ b/execution-engine/engine/src/function_index.rs
@@ -29,6 +29,8 @@ pub enum FunctionIndex {
     AddAssociatedKeyFuncIndex = 22,
     RemoveAssociatedKeyFuncIndex = 23,
     SetActionThresholdFuncIndex = 24,
+    SerKnownURefs = 25,
+    ListKnownURefsIndex = 26,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine/src/function_index.rs
+++ b/execution-engine/engine/src/function_index.rs
@@ -31,6 +31,7 @@ pub enum FunctionIndex {
     SetActionThresholdFuncIndex = 24,
     SerKnownURefs = 25,
     ListKnownURefsIndex = 26,
+    RemoveURef = 27,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -53,6 +53,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::SerFnFuncIndex.into(),
             ),
+            "serialize_known_urefs" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 0][..], Some(ValueType::I32)),
+                FunctionIndex::SerKnownURefs.into(),
+            ),
             "write" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], None),
                 FunctionIndex::WriteFuncIndex.into(),
@@ -140,6 +144,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
             "set_action_threshold" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::SetActionThresholdFuncIndex.into(),
+            ),
+            "list_known_urefs" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                FunctionIndex::ListKnownURefsIndex.into(),
             ),
             _ => {
                 return Err(InterpreterError::Function(format!(

--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -149,6 +149,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::ListKnownURefsIndex.into(),
             ),
+            "remove_uref" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 2][..], None),
+                FunctionIndex::RemoveURef.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -84,6 +84,10 @@ where
         self.uref_lookup.get(name)
     }
 
+    pub fn list_known_urefs(&self) -> &BTreeMap<String, Key> {
+        &self.uref_lookup
+    }
+
     pub fn fn_store_id(&self) -> u32 {
         self.fn_store_id
     }


### PR DESCRIPTION
### Overview
Adds `remove_uref` FFI/API methods for removing entries in the context's `known_uref` map.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-391

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
This PR is against dev but builds on #689. Here's the proper diff: https://github.com/CasperLabs/CasperLabs/compare/EE-389...ee-391