### PR TITLE
EE-424: add match cases to pretty printer so they are exhaustive

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -35,6 +35,7 @@ object PrettyPrinter {
         case None    => "Write(Nothing)"
         case Some(v) => s"Write(${buildString(v)})"
       }
+    case Transform.TransformInstance.AddU64(TransformAddUInt64(x)) => s"AddU64($x)"
   }
 
   def buildString(v: Option[ProtocolVersion]): String = v match {
@@ -74,6 +75,8 @@ object PrettyPrinter {
     case Value.Value.StringValue(s)               => s"String($s)"
     case Value.Value.BigInt(v)                    => s"BigInt(${v.value})"
     case Value.Value.Key(key)                     => buildString(key)
+    case Value.Value.LongValue(l)                 => s"Long($l)"
+    case Value.Value.Unit(_)                      => "Unit"
   }
 
   def buildString(b: BlockMessage): String =


### PR DESCRIPTION
### Overview
This will prevent some errors we would otherwise encounter some time in the future. E.g. `Value.Unit` was one of the missing cases and `Unit` is used in token stuff because it is written as the value under urefs used as purses.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-424

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
