### PR TITLE
CON-322: update visualdag to differ main parent from other parents

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -155,8 +155,16 @@ object GraphzGenerator {
       .flatMap(_.values.toList)
       .traverse {
         case ValidatorBlock(blockHash, parentsHashes, _) =>
-          parentsHashes
-            .traverse(p => g.edge(blockHash, p, constraint = Some(false)))
+          parentsHashes.zipWithIndex
+            .traverse {
+              case (p, index) =>
+                val style = if (index == 0) {
+                  Some(Bold)
+                } else {
+                  None
+                }
+                g.edge(blockHash, p, style = style, constraint = Some(false))
+            }
       }
       .as(())
 

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -158,6 +158,7 @@ object GraphzGenerator {
           parentsHashes.zipWithIndex
             .traverse {
               case (p, index) =>
+                // Bolding the edge to main parent
                 val style = if (index == 0) {
                   Some(Bold)
                 } else {

--- a/graphz/src/test/scala/io/casperlabs/graphz/GraphzSpec.scala
+++ b/graphz/src/test/scala/io/casperlabs/graphz/GraphzSpec.scala
@@ -253,7 +253,7 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
         _ <- g.node("1", shape = PlainText)
         _ <- g.node("0", shape = PlainText)
         _ <- g.edge("0" -> "1")
-        _ <- g.edge("1" -> "2")
+        _ <- g.edge("1", "2", style = Some(Bold), constraint = Some(false))
         _ <- g.edge("2" -> "3")
         _ <- g.close
       } yield g
@@ -290,7 +290,7 @@ class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with Appe
           |    "1" [shape=plaintext]
           |    "0" [shape=plaintext]
           |    "0" -> "1"
-          |    "1" -> "2"
+          |    "1" -> "2" [constraint=false style=bold]
           |    "2" -> "3"
           |  }
           |}""".stripMargin


### PR DESCRIPTION
Signed-off-by: Abner Zheng <abnerzheng@gmail.com>

### Overview
Since we update single parent fork-choice rule, it is more convenient to differ the main parent from other parents in visual dag for debugging. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-322

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
