### PR TITLE
OP-410: Make payment and gas_price optional

### DIFF
--- a/integration-testing/client/CasperClient/casper_client/casper_client.py
+++ b/integration-testing/client/CasperClient/casper_client/casper_client.py
@@ -168,7 +168,7 @@ class CasperClient:
         self.controlService = GRPCService(self.internal_port, ControlServiceStub)
 
     @api
-    def deploy(self, from_addr: bytes = None, gas_limit: int = None, gas_price: int = None, 
+    def deploy(self, from_addr: bytes = None, gas_limit: int = None, gas_price: int = 10, 
                payment: str = None, session: str = None, nonce: int = 0,
                public_key: str = None, private_key: str = None, args: bytes = None):
         """
@@ -190,6 +190,8 @@ class CasperClient:
         :param args:          List of ABI encoded arguments
         :return:              Tuple: (deserialized DeployServiceResponse object, deploy_hash)
         """
+
+        payment = payment or session
 
         def hash(data: bytes) -> bytes:
             h = blake2b(digest_size=32)
@@ -392,7 +394,7 @@ def deploy_command(casper_client, args):
     response, deploy_hash = casper_client.deploy(getattr(args,'from'),
                                                  args.gas_limit,
                                                  args.gas_price, 
-                                                 args.payment,
+                                                 args.payment or args.session,
                                                  args.session,
                                                  args.nonce,
                                                  args.public_key or None,
@@ -484,9 +486,9 @@ def command_line_tool():
     parser.addCommand('deploy', deploy_command, 'Deploy a smart contract source file to Casper on an existing running node. The deploy will be packaged and sent as a block to the network depending on the configuration of the Casper instance',
                       [[('-f', '--from'), dict(required=True, type=lambda x: bytes(x, 'utf-8'), help='Purse address that will be used to pay for the deployment.')],
                        [('-g', '--gas-limit'), dict(required=True, type=int, help='[Deprecated] The amount of gas to use for the transaction (unused gas is refunded). Must be positive integer.')],
-                       [('--gas-price',), dict(required=True, type=int, help='The price of gas for this transaction in units dust/gas. Must be positive integer.')],
-                       [('-n', '--nonce'), dict(required=False, type=int, default=0, help='This allows you to overwrite your own pending transactions that use the same nonce.')],
-                       [('-p', '--payment'), dict(required=True, type=str, help='Path to the file with payment code')],
+                       [('--gas-price',), dict(required=False, type=int, default=10, help='The price of gas for this transaction in units dust/gas. Must be positive integer.')],
+                       [('-n', '--nonce'), dict(required=True, type=int, help='This allows you to overwrite your own pending transactions that use the same nonce.')],
+                       [('-p', '--payment'), dict(required=False, type=str, default=None, help='Path to the file with payment code, by default fallbacks to the --session code')],
                        [('-s', '--session'), dict(required=True, type=str, help='Path to the file with session code')],
                        [('--args'), dict(required=False, type=str, help='JSON encoded list of args, e.g.: [{"u32":1024},{"u64":12}]')],
                        [('--private-key',), dict(required=True, type=str, help='Path to the file with account public key (Ed25519)')],


### PR DESCRIPTION
### Overview
This PR makes `payment` and `gas_price` deploy parameters optional in Python client,
as in Scala client, see Node-633.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-410

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
