### PR TITLE
EE-440: Include mint URef in PoS named keys when it is created at genesis

### DIFF
--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -742,7 +742,9 @@ mod tests {
         // rustc isn't smart enough to figure that out
         let pos_contract_raw: Vec<u8> = pos_contract_bytes.into();
         assert_eq!(pos_contract.bytes().to_vec(), pos_contract_raw);
-        assert_eq!(pos_contract.urefs_lookup().len(), 3); // 2 for bonded validators, 1 for PoS purse.
+        // 2 for bonded validators, 1 for PoS purse, 2 for mint
+        let expected_num_known_urefs = 5;
+        assert_eq!(pos_contract.urefs_lookup().len(), expected_num_known_urefs);
 
         let validator_a_name: String =
             pos_validator_key(genesis_validator_a_public_key, genesis_validator_a_stake);

--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -237,8 +237,14 @@ fn create_pos_effects(
         .map(|key| (key, Key::Hash([0u8; 32])))
         .collect();
 
-    let pos_purse = rng.get_uref(POS_PURSE);
+    // Include the mint contract in its known_urefs
+    let mint_public = rng.get_uref(MINT_PUBLIC_ADDRESS);
+    let mint_private = rng.get_uref(MINT_PRIVATE_ADDRESS);
+    known_urefs.insert(String::from(execution::MINT_NAME), Key::URef(mint_public));
+    known_urefs.insert(mint_private.as_string(), Key::URef(mint_private));
 
+    // Include PoS purse in its known_urefs
+    let pos_purse = rng.get_uref(POS_PURSE);
     known_urefs.insert(POS_PURSE.to_string(), Key::URef(pos_purse));
 
     // Create PoS Contract object.

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -40,7 +40,7 @@ use storage::global_state::StateReader;
 use tracking_copy::TrackingCopy;
 use URefAddr;
 
-const MINT_NAME: &str = "mint";
+pub const MINT_NAME: &str = "mint";
 const POS_NAME: &str = "pos";
 
 #[derive(Debug)]


### PR DESCRIPTION
### Overview
PoS doesn't work unless it can access the mint.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-440

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
