### PR TITLE
EE-406: Mint's "transfer" method should return an enum value, not a string

### DIFF
--- a/execution-engine/blessed-contracts/mint-token/src/internal_purse_id.rs
+++ b/execution-engine/blessed-contracts/mint-token/src/internal_purse_id.rs
@@ -1,24 +1,6 @@
-use core::fmt;
-
 use cl_std::contract_api;
-use cl_std::uref::{AccessRights, URef};
-
-#[derive(Debug, Copy, Clone)]
-pub enum PurseIdError {
-    InvalidURef,
-    InvalidAccessRights(Option<AccessRights>),
-}
-
-impl fmt::Display for PurseIdError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            PurseIdError::InvalidURef => write!(f, "invalid uref"),
-            PurseIdError::InvalidAccessRights(maybe_access_rights) => {
-                write!(f, "invalid access rights: {:?}", maybe_access_rights)
-            }
-        }
-    }
-}
+use cl_std::system_contracts::mint::purse_id::PurseIdError;
+use cl_std::uref::URef;
 
 pub struct WithdrawId([u8; 32]);
 

--- a/execution-engine/blessed-contracts/mint-token/src/lib.rs
+++ b/execution-engine/blessed-contracts/mint-token/src/lib.rs
@@ -20,6 +20,7 @@ use core::convert::TryInto;
 
 use cl_std::contract_api;
 use cl_std::key::Key;
+use cl_std::system_contracts::mint::error::Error;
 use cl_std::uref::{AccessRights, URef};
 use cl_std::value::U512;
 
@@ -94,20 +95,22 @@ pub extern "C" fn call() {
 
             let source: WithdrawId = match WithdrawId::from_uref(source) {
                 Ok(withdraw_id) => withdraw_id,
-                Err(error) => contract_api::ret(&format!("Error: {}", error), &vec![]),
+                Err(error) => {
+                    let transfer_result: Result<(), Error> = Err(error.into());
+                    contract_api::ret(&transfer_result, &vec![])
+                }
             };
 
             let target: DepositId = match DepositId::from_uref(target) {
                 Ok(deposit_id) => deposit_id,
-                Err(error) => contract_api::ret(&format!("Error: {}", error), &vec![]),
+                Err(error) => {
+                    let transfer_result: Result<(), Error> = Err(error.into());
+                    contract_api::ret(&transfer_result, &vec![])
+                }
             };
 
-            let transfer_message = match mint.transfer(source, target, amount) {
-                Ok(_) => String::from("Successful transfer"),
-                Err(e) => format!("Error: {:?}", e),
-            };
-
-            contract_api::ret(&transfer_message, &vec![]);
+            let transfer_result = mint.transfer(source, target, amount);
+            contract_api::ret(&transfer_result, &vec![]);
         }
 
         _ => panic!("Unknown method name!"),

--- a/execution-engine/blessed-contracts/mint-token/src/mint.rs
+++ b/execution-engine/blessed-contracts/mint-token/src/mint.rs
@@ -1,13 +1,7 @@
 use cl_std::value::U512;
 
 use capabilities::{Addable, Readable, Writable};
-
-#[derive(Debug, PartialEq, Eq)]
-pub enum Error {
-    InsufficientFunds,
-    SourceNotFound,
-    DestNotFound,
-}
+use cl_std::system_contracts::mint::error::Error;
 
 pub trait Mint<A, RW>
 where

--- a/execution-engine/common/src/gens.rs
+++ b/execution-engine/common/src/gens.rs
@@ -9,7 +9,7 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use proptest::collection::{btree_map, vec};
 use proptest::prelude::*;
-use proptest::{array, bits, option};
+use proptest::{array, bits, option, result};
 
 pub fn u8_slice_32() -> impl Strategy<Value = [u8; 32]> {
     vec(any::<u8>(), 32).prop_map(|b| {
@@ -161,4 +161,8 @@ pub fn value_arb() -> impl Strategy<Value = Value> {
         Just(Value::Unit),
         (any::<u64>().prop_map(Value::UInt64)),
     ]
+}
+
+pub fn result_arb() -> impl Strategy<Value = Result<u32, u32>> {
+    result::maybe_ok(any::<u32>(), any::<u32>())
 }

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -32,6 +32,7 @@ pub mod contract_api;
 #[cfg(any(test, feature = "gens"))]
 pub mod gens;
 pub mod key;
+pub mod system_contracts;
 #[cfg(any(test, feature = "gens"))]
 pub mod test_utils;
 pub mod uref;

--- a/execution-engine/common/src/system_contracts/error.rs
+++ b/execution-engine/common/src/system_contracts/error.rs
@@ -1,0 +1,13 @@
+use crate::system_contracts::mint;
+
+/// An aggregate enum error with variants for each system contract's error.
+#[derive(Debug)]
+pub enum Error {
+    MintError(mint::error::Error),
+}
+
+impl From<mint::error::Error> for Error {
+    fn from(error: mint::error::Error) -> Error {
+        Error::MintError(error)
+    }
+}

--- a/execution-engine/common/src/system_contracts/mint/error.rs
+++ b/execution-engine/common/src/system_contracts/mint/error.rs
@@ -1,0 +1,62 @@
+/// Implementation of error codes that are shared between contract
+/// implementation and FFI.
+use alloc::vec::Vec;
+
+use crate::bytesrepr::{self, FromBytes, ToBytes};
+use crate::system_contracts::mint::purse_id::PurseIdError;
+
+/// An enum error that is capable of carrying a value across FFI-Host
+/// boundary.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[repr(u32)]
+pub enum Error {
+    InsufficientFunds = 0,
+    SourceNotFound = 1,
+    DestNotFound = 2,
+    /// See PurseIdError::InvalidURef
+    InvalidURef = 3,
+    /// See PurseIdError::InvalidAccessRights
+    InvalidAccessRights = 4,
+}
+
+impl From<PurseIdError> for Error {
+    fn from(purse_id_error: PurseIdError) -> Error {
+        match purse_id_error {
+            PurseIdError::InvalidURef => Error::InvalidURef,
+            PurseIdError::InvalidAccessRights(_) => {
+                // This one does not carry state from PurseIdError to the
+                // new Error enum. The reason is that Error is supposed to
+                // be simple in serialization and deserialization, so extra
+                // state is currently discarded.
+                Error::InvalidAccessRights
+            }
+        }
+    }
+}
+
+impl From<u32> for Error {
+    fn from(value: u32) -> Error {
+        match value {
+            d if d == Error::InsufficientFunds as u32 => Error::InsufficientFunds,
+            d if d == Error::SourceNotFound as u32 => Error::SourceNotFound,
+            d if d == Error::DestNotFound as u32 => Error::DestNotFound,
+            d if d == Error::InvalidURef as u32 => Error::InvalidURef,
+            d if d == Error::InvalidAccessRights as u32 => Error::InvalidAccessRights,
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl ToBytes for Error {
+    fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
+        let value = *self as u32;
+        value.to_bytes()
+    }
+}
+
+impl FromBytes for Error {
+    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
+        let (value, rem): (u32, _) = FromBytes::from_bytes(bytes)?;
+        Ok((value.into(), rem))
+    }
+}

--- a/execution-engine/common/src/system_contracts/mint/mod.rs
+++ b/execution-engine/common/src/system_contracts/mint/mod.rs
@@ -1,0 +1,2 @@
+pub mod error;
+pub mod purse_id;

--- a/execution-engine/common/src/system_contracts/mint/purse_id.rs
+++ b/execution-engine/common/src/system_contracts/mint/purse_id.rs
@@ -1,0 +1,19 @@
+use crate::uref::AccessRights;
+use alloc::fmt;
+
+#[derive(Debug, Copy, Clone)]
+pub enum PurseIdError {
+    InvalidURef,
+    InvalidAccessRights(Option<AccessRights>),
+}
+
+impl fmt::Display for PurseIdError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            PurseIdError::InvalidURef => write!(f, "invalid uref"),
+            PurseIdError::InvalidAccessRights(maybe_access_rights) => {
+                write!(f, "invalid access rights: {:?}", maybe_access_rights)
+            }
+        }
+    }
+}

--- a/execution-engine/common/src/system_contracts/mod.rs
+++ b/execution-engine/common/src/system_contracts/mod.rs
@@ -1,0 +1,8 @@
+//! Supporting code for system contract implementation.
+//!
+//! Submodules contains supporting code and logic that is shared between host
+//! and the contract implementation.
+//!
+//! Naming of the modules is related to actual system contract that is user of
+//! the supporting code i.e. mint.
+pub mod mint;

--- a/execution-engine/common/src/system_contracts/mod.rs
+++ b/execution-engine/common/src/system_contracts/mod.rs
@@ -5,4 +5,5 @@
 //!
 //! Naming of the modules is related to actual system contract that is user of
 //! the supporting code i.e. mint.
+pub mod error;
 pub mod mint;

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -798,12 +798,12 @@ where
         amount_ptr: u32,
         amount_size: u32,
     ) -> Result<PurseTransferResult, Error> {
-        let source_purse: PurseId = {
+        let source: PurseId = {
             let bytes = self.bytes_from_mem(source_ptr, source_size as usize)?;
             deserialize(&bytes).map_err(Error::BytesRepr)?
         };
 
-        let target_purse: PurseId = {
+        let target: PurseId = {
             let bytes = self.bytes_from_mem(target_ptr, target_size as usize)?;
             deserialize(&bytes).map_err(Error::BytesRepr)?
         };
@@ -815,7 +815,7 @@ where
 
         let mint_contract_key = Key::URef(self.get_mint_contract_uref()?);
 
-        match self.mint_transfer(mint_contract_key, source_purse, target_purse, amount) {
+        match self.mint_transfer(mint_contract_key, source, target, amount) {
             Ok(_) => Ok(PurseTransferResult::TransferSuccessful),
             Err(_) => Ok(PurseTransferResult::TransferError),
         }

--- a/execution-engine/engine/src/execution.rs
+++ b/execution-engine/engine/src/execution.rs
@@ -21,6 +21,7 @@ use common::bytesrepr::{deserialize, Error as BytesReprError, ToBytes, U32_SIZE}
 use common::contract_api::argsparser::ArgsParser;
 use common::contract_api::{PurseTransferResult, TransferResult};
 use common::key::Key;
+use common::system_contracts::mint;
 use common::uref::{AccessRights, URef};
 use common::value::account::{
     ActionType, AddKeyFailure, BlockTime, PublicKey, PurseId, RemoveKeyFailure,
@@ -72,6 +73,7 @@ pub enum Error {
     AddKeyFailure(AddKeyFailure),
     RemoveKeyFailure(RemoveKeyFailure),
     SetThresholdFailure(SetThresholdFailure),
+    MintError(mint::error::Error),
 }
 
 impl fmt::Display for Error {
@@ -131,6 +133,12 @@ impl From<RemoveKeyFailure> for Error {
 impl From<SetThresholdFailure> for Error {
     fn from(err: SetThresholdFailure) -> Error {
         Error::SetThresholdFailure(err)
+    }
+}
+
+impl From<mint::error::Error> for Error {
+    fn from(err: mint::error::Error) -> Error {
+        Error::MintError(err)
     }
 }
 
@@ -647,7 +655,7 @@ where
         source: PurseId,
         target: PurseId,
         amount: U512,
-    ) -> Result<bool, Error> {
+    ) -> Result<(), Error> {
         let source_value: URef = source.value();
         let target_value: URef = target.value();
 
@@ -660,9 +668,11 @@ where
 
         self.call_contract(mint_contract_key, args_bytes, urefs_bytes)?;
 
-        let result: String = deserialize(&self.host_buf)?;
-
-        Ok(&result == "Successful transfer")
+        // This will deserialize `host_buf` into the Result type which carries
+        // mint contract error.
+        let result: Result<(), mint::error::Error> = deserialize(&self.host_buf)?;
+        // Wraps mint error into a more general error type
+        result.map_err(Error::from)
     }
 
     /// Creates a new account at a given public key, transferring a given amount of tokens from
@@ -686,33 +696,34 @@ where
             return Ok(TransferResult::TransferError);
         }
 
-        if self.mint_transfer(mint_contract_key, source, target_purse_id, amount)? {
-            let known_urefs = vec![
-                (
-                    String::from(MINT_NAME),
-                    self.get_mint_contract_public_uref_key()?,
-                ),
-                (
-                    String::from(POS_NAME),
-                    self.get_pos_contract_public_uref_key()?,
-                ),
-                (pos_contract_uref.as_string(), pos_contract_key),
-                (mint_contract_uref.as_string(), mint_contract_key),
-            ]
-            .into_iter()
-            .map(|(name, key)| {
-                if let Some(uref) = key.as_uref() {
-                    (name, Key::URef(URef::new(uref.addr(), AccessRights::READ)))
-                } else {
-                    (name, key)
-                }
-            })
-            .collect();
-            let account = Account::create(target_addr, known_urefs, target_purse_id);
-            self.context.write_account(target_key, account)?;
-            Ok(TransferResult::TransferredToNewAccount)
-        } else {
-            Ok(TransferResult::TransferError)
+        match self.mint_transfer(mint_contract_key, source, target_purse_id, amount) {
+            Ok(_) => {
+                let known_urefs = vec![
+                    (
+                        String::from(MINT_NAME),
+                        self.get_mint_contract_public_uref_key()?,
+                    ),
+                    (
+                        String::from(POS_NAME),
+                        self.get_pos_contract_public_uref_key()?,
+                    ),
+                    (pos_contract_uref.as_string(), pos_contract_key),
+                    (mint_contract_uref.as_string(), mint_contract_key),
+                ]
+                .into_iter()
+                .map(|(name, key)| {
+                    if let Some(uref) = key.as_uref() {
+                        (name, Key::URef(URef::new(uref.addr(), AccessRights::READ)))
+                    } else {
+                        (name, key)
+                    }
+                })
+                .collect();
+                let account = Account::create(target_addr, known_urefs, target_purse_id);
+                self.context.write_account(target_key, account)?;
+                Ok(TransferResult::TransferredToNewAccount)
+            }
+            Err(_) => Ok(TransferResult::TransferError),
         }
     }
 
@@ -730,10 +741,9 @@ where
         // This appears to be a load-bearing use of `RuntimeContext::insert_uref`.
         self.context.insert_uref(target.value());
 
-        if self.mint_transfer(mint_contract_key, source, target, amount)? {
-            Ok(TransferResult::TransferredToExistingAccount)
-        } else {
-            Ok(TransferResult::TransferError)
+        match self.mint_transfer(mint_contract_key, source, target, amount) {
+            Ok(_) => Ok(TransferResult::TransferredToExistingAccount),
+            Err(_) => Ok(TransferResult::TransferError),
         }
     }
 
@@ -805,11 +815,9 @@ where
 
         let mint_contract_key = Key::URef(self.get_mint_contract_uref()?);
 
-        if self.mint_transfer(mint_contract_key, source_purse, target_purse, amount)? {
-            Ok(PurseTransferResult::TransferSuccessful)
-        } else {
-            // TODO: Improve returned type (insufficient funds/access rights, non-existent purses)
-            Ok(PurseTransferResult::TransferError)
+        match self.mint_transfer(mint_contract_key, source_purse, target_purse, amount) {
+            Ok(_) => Ok(PurseTransferResult::TransferSuccessful),
+            Err(_) => Ok(PurseTransferResult::TransferError),
         }
     }
 }


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

This changes the way mint's `transfer` function works: now it returns an `Error` enum that's defined on the host side. With this PR system contracts share _some_ logic on contract side and on host side.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-406

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
