### PR TITLE
EE-221: get_uref should not panic when a name is not found

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -348,6 +348,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ee-221-regression"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.10.0",
+]
+
+[[package]]
 name = "ee-401-regression"
 version = "0.1.0"
 dependencies = [

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "test-contracts/blessed-urefs-access-rights",
     "test-contracts/transfer-purse-to-account",
     "test-contracts/deserialize-error",
+    "test-contracts/ee-221-regression",
     "validator-contracts/bonding",
     "validator-contracts/unbonding",
     "wasm-prep",

--- a/execution-engine/blessed-contracts/pos/src/lib.rs
+++ b/execution-engine/blessed-contracts/pos/src/lib.rs
@@ -123,7 +123,7 @@ pub extern "C" fn call() {
     let method_name: String = contract_api::get_arg(0);
     let timestamp = contract_api::get_blocktime();
     let pos_purse = match contract_api::get_uref(PURSE_KEY) {
-        Key::URef(uref) => PurseId::new(uref),
+        Some(Key::URef(uref)) => PurseId::new(uref),
         _ => panic!("PoS purse ID not found"),
     };
 

--- a/execution-engine/comm/tests/regression_test_ee_221.rs
+++ b/execution-engine/comm/tests/regression_test_ee_221.rs
@@ -1,0 +1,32 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate common;
+extern crate execution_engine;
+extern crate grpc;
+extern crate shared;
+extern crate storage;
+
+use std::collections::HashMap;
+
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(dead_code)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+
+#[ignore]
+#[test]
+fn should_run_ee_221_get_uref_regression_test() {
+    // This test runs a contract that's after every call extends the same key with more data
+    let _result = WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec(
+            GENESIS_ADDR,
+            "ee_221_regression.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+        )
+        .expect_success()
+        .commit()
+        .finish();
+}

--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -221,7 +221,7 @@ pub fn get_arg<T: FromBytes>(i: u32) -> T {
 /// Return the unforgable reference known by the current module under the given name.
 /// This either comes from the known_urefs of the account or contract,
 /// depending on whether the current module is a sub-call or not.
-pub fn get_uref(name: &str) -> Key {
+pub fn get_uref(name: &str) -> Option<Key> {
     let (name_ptr, name_size, _bytes) = str_ref_to_ptr(name);
     let key_size = unsafe { ext_ffi::get_uref(name_ptr, name_size) };
     let dest_ptr = alloc_bytes(key_size);

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -265,10 +265,7 @@ where
     /// Load the uref known by the given name into the Wasm memory
     pub fn get_uref(&mut self, name_ptr: u32, name_size: u32) -> Result<usize, Trap> {
         let name = self.string_from_mem(name_ptr, name_size)?;
-        let uref = self
-            .context
-            .get_uref(&name)
-            .ok_or_else(|| Error::URefNotFound(name))?;
+        let uref = self.context.get_uref(&name).map(Clone::clone);
         let uref_bytes = uref.to_bytes().map_err(Error::BytesRepr)?;
 
         self.host_buf = uref_bytes;

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -265,7 +265,7 @@ where
     /// Load the uref known by the given name into the Wasm memory
     pub fn get_uref(&mut self, name_ptr: u32, name_size: u32) -> Result<usize, Trap> {
         let name = self.string_from_mem(name_ptr, name_size)?;
-        let uref = self.context.get_uref(&name).map(Clone::clone);
+        let uref = self.context.get_uref(&name).cloned();
         let uref_bytes = uref.to_bytes().map_err(Error::BytesRepr)?;
 
         self.host_buf = uref_bytes;

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -265,6 +265,9 @@ where
     /// Load the uref known by the given name into the Wasm memory
     pub fn get_uref(&mut self, name_ptr: u32, name_size: u32) -> Result<usize, Trap> {
         let name = self.string_from_mem(name_ptr, name_size)?;
+        // Take an optional uref, and pass its serialized value as is.
+        // This makes it easy to deserialize optional value on the other
+        // side without failing the execution when the value does not exist.
         let uref = self.context.get_uref(&name).cloned();
         let uref_bytes = uref.to_bytes().map_err(Error::BytesRepr)?;
 

--- a/execution-engine/scripts/run-contract-tests.sh
+++ b/execution-engine/scripts/run-contract-tests.sh
@@ -21,6 +21,7 @@ CONTRACTS=(
     "blessed-urefs-access-rights"
     "transfer-purse-to-account"
     "deserialize-error"
+    "ee-221-regression"
 )
 
 source "${HOME}/.cargo/env"

--- a/execution-engine/test-contracts/ee-221-regression/Cargo.toml
+++ b/execution-engine/test-contracts/ee-221-regression/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ee-221-regression"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@papierski.net>"]
+edition = "2018"
+
+[lib]
+name = "ee_221_regression"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std"]
+
+[dependencies]
+cl_std = { path = "../../common", package = "casperlabs-contract-ffi" }

--- a/execution-engine/test-contracts/ee-221-regression/src/lib.rs
+++ b/execution-engine/test-contracts/ee-221-regression/src/lib.rs
@@ -5,9 +5,19 @@ extern crate alloc;
 
 extern crate cl_std;
 
-use cl_std::contract_api::get_uref;
+use cl_std::contract_api::{add_uref, get_uref, new_uref, revert};
+use cl_std::key::Key;
+use cl_std::uref::URef;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let _ = get_uref("nonexistinguref");
+    let res1 = get_uref("nonexistinguref");
+    assert!(res1.is_none());
+
+    let new_uref: URef = new_uref(()).into();
+    add_uref("nonexistinguref", &Key::URef(new_uref));
+
+    let res2 = get_uref("nonexistinguref");
+
+    assert_eq!(res2.unwrap_or_else(|| revert(101)), new_uref.into());
 }

--- a/execution-engine/test-contracts/ee-221-regression/src/lib.rs
+++ b/execution-engine/test-contracts/ee-221-regression/src/lib.rs
@@ -5,19 +5,18 @@ extern crate alloc;
 
 extern crate cl_std;
 
-use cl_std::contract_api::{add_uref, get_uref, new_uref, revert};
+use cl_std::contract_api::{add_uref, get_uref, new_uref};
 use cl_std::key::Key;
-use cl_std::uref::URef;
 
 #[no_mangle]
 pub extern "C" fn call() {
     let res1 = get_uref("nonexistinguref");
     assert!(res1.is_none());
 
-    let new_uref: URef = new_uref(()).into();
-    add_uref("nonexistinguref", &Key::URef(new_uref));
+    let key = Key::URef(new_uref(()).into());
+    add_uref("nonexistinguref", &key);
 
     let res2 = get_uref("nonexistinguref");
 
-    assert_eq!(res2.unwrap_or_else(|| revert(101)), new_uref.into());
+    assert_eq!(res2, Some(key));
 }

--- a/execution-engine/test-contracts/ee-221-regression/src/lib.rs
+++ b/execution-engine/test-contracts/ee-221-regression/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+#![feature(alloc, cell_update)]
+
+extern crate alloc;
+
+extern crate cl_std;
+
+use cl_std::contract_api::get_uref;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let _ = get_uref("nonexistinguref");
+}

--- a/execution-engine/test-contracts/known-urefs/src/lib.rs
+++ b/execution-engine/test-contracts/known-urefs/src/lib.rs
@@ -7,7 +7,7 @@ extern crate cl_std;
 use alloc::string::String;
 
 use cl_std::contract_api::{
-    add, add_uref, get_uref, has_uref, list_known_urefs, new_uref, read, remove_uref, write,
+    add, add_uref, get_uref, has_uref, list_known_urefs, new_uref, read, remove_uref, revert, write,
 };
 use cl_std::key::Key;
 use cl_std::value::U512;
@@ -42,12 +42,9 @@ pub extern "C" fn call() {
     assert_eq!(hello_world, "Hello, world!");
 
     // Read data through dedicated FFI function
-    let hello_world: String = read(
-        get_uref("URef1")
-            .expect("should have URef1")
-            .to_u_ptr()
-            .expect("Unable to get uptr"),
-    );
+    let uref1 = get_uref("URef1").unwrap_or_else(|| revert(100));
+    let uref1_ptr = uref1.to_u_ptr().unwrap_or_else(|| revert(101));
+    let hello_world: String = read(uref1_ptr);
     assert_eq!(hello_world, "Hello, world!");
 
     // Remove uref
@@ -58,7 +55,7 @@ pub extern "C" fn call() {
     assert!(has_uref("URef2"));
 
     // Get the big value back
-    let big_value_key = get_uref("URef2").expect("should have URef2");
+    let big_value_key = get_uref("URef2").unwrap_or_else(|| revert(102));
     let big_value_uptr = big_value_key
         .to_u_ptr()
         .expect("Unable to get uptr for URef2");

--- a/execution-engine/test-contracts/known-urefs/src/lib.rs
+++ b/execution-engine/test-contracts/known-urefs/src/lib.rs
@@ -42,7 +42,12 @@ pub extern "C" fn call() {
     assert_eq!(hello_world, "Hello, world!");
 
     // Read data through dedicated FFI function
-    let hello_world: String = read(get_uref("URef1").to_u_ptr().expect("Unable to get uptr"));
+    let hello_world: String = read(
+        get_uref("URef1")
+            .expect("should have URef1")
+            .to_u_ptr()
+            .expect("Unable to get uptr"),
+    );
     assert_eq!(hello_world, "Hello, world!");
 
     // Remove uref
@@ -53,7 +58,7 @@ pub extern "C" fn call() {
     assert!(has_uref("URef2"));
 
     // Get the big value back
-    let big_value_key = get_uref("URef2");
+    let big_value_key = get_uref("URef2").expect("should have URef2");
     let big_value_uptr = big_value_key
         .to_u_ptr()
         .expect("Unable to get uptr for URef2");

--- a/execution-engine/test-contracts/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/test-contracts/transfer-purse-to-account/src/lib.rs
@@ -16,12 +16,13 @@ use cl_std::value::account::{PublicKey, PurseId};
 use cl_std::value::U512;
 
 fn get_balance(purse_id: PurseId) -> Option<U512> {
-    let mint_public_hash = get_uref("mint").expect("should have mint uref");
-    let mint_contract_key: Key = read(mint_public_hash.to_u_ptr().unwrap_or_else(|| revert(103)));
+    let mint_public_hash = get_uref("mint").unwrap_or_else(|| revert(100));
+    let mint_public_uptr = mint_public_hash.to_u_ptr().unwrap_or_else(|| revert(101));
+    let mint_contract_key: Key = read(mint_public_uptr);
 
     let mint_contract_pointer = match mint_contract_key.to_c_ptr() {
         Some(ptr) => ptr,
-        None => revert(104),
+        None => revert(102),
     };
 
     let main_purse_uref: URef = purse_id.value();
@@ -42,7 +43,7 @@ pub extern "C" fn call() {
     let transfer_result = transfer_from_purse_to_account(source, destination, amount);
 
     // // Assert is done here
-    let final_balance = get_balance(source).unwrap_or_else(|| revert(104));
+    let final_balance = get_balance(source).unwrap_or_else(|| revert(103));
 
     let result = format!("{:?}", transfer_result);
     // Add new urefs

--- a/execution-engine/test-contracts/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/test-contracts/transfer-purse-to-account/src/lib.rs
@@ -16,7 +16,7 @@ use cl_std::value::account::{PublicKey, PurseId};
 use cl_std::value::U512;
 
 fn get_balance(purse_id: PurseId) -> Option<U512> {
-    let mint_public_hash = get_uref("mint");
+    let mint_public_hash = get_uref("mint").expect("should have mint uref");
     let mint_contract_key: Key = read(mint_public_hash.to_u_ptr().unwrap_or_else(|| revert(103)));
 
     let mint_contract_pointer = match mint_contract_key.to_c_ptr() {

--- a/execution-engine/test-contracts/transfer-purse-to-purse/src/lib.rs
+++ b/execution-engine/test-contracts/transfer-purse-to-purse/src/lib.rs
@@ -16,7 +16,7 @@ use cl_std::value::account::PurseId;
 use cl_std::value::U512;
 
 fn get_balance(purse_id: PurseId) -> Option<U512> {
-    let mint_public_hash = get_uref("mint");
+    let mint_public_hash = get_uref("mint").expect("should have mint uref");
     let mint_contract_key: Key = read(mint_public_hash.to_u_ptr().unwrap_or_else(|| revert(103)));
 
     let mint_contract_pointer = match mint_contract_key.to_c_ptr() {
@@ -40,7 +40,10 @@ pub extern "C" fn call() {
     add_uref("purse:main", &Key::from(main_purse.value()));
 
     let src_purse_name: String = get_arg(0);
-    let src_purse = match get_uref(&src_purse_name).as_uref() {
+    let src_purse = match get_uref(&src_purse_name)
+        .unwrap_or_else(|| panic!("should have uref {}", src_purse_name))
+        .as_uref()
+    {
         Some(uref) => PurseId::new(*uref),
         None => revert(101),
     };
@@ -53,7 +56,8 @@ pub extern "C" fn call() {
         add_uref(&dst_purse_name, &purse.value().into());
         purse
     } else {
-        let uref_key = get_uref(&dst_purse_name);
+        let uref_key = get_uref(&dst_purse_name)
+            .unwrap_or_else(|| panic!("should have uref {}", dst_purse_name));
         match uref_key.as_uref() {
             Some(uref) => PurseId::new(*uref),
             None => revert(102),

--- a/execution-engine/validator-contracts/bonding/src/lib.rs
+++ b/execution-engine/validator-contracts/bonding/src/lib.rs
@@ -19,8 +19,8 @@ const POS_CONTRACT_NAME: &str = "pos";
 // Issues bonding request to the PoS contract.
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> =
-        unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME).to_u_ptr(), 66);
+    let pos_uref = unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME), 55);
+    let pos_public: UPointer<Key> = unwrap_or_revert(pos_uref.to_u_ptr(), 66);
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 

--- a/execution-engine/validator-contracts/unbonding/src/lib.rs
+++ b/execution-engine/validator-contracts/unbonding/src/lib.rs
@@ -20,8 +20,8 @@ const UNBOND_METHOD_NAME: &str = "unbond";
 // Otherwise (`Some<u64>`) unbonds with part of the bonded stakes.
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> =
-        unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME).to_u_ptr(), 66);
+    let pos_uref = unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME), 55);
+    let pos_public: UPointer<Key> = unwrap_or_revert(pos_uref.to_u_ptr(), 66);
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 

--- a/integration-testing/contracts/Cargo.lock
+++ b/integration-testing/contracts/Cargo.lock
@@ -33,7 +33,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -61,7 +61,7 @@ dependencies = [
 name = "combined-contracts-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
@@ -122,14 +122,14 @@ dependencies = [
 name = "get-caller-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "get-caller-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
@@ -150,14 +150,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "list-known-urefs-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "list-known-urefs-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
@@ -412,98 +412,98 @@ dependencies = [
 name = "test-bonding-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-call-hello-name"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-counter-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-counter-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-direct-revert-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-direct-revert-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-mailing-list-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-mailing-list-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-store-hello-name"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-subcall-revert-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-subcall-revert-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test-unbonding-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test_args_multi"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
 name = "test_args_u32"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]
@@ -514,7 +514,7 @@ version = "0.1.0"
 name = "transfer_to_account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.9.0",
+ "casperlabs-contract-ffi 0.10.0",
 ]
 
 [[package]]

--- a/integration-testing/contracts/bonding/call/src/lib.rs
+++ b/integration-testing/contracts/bonding/call/src/lib.rs
@@ -14,7 +14,7 @@ use common::contract_api::{call_contract, PurseTransferResult, get_uref, transfe
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = get_uref("pos").to_u_ptr().unwrap();
+    let pos_public: UPointer<Key> = get_uref("pos").unwrap().to_u_ptr().unwrap();
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = pos_contract.to_c_ptr().unwrap();
 

--- a/integration-testing/contracts/combined-contracts/define/src/lib.rs
+++ b/integration-testing/contracts/combined-contracts/define/src/lib.rs
@@ -29,7 +29,7 @@ pub extern "C" fn hello_name_ext() {
 
 
 fn get_list_key(name: &str) -> UPointer<Vec<String>> {
-    get_uref(name).to_u_ptr().unwrap()
+    get_uref(name).unwrap().to_u_ptr().unwrap()
 }
 
 fn update_list(name: String) {
@@ -88,7 +88,7 @@ fn publish(msg: String) {
 
 #[no_mangle]
 pub extern "C" fn counter_ext() {
-    let i_key: UPointer<i32> = get_uref("count").to_u_ptr().unwrap();
+    let i_key: UPointer<i32> = get_uref("count").unwrap().to_u_ptr().unwrap();
     let method_name: String = get_arg(0);
     match method_name.as_str() {
         "inc" => add(i_key, 1),

--- a/integration-testing/contracts/counter/call/src/lib.rs
+++ b/integration-testing/contracts/counter/call/src/lib.rs
@@ -11,7 +11,8 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pointer = if let Key::Hash(hash) = get_uref("counter") {
+    let counter_uref = get_uref("counter").unwrap_or_else(|| revert(100));
+    let pointer = if let Key::Hash(hash) = counter_uref {
         ContractPointer::Hash(hash)
     } else {
         revert(66)

--- a/integration-testing/contracts/counter/define/src/lib.rs
+++ b/integration-testing/contracts/counter/define/src/lib.rs
@@ -13,7 +13,7 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn counter_ext() {
-    let i_key: UPointer<i32> = get_uref("count").to_u_ptr().unwrap();
+    let i_key: UPointer<i32> = get_uref("count").unwrap().to_u_ptr().unwrap();
     let method_name: String = get_arg(0);
     match method_name.as_str() {
         "inc" => add(i_key, 1),

--- a/integration-testing/contracts/get-caller/call/src/lib.rs
+++ b/integration-testing/contracts/get-caller/call/src/lib.rs
@@ -11,7 +11,8 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pointer = if let Key::Hash(hash) = get_uref("get_caller") {
+    let get_caller_uref = get_uref("get_caller").unwrap_or_else(|| revert(100));
+    let pointer = if let Key::Hash(hash) = get_caller_uref {
         ContractPointer::Hash(hash)
     } else {
         revert(66)

--- a/integration-testing/contracts/hello-name/call/src/lib.rs
+++ b/integration-testing/contracts/hello-name/call/src/lib.rs
@@ -13,7 +13,9 @@ use common::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pointer = if let Key::Hash(hash) = get_uref("hello_name") {
+
+    let hello_name_uref = get_uref("hello_name").unwrap_or_else(|| revert(100));
+    let pointer = if let Key::Hash(hash) = hello_name_uref {
         ContractPointer::Hash(hash)
     } else {
         revert(66); // exit code is currently arbitrary

--- a/integration-testing/contracts/list-known-urefs/call/src/lib.rs
+++ b/integration-testing/contracts/list-known-urefs/call/src/lib.rs
@@ -11,7 +11,8 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pointer = if let Key::Hash(hash) = get_uref("list_known_urefs") {
+    let list_known_urefs_uref = get_uref("list_known_urefs").unwrap_or_else(|| revert(100));
+    let pointer = if let Key::Hash(hash) = list_known_urefs_uref {
         ContractPointer::Hash(hash)
     } else {
         revert(66); // exit code is currently arbitrary

--- a/integration-testing/contracts/list-known-urefs/define/src/lib.rs
+++ b/integration-testing/contracts/list-known-urefs/define/src/lib.rs
@@ -7,14 +7,14 @@ extern crate common;
 use alloc::borrow::ToOwned;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
-use common::contract_api::{add_uref, get_uref, list_known_urefs, new_uref, store_function};
+use common::contract_api::{add_uref, get_uref, list_known_urefs, new_uref, store_function, revert};
 use common::key::Key;
 use common::value::Value;
 use core::iter;
 
 #[no_mangle]
 pub extern "C" fn list_known_urefs_ext() {
-    let passed_in_uref = get_uref("Foo");
+    let passed_in_uref = get_uref("Foo").unwrap_or_else(|| revert(100));
     let uref = new_uref(Value::String("Test".to_owned()));
     add_uref("Bar", &uref.clone().into());
     let contracts_known_urefs = list_known_urefs();

--- a/integration-testing/contracts/mailing-list/call/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/call/src/lib.rs
@@ -12,7 +12,8 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pointer = if let Key::Hash(hash) = get_uref("mailing") {
+    let mailing_uref = get_uref("mailing").unwrap_or_else(|| revert(100));
+    let pointer = if let Key::Hash(hash) = mailing_uref {
         ContractPointer::Hash(hash)
     } else {
         revert(66); // exit code is currently arbitrary
@@ -25,7 +26,9 @@ pub extern "C" fn call() {
         Some(sub_key) => {
             let key_name = "mail_feed";
             add_uref(key_name, &sub_key);
-            if sub_key != get_uref(key_name){
+
+            let key_name_uref = get_uref(key_name).unwrap_or_else(|| revert(101));
+            if sub_key != key_name_uref {
                 revert(1);
             }
 

--- a/integration-testing/contracts/mailing-list/define/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/define/src/lib.rs
@@ -14,7 +14,7 @@ use common::key::Key;
 use common::uref::URef;
 
 fn get_list_key(name: &str) -> UPointer<Vec<String>> {
-    get_uref(name).to_u_ptr().unwrap()
+    get_uref(name).unwrap().to_u_ptr().unwrap()
 }
 
 fn update_list(name: String) {

--- a/integration-testing/contracts/subcall-revert-test/call/src/lib.rs
+++ b/integration-testing/contracts/subcall-revert-test/call/src/lib.rs
@@ -11,7 +11,8 @@ use common::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pointer = if let Key::Hash(hash) = get_uref("revert_test") {
+    let revert_test_uref = get_uref("revert_test").unwrap_or_else(|| revert(100));
+    let pointer = if let Key::Hash(hash) = revert_test_uref {
         ContractPointer::Hash(hash)
     } else {
         revert(66); // exit code is currently arbitrary

--- a/integration-testing/contracts/unbonding/call/src/lib.rs
+++ b/integration-testing/contracts/unbonding/call/src/lib.rs
@@ -12,7 +12,7 @@ use common::value::uint::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = contract_api::get_uref("pos").to_u_ptr().unwrap();
+    let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = pos_contract.to_c_ptr().unwrap();
 


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

Calling `get_uref` with non existing uref makes the execution fail.

This PR adds a failing test case that proves `get_uref` bug, and contains a fix that changes `get_uref` signature that returns `Option<Key>` instead.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-221

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
