### PR TITLE
EE-390: Add `get_caller` FFI/API methods that return caller's public key.

### DIFF
--- a/execution-engine/common/src/bytesrepr.rs
+++ b/execution-engine/common/src/bytesrepr.rs
@@ -554,6 +554,11 @@ mod proptests {
         fn test_access_rights(access_right in access_rights_arb()) {
             assert!(test_serialization_roundtrip(&access_right))
         }
+
+        #[test]
+        fn test_public_key(pk in public_key_arb()) {
+            assert!(test_serialization_roundtrip(&pk))
+        }
     }
 
 }

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -251,6 +251,22 @@ pub fn remove_uref(name: &str) {
     unsafe { ext_ffi::remove_uref(name_ptr, name_size) }
 }
 
+/// Returns caller of current context.
+/// When in root context (not in the sub call) - returns None.
+/// When in the sub call - returns public key of the account that made the deploy.
+pub fn get_caller() -> Option<PublicKey> {
+    //  TODO: Once `PUBLIC_KEY_SIZE` is fixed, replace 36 with it.
+    let dest_ptr = alloc_bytes(36);
+    let result = unsafe { ext_ffi::get_caller(dest_ptr) };
+    if result == 1 {
+        let bytes = unsafe { Vec::from_raw_parts(dest_ptr, 36, 36) };
+        let pk = deserialize(&bytes).unwrap();
+        Some(pk)
+    } else {
+        None
+    }
+}
+
 /// Return `t` to the host, terminating the currently running module.
 /// Note this function is only relevent to contracts stored on chain which
 /// return a value to their caller. The return value of a directly deployed

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -90,6 +90,7 @@ mod ext_ffi {
         pub fn remove_associated_key(public_key_ptr: *const u8) -> i32;
         pub fn set_action_threshold(permission_level: u32, threshold: i32) -> i32;
         pub fn remove_uref(name_ptr: *const u8, name_size: usize);
+        pub fn get_caller(dest_ptr: *const u8) -> i32;
     }
 }
 

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -226,6 +226,11 @@ pub const WEIGHT_SIZE: usize = U8_SIZE;
 #[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Debug)]
 pub struct PublicKey([u8; KEY_SIZE]);
 
+// TODO: This needs to be updated, `PUBLIC_KEY_SIZE` is not 32 bytes as KEY_SIZE * U8_SIZE.
+// I am not changing that as I don't want to deal with ripple effect.
+
+// Public key is encoded as its underlying [u8; 32] array, which in turn
+// is serialized as u8 + [u8; 32], u8 represents the length and then 32 element array.
 pub const PUBLIC_KEY_SIZE: usize = KEY_SIZE * U8_SIZE;
 
 impl PublicKey {
@@ -407,8 +412,8 @@ impl Account {
         &mut self.known_urefs
     }
 
-    pub fn pub_key(&self) -> &[u8; 32] {
-        &self.public_key
+    pub fn pub_key(&self) -> [u8; 32] {
+        self.public_key
     }
 
     pub fn purse_id(&self) -> PurseId {

--- a/execution-engine/engine/src/function_index.rs
+++ b/execution-engine/engine/src/function_index.rs
@@ -32,6 +32,7 @@ pub enum FunctionIndex {
     SerKnownURefs = 25,
     ListKnownURefsIndex = 26,
     RemoveURef = 27,
+    GetCallerIndex = 28,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -153,6 +153,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::RemoveURef.into(),
             ),
+            "get_caller" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], Some(ValueType::I32)),
+                FunctionIndex::GetCallerIndex.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",


### PR DESCRIPTION
### Overview
As in the title.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-390

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
There are accompanying test contracts here: https://github.com/CasperLabs/contract-examples/pull/22 . 