### PR TITLE
EE-444: Remove unnecessary validation happening in remove_uref

### DIFF
--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -149,7 +149,7 @@ where
                         .borrow_mut()
                         .read(self.correlation_id, &contract_key)
                         .map_err(Into::into)?
-                        .ok_or(Error::KeyNotFound(contract_uref))?;
+                        .ok_or_else(|| Error::KeyNotFound(contract_uref))?;
 
                     value.try_into().map_err(|found| {
                         Error::TypeMismatch(shared::transform::TypeMismatch {

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -108,9 +108,9 @@ where
         name: &str,
     ) -> Result<(), Error> {
         contract.get_urefs_lookup_mut().remove(name);
+        // By this point in the code path, there is no further validation needed.
         let validated_uref = Validated::new(contract_key, Validated::valid)?;
-        let validated_value =
-            Validated::new(Value::Contract(contract), |value| self.validate_keys(value))?;
+        let validated_value = Validated::new(Value::Contract(contract), Validated::valid)?;
 
         self.state
             .borrow_mut()
@@ -139,7 +139,26 @@ where
                 Ok(())
             }
             contract_uref @ Key::URef(_) => {
-                let mut contract: Contract = self.read_gs_typed(&contract_uref)?;
+                // We do not need to validate the base key because a contract
+                // is always able to remove keys from its own known_urefs.
+                let contract_key = Validated::new(contract_uref, Validated::valid)?;
+
+                let mut contract: Contract = {
+                    let value: Value = self
+                        .state
+                        .borrow_mut()
+                        .read(self.correlation_id, &contract_key)
+                        .map_err(Into::into)?
+                        .ok_or(Error::KeyNotFound(contract_uref))?;
+
+                    value.try_into().map_err(|found| {
+                        Error::TypeMismatch(shared::transform::TypeMismatch {
+                            expected: "Contract".to_owned(),
+                            found,
+                        })
+                    })?
+                };
+
                 self.uref_lookup.remove(name);
                 self.remove_uref_from_contract(contract_uref, contract, name)
             }


### PR DESCRIPTION
### Overview
This validation was causing a contract stored under a uref to need to "know itself", similar to the issue resolved in #757 . This PR resolves the issue for `remove_uref`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-444

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
