### PR TITLE
NO-TICKET: Add PoS addresses to the `known_urefs` of the accounts.

### DIFF
--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -8,8 +8,8 @@ use rand::RngCore;
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
-use common::value::{Contract, U512, Value};
 use common::value::account::{PublicKey, PurseId};
+use common::value::{Contract, Value, U512};
 use engine_state::execution_effect::ExecutionEffect;
 use engine_state::op::Op;
 use engine_state::utils::WasmiBytes;
@@ -323,11 +323,11 @@ mod tests {
     use std::collections::HashMap;
 
     use common::key::{addr_to_hex, Key};
-    use common::value::{Contract, U512, Value};
     use common::value::account::PublicKey;
+    use common::value::{Contract, Value, U512};
     use engine_state::create_genesis_effects;
     use engine_state::genesis::{
-        GENESIS_ACCOUNT_PURSE, GenesisURefsSource, MINT_GENESIS_ACCOUNT_BALANCE_UREF,
+        GenesisURefsSource, GENESIS_ACCOUNT_PURSE, MINT_GENESIS_ACCOUNT_BALANCE_UREF,
         MINT_POS_BALANCE_UREF, MINT_PRIVATE_ADDRESS, MINT_PUBLIC_ADDRESS, POS_PRIVATE_ADDRESS,
         POS_PUBLIC_ADDRESS,
     };

--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -8,8 +8,8 @@ use rand::RngCore;
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
+use common::value::{Contract, U512, Value};
 use common::value::account::{PublicKey, PurseId};
-use common::value::{Contract, Value, U512};
 use engine_state::execution_effect::ExecutionEffect;
 use engine_state::op::Op;
 use engine_state::utils::WasmiBytes;
@@ -95,6 +95,8 @@ fn create_mint_effects(
     );
 
     let purse_id_uref = rng.get_uref(GENESIS_ACCOUNT_PURSE);
+    let pos_public_uref = rng.get_uref(POS_PUBLIC_ADDRESS);
+    let pos_private_uref = rng.get_uref(POS_PRIVATE_ADDRESS);
 
     // Create genesis genesis_account
     let genesis_account = {
@@ -102,6 +104,8 @@ fn create_mint_effects(
         // TODO: do we need to deal with NamedKey ???
         let known_urefs = &[
             (String::from("mint"), Key::URef(public_uref)),
+            (String::from("pos"), Key::URef(pos_public_uref)),
+            (pos_private_uref.as_string(), Key::URef(pos_private_uref)),
             (
                 mint_contract_uref.as_string(),
                 Key::URef(mint_contract_uref),
@@ -319,11 +323,11 @@ mod tests {
     use std::collections::HashMap;
 
     use common::key::{addr_to_hex, Key};
+    use common::value::{Contract, U512, Value};
     use common::value::account::PublicKey;
-    use common::value::{Contract, Value, U512};
     use engine_state::create_genesis_effects;
     use engine_state::genesis::{
-        GenesisURefsSource, GENESIS_ACCOUNT_PURSE, MINT_GENESIS_ACCOUNT_BALANCE_UREF,
+        GENESIS_ACCOUNT_PURSE, GenesisURefsSource, MINT_GENESIS_ACCOUNT_BALANCE_UREF,
         MINT_POS_BALANCE_UREF, MINT_PRIVATE_ADDRESS, MINT_PUBLIC_ADDRESS, POS_PRIVATE_ADDRESS,
         POS_PUBLIC_ADDRESS,
     };

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -18,15 +18,15 @@ use wasmi::{
 
 use args::Args;
 use common::bytesrepr::{deserialize, Error as BytesReprError, ToBytes, U32_SIZE};
-use common::contract_api::{PurseTransferResult, TransferResult};
 use common::contract_api::argsparser::ArgsParser;
+use common::contract_api::{PurseTransferResult, TransferResult};
 use common::key::Key;
 use common::uref::{AccessRights, URef};
-use common::value::{Account, U512, Value};
 use common::value::account::{
-    ActionType, AddKeyFailure, BlockTime, PUBLIC_KEY_SIZE, PublicKey, PurseId,
-    RemoveKeyFailure, SetThresholdFailure, Weight,
+    ActionType, AddKeyFailure, BlockTime, PublicKey, PurseId, RemoveKeyFailure,
+    SetThresholdFailure, Weight, PUBLIC_KEY_SIZE,
 };
+use common::value::{Account, Value, U512};
 use engine_state::execution_result::ExecutionResult;
 use execution::Error::{KeyNotFound, URefNotFound};
 use function_index::FunctionIndex;
@@ -1528,10 +1528,10 @@ mod tests {
 
     use common::key::Key;
     use common::uref::{AccessRights, URef};
-    use common::value::{Account, Value};
     use common::value::account::{
         AccountActivity, AssociatedKeys, BlockTime, PublicKey, PurseId, Weight,
     };
+    use common::value::{Account, Value};
     use engine_state::execution_effect::ExecutionEffect;
     use engine_state::execution_result::ExecutionResult;
     use execution::{create_rng, Executor, WasmiExecutor};

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -16,21 +16,17 @@ use wasmi::{
     ModuleRef, RuntimeArgs, RuntimeValue, Trap,
 };
 
+use args::Args;
 use common::bytesrepr::{deserialize, Error as BytesReprError, ToBytes, U32_SIZE};
+use common::contract_api::{PurseTransferResult, TransferResult};
 use common::contract_api::argsparser::ArgsParser;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
+use common::value::{Account, U512, Value};
 use common::value::account::{
-    ActionType, AddKeyFailure, BlockTime, PublicKey, PurseId, RemoveKeyFailure,
-    SetThresholdFailure, Weight, PUBLIC_KEY_SIZE,
+    ActionType, AddKeyFailure, BlockTime, PUBLIC_KEY_SIZE, PublicKey, PurseId,
+    RemoveKeyFailure, SetThresholdFailure, Weight,
 };
-use common::value::{Account, Value, U512};
-use shared::newtypes::{CorrelationId, Validated};
-use shared::transform::TypeMismatch;
-use storage::global_state::StateReader;
-
-use args::Args;
-use common::contract_api::{PurseTransferResult, TransferResult};
 use engine_state::execution_result::ExecutionResult;
 use execution::Error::{KeyNotFound, URefNotFound};
 use function_index::FunctionIndex;
@@ -38,10 +34,14 @@ use resolvers::create_module_resolver;
 use resolvers::error::ResolverError;
 use resolvers::memory_resolver::MemoryResolver;
 use runtime_context::RuntimeContext;
+use shared::newtypes::{CorrelationId, Validated};
+use shared::transform::TypeMismatch;
+use storage::global_state::StateReader;
 use tracking_copy::TrackingCopy;
 use URefAddr;
 
 const MINT_NAME: &str = "mint";
+const POS_NAME: &str = "pos";
 
 #[derive(Debug)]
 pub enum Error {
@@ -599,6 +599,13 @@ where
         }
     }
 
+    fn get_pos_contract_public_uref_key(&mut self) -> Result<Key, Error> {
+        match self.context.get_uref(POS_NAME) {
+            Some(key @ Key::URef(_)) => Ok(*key),
+            _ => Err(URefNotFound(String::from(POS_NAME))),
+        }
+    }
+
     /// looks up the public mint contract key in the caller's [uref_lookup] map and then
     /// gets the "internal" mint contract uref stored under the public mint contract key.
     fn get_mint_contract_uref(&mut self) -> Result<URef, Error> {
@@ -606,6 +613,15 @@ where
         let internal_mint_uref = match self.context.read_gs(&public_mint_key)? {
             Some(Value::Key(Key::URef(uref))) => uref,
             _ => return Err(KeyNotFound(public_mint_key)),
+        };
+        Ok(internal_mint_uref)
+    }
+
+    fn get_pos_contract_uref(&mut self) -> Result<URef, Error> {
+        let public_pos_key = self.get_pos_contract_public_uref_key()?;
+        let internal_mint_uref = match self.context.read_gs(&public_pos_key)? {
+            Some(Value::Key(Key::URef(uref))) => uref,
+            _ => return Err(KeyNotFound(public_pos_key)),
         };
         Ok(internal_mint_uref)
     }
@@ -665,7 +681,9 @@ where
         amount: U512,
     ) -> Result<TransferResult, Error> {
         let mint_contract_uref = self.get_mint_contract_uref()?;
+        let pos_contract_uref = self.get_pos_contract_uref()?;
         let mint_contract_key = Key::URef(mint_contract_uref);
+        let pos_contract_key = Key::URef(pos_contract_uref);
         let target_addr = target.value();
         let target_key = Key::Account(target_addr);
 
@@ -683,6 +701,11 @@ where
                     String::from(MINT_NAME),
                     self.get_mint_contract_public_uref_key()?,
                 ),
+                (
+                    String::from(POS_NAME),
+                    self.get_pos_contract_public_uref_key()?,
+                ),
+                (pos_contract_uref.as_string(), pos_contract_key),
                 (mint_contract_uref.as_string(), mint_contract_key),
             ];
             let account = Account::create(target_addr, known_urefs, target_purse_id);
@@ -1493,27 +1516,30 @@ pub fn key_to_tuple(key: Key) -> Option<([u8; 32], Option<AccessRights>)> {
 
 #[cfg(test)]
 mod tests {
-    use super::Error;
-    use common::key::Key;
-    use common::uref::{AccessRights, URef};
-    use common::value::account::{
-        AccountActivity, AssociatedKeys, BlockTime, PublicKey, PurseId, Weight,
-    };
-    use common::value::{Account, Value};
-    use engine_state::execution_effect::ExecutionEffect;
-    use engine_state::execution_result::ExecutionResult;
-    use execution::{create_rng, Executor, WasmiExecutor};
-    use parity_wasm::builder::ModuleBuilder;
-    use parity_wasm::elements::{External, ImportEntry, MemoryType, Module};
-    use rand::RngCore;
-    use rand_chacha::ChaChaRng;
-    use shared::newtypes::CorrelationId;
     use std::cell::RefCell;
     use std::collections::btree_map::BTreeMap;
     use std::collections::HashMap;
     use std::rc::Rc;
+
+    use parity_wasm::builder::ModuleBuilder;
+    use parity_wasm::elements::{External, ImportEntry, MemoryType, Module};
+    use rand::RngCore;
+    use rand_chacha::ChaChaRng;
+
+    use common::key::Key;
+    use common::uref::{AccessRights, URef};
+    use common::value::{Account, Value};
+    use common::value::account::{
+        AccountActivity, AssociatedKeys, BlockTime, PublicKey, PurseId, Weight,
+    };
+    use engine_state::execution_effect::ExecutionEffect;
+    use engine_state::execution_result::ExecutionResult;
+    use execution::{create_rng, Executor, WasmiExecutor};
+    use shared::newtypes::CorrelationId;
     use storage::global_state::StateReader;
     use tracking_copy::TrackingCopy;
+
+    use super::Error;
 
     fn on_fail_charge_test_helper<T>(
         f: impl Fn() -> Result<T, Error>,

--- a/execution-engine/test-contracts/known-urefs/src/lib.rs
+++ b/execution-engine/test-contracts/known-urefs/src/lib.rs
@@ -3,7 +3,9 @@
 
 extern crate alloc;
 extern crate cl_std;
+
 use alloc::string::String;
+
 use cl_std::contract_api::{
     add, add_uref, get_uref, has_uref, list_known_urefs, new_uref, read, remove_uref, write,
 };
@@ -12,13 +14,14 @@ use cl_std::value::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    // Account starts with two known urefs: mint, and purse_id
-    assert_eq!(list_known_urefs().len(), 2);
+    let initi_uref_num = 4;
+    // Account starts with four known urefs: mint public uref, mint private uref, pos public uref & pos private uref.
+    assert_eq!(list_known_urefs().len(), initi_uref_num);
 
     // Add new urefs
     let hello_world_uref1: Key = new_uref(String::from("Hello, world!")).into();
     add_uref("URef1", &hello_world_uref1);
-    assert_eq!(list_known_urefs().len(), 3);
+    assert_eq!(list_known_urefs().len(), initi_uref_num + 1);
 
     // Verify if the uref is present
     assert!(has_uref("URef1"));
@@ -26,7 +29,7 @@ pub extern "C" fn call() {
     let big_value_uref: Key = new_uref(U512::max_value()).into();
     add_uref("URef2", &big_value_uref);
 
-    assert_eq!(list_known_urefs().len(), 4);
+    assert_eq!(list_known_urefs().len(), initi_uref_num + 2);
 
     // Read data hidden behind `URef1` uref
     let hello_world: String = read(
@@ -75,5 +78,5 @@ pub extern "C" fn call() {
     // Cleaned up state
     assert!(!has_uref("URef1"));
     assert!(!has_uref("URef2"));
-    assert_eq!(list_known_urefs().len(), 2);
+    assert_eq!(list_known_urefs().len(), initi_uref_num);
 }


### PR DESCRIPTION
### Overview
PoS contract, even though was persisted in the GlobalState, wasn't added to the `known_urefs` of newly created accounts (or even genesis account). This PR adds it to both places. Tested empirically, unit tests to follow (https://casperlabs.atlassian.net/browse/EE-437).

### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
n/a