### PR TITLE
NODE-720: Fix initial sync

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -286,7 +286,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: Metrics: 
   ): F[Boolean] =
     for {
       faultTolerance <- FinalityDetector[F].normalizedFaultTolerance(dag, blockHash)
-      _ <- Log[F].info(
+      _ <- Log[F].trace(
             s"Fault tolerance for block ${PrettyPrinter.buildString(blockHash)} is $faultTolerance; threshold is $faultToleranceThreshold"
           )
     } yield faultTolerance > faultToleranceThreshold

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -370,7 +370,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
   }
 
   //todo we need some genenis Contract to pass this test
-//  it should "allow bonding and distribute the joining fee" in {
+// it should "allow bonding and distribute the joining fee" in {
 //    val nodes =
 //      HashSetCasperTestNode.network(
 //        validatorKeys :+ otherSk,
@@ -747,13 +747,13 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       // this block will be propagated to all nodes and force nodes(2) to ask for missing blocks.
       br <- deploy(nodes(0), makeDeployA()) // block h1
 
-      // node(0) just created this block, so it should have it.
+      // node(0) just created this block, soit should have it.
       _ <- nodes(0).casperEff.contains(br) shouldBeF true
       // Let every node get everything.
       _ <- List.fill(22)(propagate(nodes)).toList.sequence
       // By now node(2) should have received all dependencies and added block h1
       _ <- nodes(2).casperEff.contains(br) shouldBeF true
-      // And if we create one more block on top of h1 it should be the only parent.
+      // And if we create one more block on top of h1it should be the only parent.
       nr <- deploy(nodes(2), makeDeployA())
       _ = nr.header.get.parentHashes.map(PrettyPrinter.buildString(_)) shouldBe Seq(
         PrettyPrinter.buildString(br.blockHash)
@@ -845,7 +845,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       // node(1) should have both block2 and block3 at this point and recognize the equivocation.
       // Because node(1) will also see that the signedBlock3 is building on top of signedBlock1Prime,
-      // it should download signedBlock1Prime as an `AdmissibleEquivocation`; otherwise if it didn't
+      //it should download signedBlock1Prime as an `AdmissibleEquivocation`; otherwise if it didn't
       // have an offspring it would be an `IgnorableEquivocation` and dropped.
       _ <- nodes(1).casperEff.contains(signedBlock3) shouldBeF true
       _ <- nodes(1).casperEff.contains(signedBlock1Prime) shouldBeF true
@@ -1268,7 +1268,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _               <- nodes(1).casperEff.deploy(deployB)
       createB         <- nodes(1).casperEff.createBlock
       Created(blockB) = createB
-      // nodes(1) should have more weight then nodes(0) so it should take over
+      // nodes(1) should have more weight then nodes(0) soit should take over
       _  <- nodes(0).casperEff.addBlock(blockB) shouldBeF Valid
       s1 <- nodes(0).casperState.read
       _  = s1.deployBuffer.pendingDeploys should contain key (deployA.deployHash)

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -747,13 +747,13 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       // this block will be propagated to all nodes and force nodes(2) to ask for missing blocks.
       br <- deploy(nodes(0), makeDeployA()) // block h1
 
-      // node(0) just created this block, soit should have it.
+      // node(0) just created this block, so it should have it.
       _ <- nodes(0).casperEff.contains(br) shouldBeF true
       // Let every node get everything.
       _ <- List.fill(22)(propagate(nodes)).toList.sequence
       // By now node(2) should have received all dependencies and added block h1
       _ <- nodes(2).casperEff.contains(br) shouldBeF true
-      // And if we create one more block on top of h1it should be the only parent.
+      // And if we create one more block on top of h1 it should be the only parent.
       nr <- deploy(nodes(2), makeDeployA())
       _ = nr.header.get.parentHashes.map(PrettyPrinter.buildString(_)) shouldBe Seq(
         PrettyPrinter.buildString(br.blockHash)
@@ -1268,7 +1268,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _               <- nodes(1).casperEff.deploy(deployB)
       createB         <- nodes(1).casperEff.createBlock
       Created(blockB) = createB
-      // nodes(1) should have more weight then nodes(0) soit should take over
+      // nodes(1) should have more weight then nodes(0) so it should take over
       _  <- nodes(0).casperEff.addBlock(blockB) shouldBeF Valid
       s1 <- nodes(0).casperState.read
       _  = s1.deployBuffer.pendingDeploys should contain key (deployA.deployHash)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -525,7 +525,7 @@ object GossipServiceCasperTestNodeFactory {
         request: StreamAncestorBlockSummariesRequest
     ): Iterant[F, consensus.BlockSummary] =
       Iterant
-        .liftF(Log[F].info(s"Recevied request for ancestors of ${request.targetBlockHashes
+        .liftF(Log[F].info(s"Received request for ancestors of ${request.targetBlockHashes
           .map(PrettyPrinter.buildString(_))}"))
         .flatMap { _ =>
           underlying.streamAncestorBlockSummaries(request)

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -37,39 +37,56 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log: Metrics](
     // reply about those that we are going to download and relay them,
     // then asynchronously sync the DAG, schedule the downloads,
     // and finally notify the consensus engine.
-    newBlocks(request, (node, hashes) => sync(node, hashes, skipRelaying = false).start)
+    newBlocks(
+      request,
+      skipRelaying = false,
+      (syncOpt, response) => syncOpt.fold(().pure[F])(_.start.void).as(response)
+    )
 
-  /* Same as 'newBlocks' but with synchronous semantics, needed for bootstrapping and some tests. */
+  /* Same as 'newBlocks' but with synchronous semantics, needed for bootstrapping and some tests.
+   * Return any error we encountered during the sync explicitly to make sure the caller handles it. */
   def newBlocksSynchronous(
       request: NewBlocksRequest,
       skipRelaying: Boolean
-  ): F[NewBlocksResponse] =
-    newBlocks(request, (node, hashes) => sync(node, hashes, skipRelaying))
+  ): F[Either[SyncError, NewBlocksResponse]] =
+    newBlocks(
+      request,
+      skipRelaying,
+      (syncOpt, response) =>
+        syncOpt.fold(response.asRight[SyncError].pure[F])(_.map(_.as(response)))
+    )
 
-  private def newBlocks(
+  /** Creates the syncing procedure if there are blocks missing,
+    * then passes the sync to the caller so it can decide whether
+    * it wants to run it in the background or foreground. */
+  private def newBlocks[T](
       request: NewBlocksRequest,
-      sync: (Node, Set[ByteString]) => F[_]
-  ): F[NewBlocksResponse] =
+      skipRelaying: Boolean,
+      start: (Option[F[Either[SyncError, Unit]]], NewBlocksResponse) => F[T]
+  ): F[T] =
     request.blockHashes.distinct.toList
       .filterA { blockHash =>
         backend.hasBlock(blockHash).map(!_)
       }
       .flatMap { newBlockHashes =>
         if (newBlockHashes.isEmpty) {
-          Applicative[F].pure(NewBlocksResponse(isNew = false))
+          start(none, NewBlocksResponse(isNew = false))
         } else {
-          sync(request.getSender, newBlockHashes.toSet).as(NewBlocksResponse(isNew = true))
+          start(
+            sync(request.getSender, newBlockHashes.toSet, skipRelaying).some,
+            NewBlocksResponse(isNew = true)
+          )
         }
       }
 
-  /** Synchronize and download any missing blocks to get to the new ones. */
+  /** Synchronize and download any missing blocks to get to the new ones.
+    * This method will complete when all the downloads are ready. */
   private def sync(
       source: Node,
       newBlockHashes: Set[ByteString],
       skipRelaying: Boolean
-  ): F[Unit] = {
-    //TODO: Define handling strategies
-    def handleSyncError(syncError: SyncError): F[Unit] = {
+  ): F[Either[SyncError, Unit]] = {
+    def logSyncError(syncError: SyncError): F[Unit] = {
       val prefix  = s"Failed to sync DAG, source: ${source.show}."
       val message = syncError.getMessage
       Log[F].warn(s"$prefix $message")
@@ -84,7 +101,7 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log: Metrics](
                      targetBlockHashes = newBlockHashes
                    )
       _ <- dagOrError.fold(
-            syncError => handleSyncError(syncError), { dag =>
+            syncError => logSyncError(syncError), { dag =>
               for {
                 _ <- Log[F].info(s"Syncing ${dag.size} blocks with ${source.show}...")
                 _ <- consensus.onPending(dag)
@@ -107,7 +124,7 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log: Metrics](
               } yield ()
             }
           )
-    } yield ()
+    } yield dagOrError.map(_ => ())
 
     trySync.onError {
       case NonFatal(ex) =>

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/StashingSynchronizer.scala
@@ -48,6 +48,9 @@ class StashingSynchronizer[F[_]: Concurrent: Par](
       res     <- attempt.rethrow
     } yield res
 
+  override def downloaded(blockHash: ByteString) =
+    underlying.downloaded(blockHash)
+
   private def run: F[Unit] =
     for {
       _               <- semaphore.withPermit(transitionedRef.set(true))

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
@@ -19,6 +19,12 @@ trait Synchronizer[F[_]] {
       source: Node,
       targetBlockHashes: Set[ByteString]
   ): F[Either[SyncError, Vector[BlockSummary]]]
+
+  /** Called when the block is finally downloaded to release any caches
+    * the synchronizer keeps around. */
+  def downloaded(
+      blockHash: ByteString
+  ): F[Unit]
 }
 
 object Synchronizer {

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
@@ -7,6 +7,8 @@ import eu.timepit.refined.numeric._
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.comm.discovery.Node
 import io.casperlabs.comm.gossiping.Synchronizer.SyncError
+import io.casperlabs.comm.gossiping.Utils.hex
+import scala.util.control.NoStackTrace
 
 trait Synchronizer[F[_]] {
 
@@ -25,7 +27,10 @@ object Synchronizer {
   // because then an attacker could probably create blocks in such a way that
   // half the honest nodes would import them and half of them would reject them?
   // Logic may be changed depending on the consensus algorithm.
-  sealed trait SyncError extends Product with Serializable
+  sealed trait SyncError extends NoStackTrace {
+    override def getMessage(): String =
+      SyncError.getMessage(this)
+  }
   object SyncError {
     final case class TooWide(
         maxBranchingFactor: Double Refined GreaterEqual[W.`1.0`.T],
@@ -39,5 +44,23 @@ object Synchronizer {
     final case class ValidationError(summary: BlockSummary, reason: Throwable)     extends SyncError
     final case class MissingDependencies(missing: Set[ByteString])                 extends SyncError
     final case class Cycle(summary: BlockSummary)                                  extends SyncError
+
+    def getMessage(error: SyncError): String =
+      error match {
+        case SyncError.TooMany(summary, limit) =>
+          s"Returned DAG is too big, limit: $limit, exceeded hash: ${hex(summary)}"
+        case SyncError.TooDeep(summaries, limit) =>
+          s"Returned DAG is too deep, limit: $limit, exceeded hashes: ${summaries.map(hex)}"
+        case SyncError.TooWide(maxBranchingFactor, maxTotal, total) =>
+          s"Returned dag seems to be exponentially wide, max branching factor: $maxBranchingFactor, max total summaries: $maxTotal, total returned: $total"
+        case SyncError.Unreachable(summary, requestedDepth) =>
+          s"During streaming source returned unreachable block summary: ${hex(summary)}, requested depth: $requestedDepth"
+        case SyncError.ValidationError(summary, e) =>
+          s"Failed to validated the block summary: ${hex(summary)}, reason: $e"
+        case SyncError.MissingDependencies(hashes) =>
+          s"Missing dependencies: ${hashes.map(hex)}"
+        case SyncError.Cycle(summary) =>
+          s"Detected cycle: ${hex(summary)}"
+      }
   }
 }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/Synchronizer.scala
@@ -43,8 +43,11 @@ object Synchronizer {
         maxTotal: Int,
         total: Int
     ) extends SyncError
-    final case class Unreachable(summary: BlockSummary, requestedDepth: Int Refined Positive)
-        extends SyncError
+    final case class Unreachable(
+        summary: BlockSummary,
+        requestedDepth: Int Refined Positive,
+        reason: String
+    ) extends SyncError
     final case class TooMany(hash: ByteString, limit: Int Refined Positive)        extends SyncError
     final case class TooDeep(hashes: Set[ByteString], limit: Int Refined Positive) extends SyncError
     final case class ValidationError(summary: BlockSummary, reason: Throwable)     extends SyncError
@@ -59,8 +62,8 @@ object Synchronizer {
           s"Returned DAG is too deep, limit: $limit, exceeded hashes: ${summaries.map(hex)}"
         case SyncError.TooWide(maxBranchingFactor, maxTotal, total) =>
           s"Returned dag seems to be exponentially wide, max branching factor: $maxBranchingFactor, max total summaries: $maxTotal, total returned: $total"
-        case SyncError.Unreachable(summary, requestedDepth) =>
-          s"During streaming source returned unreachable block summary: ${hex(summary)}, requested depth: $requestedDepth"
+        case SyncError.Unreachable(summary, requestedDepth, reason) =>
+          s"During streaming source returned unreachable block summary: ${hex(summary)}, requested depth: $requestedDepth, reason: $reason"
         case SyncError.ValidationError(summary, e) =>
           s"Failed to validated the block summary: ${hex(summary)}, reason: $e"
         case SyncError.MissingDependencies(hashes) =>

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/SynchronizerImpl.scala
@@ -32,20 +32,22 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     // Before the initial sync has succeeded we allow more depth.
     isInitialRef: Ref[F, Boolean],
     // Only allow 1 sync per node at a time to not traverse the same thing twice.
-    sourceSemaphores: Ref[F, Map[Node, Semaphore[F]]]
+    sourceSemaphoresRef: Ref[F, Map[Node, Semaphore[F]]],
+    // Keep the synced DAG in memory so we can avoid traversing them repeatedly.
+    syncedSummariesRef: Ref[F, Map[ByteString, SynchronizerImpl.SyncedSummary]]
 ) extends Synchronizer[F] {
   type Effect[A] = EitherT[F, SyncError, A]
 
   import io.casperlabs.comm.gossiping.SynchronizerImpl._
 
   private def getSemaphore(source: Node): F[Semaphore[F]] =
-    sourceSemaphores.get.map(_.get(source)).flatMap {
+    sourceSemaphoresRef.get.map(_.get(source)).flatMap {
       case Some(semaphore) =>
         semaphore.pure[F]
       case None =>
         for {
           s0 <- Semaphore[F](1)
-          s1 <- sourceSemaphores.modify { ss =>
+          s1 <- sourceSemaphoresRef.modify { ss =>
                  ss.get(source) map { s1 =>
                    ss -> s1
                  } getOrElse {
@@ -54,6 +56,11 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
                }
         } yield s1
     }
+
+  // This is supposed to be called every time a scheduled download is finished,
+  // even when the resolution is that we already had it, so there should be no leaks.
+  override def downloaded(blockHash: ByteString) =
+    syncedSummariesRef.update(_ - blockHash)
 
   override def syncDag(
       source: Node,
@@ -68,6 +75,7 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
       isInitial      <- isInitialRef.get
       syncStateOrError <- Metrics[F].gauge("syncs_ongoing") {
                            loop(
+                             source,
                              service,
                              targetBlockHashes.toList,
                              tips ::: justifications,
@@ -76,15 +84,8 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
                            )
                          }
       res <- syncStateOrError.fold(
-              _.asLeft[Vector[BlockSummary]].pure[F], { syncState =>
-                missingDependencies(syncState.parentToChildren).map { missing =>
-                  if (missing.isEmpty) {
-                    topologicalSort(syncState).asRight[SyncError]
-                  } else {
-                    MissingDependencies(missing.toSet).asLeft[Vector[BlockSummary]]
-                  }
-                }
-              }
+              _.asLeft[Vector[BlockSummary]].pure[F],
+              finalizeResult(source, _)
             )
       _ <- Metrics[F].incrementCounter(if (res.isLeft) "syncs_failed" else "syncs_succeeded")
     } yield res
@@ -101,6 +102,7 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
   }
 
   private def loop(
+      source: Node,
       service: GossipService[F],
       targetBlockHashes: List[ByteString],
       knownBlockHashes: List[ByteString],
@@ -119,22 +121,59 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
       ).flatMap {
         case left @ Left(_) => (left: Either[SyncError, SyncState]).pure[F]
         case Right(newSyncState) =>
-          missingDependencies(newSyncState.parentToChildren)
+          missingDependencies(source, newSyncState.parentToChildren)
             .flatMap(
               missing =>
                 if (prevSyncState.summaries == newSyncState.summaries)
+                  // Looks like we received nothing new.
                   prevSyncState.asRight[SyncError].pure[F]
                 else
-                  loop(service, missing, knownBlockHashes, newSyncState, isInitial)
+                  // We have new roots for the DAG, we can ask the source to expand.
+                  loop(
+                    source,
+                    service,
+                    missing,
+                    knownBlockHashes,
+                    newSyncState.copy(iteration = prevSyncState.iteration + 1),
+                    isInitial
+                  )
             )
       }
     }
 
+  private def finalizeResult(
+      source: Node,
+      syncState: SyncState
+  ): F[Either[SyncError, Vector[BlockSummary]]] =
+    // Check that the stream didn't die before connecting to our DAG.
+    missingDependencies(source, syncState.parentToChildren) flatMap { missing =>
+      if (missing.isEmpty) {
+        for {
+          _         <- addSynced(source, syncState)
+          summaries = topologicalSort(syncState)
+        } yield summaries.asRight[SyncError]
+      } else {
+        MissingDependencies(missing.toSet).asLeft[Vector[BlockSummary]].leftWiden[SyncError].pure[F]
+      }
+    }
+
+  /** Find the roots of a partial DAG that we don't have in our backend. */
   private def missingDependencies(
+      source: Node,
       parentToChildren: Map[ByteString, Set[ByteString]]
   ): F[List[ByteString]] =
-    danglingParents(parentToChildren).toList.filterA(backend.notInDag)
+    danglingParents(parentToChildren).toList.filterA { blockHash =>
+      for {
+        syncedSummaries <- syncedSummariesRef.get
+        // TODO: We could say that if we have it from *any* source, but not this,
+        // then we add the new source to all dependencies and don't loop any more.
+        // This could cut down traversing from sources we have not synced with before.
+        isSynced  = syncedSummaries.get(blockHash).fold(false)(_.sources(source))
+        isMissing <- if (isSynced) false.pure[F] else backend.notInDag(blockHash)
+      } yield isMissing
+    }
 
+  /** Find parents which have no children. */
   private def danglingParents(
       parentToChildren: Map[ByteString, Set[ByteString]]
   ): Set[ByteString] = {
@@ -148,6 +187,18 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
   private def topologicalSort(syncState: SyncState): Vector[BlockSummary] =
     syncState.summaries.values.toVector.sortBy(_.getHeader.rank)
 
+  /** Remember that we got these summaries from this source,
+    * so next time we don't have to travel that far back in their DAG. */
+  private def addSynced(source: Node, syncState: SyncState): F[Unit] =
+    syncedSummariesRef.update { syncedSummaries =>
+      syncState.summaries.values.foldLeft(syncedSummaries) {
+        case (syncedSummaries, summary) =>
+          val ss = syncedSummaries.get(summary.blockHash).getOrElse(SyncedSummary(summary))
+          syncedSummaries + (summary.blockHash -> ss.addSource(source))
+      }
+    }
+
+  /** Ask the source to traverse back from whatever our last unknown blocks were. */
   private def traverse(
       service: GossipService[F],
       targetBlockHashes: List[ByteString],
@@ -267,66 +318,46 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     }
   }
 
-  /** Check that `toCheck` can be reached from the current `targetBlockHashes` within the distance
-    * of a single `maxDepthAncestorsRequest`. If so, return the distance to the original targets,
-    * i.e. the ones that can be multiple recursive steps away already. */
+  /** Check that `toCheck` can be reached from the current original target
+    * within the iterations we have done using our depth-per-request setting.
+    */
   private def reachable(
       syncState: SyncState,
       toCheck: BlockSummary,
       targetBlockHashes: Set[ByteString]
   ): EitherT[F, SyncError, Int] = {
-    // One map with all the children's parents in it.
-    def getParents(children: List[ByteString]): Map[ByteString, Set[ByteString]] =
-      children
-        .map(hash => Map(hash -> syncState.childToParents(hash)))
-        .foldLeft(Monoid.empty[Map[ByteString, Set[ByteString]]]) { case (a, b) => a |+| b }
+    def unreachable =
+      EitherT((Unreachable(toCheck, maxDepthAncestorsRequest): SyncError).asLeft[Int].pure[F])
 
-    // Start with the current targets and move towards their children until we find
-    // `toCheck`, or go farther then the allowed distance.
-    @annotation.tailrec
-    def loop(
-        childrenToParents: Map[ByteString, Set[ByteString]],
-        counter: Int
-    ): EitherT[F, SyncError, Int] =
-      if (counter <= maxDepthAncestorsRequest && childrenToParents.nonEmpty) {
-        val maybeChildOfToCheckDistance = {
-          val childrenDistances = childrenToParents.collect {
-            case (child, parents) if parents(toCheck.blockHash) =>
-              syncState.distanceFromOriginalTarget(child)
-          }.toList
-
-          if (childrenDistances.nonEmpty) {
-            Some(childrenDistances.min)
-          } else {
-            None
-          }
-        }
-
-        // Not using .fold because it won't be tail-recursive
-        if (maybeChildOfToCheckDistance.nonEmpty) {
-          EitherT((counter + maybeChildOfToCheckDistance.get + 1).asRight[SyncError].pure[F])
-        } else {
-          loop(getParents(childrenToParents.values.toSet.flatten.toList), counter + 1)
-        }
+    // Check that we can reach a target within the request depth.
+    def targetReachable(i: Int, front: Set[ByteString]): Boolean =
+      if (front.intersect(targetBlockHashes).nonEmpty) {
+        true
+      } else if (i > maxDepthAncestorsRequest) {
+        false
       } else {
-        EitherT((Unreachable(toCheck, maxDepthAncestorsRequest): SyncError).asLeft[Int].pure[F])
+        val nextFront =
+          front.flatMap(syncState.parentToChildren.getOrElse(_, Set.empty)).diff(front)
+        targetReachable(i + 1, nextFront)
       }
 
     if (syncState.originalTargets(toCheck.blockHash)) {
       EitherT(0.asRight[SyncError].pure[F])
     } else {
-      // `toCheck` can be one of the targets, so start with the parents and walk from there; 0 distance
-      val targetsToParents = getParents(targetBlockHashes.toList)
-
-      // If `toCheck` is not part of the original targets then there must have been something
-      // that lead us here and that will already have its distance established. Start from there.
-      val childrenOfTargets = getParents(
-        targetBlockHashes.flatMap(syncState.parentToChildren(_)).toList
-      )
-
-      // Not sure if the same `counter` value should apply to both of those groups.
-      // But with counter=1 and maxDepthAncestorsRequest=1 it failed to sync some block in HashSetCasperTest.
-      loop(targetsToParents ++ childrenOfTargets, counter = 0)
+      // If we got here it should have been through a child, which should already have a distance.
+      val children = syncState.parentToChildren.getOrElse(toCheck.blockHash, Set.empty)
+      if (children.isEmpty) {
+        unreachable
+      } else {
+        val distFromOriginal = children.map(syncState.distanceFromOriginalTarget).min + 1
+        if (distFromOriginal > syncState.iteration * maxDepthAncestorsRequest) {
+          unreachable
+        } else if (!targetReachable(0, Set(toCheck.blockHash))) {
+          unreachable
+        } else {
+          EitherT((distFromOriginal).asRight[SyncError].pure[F])
+        }
+      }
     }
   }
 }
@@ -334,6 +365,17 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
 object SynchronizerImpl {
   implicit val metricsSource: Metrics.Source =
     Metrics.Source(GossipingMetricsSource, "Synchronizer")
+
+  /** Remember that we already traversed a summary so next time we can
+    * simply add the node as a new source or return as soon as we find
+    * that it has been already added.
+    */
+  case class SyncedSummary(
+      summary: BlockSummary,
+      sources: Set[Node] = Set.empty
+  ) {
+    def addSource(source: Node) = copy(sources = sources + source)
+  }
 
   def apply[F[_]: Concurrent: Log: Metrics](
       connectToGossip: Node => F[GossipService[F]],
@@ -344,19 +386,24 @@ object SynchronizerImpl {
       maxDepthAncestorsRequest: Int Refined Positive,
       maxInitialBlockCount: Int Refined Positive,
       isInitialRef: Ref[F, Boolean]
-  ) = Ref[F].of(Map.empty[Node, Semaphore[F]]).map { semaphores =>
-    new SynchronizerImpl[F](
-      connectToGossip,
-      backend,
-      maxPossibleDepth,
-      minBlockCountToCheckBranchingFactor,
-      maxBranchingFactor,
-      maxDepthAncestorsRequest,
-      maxInitialBlockCount,
-      isInitialRef,
-      semaphores
-    )
-  }
+  ) =
+    for {
+      semaphoresRef      <- Ref[F].of(Map.empty[Node, Semaphore[F]])
+      syncedSummariesRef <- Ref[F].of(Map.empty[ByteString, SyncedSummary])
+    } yield {
+      new SynchronizerImpl[F](
+        connectToGossip,
+        backend,
+        maxPossibleDepth,
+        minBlockCountToCheckBranchingFactor,
+        maxBranchingFactor,
+        maxDepthAncestorsRequest,
+        maxInitialBlockCount,
+        isInitialRef,
+        semaphoresRef,
+        syncedSummariesRef
+      )
+    }
 
   /** Export base 0 values so we have non-empty series for charts. */
   def establishMetrics[F[_]: Monad: Metrics] =
@@ -377,26 +424,30 @@ object SynchronizerImpl {
   }
 
   final case class SyncState(
+      iteration: Int,
       originalTargets: Set[ByteString],
       summaries: Map[ByteString, BlockSummary],
       parentToChildren: Map[ByteString, Set[ByteString]],
       childToParents: Map[ByteString, Set[ByteString]],
       distanceFromOriginalTarget: Map[ByteString, Int]
   ) {
-    def append(summary: BlockSummary, distance: Int): SyncState =
+    def append(summary: BlockSummary, distance: Int): SyncState = {
+      val deps = dependencies(summary)
       SyncState(
+        iteration,
         originalTargets,
         summaries + (summary.blockHash -> summary),
-        parentToChildren = dependencies(summary).foldLeft(parentToChildren) {
+        parentToChildren = deps.foldLeft(parentToChildren) {
           case (acc, dependency) =>
             acc + (dependency -> (acc(dependency) + summary.blockHash))
         },
-        childToParents = dependencies(summary).foldLeft(childToParents) {
+        childToParents = deps.foldLeft(childToParents) {
           case (acc, dependency) =>
             acc + (summary.blockHash -> (acc(summary.blockHash) + dependency))
         },
         distanceFromOriginalTarget.updated(summary.blockHash, distance)
       )
+    }
   }
 
   private def dependencies(summary: BlockSummary): List[ByteString] =
@@ -405,6 +456,7 @@ object SynchronizerImpl {
   object SyncState {
     def initial(originalTargets: Set[ByteString]) =
       SyncState(
+        iteration = 1,
         originalTargets,
         summaries = Map.empty,
         parentToChildren = Map.empty.withDefaultValue(Set.empty),

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/SynchronizerImpl.scala
@@ -193,7 +193,7 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     syncedSummariesRef.update { syncedSummaries =>
       syncState.summaries.values.foldLeft(syncedSummaries) {
         case (syncedSummaries, summary) =>
-          val ss = syncedSummaries.get(summary.blockHash).getOrElse(SyncedSummary(summary))
+          val ss = syncedSummaries.getOrElse(summary.blockHash, SyncedSummary(summary))
           syncedSummaries + (summary.blockHash -> ss.addSource(source))
       }
     }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -616,6 +616,7 @@ object DownloadManagerSpec {
   object MockGossipService {
     private val emptySynchronizer = new Synchronizer[Task] {
       def syncDag(source: Node, targetBlockHashes: Set[ByteString]) = ???
+      def downloaded(blockHash: ByteString): Task[Unit]             = ???
     }
     private val emptyDownloadManager = new DownloadManager[Task] {
       def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean) = ???

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -926,6 +926,7 @@ class GrpcGossipServiceSpec
                       // to `newBlocks` returns before all the syncing and downloading is finished.
                       Task.now(dag.asRight[SyncError]).delayResult(250.millis)
                     }
+                    def downloaded(blockHash: ByteString) = Task.unit
                   }
 
                   val downloadManager = new DownloadManager[Task] {
@@ -1112,6 +1113,7 @@ object GrpcGossipServiceSpec extends TestRuntime {
   object TestEnvironment {
     private val emptySynchronizer = new Synchronizer[Task] {
       def syncDag(source: Node, targetBlockHashes: Set[ByteString]) = ???
+      def downloaded(blockHash: ByteString): Task[Unit]             = ???
     }
     private val emptyDownloadManager = new DownloadManager[Task] {
       def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean) = ???

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -218,6 +218,7 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
 
   object MockSynchronizer extends Synchronizer[Task] {
     def syncDag(source: Node, targetBlockHashes: Set[ByteString]) = ???
+    def downloaded(blockHash: ByteString): Task[Unit]             = ???
   }
 
   object MockDownloadManager extends DownloadManager[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -2,6 +2,7 @@ package io.casperlabs.comm.gossiping
 
 import java.util.concurrent.TimeoutException
 
+import cats.syntax.either._
 import cats.effect.concurrent.Semaphore
 import com.google.protobuf.ByteString
 import eu.timepit.refined._
@@ -12,6 +13,7 @@ import io.casperlabs.casper.consensus.{Approval, BlockSummary, GenesisCandidate}
 import io.casperlabs.comm.discovery.{Node, NodeDiscovery, NodeIdentifier}
 import io.casperlabs.comm.gossiping.InitialSynchronizationImpl.SynchronizationError
 import io.casperlabs.comm.gossiping.InitialSynchronizationSpec.TestFixture
+import io.casperlabs.comm.gossiping.Synchronizer.SyncError
 import io.casperlabs.shared.Log.NOPLog
 import io.casperlabs.metrics.Metrics
 import monix.eval.Task
@@ -251,9 +253,10 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
     override def newBlocksSynchronous(
         request: NewBlocksRequest,
         skipRelaying: Boolean
-    ): Task[NewBlocksResponse] = {
+    ): Task[Either[SyncError, NewBlocksResponse]] = {
       asked.transform(_ :+ request.getSender)
-      sync(request.getSender, request.blockHashes).map(b => NewBlocksResponse(isNew = b))
+      sync(request.getSender, request.blockHashes)
+        .map(b => NewBlocksResponse(isNew = b).asRight[SyncError])
     }
   }
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/StashingSynchronizerSpec.scala
@@ -157,6 +157,8 @@ object StashingSynchronizerSpec {
           case Right(e) => Task.now(e.asLeft[Vector[BlockSummary]])
         }
       }
+
+    def downloaded(blockHash: ByteString): Task[Unit] = Task.unit
   }
 
   object TestFixture {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/SynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/SynchronizerSpec.scala
@@ -51,7 +51,7 @@ class SynchronizerSpec
         genPartialDagFromTips
       ) { dag =>
         log.reset()
-        TestFixture(dag)(maxInitialBlockCount = 1, isInitial = true) { (synchronizer, _, _) =>
+        TestFixture(dag)(maxInitialBlockCount = 1, isInitial = true) { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isLeft shouldBe true
             dagOrError.left.get shouldBe an[SyncError.TooMany]
@@ -77,7 +77,7 @@ class SynchronizerSpec
           )
 
         def test(cycledDag: Vector[BlockSummary]): Unit = TestFixture(cycledDag)() {
-          (synchronizer, _, _) =>
+          (synchronizer, _) =>
             synchronizer.syncDag(Node(), Set(dag.head.blockHash)) foreachL { dagOrError =>
               dagOrError.isLeft shouldBe true
               dagOrError.left.get shouldBe an[SyncError.Cycle]
@@ -97,7 +97,7 @@ class SynchronizerSpec
         arbitrary[Boolean]
       ) { (dag, n, isInitial) =>
         log.reset()
-        TestFixture(dag)(maxPossibleDepth = n, isInitial = isInitial) { (synchronizer, _, _) =>
+        TestFixture(dag)(maxPossibleDepth = n, isInitial = isInitial) { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             if (isInitial) {
               dagOrError.isLeft shouldBe false
@@ -118,7 +118,7 @@ class SynchronizerSpec
       ) { (dag, n) =>
         log.reset()
         TestFixture(dag)(maxBranchingFactor = n, minBlockCountToCheckBranchingFactor = 0) {
-          (synchronizer, _, _) =>
+          (synchronizer, _) =>
             synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
               dagOrError.isLeft shouldBe true
               dagOrError.left.get shouldBe an[SyncError.TooWide]
@@ -132,7 +132,7 @@ class SynchronizerSpec
         arbBlockSummary.arbitrary
       ) { (dag, arbitraryBlock) =>
         log.reset()
-        TestFixture(dag :+ arbitraryBlock)() { (synchronizer, _, _) =>
+        TestFixture(dag :+ arbitraryBlock)() { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isLeft shouldBe true
             dagOrError.left.get shouldBe an[SyncError.Unreachable]
@@ -146,7 +146,7 @@ class SynchronizerSpec
         genPositiveInt(1, consensusConfig.dagDepth - 2)
       ) { (dag, n) =>
         log.reset()
-        TestFixture(dag)(maxDepthAncestorsRequest = n) { (synchronizer, _, _) =>
+        TestFixture(dag)(maxDepthAncestorsRequest = n) { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isLeft shouldBe true
             dagOrError.left.get shouldBe an[SyncError.Unreachable]
@@ -160,7 +160,7 @@ class SynchronizerSpec
       ) { dag =>
         log.reset()
         val e = new RuntimeException("Boom!")
-        TestFixture(dag)(validate = _ => Task.raiseError[Unit](e)) { (synchronizer, _, _) =>
+        TestFixture(dag)(validate = _ => Task.raiseError[Unit](e)) { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isLeft shouldBe true
             dagOrError.left.get shouldBe an[SyncError.ValidationError]
@@ -174,7 +174,7 @@ class SynchronizerSpec
         genPartialDagFromTips
       ) { dag =>
         log.reset()
-        TestFixture(dag)(notInDag = _ => Task.now(true)) { (synchronizer, _, _) =>
+        TestFixture(dag)(notInDag = _ => Task.now(true)) { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isLeft shouldBe true
             dagOrError.left.get shouldBe an[SyncError.MissingDependencies]
@@ -188,12 +188,32 @@ class SynchronizerSpec
       ) { dag =>
         log.reset()
         val e = new RuntimeException("Boom!")
-        TestFixture(dag)(error = e.some) { (synchronizer, _, _) =>
+        TestFixture(dag)(error = e.some) { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).attempt.foreachL { dagOrError =>
             dagOrError.isLeft shouldBe true
             dagOrError.left.get shouldBe e
             log.causes should have size 1
             log.causes.head shouldBe e
+          }
+        }
+      }
+    }
+    "started multiple sync with the same node" should {
+      "only run one sync at a time" in forAll(
+        genPartialDagFromTips
+      ) { dag =>
+        log.reset()
+        TestFixture(dag)() { (synchronizer, variables) =>
+          for {
+            fibers <- List.range(0, 5).traverse { _ =>
+                       synchronizer
+                         .syncDag(Node(), Set(dag.head.blockHash))
+                         .map(_ => variables.requestsGauge.get())
+                         .start
+                     }
+            readings <- fibers.traverse(_.join)
+          } yield {
+            readings.max should be <= 1
           }
         }
       }
@@ -207,7 +227,7 @@ class SynchronizerSpec
       ) { (dag, n) =>
         log.reset()
         TestFixture(dag)(maxBranchingFactor = n, minBlockCountToCheckBranchingFactor = Int.MaxValue) {
-          (synchronizer, _, _) =>
+          (synchronizer, _) =>
             synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
               dagOrError.isRight shouldBe true
               dagOrError.right.get should contain allElementsOf dag
@@ -222,9 +242,9 @@ class SynchronizerSpec
       ) { (dag, tip, justification) =>
         log.reset()
         TestFixture(dag)(tips = List(tip), justifications = List(justification)) {
-          (synchronizer, _, knownHashes) =>
+          (synchronizer, variables) =>
             synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { _ =>
-              knownHashes should contain allElementsOf (tip :: justification :: Nil)
+              variables.knownHashes should contain allElementsOf (tip :: justification :: Nil)
             }
         }
       }
@@ -244,12 +264,12 @@ class SynchronizerSpec
         TestFixture(grouped: _*)(
           maxDepthAncestorsRequest = ancestorsDepthRequest,
           notInDag = bs => Task.now(!finalParents(bs))
-        ) { (synchronizer, requestsCount, _) =>
+        ) { (synchronizer, variables) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isRight shouldBe true
             val d = dagOrError.right.get
             d should contain allElementsOf dag.dropRight(consensusConfig.dagWidth)
-            requestsCount
+            variables.requestsCounter
               .get() shouldBe (grouped.size.toDouble / ancestorsDepthRequest).ceil.toInt + 1
           }
         }
@@ -278,7 +298,7 @@ class SynchronizerSpec
           loop(Nil, List(summary)).distinct
         }
 
-        TestFixture(dag)() { (synchronizer, _, _) =>
+        TestFixture(dag)() { (synchronizer, _) =>
           synchronizer.syncDag(Node(), Set(dag.head.blockHash)).foreachL { dagOrError =>
             dagOrError.isRight shouldBe true
             val d = dagOrError.right.get
@@ -318,7 +338,8 @@ object SynchronizerSpec {
 
   object MockGossipService {
     def apply(
-        counter: AtomicInt,
+        requestsCounter: AtomicInt,
+        requestsGauge: AtomicInt,
         error: Option[RuntimeException],
         knownHashes: ListBuffer[ByteString],
         dags: Vector[BlockSummary]*
@@ -330,13 +351,21 @@ object SynchronizerSpec {
               request: StreamAncestorBlockSummariesRequest
           ): Iterant[Task, BlockSummary] = {
             request.knownBlockHashes.foreach(h => knownHashes += h)
-            error.fold(
-              Iterant.fromSeq[Task, BlockSummary](
-                dags.lift(counter.getAndIncrement()).getOrElse(Vector.empty)
-              )
-            ) { e =>
-              Iterant.raiseError(e)
-            }
+            Iterant
+              .resource {
+                Task.delay(requestsGauge.increment())
+              } { _ =>
+                Task.delay(requestsGauge.decrement())
+              }
+              .flatMap { _ =>
+                error.fold(
+                  Iterant.fromSeq[Task, BlockSummary](
+                    dags.lift(requestsCounter.getAndIncrement()).getOrElse(Vector.empty)
+                  )
+                ) { e =>
+                  Iterant.raiseError(e)
+                }
+              }
           }
 
           def streamDagTipBlockSummaries(
@@ -352,6 +381,12 @@ object SynchronizerSpec {
       }
   }
 
+  case class TestVariables(
+      requestsCounter: AtomicInt,
+      requestsGauge: AtomicInt,
+      knownHashes: ListBuffer[ByteString]
+  )
+
   object TestFixture {
     def apply(dags: Vector[BlockSummary]*)(
         maxPossibleDepth: Int Refined Positive = Int.MaxValue,
@@ -365,12 +400,14 @@ object SynchronizerSpec {
         error: Option[RuntimeException] = None,
         tips: List[ByteString] = Nil,
         justifications: List[ByteString] = Nil
-    )(test: (Synchronizer[Task], AtomicInt, ListBuffer[ByteString]) => Task[Unit]): Unit = {
+    )(test: (Synchronizer[Task], TestVariables) => Task[Unit]): Unit = {
       val requestsCounter = AtomicInt(0)
+      val requestsGauge   = AtomicInt(0)
       val knownHashes     = ListBuffer.empty[ByteString]
 
-      val synchronizer = new SynchronizerImpl[Task](
-        connectToGossip = _ => MockGossipService(requestsCounter, error, knownHashes, dags: _*),
+      SynchronizerImpl[Task](
+        connectToGossip =
+          _ => MockGossipService(requestsCounter, requestsGauge, error, knownHashes, dags: _*),
         backend = MockBackend(tips, justifications, notInDag, validate),
         maxPossibleDepth = maxPossibleDepth,
         minBlockCountToCheckBranchingFactor = minBlockCountToCheckBranchingFactor,
@@ -378,8 +415,10 @@ object SynchronizerSpec {
         maxDepthAncestorsRequest = maxDepthAncestorsRequest,
         maxInitialBlockCount = maxInitialBlockCount,
         isInitialRef = Ref.unsafe[Task, Boolean](isInitial)
-      )
-      test(synchronizer, requestsCounter, knownHashes).runSyncUnsafe(5.seconds)
+      ).flatMap { synchronizer =>
+          test(synchronizer, TestVariables(requestsCounter, requestsGauge, knownHashes))
+        }
+        .runSyncUnsafe(5.seconds)
     }
   }
 }

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -583,8 +583,8 @@ package object gossiping {
 
                       override def onDownloaded(blockHash: ByteString) =
                         // Calling `addBlock` during validation has already stored the block,
-                        // so we have nothing more to do here.
-                        ().pure[F]
+                        // so we have nothing more to do here with the consensus.
+                        synchronizer.downloaded(blockHash)
 
                       override def listTips =
                         for {


### PR DESCRIPTION
### Overview
Changes the synchronizer to avoid syncing the same DAG over and over with the same source:
* fixes the initial synchronizer to receive errors rather than just let the underlying synchronizer log the problem and return successfully, which should leave the initial flag on `true` until an operation actually succeeds
* only runs one sync per source at a time to avoid hammering the same node with multiple streaming requests and also so that the 2nd sync sees the results of the 1st
* keeps the summaries which were sync'ed but not yet downloaded in memory so that if the same source tells us about the same part of the DAG again we can treat it as something we already have and stop iterating backwards

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-720

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
One more thing I wanted to add was that once we see a summary in the stream which we know already we can just visit all its dependencies (we should already have them right there) and add the new source. This can help when we have a big network and the initial sync takes a long time, while other nodes keep notifying us about new blocks: we can just add them as alternative sources for the full DAG without having to go through the sync with them.
