### PR TITLE
NODE-536: Bump timeouts for a failed test of GrpcGossipServiceServer

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -265,7 +265,7 @@ class GrpcGossipServiceSpec
         "only allow them up to the limit" in {
           val maxParallelBlockDownloads = 2
           forAll { (block: Block) =>
-            runTestUnsafe(TestData.fromBlock(block), timeout = 10.seconds) {
+            runTestUnsafe(TestData.fromBlock(block), timeout = 15.seconds) {
               TestEnvironment(testDataRef, maxParallelBlockDownloads = maxParallelBlockDownloads)
                 .use { stub =>
                   val parallelNow = new AtomicInteger(0)


### PR DESCRIPTION
### Overview
As in the title

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-536

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._