### PR TITLE
EE-524: Add impl TryFrom<&[u8]> for PublicKey.

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -903,8 +903,8 @@ fn execution_error(msg: String, cost: u64, effect: ExecutionEffect) -> ipc::Depl
 }
 
 pub fn to_domain_validators(bond: &ipc::Bond) -> Result<(PublicKey, U512), String> {
-    let pk = PublicKey::from_slice(bond.get_validator_public_key())
-        .ok_or("Public key has to be exactly 32 bytes long.")?;
+    let pk = PublicKey::try_from(bond.get_validator_public_key())
+        .map_err(|_| "Public key has to be exactly 32 bytes long.")?;
     match bond.get_stake().try_into() {
         Ok(bond) => Ok((pk, bond)),
         Err(err) => {

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -282,13 +282,13 @@ impl From<[u8; KEY_SIZE]> for PublicKey {
 }
 
 #[derive(Debug)]
-pub struct TryFromSliceForPublicKeyError;
+pub struct TryFromSliceForPublicKeyError(());
 
 impl TryFrom<&[u8]> for PublicKey {
-    type Error = TryPublicKeyFromSliceError;
+    type Error = TryFromSliceForPublicKeyError;
     fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
         if bytes.len() != KEY_SIZE {
-            return Err(TryPublicKeyFromSliceError);
+            return Err(TryFromSliceForPublicKeyError(()));
         }
         let mut public_key = [0u8; 32];
         public_key.copy_from_slice(bytes);

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -282,7 +282,7 @@ impl From<[u8; KEY_SIZE]> for PublicKey {
 }
 
 #[derive(Debug)]
-pub struct TryPublicKeyFromSliceError;
+pub struct TryFromSliceForPublicKeyError;
 
 impl TryFrom<&[u8]> for PublicKey {
     type Error = TryPublicKeyFromSliceError;


### PR DESCRIPTION
This change refactors `PublicKey::from_slice` into using actual
`TryFrom` trait in preparation for EE-525.

### Overview
_Provide a brief description of what this PR does, and why it's needed._

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._
https://casperlabs.atlassian.net/browse/EE-525

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
