### PR TITLE
EE-462: EE makes use of gas_price when computing gas_limit

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -459,7 +459,7 @@ object ProtoUtil {
     session = d.getBody.session.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
     payment = d.getBody.payment.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
     // The new data type doesn't have a limit field. Remove this once payment is implemented.
-    tokensTransferedInPayment =
+    tokensTransferredInPayment =
       if (d.getBody.getPayment.code.isEmpty || d.getBody.getPayment == d.getBody.getSession) {
         sys.env.get("CL_DEFAULT_GAS_LIMIT").map(_.toLong).getOrElse(GAS_LIMIT)
       } else 0L,

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -449,10 +449,10 @@ object ProtoUtil {
 
   // https://casperlabs.atlassian.net/browse/EE-283
   // We are hardcoding exchange rate for DEV NET at 10:1
-  // (1 token buys you 10 units of gas).
+  // (1 gas costs you 10 tokens).
   // Later, post DEV NET, conversion rate will be part of a deploy.
-  val GAS_PRICE = 10L
-  val GAS_LIMIT = 100000000L
+  val GAS_PRICE      = 10L
+  val PAYMENT_TOKENS = 1000000000L
 
   def deployDataToEEDeploy(d: Deploy): ipc.Deploy = ipc.Deploy(
     address = d.getHeader.accountPublicKey,
@@ -461,7 +461,7 @@ object ProtoUtil {
     // The new data type doesn't have a limit field. Remove this once payment is implemented.
     tokensTransferredInPayment =
       if (d.getBody.getPayment.code.isEmpty || d.getBody.getPayment == d.getBody.getSession) {
-        sys.env.get("CL_DEFAULT_GAS_LIMIT").map(_.toLong).getOrElse(GAS_LIMIT)
+        sys.env.get("CL_DEFAULT_PAYMENT_TOKENS").map(_.toLong).getOrElse(PAYMENT_TOKENS)
       } else 0L,
     gasPrice = GAS_PRICE,
     nonce = d.getHeader.nonce,

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -459,7 +459,7 @@ object ProtoUtil {
     session = d.getBody.session.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
     payment = d.getBody.payment.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
     // The new data type doesn't have a limit field. Remove this once payment is implemented.
-    gasLimit =
+    tokensTransferedInPayment =
       if (d.getBody.getPayment.code.isEmpty || d.getBody.getPayment == d.getBody.getSession) {
         sys.env.get("CL_DEFAULT_GAS_LIMIT").map(_.toLong).getOrElse(GAS_LIMIT)
       } else 0L,

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -523,7 +523,8 @@ where
 
             let nonce = deploy.nonce;
             // TODO: is the rounding in this division ok?
-            let gas_limit = (deploy.tokens_transferred_in_payment as u64) / (deploy.gas_price as u64);
+            let gas_limit =
+                (deploy.tokens_transferred_in_payment as u64) / (deploy.gas_price as u64);
             let protocol_version = protocol_version.value;
             engine_state
                 .run_deploy(

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -523,7 +523,7 @@ where
 
             let nonce = deploy.nonce;
             // TODO: is the rounding in this division ok?
-            let gas_limit = (deploy.tokens_transfered_in_payment as u64) / (deploy.gas_price as u64);
+            let gas_limit = (deploy.tokens_transferred_in_payment as u64) / (deploy.gas_price as u64);
             let protocol_version = protocol_version.value;
             engine_state
                 .run_deploy(

--- a/execution-engine/comm/src/engine_server/mod.rs
+++ b/execution-engine/comm/src/engine_server/mod.rs
@@ -522,7 +522,8 @@ where
             };
 
             let nonce = deploy.nonce;
-            let gas_limit = deploy.gas_limit as u64;
+            // TODO: is the rounding in this division ok?
+            let gas_limit = (deploy.tokens_transfered_in_payment as u64) / (deploy.gas_price as u64);
             let protocol_version = protocol_version.value;
             engine_state
                 .run_deploy(

--- a/execution-engine/comm/tests/test_support.rs
+++ b/execution-engine/comm/tests/test_support.rs
@@ -46,7 +46,7 @@ pub fn get_protocol_version() -> ProtocolVersion {
 pub fn get_mock_deploy() -> Deploy {
     let mut deploy = Deploy::new();
     deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
-    deploy.set_gas_limit(1000);
+    deploy.set_tokens_transfered_in_payment(1000);
     deploy.set_gas_price(1);
     deploy.set_nonce(1);
     let mut deploy_code = DeployCode::new();
@@ -155,7 +155,7 @@ pub fn create_exec_request(
 
     let mut deploy = Deploy::new();
     deploy.set_address(address.to_vec());
-    deploy.set_gas_limit(1_000_000_000);
+    deploy.set_tokens_transfered_in_payment(1_000_000_000);
     deploy.set_gas_price(1);
     deploy.set_nonce(nonce);
     let mut deploy_code = DeployCode::new();

--- a/execution-engine/comm/tests/test_support.rs
+++ b/execution-engine/comm/tests/test_support.rs
@@ -46,7 +46,7 @@ pub fn get_protocol_version() -> ProtocolVersion {
 pub fn get_mock_deploy() -> Deploy {
     let mut deploy = Deploy::new();
     deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
-    deploy.set_tokens_transfered_in_payment(1000);
+    deploy.set_tokens_transferred_in_payment(1000);
     deploy.set_gas_price(1);
     deploy.set_nonce(1);
     let mut deploy_code = DeployCode::new();
@@ -155,7 +155,7 @@ pub fn create_exec_request(
 
     let mut deploy = Deploy::new();
     deploy.set_address(address.to_vec());
-    deploy.set_tokens_transfered_in_payment(1_000_000_000);
+    deploy.set_tokens_transferred_in_payment(1_000_000_000);
     deploy.set_gas_price(1);
     deploy.set_nonce(nonce);
     let mut deploy_code = DeployCode::new();

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -19,7 +19,7 @@ message Deploy {
     bytes address = 1; // length 32 bytes
     DeployCode session = 3;
     DeployCode payment = 4;
-    uint64 tokens_transfered_in_payment  = 5; // in units of Tokens -- someday this will come from running payment code
+    uint64 tokens_transferred_in_payment = 5; // in units of Tokens -- someday this will come from running payment code
     uint64 gas_price = 6; // in units of Token / Gas
     uint64 nonce = 7;
     // Public keys used to sign this deploy, to be checked against the keys

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -19,8 +19,8 @@ message Deploy {
     bytes address = 1; // length 32 bytes
     DeployCode session = 3;
     DeployCode payment = 4;
-    uint64 gas_limit = 5;
-    uint64 gas_price = 6;
+    uint64 tokens_transfered_in_payment  = 5; // in units of Tokens -- someday this will come from running payment code
+    uint64 gas_price = 6; // in units of Token / Gas
     uint64 nonce = 7;
     // Public keys used to sign this deploy, to be checked against the keys
     // associated with the account.


### PR DESCRIPTION
### Overview
This logic is closer to what the final version will be. The main difference here is that the `tokens_transfered_in_payment` is passed down from the node instead of actually being computed by the payment code.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-462

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
