### PR TITLE
NO-TICKET: Add support for local key queries to the node.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -215,8 +215,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val keyType =
       opt[String](
         name = "type",
-        descr = "Type of base key. Must be one of 'hash', 'uref', 'address'",
-        validate = s => Set("hash", "uref", "address").contains(s.toLowerCase),
+        descr =
+          "Type of base key. Must be one of 'hash', 'uref', 'address' or 'local'. For 'local' key type, 'key' value format is {seed}:{rest}, where both parts are hex encoded.",
+        validate = s => Set("hash", "uref", "address", "local").contains(s.toLowerCase),
         default = Option("address")
       )
 

--- a/node/src/main/scala/io/casperlabs/node/api/Utils.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Utils.scala
@@ -1,15 +1,18 @@
 package io.casperlabs.node.api
 
-import cats.ApplicativeError
-import cats.syntax.applicative._
+import cats.implicits._
+import cats.Monad
 import com.google.protobuf.ByteString
-import io.casperlabs.crypto.codec.Base16
-import io.casperlabs.ipc
 import io.casperlabs.casper.consensus.state
+import io.casperlabs.catscontrib.MonadThrowable
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.crypto.hash.Blake2b256
+
+import scala.util.Try
 
 object Utils {
-  def toKey[F[_]](keyType: String, keyValue: String)(
-      implicit appErr: ApplicativeError[F, Throwable]
+  def toKey[F[_]: Monad](keyType: String, keyValue: String)(
+      implicit appErr: MonadThrowable[F]
   ): F[state.Key] = {
     val keyBytes = ByteString.copyFrom(Base16.decode(keyValue))
     keyType.toLowerCase match {
@@ -42,6 +45,32 @@ object Utils {
                 s"Key of type address must have exactly 32 bytes, $n =/= 32 provided."
               )
             )
+        }
+      case "local" =>
+        for {
+          (seed, bytes) <- appErr
+                            .fromTry {
+                              Try(keyValue.split(':').map(Base16.decode(_)))
+                                .filter(_.length == 2)
+                                .map(arr => (arr(0), arr(1)))
+                            }
+                            .handleErrorWith(
+                              _ =>
+                                appErr.raiseError(
+                                  new IllegalArgumentException(
+                                    "Expected local key encoded as {seed}:{rest}. Where both seed and rest parts are hex encoded."
+                                  )
+                                )
+                            )
+          _ <- appErr
+                .raiseError(
+                  new IllegalArgumentException("Seed of Local key has to be exactly 32 bytes long.")
+                )
+                .whenA(seed.length != 32)
+        } yield {
+          // This is what EE does when creating local key address.
+          val hash = Blake2b256.hash(seed ++ bytes)
+          state.Key(state.Key.Value.Local(state.Key.Local(ByteString.copyFrom(hash))))
         }
       case _ =>
         appErr.raiseError(

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -111,6 +111,7 @@ message StateQuery {
         HASH = 1;
         UREF = 2;
         ADDRESS = 3;
+        LOCAL = 4;
     }
 }
 


### PR DESCRIPTION
### Overview
Adds `local` key type support to `StateQuery` endpoint of the node. Key value for the `local` key format is expected to be `{seed}:{rest}` where both parts are hex encoded.

### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
