### PR TITLE
NODE-630: Fix the use of `filterKeys`

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -48,23 +48,23 @@ case class DeployBuffer(
   // Removes deploys that were included in a finalized block.
   def remove(deployHashes: Set[DeployHash]) =
     copy(
-      processedDeploys = processedDeploys.filterKeys(h => !deployHashes(h)),
+      processedDeploys = processedDeploys.filterNot(kv => deployHashes(kv._1)),
       // They could be in pendingDeploys too if they were sent to multiple nodes.
-      pendingDeploys = pendingDeploys.filterKeys(h => !deployHashes(h))
+      pendingDeploys = pendingDeploys.filterNot(kv => deployHashes(kv._1))
     )
 
   // Move some deploys from pending to processed.
   def processed(deployHashes: Set[DeployHash]) =
     copy(
-      processedDeploys = processedDeploys ++ pendingDeploys.filterKeys(deployHashes),
-      pendingDeploys = pendingDeploys.filterKeys(h => !deployHashes(h))
+      processedDeploys = processedDeploys ++ pendingDeploys.filter(kv => deployHashes(kv._1)),
+      pendingDeploys = pendingDeploys.filterNot(kv => deployHashes(kv._1))
     )
 
   // Move some deploys back from processed to pending.
   def orphaned(deployHashes: Set[DeployHash]) =
     copy(
-      processedDeploys = processedDeploys.filterKeys(h => !deployHashes(h)),
-      pendingDeploys = pendingDeploys ++ processedDeploys.filterKeys(deployHashes)
+      processedDeploys = processedDeploys.filterNot(kv => deployHashes(kv._1)),
+      pendingDeploys = pendingDeploys ++ processedDeploys.filter(kv => deployHashes(kv._1))
     )
 
   def get(deployHash: DeployHash): Option[Deploy] =

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -671,7 +671,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: Metrics: 
 
     Cell[F, CasperState].modify { s =>
       s.copy(
-        blockBuffer = s.blockBuffer.filterKeys(h => !addedBlockHashes(h)),
+        blockBuffer = s.blockBuffer.filterNot(kv => addedBlockHashes(kv._1)),
         deployBuffer = s.deployBuffer.processed(processedDeployHashes),
         dependencyDag = addedBlocks.foldLeft(s.dependencyDag) {
           case (dag, block) =>


### PR DESCRIPTION
### Overview
Buffer clearing relied on `filterKeys` but that _wraps_ values rather then copies the `Map`, so over time it caused stack overflow.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-630

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Thanks @AbnerZheng 
