### PR TITLE
NODE-665: Reject deploys in read-only mode.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -113,6 +113,8 @@ object BlockAPI {
               Metrics[F].incrementCounter("deploys-success") *> ().pure[F]
             case Left(ex: IllegalArgumentException) =>
               MonadThrowable[F].raiseError[Unit](InvalidArgument(ex.getMessage))
+            case Left(ex: IllegalStateException) =>
+              MonadThrowable[F].raiseError[Unit](FailedPrecondition(ex.getMessage))
             case Left(ex) =>
               MonadThrowable[F].raiseError[Unit](ex)
           }


### PR DESCRIPTION
### Overview
In read-only mode the node rejected making blocks but it still accepted deploys.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-648

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I'm not happy about how some parts of casper return statuses, some raise generic Java exceptions, while the API has to raise gRPC exceptions. Unfortunately the read-only status is part of the CreateBlockStatus ADT only. In a future refactoring it would be good to unify error handling.
