### PR TITLE
EE-269: add get_balance API function

### DIFF
--- a/execution-engine/common/src/contract_api/mod.rs
+++ b/execution-engine/common/src/contract_api/mod.rs
@@ -416,7 +416,7 @@ pub fn get_balance(purse_id: PurseId) -> Option<U512> {
         Vec::from_raw_parts(dest_ptr, value_size, value_size)
     };
 
-    let balance: U512 = deserialize(&balance_bytes).unwrap_or_else(|_| revert(666));
+    let balance: U512 = deserialize(&balance_bytes).unwrap_or_else(|_| revert(100));
 
     Some(balance)
 }

--- a/execution-engine/common/src/lib.rs
+++ b/execution-engine/common/src/lib.rs
@@ -122,6 +122,7 @@ mod ext_ffi {
             amount_ptr: *const u8,
             amount_size: usize,
         ) -> i32;
+        pub fn get_balance(purse_id_ptr: *const u8, purse_id_size: usize) -> i32;
     }
 }
 

--- a/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
@@ -5,34 +5,12 @@
 extern crate alloc;
 extern crate cl_std;
 
-use alloc::string::String;
 use cl_std::contract_api::{
-    add_uref, call_contract, get_arg, get_uref, main_purse, new_uref, read, revert,
-    transfer_from_purse_to_account,
+    add_uref, get_arg, get_balance, main_purse, new_uref, revert, transfer_from_purse_to_account,
 };
 use cl_std::key::Key;
-use cl_std::uref::URef;
 use cl_std::value::account::{PublicKey, PurseId};
 use cl_std::value::U512;
-
-fn get_balance(purse_id: PurseId) -> Option<U512> {
-    let mint_public_hash = get_uref("mint").unwrap_or_else(|| revert(100));
-    let mint_public_uptr = mint_public_hash.to_u_ptr().unwrap_or_else(|| revert(101));
-    let mint_contract_key: Key = read(mint_public_uptr);
-
-    let mint_contract_pointer = match mint_contract_key.to_c_ptr() {
-        Some(ptr) => ptr,
-        None => revert(102),
-    };
-
-    let main_purse_uref: URef = purse_id.value();
-
-    call_contract(
-        mint_contract_pointer,
-        &(String::from("balance"), main_purse_uref),
-        &vec![main_purse_uref.into()],
-    )
-}
 
 #[no_mangle]
 pub extern "C" fn call() {
@@ -42,7 +20,7 @@ pub extern "C" fn call() {
 
     let transfer_result = transfer_from_purse_to_account(source, destination, amount);
 
-    // // Assert is done here
+    // Assert is done here
     let final_balance = get_balance(source).unwrap_or_else(|| revert(103));
 
     let result = format!("{:?}", transfer_result);

--- a/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
@@ -7,31 +7,12 @@ extern crate cl_std;
 
 use alloc::string::String;
 use cl_std::contract_api::{
-    add_uref, call_contract, create_purse, get_arg, get_uref, has_uref, main_purse, new_uref, read,
-    revert, transfer_from_purse_to_purse,
+    add_uref, create_purse, get_arg, get_balance, get_uref, has_uref, main_purse, new_uref, revert,
+    transfer_from_purse_to_purse,
 };
 use cl_std::key::Key;
-use cl_std::uref::URef;
 use cl_std::value::account::PurseId;
 use cl_std::value::U512;
-
-fn get_balance(purse_id: PurseId) -> Option<U512> {
-    let mint_public_hash = get_uref("mint").unwrap_or_else(|| revert(100));
-    let mint_contract_key: Key = read(mint_public_hash.to_u_ptr().unwrap_or_else(|| revert(101)));
-
-    let mint_contract_pointer = match mint_contract_key.to_c_ptr() {
-        Some(ptr) => ptr,
-        None => revert(102),
-    };
-
-    let main_purse_uref: URef = purse_id.value();
-
-    call_contract(
-        mint_contract_pointer,
-        &(String::from("balance"), main_purse_uref),
-        &vec![main_purse_uref.into()],
-    )
-}
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/engine/src/function_index.rs
+++ b/execution-engine/engine/src/function_index.rs
@@ -39,6 +39,7 @@ pub enum FunctionIndex {
     TransferToAccountIndex = 32,
     TransferFromPurseToAccountIndex = 33,
     TransferFromPurseToPurseIndex = 34,
+    GetBalanceIndex = 35,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine/src/resolvers/resolver_v1.rs
+++ b/execution-engine/engine/src/resolvers/resolver_v1.rs
@@ -181,6 +181,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::TransferFromPurseToPurseIndex.into(),
             ),
+            "get_balance" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
+                FunctionIndex::GetBalanceIndex.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",


### PR DESCRIPTION
This PR introduces a new get_balance ffi, corresponding contract_api helper function, and updates an integration test to exercise the functionality.

https://casperlabs.atlassian.net/browse/EE-269

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

Co-authored-by: Henry Till <henrytill@gmail.com>
