### PR TITLE
EE-435: Return purse urefs with extra urefs.

### DIFF
--- a/execution-engine/blessed-contracts/mint-token/src/lib.rs
+++ b/execution-engine/blessed-contracts/mint-token/src/lib.rs
@@ -74,9 +74,7 @@ pub extern "C" fn call() {
         "create" => {
             let purse_id = mint.create();
             let purse_key = URef::new(purse_id.raw_id(), AccessRights::READ_ADD_WRITE);
-            // TODO: return `purse_key` in extra_urefs, currently broken
-            // Ref: https://casperlabs.atlassian.net/browse/EE-401
-            contract_api::ret(&purse_key, &vec![])
+            contract_api::ret(&purse_key, &vec![purse_key])
         }
 
         "balance" => {


### PR DESCRIPTION

### Overview
_Provide a brief description of what this PR does, and why it's needed._

This makes transfer functions not fail with `ForgedReference` due to the
fact that created purse with `create_purse` doesn't extend known urefs.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-435

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
