### PR TITLE
NO-TICKET: Add `Display` and `Debug` impls for `PublicKey` and `URef`.

### DIFF
--- a/execution-engine/common/src/key.rs
+++ b/execution-engine/common/src/key.rs
@@ -51,7 +51,8 @@ impl Key {
 
 // There is no impl LowerHex for neither [u8; 32] nor &[u8] in std.
 // I can't impl them b/c they're not living in current crate.
-fn addr_to_hex(addr: &[u8; 32]) -> String {
+/// Creates a hex string from [u8; 32] table.
+pub fn addr_to_hex(addr: &[u8; 32]) -> String {
     let mut str = String::with_capacity(64);
     for b in addr {
         write!(&mut str, "{:02x}", b).unwrap();
@@ -62,18 +63,10 @@ fn addr_to_hex(addr: &[u8; 32]) -> String {
 impl core::fmt::Display for Key {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
-            Key::Account(addr) => write!(f, "Account({})", addr_to_hex(addr)),
-            Key::Hash(addr) => write!(f, "Hash({})", addr_to_hex(addr)),
-            Key::URef(uref) => {
-                let addr = uref.addr();
-                let access_rights_o = uref.access_rights();
-                if let Some(access_rights) = access_rights_o {
-                    write!(f, "URef({}, {})", addr_to_hex(&addr), access_rights)
-                } else {
-                    write!(f, "URef({}, None)", addr_to_hex(&addr))
-                }
-            }
-            Key::Local(hash) => write!(f, "Local({})", addr_to_hex(hash)),
+            Key::Account(addr) => write!(f, "Key::Account({})", addr_to_hex(addr)),
+            Key::Hash(addr) => write!(f, "Key::Hash({})", addr_to_hex(addr)),
+            Key::URef(uref) => write!(f, "Key::{}", uref), // Display impl for URef will append URef(…).
+            Key::Local(hash) => write!(f, "Key::Local({})", addr_to_hex(hash)),
         }
     }
 }
@@ -264,19 +257,22 @@ mod tests {
         let account_key = Key::Account(addr_array);
         assert_eq!(
             format!("{}", account_key),
-            format!("Account({})", expected_hash)
+            format!("Key::Account({})", expected_hash)
         );
         let uref_key = Key::URef(URef::new(addr_array, AccessRights::READ));
         assert_eq!(
             format!("{}", uref_key),
-            format!("URef({}, READ)", expected_hash)
+            format!("Key::URef({}, READ)", expected_hash)
         );
         let hash_key = Key::Hash(addr_array);
-        assert_eq!(format!("{}", hash_key), format!("Hash({})", expected_hash));
+        assert_eq!(
+            format!("{}", hash_key),
+            format!("Key::Hash({})", expected_hash)
+        );
         let local_key = Key::Local(addr_array);
         assert_eq!(
             format!("{}", local_key),
-            format!("Local({})", expected_hash)
+            format!("Key::Local({})", expected_hash)
         );
     }
 }

--- a/execution-engine/common/src/uref.rs
+++ b/execution-engine/common/src/uref.rs
@@ -151,7 +151,7 @@ impl URef {
     }
 
     pub fn as_string(&self) -> String {
-        format!("{:?}", self.0)
+        format!("{:?}", self)
     }
 }
 
@@ -216,7 +216,8 @@ mod tests {
 
     use crate::gens;
     use crate::test_utils;
-    use crate::uref::AccessRights;
+    use crate::uref::{AccessRights, URef};
+    use alloc::string::String;
 
     fn test_readable(right: AccessRights, is_true: bool) {
         assert_eq!(right.is_readable(), is_true)
@@ -268,5 +269,20 @@ mod tests {
         fn test_uref(uref in gens::uref_arb()) {
             assert!(test_utils::test_serialization_roundtrip(&uref));
         }
+    }
+
+    #[test]
+    fn uref_as_string() {
+        // Since we are putting URefs to known_urefs map keyed by the label that `as_string()`
+        // returns, any changes to the string representation of that type cannot break the format.
+        let expected_hash = core::iter::repeat("0").take(64).collect::<String>();
+        let addr_array = [0u8; 32];
+        let uref_a = URef::new(addr_array, AccessRights::READ);
+        assert_eq!(uref_a.as_string(), format!("URef({}, READ)", expected_hash));
+        let uref_b = URef::new(addr_array, AccessRights::WRITE);
+        assert_eq!(
+            uref_b.as_string(),
+            format!("URef({}, WRITE)", expected_hash)
+        );
     }
 }

--- a/execution-engine/common/src/uref.rs
+++ b/execution-engine/common/src/uref.rs
@@ -70,8 +70,31 @@ impl bytesrepr::FromBytes for AccessRights {
 }
 
 /// Represents an unforgeable reference
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct URef([u8; UREF_ADDR_SIZE], Option<AccessRights>);
+
+impl core::fmt::Display for URef {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        let addr = self.addr();
+        let access_rights_o = self.access_rights();
+        if let Some(access_rights) = access_rights_o {
+            write!(
+                f,
+                "URef({}, {})",
+                super::key::addr_to_hex(&addr),
+                access_rights
+            )
+        } else {
+            write!(f, "URef({}, None)", super::key::addr_to_hex(&addr))
+        }
+    }
+}
+
+impl core::fmt::Debug for URef {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
 
 impl URef {
     /// Creates a [`URef`] from an id and access rights.

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -1,9 +1,10 @@
 use crate::bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE, U8_SIZE};
-use crate::key::{Key, UREF_SIZE};
+use crate::key::{addr_to_hex, Key, UREF_SIZE};
 use crate::uref::{URef, UREF_SIZE_SERIALIZED};
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
+use core::fmt::{Debug, Display, Formatter};
 use failure::Fail;
 
 const DEFAULT_NONCE: u64 = 0;
@@ -241,8 +242,20 @@ impl Weight {
 
 pub const WEIGHT_SIZE: usize = U8_SIZE;
 
-#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy, Debug)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy)]
 pub struct PublicKey([u8; KEY_SIZE]);
+
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        write!(f, "PublicKey({})", addr_to_hex(&self.0))
+    }
+}
+
+impl Debug for PublicKey {
+    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
+        write!(f, "{}", self)
+    }
+}
 
 // TODO: This needs to be updated, `PUBLIC_KEY_SIZE` is not 32 bytes as KEY_SIZE * U8_SIZE.
 // I am not changing that as I don't want to deal with ripple effect.


### PR DESCRIPTION
### Overview
As in the ticket. It also fixes the bug that was lurking in the `URef::as_string()` method. Taken from the description of the last commit:
> Previously it [`URef::as_string()`] only formatted an address part (of the `URef`) but during setup of the `RuntimeContext`, known urefs map (`BTreeMap<String, Key>`) is turned into `HashMap<URef, HashSet<AccessRights>>`. Having the same key value used for URefs with different `AccessRights` (because it only cares about the address part) means we would be overwriting URefs in the `known_urefs`, effectively losing access to some of the URefs.

### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
This was initially done during work on #726 .