### PR TITLE
EE-470: ExecutionEngine should use empty root hash when running genesis block.

### DIFF
--- a/execution-engine/comm/tests/regression_test_genesis_hash_mismatch_node_635.rs
+++ b/execution-engine/comm/tests/regression_test_genesis_hash_mismatch_node_635.rs
@@ -1,0 +1,68 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate common;
+extern crate execution_engine;
+extern crate grpc;
+extern crate shared;
+extern crate storage;
+
+use std::collections::HashMap;
+
+use storage::global_state::in_memory::InMemoryGlobalState;
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(unused)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [12; 32];
+
+#[ignore]
+#[test]
+fn regression_test_genesis_hash_mismatch() {
+    let mut builder_base = WasmTestBuilder::default();
+
+    // Step 1.
+    let builder = builder_base.run_genesis(GENESIS_ADDR, HashMap::new());
+
+    // This is trie's post state hash after calling run_genesis endpoint.
+    // Step 1a)
+    let genesis_run_hash = builder.get_genesis_hash();
+    let genesis_transforms = builder.get_genesis_transforms().clone();
+
+    let empty_root_hash = {
+        let gs = InMemoryGlobalState::empty().expect("Empty GlobalState.");
+        gs.root_hash
+    };
+
+    // This is trie's post state hash after committing genesis effects on top of empty trie.
+    // Step 1b)
+    let genesis_transforms_hash = builder
+        .commit_effects(empty_root_hash.to_vec(), genesis_transforms)
+        .get_poststate_hash();
+
+    // They should match.
+    assert_eq!(genesis_run_hash, genesis_transforms_hash);
+
+    // Step 2.
+    builder
+        .exec(GENESIS_ADDR, "local_state.wasm", DEFAULT_BLOCK_TIME, 1)
+        .commit()
+        .expect_success();
+
+    // No step 3.
+    // Step 4.
+    builder.run_genesis(GENESIS_ADDR, HashMap::new());
+
+    // Step 4a)
+    let second_genesis_run_hash = builder.get_genesis_hash();
+    let second_genesis_transforms = builder.get_genesis_transforms().clone();
+
+    // Step 4b)
+    let second_genesis_transforms_hash = builder
+        .commit_effects(empty_root_hash.to_vec(), second_genesis_transforms)
+        .get_poststate_hash();
+
+    assert_eq!(second_genesis_run_hash, second_genesis_transforms_hash);
+
+    assert_eq!(second_genesis_run_hash, genesis_run_hash);
+    assert_eq!(second_genesis_transforms_hash, genesis_transforms_hash);
+}

--- a/execution-engine/comm/tests/test_genesis_hash_match.rs
+++ b/execution-engine/comm/tests/test_genesis_hash_match.rs
@@ -1,0 +1,41 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate common;
+extern crate execution_engine;
+extern crate grpc;
+extern crate shared;
+extern crate storage;
+
+use std::collections::HashMap;
+
+use storage::global_state::in_memory::InMemoryGlobalState;
+use test_support::WasmTestBuilder;
+
+#[allow(unused)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [12; 32];
+
+#[ignore]
+#[test]
+fn test_genesis_hash_match() {
+    let mut builder_base = WasmTestBuilder::default();
+
+    let builder = builder_base.run_genesis(GENESIS_ADDR, HashMap::new());
+
+    // This is trie's post state hash after calling run_genesis endpoint.
+    let genesis_run_hash = builder.get_genesis_hash();
+    let genesis_transforms = builder.get_genesis_transforms().clone();
+
+    let empty_root_hash = {
+        let gs = InMemoryGlobalState::empty().expect("Empty GlobalState.");
+        gs.root_hash
+    };
+
+    // This is trie's post state hash after committing genesis effects on top of empty trie.
+    let genesis_transforms_hash = builder
+        .commit_effects(empty_root_hash.to_vec(), genesis_transforms)
+        .get_poststate_hash();
+
+    // They should match.
+    assert_eq!(genesis_run_hash, genesis_transforms_hash);
+}

--- a/execution-engine/comm/tests/test_support.rs
+++ b/execution-engine/comm/tests/test_support.rs
@@ -29,10 +29,6 @@ use shared::test_utils;
 use shared::transform::Transform;
 use storage::global_state::in_memory::InMemoryGlobalState;
 
-//use common::bytesrepr::ToBytes;
-//use common::key::Key;
-//use common::value::Value;
-
 pub const DEFAULT_BLOCK_TIME: u64 = 0;
 pub const MOCKED_ACCOUNT_ADDRESS: [u8; 32] = [48u8; 32];
 pub const COMPILED_WASM_PATH: &str = "../target/wasm32-unknown-unknown/debug";
@@ -563,11 +559,25 @@ impl WasmTestBuilder {
             .expect("Unable to obtain mint contract uref. Please run genesis first.")
     }
 
-    pub fn get_genesis_transforms(&self) -> &HashMap<common::key::Key, Transform> {
+    pub fn get_genesis_transforms(
+        &self,
+    ) -> &HashMap<common::key::Key, shared::transform::Transform> {
         &self
             .genesis_transforms
             .as_ref()
             .expect("should have genesis transforms")
+    }
+
+    pub fn get_genesis_hash(&self) -> Vec<u8> {
+        self.genesis_hash
+            .clone()
+            .expect("Genesis hash should be present. Should be called after run_genesis.")
+    }
+
+    pub fn get_poststate_hash(&self) -> Vec<u8> {
+        self.post_state_hash
+            .clone()
+            .expect("Should have post-state hash.")
     }
 
     pub fn finish(&self) -> WasmTestResult {

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -67,7 +67,7 @@ where
             protocol_version,
         )?;
         let mut state_guard = self.state.lock();
-        let prestate_hash = state_guard.current_root();
+        let prestate_hash = state_guard.empty_root();
         let commit_result = state_guard
             .commit(correlation_id, prestate_hash, effects.transforms.to_owned())
             .map_err(Into::into)?;

--- a/execution-engine/storage/src/global_state/in_memory.rs
+++ b/execution-engine/storage/src/global_state/in_memory.rs
@@ -4,12 +4,11 @@ use std::sync::Arc;
 
 use common::key::Key;
 use common::value::Value;
-use shared::newtypes::{Blake2bHash, CorrelationId};
-use shared::transform::Transform;
-
 use error;
 use global_state::StateReader;
 use global_state::{commit, CommitResult, History};
+use shared::newtypes::{Blake2bHash, CorrelationId};
+use shared::transform::Transform;
 use trie::operations::create_hashed_empty_trie;
 use trie::Trie;
 use trie_store::in_memory::{
@@ -23,6 +22,7 @@ pub struct InMemoryGlobalState {
     pub environment: Arc<InMemoryEnvironment>,
     pub store: Arc<InMemoryTrieStore>,
     pub root_hash: Blake2bHash,
+    pub empty_root_hash: Blake2bHash,
 }
 
 impl InMemoryGlobalState {
@@ -37,7 +37,12 @@ impl InMemoryGlobalState {
             txn.commit()?;
             root_hash
         };
-        Ok(InMemoryGlobalState::new(environment, store, root_hash))
+        Ok(InMemoryGlobalState::new(
+            environment,
+            store,
+            root_hash,
+            root_hash,
+        ))
     }
 
     /// Creates a state from an existing environment, store, and root_hash.
@@ -46,11 +51,13 @@ impl InMemoryGlobalState {
         environment: Arc<InMemoryEnvironment>,
         store: Arc<InMemoryTrieStore>,
         root_hash: Blake2bHash,
+        empty_root_hash: Blake2bHash,
     ) -> Self {
         InMemoryGlobalState {
             environment,
             store,
             root_hash,
+            empty_root_hash,
         }
     }
 
@@ -120,6 +127,7 @@ impl History for InMemoryGlobalState {
             environment: Arc::clone(&self.environment),
             store: Arc::clone(&self.store),
             root_hash: prestate_hash,
+            empty_root_hash: self.empty_root_hash,
         });
         txn.commit()?;
         Ok(maybe_state)
@@ -146,6 +154,10 @@ impl History for InMemoryGlobalState {
 
     fn current_root(&self) -> Blake2bHash {
         self.root_hash
+    }
+
+    fn empty_root(&self) -> Blake2bHash {
+        self.empty_root_hash
     }
 }
 

--- a/execution-engine/storage/src/global_state/mod.rs
+++ b/execution-engine/storage/src/global_state/mod.rs
@@ -1,6 +1,3 @@
-pub mod in_memory;
-pub mod lmdb;
-
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::BuildHasher;
@@ -8,13 +5,15 @@ use std::time::Instant;
 
 use common::key::Key;
 use common::value::Value;
+use shared::logging::{log_duration, log_metric, GAUGE};
 use shared::newtypes::{Blake2bHash, CorrelationId};
 use shared::transform::{self, Transform, TypeMismatch};
-
-use shared::logging::{log_duration, log_metric, GAUGE};
 use trie::Trie;
 use trie_store::operations::{read, write, ReadResult, WriteResult};
 use trie_store::{Transaction, TransactionSource, TrieStore};
+
+pub mod in_memory;
+pub mod lmdb;
 
 /// A reader of state
 pub trait StateReader<K, V> {
@@ -73,6 +72,8 @@ pub trait History {
     ) -> Result<CommitResult, Self::Error>;
 
     fn current_root(&self) -> Blake2bHash;
+
+    fn empty_root(&self) -> Blake2bHash;
 }
 
 const GLOBAL_STATE_COMMIT_READS: &str = "global_state_commit_reads";


### PR DESCRIPTION
### Overview
As in the title.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-470

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
n/a