### PR TITLE
NODE-634: add bonding + unbonding contracts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -314,6 +314,7 @@ pipeline:
 
   package-sbt-artifacts-merge:
     commands:
+      - "make build-validator-contracts"
       - "sbt update test client/debian:packageBin client/universal:packageZipTarball client/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball node/rpm:packageBin node/docker:publishLocal client/docker:publishLocal"
       - "mkdir -p artifacts/${DRONE_BRANCH}"
       - "cp client/target/casperlabs-client_*_all.deb client/target/universal/*.tgz artifacts/${DRONE_BRANCH}"

--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,7 @@ execution-engine/gens/*.lock
 execution-engine/blessed-contracts/mint-token/*.lock
 execution-engine/blessed-contracts/pos/*.lock
 
+# wasms
+client/src/main/resources/*.wasm
+
 .make

--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,6 @@ client/src/main/resources/%.wasm: .make/validator-contracts/%
 	$(eval CONTRACT=$*)
 	cp execution-engine/target/wasm32-unknown-unknown/release/$(CONTRACT).wasm $@
 
-.PHONY: build-validator-contracts
 build-validator-contracts: \
 	client/src/main/resources/bonding.wasm \
 	client/src/main/resources/unbonding.wasm

--- a/Makefile
+++ b/Makefile
@@ -244,9 +244,14 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 	docker tag casperlabs/grpcwebproxy:latest $(DOCKER_USERNAME)/grpcwebproxy:$(DOCKER_LATEST_TAG)
 	mkdir -p $(dir $@) && touch $@
 
+.make/client/contracts: build-validator-contracts
+	mkdir -p $(dir $@) && touch $@
+
+.make/node/contracts:
+	mkdir -p $(dir $@) && touch $@
 
 # Refresh Scala build artifacts if source was changed.
-.make/sbt-stage/%: $(SCALA_SRC)
+.make/sbt-stage/%: $(SCALA_SRC) .make/%/contracts
 	$(eval PROJECT = $*)
 	sbt -mem 5000 $(PROJECT)/universal:stage
 	mkdir -p $(dir $@) && touch $@
@@ -325,6 +330,22 @@ package-blessed-contracts: \
 	cd execution-engine/blessed-contracts/$(CONTRACT) && \
 	cargo +$(RUST_TOOLCHAIN) build --release --target wasm32-unknown-unknown --target-dir target
 	mkdir -p $(dir $@) && touch $@
+
+# Compile a validator contract;
+.make/validator-contracts/%: $(RUST_SRC) .make/rustup-update
+	$(eval CONTRACT=$*)
+	cd execution-engine/validator-contracts/$(CONTRACT) && \
+	cargo +$(RUST_TOOLCHAIN) build --release --target wasm32-unknown-unknown
+	mkdir -p $(dir $@) && touch $@
+
+client/src/main/resources/%.wasm: .make/validator-contracts/%
+	$(eval CONTRACT=$*)
+	cp execution-engine/target/wasm32-unknown-unknown/release/$(CONTRACT).wasm $@
+
+.PHONY: build-validator-contracts
+build-validator-contracts: \
+	client/src/main/resources/bonding.wasm \
+	client/src/main/resources/unbonding.wasm
 
 # Package all blessed contracts that we have to make available for download.
 execution-engine/target/blessed-contracts.tar.gz: \

--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -126,6 +126,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "bonding"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.9.0",
+]
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,6 +1770,13 @@ dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unbonding"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.9.0",
 ]
 
 [[package]]

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -25,5 +25,7 @@ members = [
     "test-contracts/main-purse",
     "test-contracts/blessed-urefs-access-rights",
     "test-contracts/transfer-purse-to-account",
+    "validator-contracts/bonding",
+    "validator-contracts/unbonding",
     "wasm-prep",
 ]

--- a/execution-engine/validator-contracts/bonding/Cargo.toml
+++ b/execution-engine/validator-contracts/bonding/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "bonding"
+version = "0.1.0"
+authors = ["Michael Birch <birchmd@casperlabs.io>"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["common/std"]
+
+[dependencies]
+common = { path = "../../common", package = "casperlabs-contract-ffi" }

--- a/execution-engine/validator-contracts/bonding/src/lib.rs
+++ b/execution-engine/validator-contracts/bonding/src/lib.rs
@@ -1,0 +1,48 @@
+#![no_std]
+#![feature(alloc)]
+
+#[macro_use]
+extern crate alloc;
+extern crate common;
+
+use common::contract_api::pointers::UPointer;
+use common::contract_api::{self, PurseTransferResult};
+use common::key::Key;
+use common::value::uint::U512;
+
+const BOND_METHOD_NAME: &str = "bond";
+const POS_CONTRACT_NAME: &str = "pos";
+
+// Bonding contract.
+//
+// Accepts bonding amount (of type `u64`) as first argument.
+// Issues bonding request to the PoS contract.
+#[no_mangle]
+pub extern "C" fn call() {
+    let pos_public: UPointer<Key> =
+        unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME).to_u_ptr(), 66);
+    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
+
+    let source_purse = contract_api::main_purse();
+    let bonding_purse = contract_api::create_purse();
+    let bond_amount: U512 = U512::from(contract_api::get_arg::<u64>(0));
+
+    match contract_api::transfer_from_purse_to_purse(source_purse, bonding_purse, bond_amount) {
+        PurseTransferResult::TransferSuccessful => contract_api::call_contract(
+            pos_pointer,
+            &(BOND_METHOD_NAME, bond_amount, bonding_purse),
+            &vec![Key::URef(bonding_purse.value())],
+        ),
+
+        PurseTransferResult::TransferError => contract_api::revert(1324),
+    }
+}
+
+fn unwrap_or_revert<T>(option: Option<T>, code: u32) -> T {
+    if let Some(value) = option {
+        value
+    } else {
+        contract_api::revert(code)
+    }
+}

--- a/execution-engine/validator-contracts/unbonding/Cargo.toml
+++ b/execution-engine/validator-contracts/unbonding/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "unbonding"
+version = "0.1.0"
+authors = ["Michael Birch <birchmd@casperlabs.io>"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["common/std"]
+
+[dependencies]
+common = { path = "../../common", package = "casperlabs-contract-ffi" }

--- a/execution-engine/validator-contracts/unbonding/src/lib.rs
+++ b/execution-engine/validator-contracts/unbonding/src/lib.rs
@@ -1,0 +1,39 @@
+#![no_std]
+#![feature(alloc)]
+
+#[macro_use]
+extern crate alloc;
+extern crate common;
+
+use common::contract_api;
+use common::contract_api::pointers::UPointer;
+use common::key::Key;
+use common::value::uint::U512;
+
+const POS_CONTRACT_NAME: &str = "pos";
+const UNBOND_METHOD_NAME: &str = "unbond";
+
+// Unbonding contract.
+//
+// Accepts unbonding amount (of type `Option<u64>`) as first argument.
+// Unbonding with `None` unbonds all stakes in the PoS contract.
+// Otherwise (`Some<u64>`) unbonds with part of the bonded stakes.
+#[no_mangle]
+pub extern "C" fn call() {
+    let pos_public: UPointer<Key> =
+        unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME).to_u_ptr(), 66);
+    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
+
+    let unbond_amount: Option<U512> = contract_api::get_arg::<Option<u64>>(0).map(U512::from);
+
+    contract_api::call_contract(pos_pointer, &(UNBOND_METHOD_NAME, unbond_amount), &vec![])
+}
+
+fn unwrap_or_revert<T>(option: Option<T>, code: u32) -> T {
+    if let Some(value) = option {
+        value
+    } else {
+        contract_api::revert(code)
+    }
+}


### PR DESCRIPTION
### Overview
This PR adds the bonding + unbonding contracts to the execution engine's Cargo workspace and adds them to the compilation pipeline, so that the compiled wasm files are staged into `client/src/main/resources`.

To stage locally:
```
make build-validator-contracts
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-634

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
