### PR TITLE
NODE-463: Ensure 2 distincts ports are picked in GrpcKademliaServiceSpec

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/KademliaServiceSpec.scala
@@ -2,12 +2,12 @@ package io.casperlabs.comm.discovery
 
 import scala.concurrent.duration._
 import scala.util.Random
-import cats._
 import cats.implicits._
+import io.casperlabs.catscontrib.MonadThrowable
 import org.scalatest._
 import io.casperlabs.comm.discovery.NodeUtils._
 
-abstract class KademliaServiceSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
+abstract class KademliaServiceSpec[F[_]: MonadThrowable: cats.effect.Timer, E <: Environment]
     extends KademliaServiceRuntime[F, E]
     with WordSpecLike
     with Matchers {


### PR DESCRIPTION
### Overview
As in the title

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-463

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._