### PR TITLE
EE-443: do not validate `base_key` in `add_ref`

### DIFF
--- a/execution-engine/engine/src/engine_state/genesis.rs
+++ b/execution-engine/engine/src/engine_state/genesis.rs
@@ -179,10 +179,6 @@ fn create_mint_effects(
         ret.insert(balance_uref.as_string(), balance_uref_key);
         // Insert PoS balance URef and its initial stakes so that PoS.
         ret.insert(pos_balance_uref.as_string(), pos_balance_uref_key);
-        ret.insert(
-            mint_contract_uref.as_string(),
-            Key::URef(mint_contract_uref),
-        );
         ret
     };
 
@@ -521,10 +517,6 @@ mod tests {
 
         let mint_known_urefs = {
             let mut ret: BTreeMap<String, Key> = BTreeMap::new();
-            ret.insert(
-                mint_contract_uref.as_string(),
-                Key::URef(mint_contract_uref),
-            );
             ret.insert(pos_balance_uref.as_string(), pos_balance_uref_key);
             ret.insert(balance_uref.as_string(), balance_uref_key);
             ret


### PR DESCRIPTION
### Overview
It doesn't make sense to demand that a contract stored under a URef "know itself" in order to add new keys to its `known_urefs` map (perhaps more accurately called named keys map). This PR removes that check.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-443

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
