### PR TITLE
EE-545: add 'use-payment-code' feature flag

### DIFF
--- a/execution-engine/comm/tests/integration_test_genesis.rs
+++ b/execution-engine/comm/tests/integration_test_genesis.rs
@@ -21,7 +21,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 #[test]
 fn should_run_genesis() {
     let global_state = InMemoryGlobalState::empty().expect("should create global state");
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     let (genesis_request, _) = test_support::create_genesis_request(GENESIS_ADDR, HashMap::new());
 

--- a/execution-engine/comm/tests/integration_test_metrics.rs
+++ b/execution-engine/comm/tests/integration_test_metrics.rs
@@ -51,7 +51,7 @@ fn should_query_with_metrics() {
     let mocked_account = mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let root_hash = global_state.root_hash.to_vec();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     let mut query_request = QueryRequest::new();
     {
@@ -103,7 +103,7 @@ fn should_exec_with_metrics() {
     let mocked_account = mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let root_hash = global_state.root_hash.to_vec();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     let mut exec_request = ExecRequest::new();
     {
@@ -153,7 +153,7 @@ fn should_commit_with_metrics() {
     let mocked_account = mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let root_hash = global_state.root_hash.to_vec();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     let request_options = RequestOptions::new();
 
@@ -199,7 +199,7 @@ fn should_validate_with_metrics() {
     let correlation_id = CorrelationId::new();
     let mocked_account = mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
     let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     let mut validate_request = ValidateRequest::new();
 

--- a/execution-engine/comm/tests/integration_test_transfer.rs
+++ b/execution-engine/comm/tests/integration_test_transfer.rs
@@ -87,7 +87,7 @@ fn should_transfer_to_account() {
     let account_key = Key::Account(ACCOUNT_1_ADDR);
 
     let global_state = InMemoryGlobalState::empty().unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     // Run genesis
 
@@ -185,7 +185,7 @@ fn should_transfer_from_account_to_account() {
     let account_2_key = Key::Account(ACCOUNT_2_ADDR);
 
     let global_state = InMemoryGlobalState::empty().unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     // Run genesis
 
@@ -334,7 +334,7 @@ fn should_transfer_to_existing_account() {
     let account_2_key = Key::Account(ACCOUNT_2_ADDR);
 
     let global_state = InMemoryGlobalState::empty().unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     // Run genesis
 
@@ -489,7 +489,7 @@ fn should_transfer_to_existing_account() {
 #[test]
 fn should_fail_when_insufficient_funds() {
     let global_state = InMemoryGlobalState::empty().unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     // Run genesis
 
@@ -602,7 +602,7 @@ fn should_create_purse() {
     let genesis_account_key = Key::Account(GENESIS_ADDR);
     let account_key = Key::Account(ACCOUNT_1_ADDR);
     let global_state = InMemoryGlobalState::empty().unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     // Run genesis & set up an account
 

--- a/execution-engine/comm/tests/regression_test_ee_401.rs
+++ b/execution-engine/comm/tests/regression_test_ee_401.rs
@@ -24,7 +24,7 @@ const GENESIS_ADDR: [u8; 32] = [0u8; 32];
 #[test]
 fn should_execute_contracts_which_provide_extra_urefs() {
     let global_state = InMemoryGlobalState::empty().unwrap();
-    let engine_state = EngineState::new(global_state);
+    let engine_state = EngineState::new(global_state, Default::default());
 
     // run genesis
 

--- a/execution-engine/comm/tests/test_support.rs
+++ b/execution-engine/comm/tests/test_support.rs
@@ -339,7 +339,7 @@ impl WasmTestBuilder {
 
     pub fn new() -> WasmTestBuilder {
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
-        let engine_state = EngineState::new(global_state);
+        let engine_state = EngineState::new(global_state, Default::default());
         WasmTestBuilder {
             engine_state: Rc::new(engine_state),
             exec_responses: Vec::new(),

--- a/execution-engine/engine/src/engine_state/engine_config.rs
+++ b/execution-engine/engine/src/engine_state/engine_config.rs
@@ -1,0 +1,26 @@
+/// The runtime configuration of the execution engine
+#[derive(Debug)]
+pub struct EngineConfig {
+    use_payment_code: bool,
+}
+
+impl EngineConfig {
+    /// Creates a new engine configuration with default parameters.
+    pub fn new() -> EngineConfig {
+        Default::default()
+    }
+
+    /// Sets the `use_payment_code` field to the given arg.
+    pub fn use_payment_code(mut self, arg: bool) -> EngineConfig {
+        self.use_payment_code = arg;
+        self
+    }
+}
+
+impl Default for EngineConfig {
+    fn default() -> Self {
+        EngineConfig {
+            use_payment_code: false,
+        }
+    }
+}

--- a/execution-engine/engine/src/engine_state/mod.rs
+++ b/execution-engine/engine/src/engine_state/mod.rs
@@ -17,10 +17,12 @@ use tracking_copy::TrackingCopy;
 use wasm_prep::wasm_costs::WasmCosts;
 use wasm_prep::Preprocessor;
 
+pub use self::engine_config::EngineConfig;
 use self::error::{Error, RootNotFound};
 use self::execution_result::ExecutionResult;
 use self::genesis::{create_genesis_effects, GenesisResult};
 
+pub mod engine_config;
 pub mod error;
 pub mod execution_effect;
 pub mod execution_result;
@@ -28,9 +30,9 @@ pub mod genesis;
 pub mod op;
 pub mod utils;
 
+#[derive(Debug)]
 pub struct EngineState<H> {
-    // Tracks the "state" of the blockchain (or is an interface to it).
-    // I think it should be constrained with a lifetime parameter.
+    config: EngineConfig,
     state: Arc<Mutex<H>>,
 }
 
@@ -39,9 +41,13 @@ where
     H: History,
     H::Error: Into<execution::Error>,
 {
-    pub fn new(state: H) -> EngineState<H> {
+    pub fn new(state: H, config: EngineConfig) -> EngineState<H> {
         let state = Arc::new(Mutex::new(state));
-        EngineState { state }
+        EngineState { config, state }
+    }
+
+    pub fn config(&self) -> &EngineConfig {
+        &self.config
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/execution-engine/engine/src/main.rs
+++ b/execution-engine/engine/src/main.rs
@@ -208,7 +208,8 @@ fn main() {
     let global_state = InMemoryGlobalState::from_pairs(CorrelationId::new(), &init_state)
         .expect("Could not create global state");
     let mut state_hash: Blake2bHash = global_state.root_hash;
-    let engine_state = EngineState::new(global_state);
+
+    let engine_state = EngineState::new(global_state, Default::default());
 
     let wasmi_executor = WasmiExecutor;
     let wasm_costs = WasmCosts::from_version(protocol_version).unwrap_or_else(|| {


### PR DESCRIPTION
### Overview
This PR adds a `--use-payment-code` (`-x`) feature flag to the execution engine to help facilitate smooth integration of this upcoming feature.  The feature is disabled by default. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-545

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
