### PR TITLE
NO-TICKET: execution-engine/common: fix warning

### DIFF
--- a/execution-engine/common/src/uref.rs
+++ b/execution-engine/common/src/uref.rs
@@ -105,6 +105,7 @@ impl URef {
 
     /// Creates a [`URef`] from an id and optional access rights.  [`URef::new`] is the
     /// preferred constructor for most common use-cases.
+    #[cfg(feature = "gens")]
     pub(crate) fn unsafe_new(
         id: [u8; UREF_ADDR_SIZE],
         maybe_access_rights: Option<AccessRights>,


### PR DESCRIPTION
### Overview
This PR fixes a compilation warning in the `common` crate.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
