### PR TITLE
NODE-587: Fix ObservableOpsSpec timing.

### DIFF
--- a/shared/src/test/scala/io/casperlabs/shared/ObservableOpsSpec.scala
+++ b/shared/src/test/scala/io/casperlabs/shared/ObservableOpsSpec.scala
@@ -36,10 +36,10 @@ class ObservableOpsSpec extends WordSpec with Matchers {
       "not cancel the stream" in {
         val list = Observable
           .range(0, 100, 1)
-          .withConsumerTimeout(100.millis)
+          .withConsumerTimeout(1.second)
           .toListL
 
-        val res = list.runSyncUnsafe(2.seconds)
+        val res = list.runSyncUnsafe(5.seconds)
         res should have size 100
       }
     }


### PR DESCRIPTION
### Overview
Done is sometimes slower than 100.millis per item, causing the test to be flaky.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-587

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
