### PR TITLE
NO-TICK: Silence logging of (already) downloaded blocks.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -580,8 +580,9 @@ package object gossiping {
                         } yield ()
 
                       override def onDownloaded(blockHash: ByteString) =
-                        // Calling `addBlock` during validation has already stored the block.
-                        Log[F].debug(s"Download ready for ${show(blockHash)}")
+                        // Calling `addBlock` during validation has already stored the block,
+                        // so we have nothing more to do here.
+                        ().pure[F]
 
                       override def listTips =
                         for {


### PR DESCRIPTION
### Overview
The logs are full of debugs logs such as `Download ready for block abc123...`, including for the ones we already had but the `Sycnhronizer` has seen the header again. That means on our 3 node test network 30 lines of logs per notification. Not useful any more.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
