### PR TITLE
NODE-632: Add bond/unbond subcommands to node's client.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -420,7 +420,7 @@ lazy val client = (project in file("client"))
     javacOptions ++= Seq("-Dnashorn.args=\"--no-deprecation-warning\""),
     packageSummary := "CasperLabs Client",
     packageDescription := "CLI tool for interaction with the CasperLabs Node",
-    libraryDependencies ++= commonDependencies ++ Seq(scallop, grpcNetty, graphvizJava),
+    libraryDependencies ++= commonDependencies ++ Seq(scallop, grpcNetty, graphvizJava, apacheCommons),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "io.casperlabs.client",
     /* Dockerization */

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -460,7 +460,7 @@ object ProtoUtil {
     payment = d.getBody.payment.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
     // The new data type doesn't have a limit field. Remove this once payment is implemented.
     tokensTransferredInPayment =
-      if (d.getBody.getPayment.code.isEmpty || d.getBody.getPayment == d.getBody.getSession) {
+      if (d.getBody.getPayment.code.isEmpty || d.getBody.getPayment.code == d.getBody.getSession.code) {
         sys.env.get("CL_DEFAULT_PAYMENT_TOKENS").map(_.toLong).getOrElse(PAYMENT_TOKENS)
       } else 0L,
     gasPrice = GAS_PRICE,

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -43,7 +43,6 @@ object DeployRuntime {
 
   def unbond[F[_]: Sync: DeployService](
       maybeAmount: Option[Long],
-      gasPrice: Long,
       nonce: Long,
       from: Option[String],
       contractCode: File,
@@ -73,14 +72,13 @@ object DeployRuntime {
       paymentCode,
       maybePublicKeyFile,
       maybePrivateKeyFile,
-      gasPrice,
+      10L, // gas price is fixed at the moment for 10:1
       ByteString.copyFrom(amountBytes)
     )
   }
 
   def bond[F[_]: Sync: DeployService](
       amount: Long,
-      gasPrice: Long,
       nonce: Long,
       from: Option[String],
       contractCode: File,
@@ -105,7 +103,7 @@ object DeployRuntime {
       paymentCode,
       maybePublicKeyFile,
       maybePrivateKeyFile,
-      gasPrice,
+      10L, // gas price is fixed at the moment for 10:1
       amountByteString
     )
   }

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -45,8 +45,7 @@ object DeployRuntime {
       maybeAmount: Option[Long],
       nonce: Long,
       from: Option[String],
-      contractCode: File,
-      paymentCode: File,
+      sessionCode: File,
       maybePublicKeyFile: Option[File],
       maybePrivateKeyFile: Option[File]
   ): F[Unit] = {
@@ -68,8 +67,8 @@ object DeployRuntime {
     deployFileProgram[F](
       from,
       nonce,
-      contractCode,
-      paymentCode,
+      sessionCode,
+      sessionCode, // currently, sessionCode == paymentCode in order to get some gas limit for the execution
       maybePublicKeyFile,
       maybePrivateKeyFile,
       10L, // gas price is fixed at the moment for 10:1
@@ -81,8 +80,7 @@ object DeployRuntime {
       amount: Long,
       nonce: Long,
       from: Option[String],
-      contractCode: File,
-      paymentCode: File,
+      sessionCode: File,
       maybePublicKeyFile: Option[File],
       maybePrivateKeyFile: Option[File]
   ): F[Unit] = {
@@ -99,8 +97,8 @@ object DeployRuntime {
     deployFileProgram[F](
       from,
       nonce,
-      contractCode,
-      paymentCode,
+      sessionCode,
+      sessionCode, // currently, sessionCode == paymentCode in order to get some gas limit for the execution
       maybePublicKeyFile,
       maybePrivateKeyFile,
       10L, // gas price is fixed at the moment for 10:1

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -44,7 +44,6 @@ object DeployRuntime {
   def unbond[F[_]: Sync: DeployService](
       maybeAmount: Option[Long],
       nonce: Long,
-      from: Option[String],
       sessionCode: File,
       privateKeyFile: File
   ): F[Unit] = {
@@ -64,7 +63,7 @@ object DeployRuntime {
     }
 
     deployFileProgram[F](
-      from,
+      None,
       nonce,
       sessionCode,
       sessionCode, // currently, sessionCode == paymentCode in order to get some gas limit for the execution
@@ -78,7 +77,6 @@ object DeployRuntime {
   def bond[F[_]: Sync: DeployService](
       amount: Long,
       nonce: Long,
-      from: Option[String],
       sessionCode: File,
       privateKeyFile: File
   ): F[Unit] = {
@@ -93,7 +91,7 @@ object DeployRuntime {
     val amountByteString = ByteString.copyFrom(amountBytes)
 
     deployFileProgram[F](
-      from,
+      None,
       nonce,
       sessionCode,
       sessionCode, // currently, sessionCode == paymentCode in order to get some gas limit for the execution

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -46,8 +46,7 @@ object DeployRuntime {
       nonce: Long,
       from: Option[String],
       sessionCode: File,
-      maybePublicKeyFile: Option[File],
-      maybePrivateKeyFile: Option[File]
+      privateKeyFile: File
   ): F[Unit] = {
     val amountBytes = maybeAmount match {
       case Some(amount) => {
@@ -69,8 +68,8 @@ object DeployRuntime {
       nonce,
       sessionCode,
       sessionCode, // currently, sessionCode == paymentCode in order to get some gas limit for the execution
-      maybePublicKeyFile,
-      maybePrivateKeyFile,
+      None,
+      Some(privateKeyFile),
       10L, // gas price is fixed at the moment for 10:1
       ByteString.copyFrom(amountBytes)
     )
@@ -81,8 +80,7 @@ object DeployRuntime {
       nonce: Long,
       from: Option[String],
       sessionCode: File,
-      maybePublicKeyFile: Option[File],
-      maybePrivateKeyFile: Option[File]
+      privateKeyFile: File
   ): F[Unit] = {
     val array: Array[Byte] = java.nio.ByteBuffer
       .allocate(8)
@@ -99,8 +97,8 @@ object DeployRuntime {
       nonce,
       sessionCode,
       sessionCode, // currently, sessionCode == paymentCode in order to get some gas limit for the execution
-      maybePublicKeyFile,
-      maybePrivateKeyFile,
+      None,
+      Some(privateKeyFile),
       10L, // gas price is fixed at the moment for 10:1
       amountByteString
     )

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -39,7 +39,46 @@ object Main {
       case ShowDeploy(hash)  => DeployRuntime.showDeploy(hash)
       case ShowDeploys(hash) => DeployRuntime.showDeploys(hash)
       case ShowBlocks(depth) => DeployRuntime.showBlocks(depth)
-
+      case Unbond(
+          amount,
+          from,
+          gasPrice,
+          nonce,
+          contractCode,
+          paymentCode,
+          maybePublicKey,
+          maybePrivateKey
+          ) =>
+        DeployRuntime.unbond(
+          amount,
+          gasPrice,
+          nonce,
+          from,
+          contractCode,
+          paymentCode,
+          maybePublicKey,
+          maybePrivateKey
+        )
+      case Bond(
+          amount,
+          from,
+          gasPrice,
+          nonce,
+          contractCode,
+          paymentCode,
+          maybePublicKey,
+          maybePrivateKey
+          ) =>
+        DeployRuntime.bond(
+          amount,
+          gasPrice,
+          nonce,
+          from,
+          contractCode,
+          paymentCode,
+          maybePublicKey,
+          maybePrivateKey
+        )
       case Deploy(
           from,
           nonce,

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -42,7 +42,6 @@ object Main {
       case Unbond(
           amount,
           from,
-          gasPrice,
           nonce,
           contractCode,
           paymentCode,
@@ -51,7 +50,6 @@ object Main {
           ) =>
         DeployRuntime.unbond(
           amount,
-          gasPrice,
           nonce,
           from,
           contractCode,
@@ -62,7 +60,6 @@ object Main {
       case Bond(
           amount,
           from,
-          gasPrice,
           nonce,
           contractCode,
           paymentCode,
@@ -71,7 +68,6 @@ object Main {
           ) =>
         DeployRuntime.bond(
           amount,
-          gasPrice,
           nonce,
           from,
           contractCode,

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -44,7 +44,6 @@ object Main {
           from,
           nonce,
           contractCode,
-          paymentCode,
           maybePublicKey,
           maybePrivateKey
           ) =>
@@ -53,7 +52,6 @@ object Main {
           nonce,
           from,
           contractCode,
-          paymentCode,
           maybePublicKey,
           maybePrivateKey
         )
@@ -62,7 +60,6 @@ object Main {
           from,
           nonce,
           contractCode,
-          paymentCode,
           maybePublicKey,
           maybePrivateKey
           ) =>
@@ -71,7 +68,6 @@ object Main {
           nonce,
           from,
           contractCode,
-          paymentCode,
           maybePublicKey,
           maybePrivateKey
         )

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -44,32 +44,28 @@ object Main {
           from,
           nonce,
           contractCode,
-          maybePublicKey,
-          maybePrivateKey
+          privateKey
           ) =>
         DeployRuntime.unbond(
           amount,
           nonce,
           from,
           contractCode,
-          maybePublicKey,
-          maybePrivateKey
+          privateKey
         )
       case Bond(
           amount,
           from,
           nonce,
           contractCode,
-          maybePublicKey,
-          maybePrivateKey
+          privateKey
           ) =>
         DeployRuntime.bond(
           amount,
           nonce,
           from,
           contractCode,
-          maybePublicKey,
-          maybePrivateKey
+          privateKey
         )
       case Deploy(
           from,

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -1,5 +1,7 @@
 package io.casperlabs.client
 
+import java.io.FileInputStream
+
 import cats.effect.{Sync, Timer}
 import io.casperlabs.client.configuration._
 import io.casperlabs.shared.{Log, UncaughtExceptionHandler}
@@ -75,8 +77,8 @@ object Main {
         DeployRuntime.deployFileProgram(
           from,
           nonce,
-          sessionCode,
-          paymentCode,
+          new FileInputStream(sessionCode),
+          new FileInputStream(paymentCode),
           maybePublicKey,
           maybePrivateKey,
           gasPrice

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -41,7 +41,6 @@ object Main {
       case ShowBlocks(depth) => DeployRuntime.showBlocks(depth)
       case Unbond(
           amount,
-          from,
           nonce,
           contractCode,
           privateKey
@@ -49,13 +48,11 @@ object Main {
         DeployRuntime.unbond(
           amount,
           nonce,
-          from,
           contractCode,
           privateKey
         )
       case Bond(
           amount,
-          from,
           nonce,
           contractCode,
           privateKey
@@ -63,7 +60,6 @@ object Main {
         DeployRuntime.bond(
           amount,
           nonce,
-          from,
           contractCode,
           privateKey
         )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -95,7 +95,7 @@ object Configuration {
           options.unbond.amount.toOption,
           options.unbond.from.toOption,
           options.unbond.nonce(),
-          options.unbond.contractPath(),
+          options.unbond.session(),
           options.unbond.privateKey()
         )
       case options.bond =>
@@ -103,7 +103,7 @@ object Configuration {
           options.unbond.amount(),
           options.unbond.from.toOption,
           options.unbond.nonce(),
-          options.unbond.contractPath(),
+          options.unbond.session(),
           options.unbond.privateKey()
         )
       case options.visualizeBlocks =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -28,14 +28,12 @@ final case class ShowDeploy(deployHash: String) extends Configuration
 final case class ShowBlocks(depth: Int)         extends Configuration
 final case class Bond(
     amount: Long,
-    from: Option[String],
     nonce: Long,
     sessionCode: File,
     privateKey: File
 ) extends Configuration
 final case class Unbond(
     amount: Option[Long],
-    from: Option[String],
     nonce: Long,
     sessionCode: File,
     privateKey: File
@@ -93,7 +91,6 @@ object Configuration {
       case options.unbond =>
         Unbond(
           options.unbond.amount.toOption,
-          options.unbond.from.toOption,
           options.unbond.nonce(),
           options.unbond.session(),
           options.unbond.privateKey()
@@ -101,7 +98,6 @@ object Configuration {
       case options.bond =>
         Bond(
           options.unbond.amount(),
-          options.unbond.from.toOption,
           options.unbond.nonce(),
           options.unbond.session(),
           options.unbond.privateKey()

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -29,13 +29,13 @@ final case class ShowBlocks(depth: Int)         extends Configuration
 final case class Bond(
     amount: Long,
     nonce: Long,
-    sessionCode: File,
+    sessionCode: Option[File],
     privateKey: File
 ) extends Configuration
 final case class Unbond(
     amount: Option[Long],
     nonce: Long,
-    sessionCode: File,
+    sessionCode: Option[File],
     privateKey: File
 ) extends Configuration
 final case class VisualizeDag(
@@ -92,14 +92,14 @@ object Configuration {
         Unbond(
           options.unbond.amount.toOption,
           options.unbond.nonce(),
-          options.unbond.session(),
+          options.unbond.session.toOption,
           options.unbond.privateKey()
         )
       case options.bond =>
         Bond(
           options.unbond.amount(),
           options.unbond.nonce(),
-          options.unbond.session(),
+          options.unbond.session.toOption,
           options.unbond.privateKey()
         )
       case options.visualizeBlocks =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -31,16 +31,14 @@ final case class Bond(
     from: Option[String],
     nonce: Long,
     sessionCode: File,
-    publicKey: Option[File],
-    privateKey: Option[File]
+    privateKey: File
 ) extends Configuration
 final case class Unbond(
     amount: Option[Long],
     from: Option[String],
     nonce: Long,
     sessionCode: File,
-    publicKey: Option[File],
-    privateKey: Option[File]
+    privateKey: File
 ) extends Configuration
 final case class VisualizeDag(
     depth: Int,
@@ -98,8 +96,7 @@ object Configuration {
           options.unbond.from.toOption,
           options.unbond.nonce(),
           options.unbond.contractPath(),
-          options.unbond.publicKey.toOption,
-          options.unbond.privateKey.toOption
+          options.unbond.privateKey()
         )
       case options.bond =>
         Bond(
@@ -107,8 +104,7 @@ object Configuration {
           options.unbond.from.toOption,
           options.unbond.nonce(),
           options.unbond.contractPath(),
-          options.unbond.publicKey.toOption,
-          options.unbond.privateKey.toOption
+          options.unbond.privateKey()
         )
       case options.visualizeBlocks =>
         VisualizeDag(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -26,6 +26,26 @@ final case class ShowBlock(blockHash: String)   extends Configuration
 final case class ShowDeploys(blockHash: String) extends Configuration
 final case class ShowDeploy(deployHash: String) extends Configuration
 final case class ShowBlocks(depth: Int)         extends Configuration
+final case class Bond(
+    amount: Long,
+    from: Option[String],
+    gasPrice: Long,
+    nonce: Long,
+    sessionCode: File,
+    paymentCode: File,
+    publicKey: Option[File],
+    privateKey: Option[File]
+) extends Configuration
+final case class Unbond(
+    amount: Option[Long],
+    from: Option[String],
+    gasPrice: Long,
+    nonce: Long,
+    sessionCode: File,
+    paymentCode: File,
+    publicKey: Option[File],
+    privateKey: Option[File]
+) extends Configuration
 final case class VisualizeDag(
     depth: Int,
     showJustificationLines: Boolean,
@@ -76,6 +96,28 @@ object Configuration {
         ShowDeploy(options.showDeploy.hash())
       case options.showBlocks =>
         ShowBlocks(options.showBlocks.depth())
+      case options.unbond =>
+        Unbond(
+          options.unbond.amount.toOption,
+          options.unbond.from.toOption,
+          options.unbond.gasPrice(),
+          options.unbond.nonce(),
+          options.unbond.contractPath(),
+          options.unbond.payment(),
+          options.unbond.publicKey.toOption,
+          options.unbond.privateKey.toOption
+        )
+      case options.bond =>
+        Bond(
+          options.unbond.amount(),
+          options.unbond.from.toOption,
+          options.unbond.gasPrice(),
+          options.unbond.nonce(),
+          options.unbond.contractPath(),
+          options.unbond.payment(),
+          options.unbond.publicKey.toOption,
+          options.unbond.privateKey.toOption
+        )
       case options.visualizeBlocks =>
         VisualizeDag(
           options.visualizeBlocks.depth(),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -31,7 +31,6 @@ final case class Bond(
     from: Option[String],
     nonce: Long,
     sessionCode: File,
-    paymentCode: File,
     publicKey: Option[File],
     privateKey: Option[File]
 ) extends Configuration
@@ -40,7 +39,6 @@ final case class Unbond(
     from: Option[String],
     nonce: Long,
     sessionCode: File,
-    paymentCode: File,
     publicKey: Option[File],
     privateKey: Option[File]
 ) extends Configuration
@@ -100,7 +98,6 @@ object Configuration {
           options.unbond.from.toOption,
           options.unbond.nonce(),
           options.unbond.contractPath(),
-          options.unbond.payment(),
           options.unbond.publicKey.toOption,
           options.unbond.privateKey.toOption
         )
@@ -110,7 +107,6 @@ object Configuration {
           options.unbond.from.toOption,
           options.unbond.nonce(),
           options.unbond.contractPath(),
-          options.unbond.payment(),
           options.unbond.publicKey.toOption,
           options.unbond.privateKey.toOption
         )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -29,7 +29,6 @@ final case class ShowBlocks(depth: Int)         extends Configuration
 final case class Bond(
     amount: Long,
     from: Option[String],
-    gasPrice: Long,
     nonce: Long,
     sessionCode: File,
     paymentCode: File,
@@ -39,7 +38,6 @@ final case class Bond(
 final case class Unbond(
     amount: Option[Long],
     from: Option[String],
-    gasPrice: Long,
     nonce: Long,
     sessionCode: File,
     paymentCode: File,
@@ -100,7 +98,6 @@ object Configuration {
         Unbond(
           options.unbond.amount.toOption,
           options.unbond.from.toOption,
-          options.unbond.gasPrice(),
           options.unbond.nonce(),
           options.unbond.contractPath(),
           options.unbond.payment(),
@@ -111,7 +108,6 @@ object Configuration {
         Bond(
           options.unbond.amount(),
           options.unbond.from.toOption,
-          options.unbond.gasPrice(),
           options.unbond.nonce(),
           options.unbond.contractPath(),
           options.unbond.payment(),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -177,12 +177,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "amount of tokens to unbond"
     )
 
-    val gasPrice = opt[Long](
-      descr = "The price of gas for this transaction in units dust/gas. Must be positive integer.",
-      validate = _ > 0,
-      required = true
-    )
-
     val contractPath =
       opt[File](
         required = true,
@@ -230,12 +224,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       name = "amount",
       validate = _ > 0,
       descr = "amount of tokens to bond",
-      required = true
-    )
-
-    val gasPrice = opt[Long](
-      descr = "The price of gas for this transaction in units dust/gas. Must be positive integer.",
-      validate = _ > 0,
       required = true
     )
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -185,7 +185,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       )
 
     val nonce = opt[Long](
-      descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
+      descr =
+        "Nonce of the account. Sequences deploys from that account. Every new deploy has to use nonce one higher than current account's nonce.",
       validate = _ > 0,
       required = true
     )
@@ -217,7 +218,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       )
 
     val nonce = opt[Long](
-      descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
+      descr =
+        "Nonce of the account. Sequences deploys from that account. Every new deploy has to use nonce one higher than current account's nonce.",
       validate = _ > 0,
       required = true
     )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -168,6 +168,116 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showBlocks)
 
+  val unbond = new Subcommand("unbond") {
+    descr("Issues unbonding request")
+
+    val amount = opt[Long](
+      name = "amount",
+      validate = _ > 0,
+      descr = "amount of tokens to unbond"
+    )
+
+    val gasPrice = opt[Long](
+      descr = "The price of gas for this transaction in units dust/gas. Must be positive integer.",
+      validate = _ > 0,
+      required = true
+    )
+
+    val contractPath =
+      opt[File](
+        required = true,
+        descr = "Path to the file with unbonding contract.",
+        validate = fileCheck
+      )
+
+    val payment =
+      opt[File](required = true, descr = "Path to the file with payment code", validate = fileCheck)
+
+    val from = opt[String](
+      descr =
+        "The public key of the account which is the context of this deployment, base16 encoded.",
+      required = false,
+      validate = hexCheck
+    )
+
+    val nonce = opt[Long](
+      descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
+      validate = _ > 0,
+      required = true
+    )
+
+    val publicKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account public key (Ed25519)",
+        validate = fileCheck
+      )
+
+    val privateKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account private key (Ed25519)",
+        validate = fileCheck
+      )
+
+  }
+  addSubcommand(unbond)
+
+  val bond = new Subcommand("bond") {
+    descr("Issues bonding request")
+
+    val amount = opt[Long](
+      name = "amount",
+      validate = _ > 0,
+      descr = "amount of tokens to bond",
+      required = true
+    )
+
+    val gasPrice = opt[Long](
+      descr = "The price of gas for this transaction in units dust/gas. Must be positive integer.",
+      validate = _ > 0,
+      required = true
+    )
+
+    val contractPath =
+      opt[File](
+        required = true,
+        descr = "Path to the file with bonding contract.",
+        validate = fileCheck
+      )
+
+    val payment =
+      opt[File](required = true, descr = "Path to the file with payment code", validate = fileCheck)
+
+    val from = opt[String](
+      descr =
+        "The public key of the account which is the context of this deployment, base16 encoded.",
+      required = false,
+      validate = hexCheck
+    )
+
+    val nonce = opt[Long](
+      descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
+      validate = _ > 0,
+      required = true
+    )
+
+    val publicKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account public key (Ed25519)",
+        validate = fileCheck
+      )
+
+    val privateKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account private key (Ed25519)",
+        validate = fileCheck
+      )
+  }
+  addSubcommand(bond)
+
   val visualizeBlocks = new Subcommand("vdag") {
     descr(
       "DAG in DOT format"

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -184,13 +184,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         validate = fileCheck
       )
 
-    val from = opt[String](
-      descr =
-        "The public key of the account which is the context of this deployment, base16 encoded.",
-      required = false,
-      validate = hexCheck
-    )
-
     val nonce = opt[Long](
       descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
       validate = _ > 0,
@@ -223,13 +216,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         descr = "Path to the file with bonding contract.",
         validate = fileCheck
       )
-
-    val from = opt[String](
-      descr =
-        "The public key of the account which is the context of this deployment, base16 encoded.",
-      required = false,
-      validate = hexCheck
-    )
 
     val nonce = opt[Long](
       descr = "This allows you to overwrite your own pending transactions that use the same nonce.",

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -197,13 +197,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       required = true
     )
 
-    val publicKey =
-      opt[File](
-        required = false,
-        descr = "Path to the file with account public key (Ed25519)",
-        validate = fileCheck
-      )
-
     val privateKey =
       opt[File](
         required = false,
@@ -243,13 +236,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       validate = _ > 0,
       required = true
     )
-
-    val publicKey =
-      opt[File](
-        required = false,
-        descr = "Path to the file with account public key (Ed25519)",
-        validate = fileCheck
-      )
 
     val privateKey =
       opt[File](

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -192,9 +192,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val privateKey =
       opt[File](
-        required = false,
         descr = "Path to the file with account private key (Ed25519)",
-        validate = fileCheck
+        validate = fileCheck,
+        required = true
       )
 
   }
@@ -225,9 +225,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val privateKey =
       opt[File](
-        required = false,
         descr = "Path to the file with account private key (Ed25519)",
-        validate = fileCheck
+        validate = fileCheck,
+        required = true
       )
   }
   addSubcommand(bond)

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -184,9 +184,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         validate = fileCheck
       )
 
-    val payment =
-      opt[File](required = true, descr = "Path to the file with payment code", validate = fileCheck)
-
     val from = opt[String](
       descr =
         "The public key of the account which is the context of this deployment, base16 encoded.",
@@ -233,9 +230,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         descr = "Path to the file with bonding contract.",
         validate = fileCheck
       )
-
-    val payment =
-      opt[File](required = true, descr = "Path to the file with payment code", validate = fileCheck)
 
     val from = opt[String](
       descr =

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -174,12 +174,12 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val amount = opt[Long](
       name = "amount",
       validate = _ > 0,
-      descr = "Amount of tokens to unbond. If not provided then a request to unbond with all staked tokens is made."
+      descr =
+        "Amount of tokens to unbond. If not provided then a request to unbond with all staked tokens is made."
     )
 
     val session =
       opt[File](
-        required = true,
         descr = "Path to the file with unbonding contract.",
         validate = fileCheck
       )
@@ -212,7 +212,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val session =
       opt[File](
-        required = true,
         descr = "Path to the file with bonding contract.",
         validate = fileCheck
       )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -174,7 +174,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val amount = opt[Long](
       name = "amount",
       validate = _ > 0,
-      descr = "amount of tokens to unbond"
+      descr = "Amount of tokens to unbond. If not provided then a request to unbond with all staked tokens is made."
     )
 
     val session =

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -177,7 +177,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "amount of tokens to unbond"
     )
 
-    val contractPath =
+    val session =
       opt[File](
         required = true,
         descr = "Path to the file with unbonding contract.",
@@ -217,7 +217,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       required = true
     )
 
-    val contractPath =
+    val session =
       opt[File](
         required = true,
         descr = "Path to the file with bonding contract.",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -86,6 +86,7 @@ object Dependencies {
   val secp256k1Java = "com.github.rchain" % "secp256k1-java" % "0.1"
   val tomlScala     = "tech.sparse"       %% "toml-scala"    % "0.1.1"
   val refinement    = "eu.timepit"        %% "refined"       % "0.9.5"
+  val apacheCommons = "commons-io" % "commons-io" % "2.6"
 
   val overrides = Seq(
     catsCore,


### PR DESCRIPTION
### Overview
Adds two new subcommands to node's client: `bond` and `unbond`. 

Usage for `ubond`:
```
casperlabs-client --host localhost unbond --help
  -a, --amount  <arg>        Amount of tokens to unbond. If not provided then a request to unbond with all staked tokens is made.
  -n, --nonce  <arg>         This allows you to overwrite your own pending
                             transactions that use the same nonce.
  -p, --private-key  <arg>   Path to the file with account private key (Ed25519)
  -s, --session  <arg>       Path to the file with unbonding contract.
```

Similarly for `bond`:
```
casperlabs-client --host localhost bond --help
  -a, --amount  <arg>        amount of tokens to bond
  -n, --nonce  <arg>         This allows you to overwrite your own pending
                             transactions that use the same nonce.
  -p, --private-key  <arg>   Path to the file with account private key (Ed25519)
  -s, --session  <arg>       Path to the file with bonding contract.
```

In both cases `--session` parameter is optional. When not provided client will use contracts that it is packaged with (requires contracts to be compiled with `bonding.wasm`/`unbonding.wasm` names and placed in client's `/resources` folder).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-632

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
