### PR TITLE
NO-TICKET: Don't run `cargo update` on builds.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -67,7 +67,6 @@ pipeline:
   rust-compile-test-pr:
     commands:
       - "cd execution-engine/"
-      - "~/.cargo/bin/cargo update"
       - "~/.cargo/bin/cargo build"
       - "~/.cargo/bin/cargo test"
       - "./scripts/run-contract-tests.sh"
@@ -128,7 +127,6 @@ pipeline:
   rust-compile-test-bors:
     commands:
       - "cd execution-engine/"
-      - "~/.cargo/bin/cargo update"
       - "~/.cargo/bin/cargo build"
       - "~/.cargo/bin/cargo test"
     image: "casperlabs/buildenv:latest"
@@ -234,7 +232,6 @@ pipeline:
   rust-compile-for-make:
     commands:
       - "cd execution-engine/"
-      - "~/.cargo/bin/cargo update"
       - "~/.cargo/bin/cargo build"
     image: "casperlabs/buildenv:latest"
     when:

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 .make/cargo-package/%: \
 		$(RUST_SRC) \
 		.make/install/protoc
-	cd $* && cargo update && cargo package
+	cd $* && cargo package
 	mkdir -p $(dir $@) && touch $@
 
 .make/cargo-publish/%: .make/cargo-package/%
@@ -345,7 +345,6 @@ execution-engine/target/release/casperlabs-engine-grpc-server: \
 		$(RUST_SRC) \
 		.make/install/protoc
 	cd execution-engine/comm && \
-	cargo update && \
 	cargo build --release
 
 # Get the .proto files for REST annotations for Github. This is here for reference about what to get from where, the files are checked in.


### PR DESCRIPTION
Either CI or locally with a makefile with this commit no dependency will
be "silently" updated anymore

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._

Next step would be to run `--locked` to ensure `Cargo.lock` is updated explicitly by user before committing just in case any dependency was updated in `Cargo.toml`.