### PR TITLE
NODE-590: Shutdown application on fatal errors

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -1,9 +1,8 @@
 package io.casperlabs.client
 
 import cats.effect.{Sync, Timer}
-import io.casperlabs.casper.protocol
 import io.casperlabs.client.configuration._
-import io.casperlabs.shared.{Log, UncaughtExceptionLogger}
+import io.casperlabs.shared.{Log, UncaughtExceptionHandler}
 import monix.eval.Task
 import monix.execution.Scheduler
 
@@ -15,7 +14,7 @@ object Main {
     implicit val scheduler: Scheduler = Scheduler.computation(
       Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
       "node-runner",
-      reporter = UncaughtExceptionLogger
+      reporter = UncaughtExceptionHandler
     )
 
     val exec =

--- a/comm/src/main/scala/io/casperlabs/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/TcpTransportLayer.scala
@@ -273,7 +273,7 @@ class TcpTransportLayer(
     cell.modify { s =>
       val parallelism = Math.max(Runtime.getRuntime.availableProcessors(), 2)
       val queueScheduler =
-        Scheduler.fixedPool("tl-dispatcher", parallelism, reporter = UncaughtExceptionLogger)
+        Scheduler.fixedPool("tl-dispatcher", parallelism, reporter = UncaughtExceptionHandler)
       for {
         server <- initQueue(s.server) {
                    Task.delay {

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -1,6 +1,5 @@
 package io.casperlabs.node
 
-import cats.effect.ExitCode
 import cats.implicits._
 import io.casperlabs.catscontrib._
 import io.casperlabs.comm._
@@ -24,7 +23,7 @@ object Main {
     implicit val scheduler: Scheduler = Scheduler.computation(
       Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
       "node-runner",
-      reporter = UncaughtExceptionLogger
+      reporter = UncaughtExceptionHandler
     )
 
     val exec: Task[Unit] =

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -48,9 +48,9 @@ class NodeRuntime private[node] (
 )(implicit log: Log[Task]) {
 
   private[this] val loopScheduler =
-    Scheduler.fixedPool("loop", 4, reporter = UncaughtExceptionLogger)
+    Scheduler.fixedPool("loop", 4, reporter = UncaughtExceptionHandler)
   private[this] val blockingScheduler =
-    Scheduler.cached("blocking-io", 4, 64, reporter = UncaughtExceptionLogger)
+    Scheduler.cached("blocking-io", 4, 64, reporter = UncaughtExceptionHandler)
   private implicit val concurrentEffectForEffect: ConcurrentEffect[Effect] =
     catsConcurrentEffectForEffect(
       scheduler

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -14,6 +14,7 @@ object UncaughtExceptionHandler extends UncaughtExceptionReporter {
         // To flush logs
         Thread.sleep(1000)
         sys.exit(1)
+      case _ =>
     }
   }
 }

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -1,13 +1,18 @@
 package io.casperlabs.shared
 
 import cats.Id
-
 import monix.execution.UncaughtExceptionReporter
 
-object UncaughtExceptionLogger extends UncaughtExceptionReporter {
+import scala.util.control.NonFatal
+
+object UncaughtExceptionHandler extends UncaughtExceptionReporter {
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private val log: Log[Id]                  = Log.logId
 
-  def reportFailure(ex: scala.Throwable): Unit =
+  override def reportFailure(ex: scala.Throwable): Unit = {
     log.error(s"Uncaught Exception : ${ex.getMessage}", ex)
+    if (!NonFatal(ex)) {
+      sys.exit(1)
+    }
+  }
 }

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -3,16 +3,17 @@ package io.casperlabs.shared
 import cats.Id
 import monix.execution.UncaughtExceptionReporter
 
-import scala.util.control.NonFatal
-
 object UncaughtExceptionHandler extends UncaughtExceptionReporter {
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private val log: Log[Id]                  = Log.logId
 
   override def reportFailure(ex: scala.Throwable): Unit = {
     log.error(s"Uncaught Exception : ${ex.getMessage}", ex)
-    if (!NonFatal(ex)) {
-      sys.exit(1)
+    ex match {
+      case _: VirtualMachineError | _: LinkageError =>
+        // To flush logs
+        Thread.sleep(1000)
+        sys.exit(1)
     }
   }
 }


### PR DESCRIPTION
### Overview
Previously, fatal errors were reported by `UncaughtExceptionReporter` killing only the thread but not a whole application leaving it in a "zombie" state.

Now the application exits if a fatal error has been thrown:
```
18:02:58.729 [node-runner-39] ERROR i.c.shared.UncaughtExceptionHandler$ - Uncaught Exception : null
java.lang.OutOfMemoryError: null
	at io.casperlabs.node.api.GrpcControlService$$anon$1.propose(GrpcControlService.scala:23)
	at io.casperlabs.node.api.control.ControlGrpcMonix$$anon$1.invoke(ControlGrpcMonix.scala:59)
	at io.casperlabs.node.api.control.ControlGrpcMonix$$anon$1.invoke(ControlGrpcMonix.scala:57)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:698)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at monix.execution.internal.forkJoin.AdaptedForkJoinTask.exec(AdaptedForkJoinTask.scala:27)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
18:02:58.731 [shutdownHook2] INFO  io.casperlabs.node.NodeRuntime - Shutting down...
18:02:58.734 [shutdownHook2] INFO  i.c.c.gossiping.DownloadManagerImpl$ - Shutting down the Download Manager...
18:02:58.757 [shutdownHook2] INFO  i.c.c.discovery.GrpcKademliaService - Shutting down Kademlia RPC server
18:02:58.760 [shutdownHook2] INFO  i.c.c.discovery.GrpcKademliaService - Disconnecting from all peers
18:02:58.761 [shutdownHook2] INFO  i.c.s.ExecutionEngineConf - Shutting down execution engine service...
18:02:58.765 [shutdownHook2] INFO  io.casperlabs.node.NodeRuntime - Goodbye.
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-590

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._