### PR TITLE
EE-393: Return currently bonded validators with `CommitResult` message.

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -902,22 +902,14 @@ fn execution_error(msg: String, cost: u64, effect: ExecutionEffect) -> ipc::Depl
     deploy_result
 }
 
-// TODO: Split into atomic functions and improve errors.
 pub fn to_domain_validators(bond: &ipc::Bond) -> Result<(PublicKey, U512), String> {
-    let address = bond.get_validator_public_key();
-    if address.len() != 32 {
-        let err_msg = "Validator public key has to be exactly 32 bytes long".to_string();
-        Err(err_msg)
-    } else {
-        let mut buff = [0u8; 32];
-        buff.copy_from_slice(&address);
-        let pk = PublicKey::new(buff);
-        match bond.get_stake().try_into() {
-            Ok(bond) => Ok((pk, bond)),
-            Err(err) => {
-                let err_msg = format!("{:?}", err);
-                Err(err_msg)
-            }
+    let pk = PublicKey::from_slice(bond.get_validator_public_key())
+        .ok_or("Public key has to be exactly 32 bytes long.")?;
+    match bond.get_stake().try_into() {
+        Ok(bond) => Ok((pk, bond)),
+        Err(err) => {
+            let err_msg = format!("{:?}", err);
+            Err(err_msg)
         }
     }
 }

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -1,7 +1,7 @@
-mod uint;
-
 use std::collections::{BTreeMap, HashMap};
 use std::convert::{TryFrom, TryInto};
+use std::fmt::Display;
+use std::string::ToString;
 
 use protobuf::ProtobufEnum;
 
@@ -9,6 +9,8 @@ use common::uref::URef;
 use common::value::account::{
     AccountActivity, ActionThresholds, AssociatedKeys, BlockTime, PublicKey, PurseId, Weight,
 };
+use common::value::U512;
+use engine_server::{ipc, state};
 use execution_engine::engine_state::error::{Error as EngineError, RootNotFound};
 use execution_engine::engine_state::execution_effect::ExecutionEffect;
 use execution_engine::engine_state::execution_result::ExecutionResult;
@@ -19,11 +21,9 @@ use shared::logging;
 use shared::logging::log_level;
 use shared::newtypes::Blake2bHash;
 use shared::transform::{self, TypeMismatch};
-use std::fmt::Display;
-use std::string::ToString;
 use storage::global_state::{CommitResult, History};
 
-use engine_server::{ipc, state};
+mod uint;
 
 /// Helper method for turning instances of Value into Transform::Write.
 fn transform_write(v: common::value::Value) -> Result<transform::Transform, ParsingError> {
@@ -902,20 +902,49 @@ fn execution_error(msg: String, cost: u64, effect: ExecutionEffect) -> ipc::Depl
     deploy_result
 }
 
+// TODO: Split into atomic functions and improve errors.
+pub fn to_domain_validators(bond: &ipc::Bond) -> Result<(PublicKey, U512), String> {
+    let address = bond.get_validator_public_key();
+    if address.len() != 32 {
+        let err_msg = "Validator public key has to be exactly 32 bytes long".to_string();
+        Err(err_msg)
+    } else {
+        let mut buff = [0u8; 32];
+        buff.copy_from_slice(&address);
+        let pk = PublicKey::new(buff);
+        match bond.get_stake().try_into() {
+            Ok(bond) => Ok((pk, bond)),
+            Err(err) => {
+                let err_msg = format!("{:?}", err);
+                Err(err_msg)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+    use std::convert::TryInto;
+
+    use proptest::prelude::*;
+
+    use common::gens::{account_arb, contract_arb, key_arb, uref_map_arb, value_arb};
+    use common::key::Key;
+    use common::uref::{AccessRights, URef};
+    use engine_server::mappings::CommitTransforms;
+    use execution_engine::engine_state::error::{Error as EngineError, RootNotFound};
+    use execution_engine::engine_state::error::Error::ExecError;
+    use execution_engine::engine_state::execution_effect::ExecutionEffect;
+    use execution_engine::engine_state::execution_result::ExecutionResult;
+    use execution_engine::execution::Error;
+    use shared::newtypes::Blake2bHash;
+    use shared::transform::gens::transform_arb;
+    use shared::transform::Transform;
+
     use super::execution_error;
     use super::ipc;
     use super::state;
-    use common::key::Key;
-    use common::uref::{AccessRights, URef};
-    use execution_engine::engine_state::error::{Error as EngineError, RootNotFound};
-    use execution_engine::engine_state::execution_effect::ExecutionEffect;
-    use execution_engine::engine_state::execution_result::ExecutionResult;
-    use shared::newtypes::Blake2bHash;
-    use shared::transform::Transform;
-    use std::collections::HashMap;
-    use std::convert::TryInto;
 
     // Test that wasm_error function actually returns DeployResult with result set to WasmError
     #[test]
@@ -1063,13 +1092,6 @@ mod tests {
             "Exit code: 10"
         );
     }
-
-    use common::gens::{account_arb, contract_arb, key_arb, uref_map_arb, value_arb};
-    use engine_server::mappings::CommitTransforms;
-    use execution_engine::engine_state::error::Error::ExecError;
-    use execution_engine::execution::Error;
-    use proptest::prelude::*;
-    use shared::transform::gens::transform_arb;
 
     proptest! {
         #[test]

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -925,8 +925,8 @@ mod tests {
     use common::key::Key;
     use common::uref::{AccessRights, URef};
     use engine_server::mappings::CommitTransforms;
-    use execution_engine::engine_state::error::{Error as EngineError, RootNotFound};
     use execution_engine::engine_state::error::Error::ExecError;
+    use execution_engine::engine_state::error::{Error as EngineError, RootNotFound};
     use execution_engine::engine_state::execution_effect::ExecutionEffect;
     use execution_engine::engine_state::execution_result::ExecutionResult;
     use execution_engine::execution::Error;

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::convert::TryInto;
 use std::fmt::Debug;
 use std::io::ErrorKind;
@@ -7,6 +8,7 @@ use std::time::Instant;
 use common::key::Key;
 use common::value::account::{BlockTime, PublicKey};
 use common::value::U512;
+use engine_server::ipc::CommitResponse;
 use execution_engine::engine_state::{
     EngineState, genesis::GenesisResult, get_bonded_validators, GetBondedValidatorsError,
 };
@@ -236,53 +238,18 @@ where
                     commit_result
                 {
                     let pos_key = Key::URef(GenesisURefsSource::default().get_pos_address());
-                    match get_bonded_validators(
+                    let bonded_validators_res = get_bonded_validators(
                         self.state(),
                         poststate_hash,
                         &pos_key,
                         correlation_id,
-                    ) {
-                        Ok(bonded_validators) => {
-                            let mut grpc_response =
-                                grpc_response_from_commit_result::<H>(prestate_hash, commit_result);
-                            let grpc_bonded_validators = bonded_validators
-                                .iter()
-                                .map(|(pk, bond)| {
-                                    let mut ipc_bond = ipc::Bond::new();
-                                    ipc_bond.set_stake((*bond).into());
-                                    ipc_bond.set_validator_public_key(pk.value().to_vec());
-                                    ipc_bond
-                                })
-                                .collect::<Vec<ipc::Bond>>()
-                                .into();
-                            grpc_response
-                                .mut_success() // We know it's a success because of the check few lines earlier.
-                                .set_bonded_validators(grpc_bonded_validators);
-                            grpc_response
-                        }
-                        Err(GetBondedValidatorsError::StorageErrors(error)) => {
-                            grpc_response_from_commit_result::<H>(poststate_hash, Err(error))
-                        }
-                        Err(GetBondedValidatorsError::PostStateHashNotFound(root_hash)) => {
-                            // I am not sure how to parse this error. It would mean that most probably
-                            // we have screwed up something in the trie store because `root_hash` was
-                            // calculated by us just a moment ago. It [root_hash] is a `poststate_hash` we return to the node.
-                            // There is no proper error variant in the `storage::error::Error` for it though.
-                            let error_message = format!("Post state hash not found {} when calculating bonded validators set.", root_hash);
-                            logging::log_error(&error_message);
-                            let mut commit_response = ipc::CommitResponse::new();
-                            let mut err = ipc::PostEffectsError::new();
-                            err.set_message(error_message);
-                            commit_response.set_failed_transform(err);
-                            commit_response
-                        }
-                        Err(GetBondedValidatorsError::PoSNotFound(key)) => {
-                            grpc_response_from_commit_result::<H>(
-                                poststate_hash,
-                                Ok(CommitResult::KeyNotFound(key)),
-                            )
-                        }
-                    }
+                    );
+                    bonded_validators_and_commit_result(
+                        prestate_hash,
+                        poststate_hash,
+                        commit_result,
+                        bonded_validators_res,
+                    )
                 } else {
                     // Commit unsuccessful.
                     grpc_response_from_commit_result::<H>(prestate_hash, commit_result)
@@ -426,32 +393,12 @@ where
             .get_genesis_validators()
             .iter()
             .map(|bond| {
-                let address = bond.get_validator_public_key();
-                if address.len() != 32 {
-                    let err_msg =
-                        "Validator public key has to be exactly 32 bytes long".to_string();
+                to_domain_validators(bond).map_err(|err_msg| {
                     logging::log_error(&err_msg);
-
                     let mut genesis_deploy_error = ipc::GenesisDeployError::new();
                     genesis_deploy_error.set_message(err_msg);
-
-                    Err(genesis_deploy_error)
-                } else {
-                    let mut buff = [0u8; 32];
-                    buff.copy_from_slice(&address);
-                    let pk = PublicKey::new(buff);
-                    match bond.get_stake().try_into() {
-                        Ok(bond) => Ok((pk, bond)),
-                        Err(err) => {
-                            let err_msg = format!("{:?}", err);
-                            logging::log_error(&err_msg);
-
-                            let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                            genesis_deploy_error.set_message(err_msg);
-                            Err(genesis_deploy_error)
-                        }
-                    }
-                }
+                    genesis_deploy_error
+                })
             })
             .collect();
 
@@ -595,6 +542,62 @@ where
                 .map_err(Into::into)
         })
         .collect()
+}
+
+// TODO: Refactor.
+pub fn bonded_validators_and_commit_result<H>(
+    prestate_hash: Blake2bHash,
+    poststate_hash: Blake2bHash,
+    commit_result: Result<CommitResult, H::Error>,
+    bonded_validators: Result<HashMap<PublicKey, U512>, GetBondedValidatorsError<H>>,
+) -> CommitResponse
+where
+    H: History,
+    H::Error: Into<EngineError> + std::fmt::Debug,
+{
+    match bonded_validators {
+        Ok(bonded_validators) => {
+            let mut grpc_response =
+                grpc_response_from_commit_result::<H>(prestate_hash, commit_result);
+            let grpc_bonded_validators = bonded_validators
+                .iter()
+                .map(|(pk, bond)| {
+                    let mut ipc_bond = ipc::Bond::new();
+                    ipc_bond.set_stake((*bond).into());
+                    ipc_bond.set_validator_public_key(pk.value().to_vec());
+                    ipc_bond
+                })
+                .collect::<Vec<ipc::Bond>>()
+                .into();
+            grpc_response
+                .mut_success() // We know it's a success because of the check few lines earlier.
+                .set_bonded_validators(grpc_bonded_validators);
+            grpc_response
+        }
+        Err(GetBondedValidatorsError::StorageErrors(error)) => {
+            grpc_response_from_commit_result::<H>(poststate_hash, Err(error))
+        }
+        Err(GetBondedValidatorsError::PostStateHashNotFound(root_hash)) => {
+            // I am not sure how to parse this error. It would mean that most probably
+            // we have screwed up something in the trie store because `root_hash` was
+            // calculated by us just a moment ago. It [root_hash] is a `poststate_hash` we return to the node.
+            // There is no proper error variant in the `storage::error::Error` for it though.
+            let error_message = format!(
+                "Post state hash not found {} when calculating bonded validators set.",
+                root_hash
+            );
+            logging::log_error(&error_message);
+            let mut commit_response = ipc::CommitResponse::new();
+            let mut err = ipc::PostEffectsError::new();
+            err.set_message(error_message);
+            commit_response.set_failed_transform(err);
+            commit_response
+        }
+        Err(GetBondedValidatorsError::PoSNotFound(key)) => grpc_response_from_commit_result::<H>(
+            poststate_hash,
+            Ok(CommitResult::KeyNotFound(key)),
+        ),
+    }
 }
 
 // Helper method which returns single DeployResult that is set to be a WasmError.

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -256,7 +256,7 @@ where
                                 .collect::<Vec<ipc::Bond>>()
                                 .into();
                             grpc_response
-                                .take_success() // We know it's a success because of the check few lines earlier.
+                                .mut_success() // We know it's a success because of the check few lines earlier.
                                 .set_bonded_validators(grpc_bonded_validators);
                             grpc_response
                         }

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -9,20 +9,20 @@ use common::key::Key;
 use common::value::account::{BlockTime, PublicKey};
 use common::value::U512;
 use engine_server::ipc::CommitResponse;
-use execution_engine::engine_state::{
-    EngineState, genesis::GenesisResult, get_bonded_validators, GetBondedValidatorsError,
-};
 use execution_engine::engine_state::error::Error as EngineError;
 use execution_engine::engine_state::execution_result::ExecutionResult;
 use execution_engine::engine_state::genesis::GenesisURefsSource;
+use execution_engine::engine_state::{
+    genesis::GenesisResult, get_bonded_validators, EngineState, GetBondedValidatorsError,
+};
 use execution_engine::execution::{Executor, WasmiExecutor};
 use execution_engine::tracking_copy::QueryResult;
 use shared::logging;
 use shared::logging::{log_duration, log_info};
 use shared::newtypes::{Blake2bHash, CorrelationId};
 use storage::global_state::{CommitResult, History};
-use wasm_prep::{Preprocessor, WasmiPreprocessor};
 use wasm_prep::wasm_costs::WasmCosts;
+use wasm_prep::{Preprocessor, WasmiPreprocessor};
 
 use self::ipc_grpc::ExecutionEngineService;
 use self::mappings::*;
@@ -545,6 +545,7 @@ where
 }
 
 // TODO: Refactor.
+#[allow(clippy::implicit_hasher)]
 pub fn bonded_validators_and_commit_result<H>(
     prestate_hash: Blake2bHash,
     poststate_hash: Blake2bHash,

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -7,17 +7,20 @@ use std::time::Instant;
 use common::key::Key;
 use common::value::account::{BlockTime, PublicKey};
 use common::value::U512;
+use execution_engine::engine_state::{
+    EngineState, genesis::GenesisResult, get_bonded_validators, GetBondedValidatorsError,
+};
 use execution_engine::engine_state::error::Error as EngineError;
 use execution_engine::engine_state::execution_result::ExecutionResult;
-use execution_engine::engine_state::{genesis::GenesisResult, EngineState};
+use execution_engine::engine_state::genesis::GenesisURefsSource;
 use execution_engine::execution::{Executor, WasmiExecutor};
 use execution_engine::tracking_copy::QueryResult;
 use shared::logging;
 use shared::logging::{log_duration, log_info};
 use shared::newtypes::{Blake2bHash, CorrelationId};
-use storage::global_state::History;
-use wasm_prep::wasm_costs::WasmCosts;
+use storage::global_state::{CommitResult, History};
 use wasm_prep::{Preprocessor, WasmiPreprocessor};
+use wasm_prep::wasm_costs::WasmCosts;
 
 use self::ipc_grpc::ExecutionEngineService;
 use self::mappings::*;
@@ -225,10 +228,66 @@ where
                 commit_response.set_failed_transform(err);
                 commit_response
             }
-            Ok(effects) => grpc_response_from_commit_result::<H>(
-                prestate_hash,
-                self.apply_effect(correlation_id, prestate_hash, effects.value()),
-            ),
+
+            Ok(effects) => {
+                let commit_result =
+                    self.apply_effect(correlation_id, prestate_hash, effects.value());
+                if let Ok(storage::global_state::CommitResult::Success(poststate_hash)) =
+                    commit_result
+                {
+                    let pos_key = Key::URef(GenesisURefsSource::default().get_pos_address());
+                    match get_bonded_validators(
+                        self.state(),
+                        poststate_hash,
+                        &pos_key,
+                        correlation_id,
+                    ) {
+                        Ok(bonded_validators) => {
+                            let mut grpc_response =
+                                grpc_response_from_commit_result::<H>(prestate_hash, commit_result);
+                            let grpc_bonded_validators = bonded_validators
+                                .iter()
+                                .map(|(pk, bond)| {
+                                    let mut ipc_bond = ipc::Bond::new();
+                                    ipc_bond.set_stake((*bond).into());
+                                    ipc_bond.set_validator_public_key(pk.value().to_vec());
+                                    ipc_bond
+                                })
+                                .collect::<Vec<ipc::Bond>>()
+                                .into();
+                            grpc_response
+                                .take_success() // We know it's a success because of the check few lines earlier.
+                                .set_bonded_validators(grpc_bonded_validators);
+                            grpc_response
+                        }
+                        Err(GetBondedValidatorsError::StorageErrors(error)) => {
+                            grpc_response_from_commit_result::<H>(poststate_hash, Err(error))
+                        }
+                        Err(GetBondedValidatorsError::PostStateHashNotFound(root_hash)) => {
+                            // I am not sure how to parse this error. It would mean that most probably
+                            // we have screwed up something in the trie store because `root_hash` was
+                            // calculated by us just a moment ago. It [root_hash] is a `poststate_hash` we return to the node.
+                            // There is no proper error variant in the `storage::error::Error` for it though.
+                            let error_message = format!("Post state hash not found {} when calculating bonded validators set.", root_hash);
+                            logging::log_error(&error_message);
+                            let mut commit_response = ipc::CommitResponse::new();
+                            let mut err = ipc::PostEffectsError::new();
+                            err.set_message(error_message);
+                            commit_response.set_failed_transform(err);
+                            commit_response
+                        }
+                        Err(GetBondedValidatorsError::PoSNotFound(key)) => {
+                            grpc_response_from_commit_result::<H>(
+                                poststate_hash,
+                                Ok(CommitResult::KeyNotFound(key)),
+                            )
+                        }
+                    }
+                } else {
+                    // Commit unsuccessful.
+                    grpc_response_from_commit_result::<H>(prestate_hash, commit_result)
+                }
+            }
         };
 
         log_duration(

--- a/execution-engine/comm/tests/integration_test_genesis.rs
+++ b/execution-engine/comm/tests/integration_test_genesis.rs
@@ -21,7 +21,7 @@ fn should_run_genesis() {
     let global_state = InMemoryGlobalState::empty().expect("should create global state");
     let engine_state = EngineState::new(global_state, false);
 
-    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR, Vec::new());
 
     let request_options = RequestOptions::new();
 

--- a/execution-engine/comm/tests/integration_test_genesis.rs
+++ b/execution-engine/comm/tests/integration_test_genesis.rs
@@ -4,6 +4,8 @@ extern crate grpc;
 extern crate shared;
 extern crate storage;
 
+use std::collections::HashMap;
+
 use grpc::RequestOptions;
 
 use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
@@ -21,7 +23,7 @@ fn should_run_genesis() {
     let global_state = InMemoryGlobalState::empty().expect("should create global state");
     let engine_state = EngineState::new(global_state, false);
 
-    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR, Vec::new());
+    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let request_options = RequestOptions::new();
 

--- a/execution-engine/comm/tests/integration_test_transfer.rs
+++ b/execution-engine/comm/tests/integration_test_transfer.rs
@@ -14,7 +14,7 @@ use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
 use common::value::{U512, Value};
-use common::value::account::{PublicKey, PurseId};
+use common::value::account::PurseId;
 use execution_engine::engine_state::EngineState;
 use shared::transform::Transform;
 use storage::global_state::in_memory::InMemoryGlobalState;
@@ -80,7 +80,6 @@ impl TestContext {
 #[ignore]
 #[test]
 fn should_transfer_to_account() {
-    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let initial_genesis_amount: U512 = U512::from(INITIAL_GENESIS_AMOUNT);
     let transfer_amount: U512 = U512::from(TRANSFER_1_AMOUNT);
     let genesis_account_key = Key::Account(GENESIS_ADDR);
@@ -92,7 +91,7 @@ fn should_transfer_to_account() {
     // Run genesis
 
     let (genesis_request, contracts) =
-        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
+        test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -174,7 +173,6 @@ fn should_transfer_to_account() {
 #[ignore]
 #[test]
 fn should_transfer_from_account_to_account() {
-    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let initial_genesis_amount: U512 = U512::from(INITIAL_GENESIS_AMOUNT);
     let transfer_1_amount: U512 = U512::from(TRANSFER_1_AMOUNT);
     let transfer_2_amount: U512 = U512::from(TRANSFER_2_AMOUNT);
@@ -188,7 +186,7 @@ fn should_transfer_from_account_to_account() {
     // Run genesis
 
     let (genesis_request, contracts) =
-        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
+        test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -318,7 +316,6 @@ fn should_transfer_from_account_to_account() {
 #[ignore]
 #[test]
 fn should_transfer_to_existing_account() {
-    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let initial_genesis_amount: U512 = U512::from(INITIAL_GENESIS_AMOUNT);
     let transfer_1_amount: U512 = U512::from(TRANSFER_1_AMOUNT);
     let transfer_2_amount: U512 = U512::from(TRANSFER_2_AMOUNT);
@@ -332,7 +329,7 @@ fn should_transfer_to_existing_account() {
     // Run genesis
 
     let (genesis_request, contracts) =
-        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
+        test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -475,14 +472,12 @@ fn should_transfer_to_existing_account() {
 #[ignore]
 #[test]
 fn should_fail_when_insufficient_funds() {
-    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let global_state = InMemoryGlobalState::empty().unwrap();
     let engine_state = EngineState::new(global_state, false);
 
     // Run genesis
 
-    let (genesis_request, _) =
-        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
+    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -579,7 +574,6 @@ fn should_fail_when_insufficient_funds() {
 #[ignore]
 #[test]
 fn should_create_purse() {
-    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let genesis_account_key = Key::Account(GENESIS_ADDR);
     let account_key = Key::Account(ACCOUNT_1_ADDR);
     let global_state = InMemoryGlobalState::empty().unwrap();
@@ -588,7 +582,7 @@ fn should_create_purse() {
     // Run genesis & set up an account
 
     let (genesis_request, contracts) =
-        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
+        test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)

--- a/execution-engine/comm/tests/integration_test_transfer.rs
+++ b/execution-engine/comm/tests/integration_test_transfer.rs
@@ -1,29 +1,26 @@
-extern crate grpc;
-
+extern crate casperlabs_engine_grpc_server;
 extern crate common;
 extern crate execution_engine;
+extern crate grpc;
 extern crate shared;
 extern crate storage;
-
-extern crate casperlabs_engine_grpc_server;
-
-#[allow(unused)]
-mod test_support;
 
 use std::collections::HashMap;
 
 use grpc::RequestOptions;
 
+use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
+use common::value::{U512, Value};
 use common::value::account::PurseId;
-use common::value::{Value, U512};
 use execution_engine::engine_state::EngineState;
 use shared::transform::Transform;
 use storage::global_state::in_memory::InMemoryGlobalState;
 
-use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
+#[allow(unused)]
+mod test_support;
 
 const INITIAL_GENESIS_AMOUNT: u32 = 1_000_000;
 
@@ -263,6 +260,8 @@ fn should_transfer_from_account_to_account() {
         .wait_drop_metadata()
         .unwrap();
 
+    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
+
     let commit_hash = commit_response.get_success().get_poststate_hash();
 
     // Exec transfer 2 contract
@@ -410,6 +409,8 @@ fn should_transfer_to_existing_account() {
         .wait_drop_metadata()
         .unwrap();
 
+    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
+
     let commit_hash = commit_response.get_success().get_poststate_hash();
 
     // Exec transfer contract
@@ -497,6 +498,8 @@ fn should_fail_when_insufficient_funds() {
         .commit(RequestOptions::new(), commit_request)
         .wait_drop_metadata()
         .unwrap();
+
+    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
 
     let commit_hash = commit_response.get_success().get_poststate_hash();
 
@@ -616,6 +619,8 @@ fn should_create_purse() {
         .commit(RequestOptions::new(), commit_request)
         .wait_drop_metadata()
         .unwrap();
+
+    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
 
     let commit_hash = commit_response.get_success().get_poststate_hash();
 

--- a/execution-engine/comm/tests/integration_test_transfer.rs
+++ b/execution-engine/comm/tests/integration_test_transfer.rs
@@ -13,8 +13,8 @@ use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineServi
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
-use common::value::{U512, Value};
 use common::value::account::PurseId;
+use common::value::{Value, U512};
 use execution_engine::engine_state::EngineState;
 use shared::transform::Transform;
 use storage::global_state::in_memory::InMemoryGlobalState;

--- a/execution-engine/comm/tests/integration_test_transfer.rs
+++ b/execution-engine/comm/tests/integration_test_transfer.rs
@@ -14,7 +14,7 @@ use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
 use common::value::{U512, Value};
-use common::value::account::PurseId;
+use common::value::account::{PublicKey, PurseId};
 use execution_engine::engine_state::EngineState;
 use shared::transform::Transform;
 use storage::global_state::in_memory::InMemoryGlobalState;
@@ -80,6 +80,7 @@ impl TestContext {
 #[ignore]
 #[test]
 fn should_transfer_to_account() {
+    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let initial_genesis_amount: U512 = U512::from(INITIAL_GENESIS_AMOUNT);
     let transfer_amount: U512 = U512::from(TRANSFER_1_AMOUNT);
     let genesis_account_key = Key::Account(GENESIS_ADDR);
@@ -90,7 +91,8 @@ fn should_transfer_to_account() {
 
     // Run genesis
 
-    let (genesis_request, contracts) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, contracts) =
+        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -172,6 +174,7 @@ fn should_transfer_to_account() {
 #[ignore]
 #[test]
 fn should_transfer_from_account_to_account() {
+    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let initial_genesis_amount: U512 = U512::from(INITIAL_GENESIS_AMOUNT);
     let transfer_1_amount: U512 = U512::from(TRANSFER_1_AMOUNT);
     let transfer_2_amount: U512 = U512::from(TRANSFER_2_AMOUNT);
@@ -184,7 +187,8 @@ fn should_transfer_from_account_to_account() {
 
     // Run genesis
 
-    let (genesis_request, contracts) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, contracts) =
+        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -260,7 +264,11 @@ fn should_transfer_from_account_to_account() {
         .wait_drop_metadata()
         .unwrap();
 
-    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
+    assert!(
+        commit_response.has_success(),
+        "Commit wasn't successful: {:?}",
+        commit_response
+    );
 
     let commit_hash = commit_response.get_success().get_poststate_hash();
 
@@ -310,6 +318,7 @@ fn should_transfer_from_account_to_account() {
 #[ignore]
 #[test]
 fn should_transfer_to_existing_account() {
+    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let initial_genesis_amount: U512 = U512::from(INITIAL_GENESIS_AMOUNT);
     let transfer_1_amount: U512 = U512::from(TRANSFER_1_AMOUNT);
     let transfer_2_amount: U512 = U512::from(TRANSFER_2_AMOUNT);
@@ -322,7 +331,8 @@ fn should_transfer_to_existing_account() {
 
     // Run genesis
 
-    let (genesis_request, contracts) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, contracts) =
+        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -409,7 +419,11 @@ fn should_transfer_to_existing_account() {
         .wait_drop_metadata()
         .unwrap();
 
-    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
+    assert!(
+        commit_response.has_success(),
+        "Commit wasn't successful: {:?}",
+        commit_response
+    );
 
     let commit_hash = commit_response.get_success().get_poststate_hash();
 
@@ -461,12 +475,14 @@ fn should_transfer_to_existing_account() {
 #[ignore]
 #[test]
 fn should_fail_when_insufficient_funds() {
+    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let global_state = InMemoryGlobalState::empty().unwrap();
     let engine_state = EngineState::new(global_state, false);
 
     // Run genesis
 
-    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, _) =
+        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -499,7 +515,11 @@ fn should_fail_when_insufficient_funds() {
         .wait_drop_metadata()
         .unwrap();
 
-    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
+    assert!(
+        commit_response.has_success(),
+        "Commit wasn't successful: {:?}",
+        commit_response
+    );
 
     let commit_hash = commit_response.get_success().get_poststate_hash();
 
@@ -559,6 +579,7 @@ fn should_fail_when_insufficient_funds() {
 #[ignore]
 #[test]
 fn should_create_purse() {
+    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let genesis_account_key = Key::Account(GENESIS_ADDR);
     let account_key = Key::Account(ACCOUNT_1_ADDR);
     let global_state = InMemoryGlobalState::empty().unwrap();
@@ -566,7 +587,8 @@ fn should_create_purse() {
 
     // Run genesis & set up an account
 
-    let (genesis_request, contracts) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, contracts) =
+        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)
@@ -620,7 +642,11 @@ fn should_create_purse() {
         .wait_drop_metadata()
         .unwrap();
 
-    assert!(commit_response.has_success(), "Commit wasn't successful: {:?}", commit_response);
+    assert!(
+        commit_response.has_success(),
+        "Commit wasn't successful: {:?}",
+        commit_response
+    );
 
     let commit_hash = commit_response.get_success().get_poststate_hash();
 

--- a/execution-engine/comm/tests/regression_test_ee_401.rs
+++ b/execution-engine/comm/tests/regression_test_ee_401.rs
@@ -5,11 +5,11 @@ extern crate grpc;
 extern crate shared;
 extern crate storage;
 
+use std::collections::HashMap;
+
 use grpc::RequestOptions;
 
 use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
-use common::value::account::PublicKey;
-use common::value::U512;
 use execution_engine::engine_state::EngineState;
 use storage::global_state::in_memory::InMemoryGlobalState;
 
@@ -21,14 +21,12 @@ const GENESIS_ADDR: [u8; 32] = [0u8; 32];
 #[ignore]
 #[test]
 fn should_execute_contracts_which_provide_extra_urefs() {
-    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let global_state = InMemoryGlobalState::empty().unwrap();
     let engine_state = EngineState::new(global_state, false);
 
     // run genesis
 
-    let (genesis_request, _) =
-        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
+    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)

--- a/execution-engine/comm/tests/regression_test_ee_401.rs
+++ b/execution-engine/comm/tests/regression_test_ee_401.rs
@@ -1,33 +1,34 @@
-extern crate grpc;
-
+extern crate casperlabs_engine_grpc_server;
 extern crate common;
 extern crate execution_engine;
+extern crate grpc;
 extern crate shared;
 extern crate storage;
 
-extern crate casperlabs_engine_grpc_server;
-
-#[allow(unused)]
-mod test_support;
-
 use grpc::RequestOptions;
 
+use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
+use common::value::account::PublicKey;
+use common::value::U512;
 use execution_engine::engine_state::EngineState;
 use storage::global_state::in_memory::InMemoryGlobalState;
 
-use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
+#[allow(unused)]
+mod test_support;
 
 const GENESIS_ADDR: [u8; 32] = [0u8; 32];
 
 #[ignore]
 #[test]
 fn should_execute_contracts_which_provide_extra_urefs() {
+    let genesis_validators = vec![(PublicKey::new([1u8; 32]), U512::from(1000))];
     let global_state = InMemoryGlobalState::empty().unwrap();
     let engine_state = EngineState::new(global_state, false);
 
     // run genesis
 
-    let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR);
+    let (genesis_request, _) =
+        test_support::create_genesis_request(GENESIS_ADDR, genesis_validators);
 
     let genesis_response = engine_state
         .run_genesis(RequestOptions::new(), genesis_request)

--- a/execution-engine/comm/tests/test_commit_validators.rs
+++ b/execution-engine/comm/tests/test_commit_validators.rs
@@ -1,0 +1,39 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate common;
+extern crate execution_engine;
+extern crate grpc;
+extern crate shared;
+extern crate storage;
+
+use std::collections::HashMap;
+
+use common::value::account::PublicKey;
+use common::value::U512;
+use test_support::WasmTestBuilder;
+
+#[allow(dead_code)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+
+#[ignore]
+#[test]
+fn should_return_bonded_validators() {
+    let genesis_validators: HashMap<PublicKey, U512> = vec![
+        (PublicKey::new([1u8; 32]), U512::from(1000)),
+        (PublicKey::new([2u8; 32]), U512::from(200)),
+    ]
+    .into_iter()
+    .collect();
+
+    let bonded_validators = WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, genesis_validators.clone())
+        .exec(GENESIS_ADDR, "local_state.wasm")
+        .commit()
+        .get_bonded_validators();
+
+    assert_eq!(bonded_validators.len(), 2); // one for `run_genesis` and one for `exec + commti`.
+
+    assert_eq!(bonded_validators[0], genesis_validators);
+    assert_eq!(bonded_validators[1], genesis_validators);
+}

--- a/execution-engine/comm/tests/test_known_urefs.rs
+++ b/execution-engine/comm/tests/test_known_urefs.rs
@@ -5,6 +5,8 @@ extern crate grpc;
 extern crate shared;
 extern crate storage;
 
+use std::collections::HashMap;
+
 use common::key::Key;
 use common::value::{U512, Value};
 use shared::transform::Transform;
@@ -19,7 +21,7 @@ const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 #[test]
 fn should_run_known_urefs_contract() {
     let transforms = WasmTestBuilder::default()
-        .run_genesis(GENESIS_ADDR, Vec::new())
+        .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(GENESIS_ADDR, "known_urefs.wasm")
         .commit()
         .expect_success()

--- a/execution-engine/comm/tests/test_known_urefs.rs
+++ b/execution-engine/comm/tests/test_known_urefs.rs
@@ -1,18 +1,17 @@
-extern crate grpc;
-
 extern crate casperlabs_engine_grpc_server;
 extern crate common;
 extern crate execution_engine;
+extern crate grpc;
 extern crate shared;
 extern crate storage;
 
-#[allow(dead_code)]
-mod test_support;
-
 use common::key::Key;
-use common::value::{Value, U512};
+use common::value::{U512, Value};
 use shared::transform::Transform;
 use test_support::WasmTestBuilder;
+
+#[allow(dead_code)]
+mod test_support;
 
 const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 
@@ -20,7 +19,7 @@ const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 #[test]
 fn should_run_known_urefs_contract() {
     let transforms = WasmTestBuilder::default()
-        .run_genesis(GENESIS_ADDR)
+        .run_genesis(GENESIS_ADDR, Vec::new())
         .exec(GENESIS_ADDR, "known_urefs.wasm")
         .commit()
         .expect_success()

--- a/execution-engine/comm/tests/test_known_urefs.rs
+++ b/execution-engine/comm/tests/test_known_urefs.rs
@@ -8,7 +8,7 @@ extern crate storage;
 use std::collections::HashMap;
 
 use common::key::Key;
-use common::value::{U512, Value};
+use common::value::{Value, U512};
 use shared::transform::Transform;
 use test_support::WasmTestBuilder;
 

--- a/execution-engine/comm/tests/test_local_state.rs
+++ b/execution-engine/comm/tests/test_local_state.rs
@@ -1,20 +1,18 @@
-extern crate grpc;
-
 extern crate casperlabs_engine_grpc_server;
 extern crate common;
 extern crate execution_engine;
+extern crate grpc;
 extern crate shared;
 extern crate storage;
-
-#[allow(dead_code)]
-mod test_support;
 
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::value::Value;
 use shared::transform::Transform;
-
 use test_support::WasmTestBuilder;
+
+#[allow(dead_code)]
+mod test_support;
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 
@@ -23,7 +21,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 fn should_run_local_state_contract() {
     // This test runs a contract that's after every call extends the same key with more data
     let transforms = WasmTestBuilder::default()
-        .run_genesis(GENESIS_ADDR)
+        .run_genesis(GENESIS_ADDR, Vec::new())
         .exec(GENESIS_ADDR, "local_state.wasm")
         .expect_success()
         .commit()

--- a/execution-engine/comm/tests/test_local_state.rs
+++ b/execution-engine/comm/tests/test_local_state.rs
@@ -5,6 +5,8 @@ extern crate grpc;
 extern crate shared;
 extern crate storage;
 
+use std::collections::HashMap;
+
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::value::Value;
@@ -21,7 +23,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 fn should_run_local_state_contract() {
     // This test runs a contract that's after every call extends the same key with more data
     let transforms = WasmTestBuilder::default()
-        .run_genesis(GENESIS_ADDR, Vec::new())
+        .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(GENESIS_ADDR, "local_state.wasm")
         .expect_success()
         .commit()

--- a/execution-engine/comm/tests/test_support.rs
+++ b/execution-engine/comm/tests/test_support.rs
@@ -12,11 +12,11 @@ use std::path::PathBuf;
 
 use grpc::RequestOptions;
 
+use casperlabs_engine_grpc_server::engine_server::ipc;
 use casperlabs_engine_grpc_server::engine_server::ipc::{
     CommitRequest, Deploy, DeployCode, DeployResult, ExecRequest, ExecResponse, GenesisRequest,
     GenesisResponse, TransformEntry,
 };
-use casperlabs_engine_grpc_server::engine_server::ipc;
 use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use casperlabs_engine_grpc_server::engine_server::mappings::CommitTransforms;
 use casperlabs_engine_grpc_server::engine_server::state::{BigInt, ProtocolVersion};
@@ -74,7 +74,7 @@ pub enum SystemContractType {
 
 pub fn create_genesis_request(
     address: [u8; 32],
-    genesis_validators: Vec<(common::value::account::PublicKey, common::value::U512)>,
+    genesis_validators: HashMap<common::value::account::PublicKey, common::value::U512>,
 ) -> (GenesisRequest, HashMap<SystemContractType, WasmiBytes>) {
     let genesis_account_addr = address.to_vec();
     let mut contracts: HashMap<SystemContractType, WasmiBytes> = HashMap::new();
@@ -308,7 +308,7 @@ impl WasmTestBuilder {
     pub fn run_genesis(
         &mut self,
         genesis_addr: [u8; 32],
-        genesis_validators: Vec<(common::value::account::PublicKey, common::value::U512)>,
+        genesis_validators: HashMap<common::value::account::PublicKey, common::value::U512>,
     ) -> &mut WasmTestBuilder {
         let (genesis_request, _contracts) =
             create_genesis_request(genesis_addr, genesis_validators);

--- a/execution-engine/comm/tests/test_support.rs
+++ b/execution-engine/comm/tests/test_support.rs
@@ -19,11 +19,11 @@ use casperlabs_engine_grpc_server::engine_server::ipc::{
 };
 use casperlabs_engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use casperlabs_engine_grpc_server::engine_server::mappings::{
-    CommitTransforms, to_domain_validators,
+    to_domain_validators, CommitTransforms,
 };
 use casperlabs_engine_grpc_server::engine_server::state::{BigInt, ProtocolVersion};
-use execution_engine::engine_state::EngineState;
 use execution_engine::engine_state::utils::WasmiBytes;
+use execution_engine::engine_state::EngineState;
 use shared::test_utils;
 use shared::transform::Transform;
 use storage::global_state::in_memory::InMemoryGlobalState;
@@ -74,6 +74,7 @@ pub enum SystemContractType {
     ProofOfStake,
 }
 
+#[allow(clippy::implicit_hasher)]
 pub fn create_genesis_request(
     address: [u8; 32],
     genesis_validators: HashMap<common::value::account::PublicKey, common::value::U512>,

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -272,11 +272,34 @@ impl PublicKey {
     pub fn value(self) -> [u8; KEY_SIZE] {
         self.0
     }
+
+    pub fn from_slice(slice: &[u8]) -> Option<PublicKey> {
+        if slice.len() != KEY_SIZE {
+            None
+        } else {
+            let mut buff = [0u8; 32];
+            buff.copy_from_slice(slice);
+            Some(PublicKey::new(buff))
+        }
+    }
 }
 
 impl From<[u8; KEY_SIZE]> for PublicKey {
     fn from(key: [u8; KEY_SIZE]) -> Self {
         PublicKey(key)
+    }
+}
+
+impl ToBytes for PublicKey {
+    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
+        ToBytes::to_bytes(&self.0)
+    }
+}
+
+impl FromBytes for PublicKey {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
+        let (key_bytes, rem): ([u8; KEY_SIZE], &[u8]) = FromBytes::from_bytes(bytes)?;
+        Ok((PublicKey::new(key_bytes), rem))
     }
 }
 
@@ -533,19 +556,6 @@ impl FromBytes for Weight {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let (byte, rem): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
         Ok((Weight::new(byte), rem))
-    }
-}
-
-impl ToBytes for PublicKey {
-    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        ToBytes::to_bytes(&self.0)
-    }
-}
-
-impl FromBytes for PublicKey {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (key_bytes, rem): ([u8; KEY_SIZE], &[u8]) = FromBytes::from_bytes(bytes)?;
-        Ok((PublicKey::new(key_bytes), rem))
     }
 }
 

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -242,7 +242,7 @@ impl Weight {
 
 pub const WEIGHT_SIZE: usize = U8_SIZE;
 
-#[derive(PartialOrd, Ord, PartialEq, Eq, Clone, Copy)]
+#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct PublicKey([u8; KEY_SIZE]);
 
 impl Display for PublicKey {

--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -318,7 +318,7 @@ mod tests {
     use std::collections::btree_map::BTreeMap;
     use std::collections::HashMap;
 
-    use common::key::{addr_to_hex, Key};
+    use common::key::Key;
     use common::value::{Contract, U512, Value};
     use common::value::account::PublicKey;
     use engine_state::create_genesis_effects;
@@ -327,7 +327,7 @@ mod tests {
         MINT_POS_BALANCE_UREF, MINT_PRIVATE_ADDRESS, MINT_PUBLIC_ADDRESS, POS_PRIVATE_ADDRESS,
         POS_PUBLIC_ADDRESS,
     };
-    use engine_state::utils::WasmiBytes;
+    use engine_state::utils::{pos_validator_key, WasmiBytes};
     use shared::test_utils;
     use shared::transform::Transform;
     use wasm_prep::wasm_costs::WasmCosts;
@@ -669,32 +669,6 @@ mod tests {
             actual_mint_contract_bytes,
             expected_mint_contract_bytes.as_slice()
         );
-    }
-
-    // Helper function to create validator labels as they are constructed in PoS.
-    fn pos_validator_key(pk: PublicKey, stakes: U512) -> String {
-        let public_key_hex: String = addr_to_hex(&pk.value());
-        // This is how PoS contract stores validator keys in its known_urefs map.
-        format!("v_{}_{}", public_key_hex, stakes)
-    }
-
-    // Dual of `pos_validator_key`. Parses PoS bond format to PublicKey, U512 pair.
-    fn pos_validator_to_tuple(pos_bond: String) -> Option<(PublicKey, U512)> {
-        let mut split_bond = pos_bond.split('_'); // expected format is "v_{public_key}_{bond}".
-        if Some("v") != split_bond.next() {
-            return None;
-        } else {
-            let hex_key: &str = split_bond.next()?;
-            let mut key_bytes = [0u8; 32];
-            for i in 0..32 {
-                key_bytes[i] = u8::from_str_radix(&hex_key[2 * i..2 * (i + 1)], 16).ok()?;
-            }
-            let pub_key = PublicKey::new(key_bytes);
-            let balance = split_bond
-                .next()
-                .and_then(|b| U512::from_dec_str(b).ok())?;
-            Some((pub_key, balance))
-        }
     }
 
     #[test]

--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -9,8 +9,8 @@ use rand_chacha::ChaChaRng;
 use common::bytesrepr::ToBytes;
 use common::key::Key;
 use common::uref::{AccessRights, URef};
-use common::value::{Contract, U512, Value};
 use common::value::account::{PublicKey, PurseId};
+use common::value::{Contract, Value, U512};
 use engine_state::execution_effect::ExecutionEffect;
 use engine_state::op::Op;
 use engine_state::utils::WasmiBytes;
@@ -335,11 +335,11 @@ mod tests {
     use std::collections::HashMap;
 
     use common::key::Key;
-    use common::value::{Contract, U512, Value};
     use common::value::account::PublicKey;
+    use common::value::{Contract, Value, U512};
     use engine_state::create_genesis_effects;
     use engine_state::genesis::{
-        GENESIS_ACCOUNT_PURSE, GenesisURefsSource, MINT_GENESIS_ACCOUNT_BALANCE_UREF,
+        GenesisURefsSource, GENESIS_ACCOUNT_PURSE, MINT_GENESIS_ACCOUNT_BALANCE_UREF,
         MINT_POS_BALANCE_UREF, MINT_PRIVATE_ADDRESS, MINT_PUBLIC_ADDRESS, POS_PRIVATE_ADDRESS,
         POS_PUBLIC_ADDRESS,
     };

--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -30,7 +30,7 @@ pub const MINT_GENESIS_ACCOUNT_BALANCE_UREF: &str = "mint_genesis_account_balanc
 pub const MINT_POS_BALANCE_UREF: &str = "mint_pos_balance_uref";
 
 /// Structure for tracking URefs generated in the genesis process.
-struct GenesisURefsSource(BTreeMap<&'static str, URef>);
+pub struct GenesisURefsSource(BTreeMap<&'static str, URef>);
 
 impl GenesisURefsSource {
     fn create_genesis_rng() -> ChaChaRng {
@@ -47,6 +47,10 @@ impl GenesisURefsSource {
             .0
             .get(label)
             .unwrap_or_else(|| panic!("URef {} wasn't generated.", label))
+    }
+
+    pub fn get_pos_address(&self) -> URef {
+        *self.0.get(POS_PRIVATE_ADDRESS).unwrap() // It's safe to unwrap as we have included it when creating `GenesisURefsSource`.
     }
 }
 

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -6,16 +6,16 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 
 use common::key::Key;
-use common::value::{U512, Value};
 use common::value::account::{BlockTime, PublicKey};
+use common::value::{Value, U512};
 use engine_state::utils::WasmiBytes;
 use execution::{self, Executor};
 use shared::newtypes::{Blake2bHash, CorrelationId};
 use shared::transform::Transform;
 use storage::global_state::{CommitResult, History, StateReader};
 use tracking_copy::TrackingCopy;
-use wasm_prep::Preprocessor;
 use wasm_prep::wasm_costs::WasmCosts;
+use wasm_prep::Preprocessor;
 
 use self::error::{Error, RootNotFound};
 use self::execution_result::ExecutionResult;

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -163,7 +163,7 @@ pub fn get_bonded_validators<H: History>(
         .checkout(root_hash)
         .map_err(GetBondedValidatorsError::StorageErrors)
         .and_then(|maybe_reader| match maybe_reader {
-            Some(reader) => match reader.read(correlation_id, pos_key) {
+            Some(reader) => match reader.read(correlation_id, &pos_key.normalize()) {
                 Ok(Some(Value::Contract(contract))) => {
                     let bonded_validators = contract
                         .urefs_lookup()

--- a/execution-engine/engine/src/engine_state/utils.rs
+++ b/execution-engine/engine/src/engine_state/utils.rs
@@ -1,9 +1,11 @@
 use parity_wasm::elements::Serialize;
 
-use wasm_prep::wasm_costs::WasmCosts;
-use wasm_prep::{Preprocessor, WasmiPreprocessor};
-
+use common::key::addr_to_hex;
+use common::value::account::PublicKey;
+use common::value::U512;
 use engine_state;
+use wasm_prep::{Preprocessor, WasmiPreprocessor};
+use wasm_prep::wasm_costs::WasmCosts;
 
 #[derive(Debug, Clone)]
 pub struct WasmiBytes(Vec<u8>);

--- a/execution-engine/engine/src/engine_state/utils.rs
+++ b/execution-engine/engine/src/engine_state/utils.rs
@@ -4,8 +4,8 @@ use common::key::addr_to_hex;
 use common::value::account::PublicKey;
 use common::value::U512;
 use engine_state;
-use wasm_prep::{Preprocessor, WasmiPreprocessor};
 use wasm_prep::wasm_costs::WasmCosts;
+use wasm_prep::{Preprocessor, WasmiPreprocessor};
 
 #[derive(Debug, Clone)]
 pub struct WasmiBytes(Vec<u8>);

--- a/execution-engine/engine/src/engine_state/utils.rs
+++ b/execution-engine/engine/src/engine_state/utils.rs
@@ -23,3 +23,27 @@ impl Into<Vec<u8>> for WasmiBytes {
         self.0
     }
 }
+
+/// Helper function to create validator labels as they are constructed in PoS.
+pub fn pos_validator_key(pk: PublicKey, stakes: U512) -> String {
+    let public_key_hex: String = addr_to_hex(&pk.value());
+    // This is how PoS contract stores validator keys in its known_urefs map.
+    format!("v_{}_{}", public_key_hex, stakes)
+}
+
+/// Dual of `pos_validator_key`. Parses PoS bond format to PublicKey, U512 pair.
+pub fn pos_validator_to_tuple(pos_bond: &str) -> Option<(PublicKey, U512)> {
+    let mut split_bond = pos_bond.split('_'); // expected format is "v_{public_key}_{bond}".
+    if Some("v") != split_bond.next() {
+        None
+    } else {
+        let hex_key: &str = split_bond.next()?;
+        let mut key_bytes = [0u8; 32];
+        for i in 0..32 {
+            key_bytes[i] = u8::from_str_radix(&hex_key[2 * i..2 * (i + 1)], 16).ok()?;
+        }
+        let pub_key = PublicKey::new(key_bytes);
+        let balance = split_bond.next().and_then(|b| U512::from_dec_str(b).ok())?;
+        Some((pub_key, balance))
+    }
+}

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -56,6 +56,7 @@ message CommitRequest {
 
 message CommitResult {
   bytes poststate_hash = 1;
+  repeated Bond bonded_validators = 2;
 }
 
 message CommitResponse {

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -149,7 +149,7 @@ class GrpcExecutionEngineService[F[_]: Defer: Sync: Log: TaskLift: Metrics] priv
   ): F[Either[Throwable, ByteString]] =
     sendMessage(CommitRequest(prestate, effects), _.commit) {
       _.result match {
-        case CommitResponse.Result.Success(CommitResult(poststateHash)) =>
+        case CommitResponse.Result.Success(CommitResult(poststateHash, _)) =>
           Right(poststateHash)
         case CommitResponse.Result.Empty =>
           Left(SmartContractEngineError("empty response"))


### PR DESCRIPTION
### Overview
When node calls `commit` endpoint on the EE, in addition to returning the post-state hash, ExecutionEngine returns currently bonded validators as found at returned post-state hash (meaning this is the validators set after executing all the deploys from the block, including bonding/unbonding requests).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-393

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
There is a node work left.