### PR TITLE
EE-537: Fix overflow error when calculating weights of keys

### DIFF
--- a/execution-engine/contract-ffi/src/value/account.rs
+++ b/execution-engine/contract-ffi/src/value/account.rs
@@ -510,8 +510,7 @@ impl AssociatedKeys {
         let total = authorization_keys
             .iter()
             .filter_map(|key| self.0.get(key))
-            .map(|w| w.value())
-            .sum();
+            .fold(0u8, |acc, w| acc.saturating_add(w.value()));
 
         Weight::new(total)
     }


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

Fixes overflow panic where user specifies keys with total cumulative weights exceed `u8::max_value()` (255) by changing add into saturating add.

https://casperlabs.atlassian.net/browse/EE-536

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
