### PR TITLE
CON-86: Temporary fix for finalization in deploy removal.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -229,19 +229,8 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: Metrics: 
                       }
                       .map(_.flatten.distinct)
 
-      finalizedBlockHashes <- blockHashes.filterA { hash =>
-                               isGreaterThanFaultToleranceThreshold(dag, hash).ifM(
-                                 true.pure[F],
-                                 // CON-86 will implement a 2nd pass that will calculate the threshold for secondary parents;
-                                 // right now the FinalityDetector only works for main parents. When it's fixed remove this part.
-                                 dag
-                                   .children(hash)
-                                   .flatMap {
-                                     _.toList.flatten
-                                       .existsM(isGreaterThanFaultToleranceThreshold(dag, _))
-                                   }
-                               )
-                             }
+      finalizedBlockHashes <- blockHashes.filterA(isFinalized(dag, _))
+
       _ <- finalizedBlockHashes.traverse { blockHash =>
             removeDeploysInBlock(blockHash) flatMap { removed =>
               Log[F]
@@ -253,6 +242,19 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: Metrics: 
             }
           }
     } yield ()
+
+  // CON-86 will implement a 2nd pass that will calculate the threshold for secondary parents;
+  // right now the FinalityDetector only works for main parents. When it's fixed remove this part.
+  private def isFinalized(dag: BlockDagRepresentation[F], blockHash: BlockHash): F[Boolean] =
+    isGreaterThanFaultToleranceThreshold(dag, blockHash).ifM(
+      true.pure[F],
+      dag
+        .children(blockHash)
+        .flatMap {
+          _.toList.flatten
+            .existsM(isFinalized(dag, _))
+        }
+    )
 
   /** Remove deploys from the history which are included in a just finalised block. */
   private def removeDeploysInBlock(blockHash: BlockHash): F[Int] =


### PR DESCRIPTION
### Overview
We get an OOM in long term testing because the `FinalityDetector` at the moment only calculates finality for the main parents, for the secondaries it will be implemented later.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-86

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
This extra handling should be removed when CON-86 is tackled.
