### PR TITLE
ECO-70: extract node/client/ee build documentation into separate file

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,0 +1,53 @@
+## Building the CasperLabs Node
+
+### Prerequisites
+
+* Java Development Kit (JDK), version 11 
+  * We recommend using the [OpenJDK](https://openjdk.java.net)
+* [protoc](https://github.com/protocolbuffers/protobuf/releases), version 3.6.1 or greater
+* [sbt](https://www.scala-sbt.org/download.html)
+* [rustup](https://www.rust-lang.org/tools/install)
+
+### Instructions
+
+The following commands should be run from the root directory of the CasperLabs repo.
+
+#### Build the node
+
+```
+sbt node/universal:stage
+```
+
+The `casperlabs-node` executable will be found here:
+
+```
+./node/target/universal/stage/bin/casperlabs-node
+```
+
+#### Build the client
+
+```
+sbt client/universal:stage
+```
+
+The `casperlabs-client` executable will be found here:
+
+```
+./client/target/universal/stage/bin/casperlabs-client
+```
+
+#### Build the casperlabs-engine-grpc-server
+
+```
+cd execution-engine
+cargo build --release
+```
+
+The `casperlabs-engine-grpc-server` executable will be found here:
+
+```
+./target/release/casperlabs-engine-grpc-server
+
+```
+
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,9 @@
 
 ## Outline
 
+- [Building a CasperLabs Node](BUILD.md)
 - [Building Example Contracts](https://github.com/CasperLabs/contract-examples/blob/master/README.md)
 - [Contributing](../CONTRIBUTING.md)
-- [Developer Guide](../DEVELOPER.md)
 - [Docker - Local Network Simulation](../hack/docker/README.md)
 - [Generating Keys](../VALIDATOR.md#setting-up-keys)
 - [Pre-Built Binary Installation](INSTALL.md)


### PR DESCRIPTION
This PR extracts how-to-build documentation for `casperlabs-node`, `casperlabs-client`, and `casperlabs-engine-grpc-server`

Rendered [here](https://github.com/EdHastingsCasperLabs/CasperLabs/blob/ECO-70/docs/BUILD.md).

https://casperlabs.atlassian.net/browse/ECO-70

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.