### PR TITLE
EE-538: Add get_associated_key api function

### DIFF
--- a/execution-engine/comm/src/engine_server/mappings/mod.rs
+++ b/execution-engine/comm/src/engine_server/mappings/mod.rs
@@ -262,8 +262,6 @@ impl From<common::value::account::Account> for super::state::Account {
         ipc_account.set_purse_id(account.purse_id().value().into());
         let associated_keys: Vec<super::state::Account_AssociatedKey> = account
             .get_associated_keys()
-            .get_all()
-            .iter()
             .map(|(key, weight)| {
                 let mut ipc_associated_key = super::state::Account_AssociatedKey::new();
                 ipc_associated_key.set_public_key(key.value().to_vec());

--- a/execution-engine/comm/tests/associated_keys.rs
+++ b/execution-engine/comm/tests/associated_keys.rs
@@ -54,8 +54,9 @@ fn should_manage_associated_key() {
         test_support::get_account(&transforms[1], &account_key).expect("should get account")
     };
 
-    let keys = account_1.get_associated_keys();
-    let gen_weight = keys.get(&genesis_key).expect("weight");
+    let gen_weight = account_1
+        .get_associated_key_weight(genesis_key)
+        .expect("weight");
 
     let expected_weight = Weight::new(2);
     assert_eq!(*gen_weight, expected_weight, "unexpected weight");
@@ -77,9 +78,13 @@ fn should_manage_associated_key() {
         test_support::get_account(&transforms[2], &account_key).expect("should get account")
     };
 
-    let keys = account_1.get_associated_keys();
+    //let keys = account_1.get_associated_keys();
 
-    assert_eq!(keys.get(&genesis_key), None, "key should be removed");
+    assert_eq!(
+        account_1.get_associated_key_weight(genesis_key),
+        None,
+        "key should be removed"
+    );
 
     let is_error = builder.is_error();
     assert!(!is_error);

--- a/execution-engine/comm/tests/associated_keys.rs
+++ b/execution-engine/comm/tests/associated_keys.rs
@@ -78,8 +78,6 @@ fn should_manage_associated_key() {
         test_support::get_account(&transforms[2], &account_key).expect("should get account")
     };
 
-    //let keys = account_1.get_associated_keys();
-
     assert_eq!(
         account_1.get_associated_key_weight(genesis_key),
         None,

--- a/execution-engine/common/src/value/account.rs
+++ b/execution-engine/common/src/value/account.rs
@@ -481,8 +481,8 @@ impl AssociatedKeys {
         self.0.get(key)
     }
 
-    pub fn get_all(&self) -> &BTreeMap<PublicKey, Weight> {
-        &self.0
+    pub fn iter(&self) -> impl Iterator<Item = (&PublicKey, &Weight)> {
+        self.0.iter()
     }
 }
 
@@ -566,12 +566,8 @@ impl Account {
         PurseId::new(add_only_uref)
     }
 
-    pub fn associated_keys(&self) -> &AssociatedKeys {
-        &self.associated_keys
-    }
-
-    pub fn get_associated_keys(&self) -> &AssociatedKeys {
-        &self.associated_keys
+    pub fn get_associated_keys(&self) -> impl Iterator<Item = (&PublicKey, &Weight)> {
+        self.associated_keys.iter()
     }
 
     pub fn action_thresholds(&self) -> &ActionThresholds {
@@ -613,6 +609,11 @@ impl Account {
     ) -> Result<(), UpdateKeyFailure> {
         // TODO(mpapierski): Authorized keys check EE-377
         self.associated_keys.update_key(public_key, weight)
+    }
+
+    pub fn get_associated_key_weight(&self, public_key: PublicKey) -> Option<&Weight> {
+        // TODO(mpapierski): Authorized keys check EE-377
+        self.associated_keys.get(&public_key)
     }
 
     pub fn set_action_threshold(

--- a/execution-engine/engine/src/runtime_context.rs
+++ b/execution-engine/engine/src/runtime_context.rs
@@ -1342,8 +1342,7 @@ mod tests {
                 _ => panic!("Invalid transform operation found"),
             };
             account
-                .associated_keys()
-                .get(&public_key)
+                .get_associated_key_weight(public_key)
                 .expect("Public key wasn't added to associated keys");
 
             let new_weight = Weight::new(100);
@@ -1358,8 +1357,7 @@ mod tests {
                 _ => panic!("Invalid transform operation found"),
             };
             let value = account
-                .associated_keys()
-                .get(&public_key)
+                .get_associated_key_weight(public_key)
                 .expect("Public key wasn't added to associated keys");
 
             assert_eq!(value, &new_weight, "value was not updated");
@@ -1377,7 +1375,7 @@ mod tests {
                 _ => panic!("Invalid transform operation found"),
             };
 
-            assert!(account.associated_keys().get(&public_key).is_none());
+            assert!(account.get_associated_key_weight(public_key).is_none());
 
             // Remove a key that was already removed
             runtime_context


### PR DESCRIPTION
This PR modifies the `get_associated_keys` function to return an iterator (and updates call sites), removes the functionally identical `associated_keys` function, modifies `Account` to fully guard usage of an account's AssociatedKeys, and modifies all call sites.

https://casperlabs.atlassian.net/browse/EE-538

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

