### PR TITLE
EE-436: Change `URef::as_string` to be less problematic

### DIFF
--- a/execution-engine/blessed-contracts/mint-token/src/lib.rs
+++ b/execution-engine/blessed-contracts/mint-token/src/lib.rs
@@ -38,10 +38,12 @@ impl Mint<ARef<U512>, RAWRef<U512>> for CLMint {
         let balance_uref: Key = contract_api::new_uref(initial_balance).into();
 
         let purse_key: URef = contract_api::new_uref(()).into();
+        let purse_uref_name = purse_key.remove_access_rights().as_string();
+
         let purse_id: WithdrawId = WithdrawId::from_uref(purse_key).unwrap();
 
         // store balance uref so that the runtime knows the mint has full access
-        contract_api::add_uref(&format!("{:?}", purse_id.raw_id()), &balance_uref);
+        contract_api::add_uref(&purse_uref_name, &balance_uref);
 
         // store association between purse id and balance uref
         //

--- a/execution-engine/comm/tests/test_transfer_purse_to_account.rs
+++ b/execution-engine/comm/tests/test_transfer_purse_to_account.rs
@@ -112,7 +112,7 @@ fn should_run_purse_to_account_transfer() {
 
     let new_purse_id = new_account.purse_id();
     // This is the new PurseId lookup key that will be present in AddKeys for a mint contract uref
-    let new_purse_id_lookup_key = format!("{:?}", new_purse_id.value().addr());
+    let new_purse_id_lookup_key = new_purse_id.value().remove_access_rights().as_string();
 
     // Obtain transforms for a mint account
     let mint_contract_uref = transfer_result.builder().get_mint_contract_uref();

--- a/execution-engine/comm/tests/test_transfer_purse_to_purse.rs
+++ b/execution-engine/comm/tests/test_transfer_purse_to_purse.rs
@@ -84,7 +84,11 @@ fn should_run_purse_to_purse_transfer() {
 
     // Lookup key used to find the actual purse uref
     // TODO: This should be more consistent
-    let purse_secondary_lookup_key = format!("{:?}", purse_secondary_key.as_uref().unwrap().addr());
+    let purse_secondary_lookup_key = purse_secondary_key
+        .as_uref()
+        .unwrap()
+        .remove_access_rights()
+        .as_string();
 
     let mint_contract_uref = transfer_result.builder().get_mint_contract_uref();
     // Obtain transforms for a mint account
@@ -200,7 +204,11 @@ fn should_run_purse_to_purse_transfer_with_error() {
 
     // Lookup key used to find the actual purse uref
     // TODO: This should be more consistent
-    let purse_secondary_lookup_key = format!("{:?}", purse_secondary_key.as_uref().unwrap().addr());
+    let purse_secondary_lookup_key = purse_secondary_key
+        .as_uref()
+        .unwrap()
+        .remove_access_rights()
+        .as_string();
 
     // Find `purse:secondary` for a balance
     let purse_secondary_uref = &mint_addkeys[&purse_secondary_lookup_key];

--- a/execution-engine/common/src/base16.rs
+++ b/execution-engine/common/src/base16.rs
@@ -1,0 +1,12 @@
+use crate::alloc::prelude::String;
+
+/// Encodes a slice of bytes in base16 form in lower case
+pub fn encode_lower(input: &[u8]) -> String {
+    input.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+#[test]
+fn test_encode_lower() {
+    assert_eq!(encode_lower(&[1, 2, 3, 254, 255]), "010203feff");
+    assert_eq!(encode_lower(&[]), "");
+}

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -26,6 +26,7 @@ extern crate proptest;
 #[global_allocator]
 pub static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
+pub mod base16;
 pub mod bytesrepr;
 pub mod contract_api;
 #[cfg(any(test, feature = "gens"))]


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

- Changes format of `URef::as_string` to be fixed in size, and handle optional `access_rights` in a future proof way (`None` just becomes 0, and valid access rights are encoded in octal)
- Mint contract uses `URef::as_string` after calling `URef::remove_access_rights` which should be similar in effect to earlier behavior where `Debug` trait implementation of `[u8; 32]` was used (access rights were discarded)

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-436

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
