### PR TITLE
EE-404: remove amount parameter from Mint::create

### DIFF
--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -612,10 +612,8 @@ where
 
     /// Calls the "create" method on the mint contract at the given mint contract key
     fn mint_create(&mut self, mint_contract_key: Key) -> Result<PurseId, Error> {
-        let amount: U512 = U512::from(0);
-
         let args_bytes = {
-            let args = ("create", amount);
+            let args = "create";
             ArgsParser::parse(&args).and_then(|args| args.to_bytes())?
         };
 


### PR DESCRIPTION
### Overview
This PR removes the `amount` parameter from `Mint::create`.  This "feature" was problematic for devnet as it would allow users to create tokens out of thin air.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-404

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
