### PR TITLE
NODE-621: Update 'hack/docker' setup to not to use the mock account

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -311,32 +311,6 @@ object Genesis {
     } yield wallets
   }
 
-  def getBondedValidators[F[_]: Monad: Sync: Log](bondsFile: Option[String]): F[Set[PublicKeyBS]] =
-    bondsFile match {
-      case None => Set.empty[PublicKeyBS].pure[F]
-      case Some(file) =>
-        Sync[F]
-          .delay {
-            Try {
-              Source
-                .fromFile(file)
-                .getLines()
-                .map(line => {
-                  val Array(pk, _) = line.trim.split(" ")
-                  PublicKey(ByteString.copyFrom(Base64.getDecoder.decode(pk)))
-                })
-                .toSet
-            }
-          }
-          .flatMap {
-            case Failure(th) =>
-              Log[F]
-                .warn(s"Failed to parse bonded validators file $file for reason ${th.getMessage}")
-                .map(_ => Set.empty)
-            case Success(x) => x.pure[F]
-          }
-    }
-
   def getBonds[F[_]: MonadThrowable: FilesAPI: Log](
       bonds: Path
   ): F[Map[PublicKey, Long]] =

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -94,10 +94,11 @@ slow:
 .casperlabs:
 	mkdir -p .casperlabs/bootstrap
 	mkdir -p .casperlabs/genesis/system-account
+	mkdir -p .casperlabs/genesis/blessed-contracts
 	mkdir -p .casperlabs/node-0
 	mkdir -p keys/account-0
 
-	@# TODO: When we start publishing blessed-contracts.tar.gz download it make it available.
+	./get-blessed-contracts.sh .casperlabs/genesis/blessed-contracts/blessed-contracts.tar.gz
 
 	../key-management/docker-gen-account-keys.sh .casperlabs/genesis/system-account
 	../key-management/docker-gen-account-keys.sh keys/account-0

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -70,13 +70,16 @@ After connection is complete, all node logs will show `Peers: 2`.
 Assuming that you cloned and compiled the [contract-examples](https://github.com/CasperLabs/contract-examples) you can deploy them by running the following:
 
 ```console
+ACCOUNT_ID="$(cat .casperlabs/genesis/system-account/account-id-hex)"
 ./client.sh node-0 deploy $PWD/../../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
-     --from 3030303030303030303030303030303030303030303030303030303030303030 \
+     --from "$ACCOUNT_ID" \
      --gas-price 1 \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm \
      --nonce 1
 ```
+
+As you may notice we make use of the `system-account` for deploys signing. This is temporal until we the add ability to create new custom accounts.
 
 After a successful deploy, you should see the following response:
 
@@ -103,15 +106,21 @@ If you check the log output, each node should get the block and provide some fee
 To sign deploy you'll need to [generate and ed25519 keypair](/VALIDATOR.md#setting-up-keys) and save them into `docker/keys`. The `client.sh` script will automatically mount this as a volume and you can pass them as CLI arguments, for example:
 
 ```console
+ACCOUNT_ID="$(cat .casperlabs/genesis/system-account/account-id-hex)"
+mkdir keys
+cp .casperlabs/genesis/system-account/account-private.pem keys
+cp .casperlabs/genesis/system-account/account-public.pem keys
 ./client.sh node-0 deploy $PWD/../../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
      --gas-price 1 \
-     --from 3030303030303030303030303030303030303030303030303030303030303030 \
+     --from "$ACCOUNT_ID" \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm \
      --nonce 1 \
      --public-key /keys/account-0/account-public.pem \
      --private-key /keys/account-0/account-private.pem
 ```
+
+As you may notice we make use of the `system-account` for deploys signing. This is temporal until we the add ability to create new custom accounts.
 
 ## Monitoring
 

--- a/hack/docker/get-blessed-contracts.sh
+++ b/hack/docker/get-blessed-contracts.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 1. Try to download blessed contracts using curl
+# 2. If failed then build it locally
+
+if [[ "$1" == /* ]] || [[ "$1" == ~* ]]; then
+    OUTPUT="$1"
+else
+    OUTPUT="$PWD/$1"
+fi
+
+CURRENT_DIR="$PWD"
+
+# Borrowed from https://github.com/robbyrussell/oh-my-zsh/blob/master/lib/git.zsh
+git_current_branch () {
+    local ref
+    ref="$(command git symbolic-ref --quiet HEAD 2> /dev/null)"
+    local ret="$?"
+    if [[ "$ret" != 0 ]]; then
+        [[ "$ret" == 128 ]] && return
+        ref="$(command git rev-parse --short HEAD 2> /dev/null)"  || return
+    fi
+    echo "${ref#refs/heads/}"
+}
+
+
+GIT_CURRENT_BRANCH="$(git_current_branch)"
+LINK="http://repo.casperlabs.io/casperlabs/repo/${GIT_CURRENT_BRANCH}/blessed-contracts.tar.gz"
+echo "Trying to download blessed contracts from $LINK using curl..."
+HTTP_STATUS_CODE="$(curl "$LINK" -o "$OUTPUT" -s -w "%{http_code}")"
+if [[ "$HTTP_STATUS_CODE" != "200" ]]; then
+    echo "Failed to download blessed contracts, building locally..."
+    cd "../.." && make package-blessed-contracts
+    cd "$CURRENT_DIR"
+    cp "../../execution-engine/target/blessed-contracts.tar.gz" "$OUTPUT"
+fi
+
+$(cd "$(dirname "$OUTPUT")" && tar -xzf "$OUTPUT")
+rm "$OUTPUT"

--- a/hack/docker/template/docker-compose.yml
+++ b/hack/docker/template/docker-compose.yml
@@ -51,6 +51,8 @@ services:
       CL_TLS_KEY: /root/.casperlabs/node/node.key.pem
       CL_GRPC_USE_TLS: "true"
       CL_METRICS_PROMETHEUS: "true"
+      CL_CASPER_MINT_CODE_PATH: /root/.casperlabs/genesis/blessed-contracts/mint_token.wasm
+      CL_CASPER_POS_CODE_PATH: /root/.casperlabs/genesis/blessed-contracts/mint_token.wasm
     entrypoint:
       - sh
       - -c


### PR DESCRIPTION
### Overview
As in the title. Uses the `system-account` instead. In the future, we will replace it to normal user accounts, I've decided to use the `system-account` only because of the lack of time due to DevNet.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-621

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._