### PR TITLE
NODE-643: Add balance subcommand to the node's client.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -122,6 +122,49 @@ object DeployRuntime {
         .map(_.map(Printer.printToUnicodeString(_)))
     )
 
+  def balance[F[_]: Sync: DeployService](address: String, blockHash: String): F[Unit] =
+    gracefulExit {
+      (for {
+        value <- DeployService[F].queryState(blockHash, "address", address, "").rethrow
+        _ <- Sync[F]
+              .raiseError(new IllegalStateException(s"Expected Account type value under $address."))
+              .whenA(!value.value.isAccount)
+        account = value.getAccount
+        mint_public <- Sync[F].fromOption(
+                        account.knownUrefs.find(_.name == "mint").flatMap(_.key),
+                        new IllegalStateException(
+                          "Account's known_urefs map did not contain Mint contract address."
+                        )
+                      )
+        mint_private <- DeployService[F]
+                         .queryState(
+                           blockHash,
+                           "uref",
+                           Base16.encode(mint_public.getUref.uref.toByteArray), // I am assuming that "mint" points to URef type key.
+                           ""
+                         )
+                         .rethrow
+        localKeyValue = {
+          val mintPrivateHex = Base16.encode(mint_private.getKey.getUref.uref.toByteArray) // Assuming that `mint_private` is of `URef` type.
+          val purseAddrHex = {
+            val purseAddr    = account.getPurseId.uref.toByteArray
+            val purseAddrSer = serializeArray(purseAddr)
+            Base16.encode(purseAddrSer)
+          }
+          s"$mintPrivateHex:$purseAddrHex"
+        }
+        balanceURef <- DeployService[F].queryState(blockHash, "local", localKeyValue, "").rethrow
+        balance <- DeployService[F]
+                    .queryState(
+                      blockHash,
+                      "uref",
+                      Base16.encode(balanceURef.getKey.getUref.uref.toByteArray),
+                      ""
+                    )
+                    .rethrow
+      } yield s"Balance:\n$address : ${balance.getBigInt.value}").attempt
+    }
+
   def visualizeDag[F[_]: Sync: DeployService: Timer](
       depth: Int,
       showJustificationLines: Boolean,

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -116,7 +116,11 @@ object DeployRuntime {
       keyValue: String,
       path: String
   ): F[Unit] =
-    gracefulExit(DeployService[F].queryState(blockHash, keyVariant, keyValue, path))
+    gracefulExit(
+      DeployService[F]
+        .queryState(blockHash, keyVariant, keyValue, path)
+        .map(_.map(Printer.printToUnicodeString(_)))
+    )
 
   def visualizeDag[F[_]: Sync: DeployService: Timer](
       depth: Int,

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -130,22 +130,22 @@ object DeployRuntime {
               .raiseError(new IllegalStateException(s"Expected Account type value under $address."))
               .whenA(!value.value.isAccount)
         account = value.getAccount
-        mint_public <- Sync[F].fromOption(
-                        account.knownUrefs.find(_.name == "mint").flatMap(_.key),
-                        new IllegalStateException(
-                          "Account's known_urefs map did not contain Mint contract address."
+        mintPublic <- Sync[F].fromOption(
+                       account.knownUrefs.find(_.name == "mint").flatMap(_.key),
+                       new IllegalStateException(
+                         "Account's known_urefs map did not contain Mint contract address."
+                       )
+                     )
+        mintPrivate <- DeployService[F]
+                        .queryState(
+                          blockHash,
+                          "uref",
+                          Base16.encode(mintPublic.getUref.uref.toByteArray), // I am assuming that "mint" points to URef type key.
+                          ""
                         )
-                      )
-        mint_private <- DeployService[F]
-                         .queryState(
-                           blockHash,
-                           "uref",
-                           Base16.encode(mint_public.getUref.uref.toByteArray), // I am assuming that "mint" points to URef type key.
-                           ""
-                         )
-                         .rethrow
+                        .rethrow
         localKeyValue = {
-          val mintPrivateHex = Base16.encode(mint_private.getKey.getUref.uref.toByteArray) // Assuming that `mint_private` is of `URef` type.
+          val mintPrivateHex = Base16.encode(mintPrivate.getKey.getUref.uref.toByteArray) // Assuming that `mint_private` is of `URef` type.
           val purseAddrHex = {
             val purseAddr    = account.getPurseId.uref.toByteArray
             val purseAddrSer = serializeArray(purseAddr)

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -1,6 +1,6 @@
 package io.casperlabs.client
 import io.casperlabs.casper.consensus
-import io.casperlabs.casper.consensus.info
+import io.casperlabs.casper.consensus.state.Value
 import simulacrum.typeclass
 
 import scala.util.Either
@@ -18,5 +18,5 @@ import scala.util.Either
       keyVariant: String,
       keyValue: String,
       path: String
-  ): F[Either[Throwable, String]]
+  ): F[Either[Throwable, Value]]
 }

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -7,6 +7,7 @@ import cats.mtl.implicits._
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 import java.security.KeyStore
+
 import javax.net.ssl._
 import com.google.protobuf.ByteString
 import com.google.protobuf.empty.Empty
@@ -14,6 +15,7 @@ import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.util.HostnameTrustManager
 import io.casperlabs.casper.consensus
 import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
+import io.casperlabs.casper.consensus.state.Value
 import io.casperlabs.graphz
 import io.casperlabs.node.api.casper.{
   CasperGrpcMonix,
@@ -32,6 +34,7 @@ import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
 import io.grpc.netty.{GrpcSslContexts, NegotiationType}
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory
 import monix.eval.Task
+
 import scala.util.Either
 
 class GrpcDeployService(conn: ConnectOptions) extends DeployService[Task] with Closeable {
@@ -145,11 +148,11 @@ class GrpcDeployService(conn: ConnectOptions) extends DeployService[Task] with C
       keyVariant: String,
       keyValue: String,
       path: String
-  ): Task[Either[Throwable, String]] =
+  ): Task[Either[Throwable, Value]] =
     StateQuery.KeyVariant.values
       .find(_.name == keyVariant.toUpperCase)
       .fold(
-        Task.raiseError[String](
+        Task.raiseError[Value](
           new java.lang.IllegalArgumentException(s"Unknown key variant: $keyVariant")
         )
       ) { kv =>
@@ -162,9 +165,7 @@ class GrpcDeployService(conn: ConnectOptions) extends DeployService[Task] with C
             )
           )
 
-        casperServiceStub
-          .getBlockState(req)
-          .map(Printer.printToUnicodeString(_))
+        casperServiceStub.getBlockState(req)
       }
       .attempt
 

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -92,5 +92,8 @@ object Main {
 
       case Query(hash, keyType, keyValue, path) =>
         DeployRuntime.queryState(hash, keyType, keyValue, path)
+
+      case Balance(address, blockHash) =>
+        DeployRuntime.balance(address, blockHash)
     }
 }

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -44,6 +44,7 @@ final case class VisualizeDag(
     out: Option[String],
     streaming: Option[Streaming]
 ) extends Configuration
+final case class Balance(address: String, blockhash: String) extends Configuration
 
 sealed trait Streaming extends Product with Serializable
 object Streaming {
@@ -115,6 +116,11 @@ object Configuration {
           options.query.keyType(),
           options.query.key(),
           options.query.path()
+        )
+      case options.balance =>
+        Balance(
+          options.balance.address(),
+          options.balance.blockHash()
         )
     }
     conf map (connect -> _)

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -321,7 +321,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val address =
       opt[String](
         name = "address",
-        descr = "Account address in hex.",
+        descr = "Account's public key in hex.",
         required = true,
         validate = hexCheck
       )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -307,5 +307,26 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(query)
 
+  val balance = new Subcommand("balance") {
+    descr("Returns the balance of the account at the specified block.")
+
+    val blockHash =
+      opt[String](
+        name = "block-hash",
+        descr = "Hash of the block to query the state of",
+        required = true,
+        validate = hexCheck
+      )
+
+    val address =
+      opt[String](
+        name = "address",
+        descr = "Account address in hex.",
+        required = true,
+        validate = hexCheck
+      )
+  }
+  addSubcommand(balance)
+
   verify()
 }

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -83,6 +83,22 @@ class DockerClient(CasperLabsClient, LoggingMixin):
                     self.logger.debug("Could not propose; no more retries!")
                     raise ex
 
+    def get_balance(self, account_address: str, block_hash: str) -> int:
+        """
+        Returns balance of account according to block given.
+
+        :param account_address: account public key in hex
+        :param block_hash: block_hash in hex
+        :return: balance as int
+        """
+        command = f"balance --address {account_address} --block-hash {block_hash}"
+        r = self.invoke_client(command)
+        try:
+            balance = r.split(' : ')[1]
+            return int(balance)
+        except Exception as e:
+            raise Exception(f'Error parsing: {r}.\n{e}')
+
     def deploy(self,
                from_address: str = None,
                gas_limit: int = 1000000,

--- a/integration-testing/test/test_account_balance.py
+++ b/integration-testing/test/test_account_balance.py
@@ -1,0 +1,18 @@
+from test.cl_node.docker_node import DockerNode
+from test.cl_node.casperlabs_accounts import Account
+
+
+def test_scala_client_balance(one_node_network):
+    node: DockerNode = one_node_network.docker_nodes[0]
+
+    # This is only in scala client, need to verify we are using correct one.
+    node.use_docker_client()
+
+    acct1, acct2, acct3 = [Account(i) for i in range(1, 4)]
+
+    # Perform multiple transfers with end result of Acct1 = 200, Acct2 = 100, Acct3 = 700
+    hashes = node.transfer_to_accounts([(1, 1000), (2, 800, 1), (3, 700, 2)])
+
+    assert node.client.get_balance(account_address=acct1.public_key_hex, block_hash=hashes[-1]) == 200
+    assert node.client.get_balance(account_address=acct2.public_key_hex, block_hash=hashes[-1]) == 100
+    assert node.client.get_balance(account_address=acct3.public_key_hex, block_hash=hashes[-1]) == 700


### PR DESCRIPTION
### Overview
As in the title.
```
casperlabs-client --host {host} balance -a {account address in hex} -b {blockHash}

Balance:
{account address in hex} : {balance}
```

Sample usage (queries balance of the Genesis account):
```
casperlabs-client --host localhost balance -a 3da321b5bf8814170485b46ad7e0a23c2d9f9a2040d0e1a001ccbc87ba43af3b -b 252d05b2d97384a6116135d0988fdd24c9f0a429adbb80fc1f69b486f3064f1d
Balance:
3da321b5bf8814170485b46ad7e0a23c2d9f9a2040d0e1a001ccbc87ba43af3b : 1234567890
```
### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-643

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
