### PR TITLE
EE-539: Fix action thresholds mapping

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -383,6 +383,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ee-539-regression"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.10.0",
+]
+
+[[package]]
 name = "either"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "contracts/test/blessed-urefs-access-rights",
     "contracts/test/transfer-purse-to-account",
     "contracts/test/deserialize-error",
+    "contracts/test/ee-539-regression",
     "contracts/validator/bonding",
     "contracts/validator/unbonding",
     "engine",

--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -335,17 +335,13 @@ impl TryFrom<&super::state::Account> for common::value::account::Account {
                     "Missing ActionThresholds object of the Account IPC message.".to_string(),
                 );
             };
-            let mut tmp: ActionThresholds = Default::default();
             let action_thresholds_ipc = value.get_action_thresholds();
-            tmp.set_deployment_threshold(Weight::new(
-                action_thresholds_ipc.get_deployment_threshold() as u8,
-            ))
-            .map_err(ParsingError::custom)?;
-            tmp.set_key_management_threshold(Weight::new(
-                action_thresholds_ipc.get_key_management_threshold() as u8,
-            ))
-            .map_err(ParsingError::custom)?;
-            tmp
+
+            ActionThresholds::new(
+                Weight::new(action_thresholds_ipc.get_deployment_threshold() as u8),
+                Weight::new(action_thresholds_ipc.get_key_management_threshold() as u8),
+            )
+            .map_err(ParsingError::custom)?
         };
         let account_activity: AccountActivity = {
             if !value.has_account_activity() {

--- a/execution-engine/comm/tests/regression_test_ee_539.rs
+++ b/execution-engine/comm/tests/regression_test_ee_539.rs
@@ -1,0 +1,34 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate common;
+extern crate execution_engine;
+extern crate grpc;
+extern crate shared;
+extern crate storage;
+
+use std::collections::HashMap;
+
+use common::value::account::Weight;
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(dead_code)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+
+#[ignore]
+#[test]
+fn should_run_ee_539_serialize_action_thresholds_regression() {
+    // This test runs a contract that's after every call extends the same key with more data
+    let _result = WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec_with_args(
+            GENESIS_ADDR,
+            "ee_539_regression.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+            (Weight::new(4), Weight::new(3)),
+        )
+        .expect_success()
+        .commit()
+        .finish();
+}

--- a/execution-engine/contracts/test/ee-539-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-539-regression/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ee-539-regression"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@papierski.net>"]
+edition = "2018"
+
+[lib]
+name = "ee_539_regression"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std"]
+
+[dependencies]
+cl_std = { path = "../../../common", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-539-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-539-regression/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![feature(alloc, cell_update)]
+
+extern crate alloc;
+
+extern crate cl_std;
+
+use cl_std::contract_api::{get_arg, revert, set_action_threshold};
+use cl_std::value::account::{ActionType, Weight};
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let key_management_threshold: Weight = get_arg(0);
+    let deployment_threshold: Weight = get_arg(1);
+
+    set_action_threshold(ActionType::KeyManagement, key_management_threshold)
+        .unwrap_or_else(|_| revert(100));
+    set_action_threshold(ActionType::Deployment, deployment_threshold)
+        .unwrap_or_else(|_| revert(200));
+}


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

Test fails with
```
thread 'should_run_ee_539_serialize_action_thresholds_regression' panicked at 'should convert: ParsingError("New threshold should be lower or equal than key management threshold")', src/libcore/result.rs:997:5     
```

The problem is that the mapping tries to create ActionThresholds by creating a default `ActionThresholds` which would have all thresholds set to 1, and then trying to set deploy threshold, which would fail for any new deploy threshold greater than 1.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
