### PR TITLE
NODE-652: Check deploy signature in blocks

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
@@ -36,19 +36,21 @@ final case object IgnorableEquivocation   extends InvalidBlock
 final case object InvalidUnslashableBlock extends InvalidBlock
 final case object MissingBlocks           extends InvalidBlock
 
-final case object InvalidBlockNumber    extends InvalidBlock with Slashable
-final case object InvalidRepeatDeploy   extends InvalidBlock with Slashable
-final case object InvalidParents        extends InvalidBlock with Slashable
-final case object InvalidSequenceNumber extends InvalidBlock with Slashable
-final case object InvalidChainId        extends InvalidBlock with Slashable
-final case object NeglectedInvalidBlock extends InvalidBlock with Slashable
-final case object NeglectedEquivocation extends InvalidBlock with Slashable
-final case object InvalidTransaction    extends InvalidBlock with Slashable
-final case object InvalidPreStateHash   extends InvalidBlock with Slashable
-final case object InvalidPostStateHash  extends InvalidBlock with Slashable
-final case object InvalidBondsCache     extends InvalidBlock with Slashable
-final case object InvalidBlockHash      extends InvalidBlock with Slashable
-final case object InvalidDeployCount    extends InvalidBlock with Slashable
+final case object InvalidBlockNumber     extends InvalidBlock with Slashable
+final case object InvalidRepeatDeploy    extends InvalidBlock with Slashable
+final case object InvalidParents         extends InvalidBlock with Slashable
+final case object InvalidSequenceNumber  extends InvalidBlock with Slashable
+final case object InvalidChainId         extends InvalidBlock with Slashable
+final case object NeglectedInvalidBlock  extends InvalidBlock with Slashable
+final case object NeglectedEquivocation  extends InvalidBlock with Slashable
+final case object InvalidTransaction     extends InvalidBlock with Slashable
+final case object InvalidPreStateHash    extends InvalidBlock with Slashable
+final case object InvalidPostStateHash   extends InvalidBlock with Slashable
+final case object InvalidBondsCache      extends InvalidBlock with Slashable
+final case object InvalidBlockHash       extends InvalidBlock with Slashable
+final case object InvalidDeployCount     extends InvalidBlock with Slashable
+final case object InvalidDeployHash      extends InvalidBlock with Slashable
+final case object InvalidDeploySignature extends InvalidBlock with Slashable
 
 object BlockStatus {
   val valid: BlockStatus      = Valid

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -41,7 +41,6 @@ final case class CasperConf(
     approveGenesisInterval: FiniteDuration,
     approveGenesisDuration: FiniteDuration,
     deployTimestamp: Option[Long],
-    ignoreDeploySignature: Boolean,
     autoProposeEnabled: Boolean,
     autoProposeCheckInterval: FiniteDuration,
     autoProposeMaxInterval: FiniteDuration,

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -913,7 +913,8 @@ object MultiParentCasperImpl {
         case InvalidUnslashableBlock | InvalidBlockNumber | InvalidParents | InvalidSequenceNumber |
             NeglectedInvalidBlock | NeglectedEquivocation | InvalidTransaction | InvalidBondsCache |
             InvalidRepeatDeploy | InvalidChainId | InvalidBlockHash | InvalidDeployCount |
-            InvalidPreStateHash | InvalidPostStateHash =>
+            InvalidDeployHash | InvalidDeploySignature | InvalidPreStateHash |
+            InvalidPostStateHash =>
           handleInvalidBlockEffect(status, block) *> dag.pure[F]
 
         case Processing | Processed =>
@@ -1023,7 +1024,8 @@ object MultiParentCasperImpl {
                 InvalidParents | InvalidSequenceNumber | NeglectedInvalidBlock |
                 NeglectedEquivocation | InvalidTransaction | InvalidBondsCache |
                 InvalidRepeatDeploy | InvalidChainId | InvalidBlockHash | InvalidDeployCount |
-                InvalidPreStateHash | InvalidPostStateHash | Processing | Processed =>
+                InvalidDeployHash | InvalidDeploySignature | InvalidPreStateHash |
+                InvalidPostStateHash | Processing | Processed =>
               Log[F].debug(
                 s"Not sending notification about ${PrettyPrinter.buildString(block.blockHash)}: $status"
               )
@@ -1089,8 +1091,9 @@ object MultiParentCasperImpl {
           case IgnorableEquivocation | InvalidUnslashableBlock | InvalidBlockNumber |
               InvalidParents | InvalidSequenceNumber | NeglectedInvalidBlock |
               NeglectedEquivocation | InvalidTransaction | InvalidBondsCache | InvalidRepeatDeploy |
-              InvalidChainId | InvalidBlockHash | InvalidDeployCount | InvalidPreStateHash |
-              InvalidPostStateHash | Processing | Processed =>
+              InvalidChainId | InvalidBlockHash | InvalidDeployCount | InvalidDeployHash |
+              InvalidDeploySignature | InvalidPreStateHash | InvalidPostStateHash | Processing |
+              Processed =>
             ().pure[F]
 
           case UnexpectedBlockException(_) =>

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -50,6 +50,13 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
         summary.getSignature.sig.isEmpty
   }
 
+  implicit class BlockOps(block: Block) {
+    def isGenesisLike =
+      block.getHeader.parentHashes.isEmpty &&
+        block.getHeader.validatorPublicKey.isEmpty &&
+        block.getSignature.sig.isEmpty
+  }
+
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
   private def checkDroppable(checks: F[Boolean]*): F[Unit] =
@@ -552,18 +559,21 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
   def deploySignatures(
       b: Block
   ): F[Unit] =
-    b.getBody.deploys.toList.findM(d => deploySignature(d.getDeploy).map(!_)).flatMap {
-      case None =>
-        Applicative[F].unit
-      case Some(d) =>
-        for {
-          _ <- Log[F]
-                .warn(
-                  ignore(b, s"${PrettyPrinter.buildString(d.getDeploy)} has invalid signature.")
-                )
-          _ <- FunctorRaise[F, InvalidBlock].raise[Unit](InvalidDeploySignature)
-        } yield ()
-    }
+    b.getBody.deploys.toList
+      .findM(d => deploySignature(d.getDeploy).map(!_))
+      .flatMap {
+        case None =>
+          Applicative[F].unit
+        case Some(d) =>
+          for {
+            _ <- Log[F]
+                  .warn(
+                    ignore(b, s"${PrettyPrinter.buildString(d.getDeploy)} has invalid signature.")
+                  )
+            _ <- FunctorRaise[F, InvalidBlock].raise[Unit](InvalidDeploySignature)
+          } yield ()
+      }
+      .whenA(!b.isGenesisLike)
 
   /**
     * Checks that the parents of `b` were chosen correctly according to the

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -68,8 +68,8 @@ class GossipServiceCasperTestNode[F[_]](
     case ValidatorIdentity(key, _, _) => ByteString.copyFrom(key)
   }
 
-  implicit val raiseInvalidBlock         = casper.validation.raiseValidateErrorThroughApplicativeError[F]
-  implicit val validation: Validation[F] = new ValidationImpl[F]
+  implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
+  implicit val validation        = HashSetCasperTestNode.makeValidation[F]
 
   implicit val lastFinalizedBlockHashContainer =
     NoOpsLastFinalizedBlockHashContainer.create[F](genesis.blockHash)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -401,6 +401,6 @@ object HashSetCasperTestNode {
       : Validation[F] =
     new ValidationImpl[F] {
       // Tests are not signing the deploys.
-      override def deploySignatures(b: Block): F[Unit] = ().pure[F]
+      override def deploySignature(d: consensus.Deploy): F[Boolean] = true.pure[F]
     }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -7,6 +7,7 @@ import cats.effect.{Concurrent, Timer}
 import cats.implicits._
 import cats.temp.par.Par
 import cats.{~>, Applicative, ApplicativeError, Defer, Id, Monad, Parallel}
+import cats.mtl.FunctorRaise
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage._
 import io.casperlabs.casper._
@@ -23,12 +24,13 @@ import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
 import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.ipc
 import io.casperlabs.casper.consensus.state.{Unit => _, BigInt => _, _}
+import io.casperlabs.casper.validation.Validation
 import io.casperlabs.ipc.DeployResult.Value.ExecutionResult
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.p2p.EffectsTestInstances._
 import io.casperlabs.shared.PathOps.RichPath
-import io.casperlabs.shared.{Cell, Log}
+import io.casperlabs.shared.{Cell, Log, Time}
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import monix.eval.Task
 import monix.eval.instances.CatsParallelForTask
@@ -37,6 +39,7 @@ import monix.execution.Scheduler
 import scala.collection.mutable.{Map => MutMap}
 import scala.util.Random
 import io.casperlabs.crypto.Keys
+import io.casperlabs.casper.validation.ValidationImpl
 
 /** Base class for test nodes with fields used by tests exposed as public. */
 abstract class HashSetCasperTestNode[F[_]](
@@ -393,4 +396,11 @@ object HashSetCasperTestNode {
   private def pad(x: Array[Byte], length: Int): Array[Byte] =
     if (x.length < length) Array.fill(length - x.length)(0.toByte) ++ x
     else x
+
+  def makeValidation[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log: Time]
+      : Validation[F] =
+    new ValidationImpl[F] {
+      // Tests are not signing the deploys.
+      override def deploySignatures(b: Block): F[Unit] = ().pure[F]
+    }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -85,7 +85,7 @@ class TransportLayerCasperTestNode[F[_]](
     LastApprovedBlock.unsafe[F](Some(ApprovedBlockWithTransforms(approvedBlock, transforms)))
 
   implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
-  implicit val validation        = new ValidationImpl[F]
+  implicit val validation        = HashSetCasperTestNode.makeValidation[F]
 
   implicit val lastFinalizedBlockHashContainer =
     NoOpsLastFinalizedBlockHashContainer.create[F](genesis.blockHash)

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -68,21 +68,30 @@ After connection is complete, all node logs will show `Peers: 2`.
 ## Cleanup
 To cleanup the network stopping and removing all containers run the command `make clean`.
 
+## Signing Deploys
+
+To sign deploy you'll need to [generate and ed25519 keypair](/hack/VALIDATOR.md#setting-up-keys) and save them into `docker/keys`. The `client.sh` script will automatically mount this as a volume and you can pass them as CLI arguments.
+
 ## Deploy some WASM code
 
 Assuming that you cloned and compiled the [contract-examples](https://github.com/CasperLabs/contract-examples) you can deploy them by running the following:
 
 ```console
 ACCOUNT_ID="$(cat .casperlabs/genesis/system-account/account-id-hex)"
+mkdir keys/system-account
+cp .casperlabs/genesis/system-account/account-private.pem keys/system-account/
+cp .casperlabs/genesis/system-account/account-public.pem keys/system-account/
 ./client.sh node-0 deploy $PWD/../../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
-     --from "$ACCOUNT_ID" \
      --gas-price 1 \
+     --from "$ACCOUNT_ID" \
      --session /data/helloname.wasm \
      --payment /data/helloname.wasm \
-     --nonce 1
+     --nonce 1 \
+     --public-key /keys/system-account/account-public.pem \
+     --private-key /keys/system-account/account-private.pem
 ```
 
-As you may notice we make use of the `system-account` for deploys signing. This is temporal until we the add ability to create new custom accounts.
+As you may notice we make use of the `system-account` for deploys signing. This is temporary until we the add ability to create new custom accounts as part of Genesis.
 
 After a successful deploy, you should see the following response:
 
@@ -103,27 +112,6 @@ Response: Success! Block f876efed8d... created and added.
 ```
 
 If you check the log output, each node should get the block and provide some feedback about the execution as well.
-
-### Signing Deploys
-
-To sign deploy you'll need to [generate and ed25519 keypair](/hack/VALIDATOR.md#setting-up-keys) and save them into `docker/keys`. The `client.sh` script will automatically mount this as a volume and you can pass them as CLI arguments, for example:
-
-```console
-ACCOUNT_ID="$(cat .casperlabs/genesis/system-account/account-id-hex)"
-mkdir keys/system-account
-cp .casperlabs/genesis/system-account/account-private.pem keys/system-account/
-cp .casperlabs/genesis/system-account/account-public.pem keys/system-account/
-./client.sh node-0 deploy $PWD/../../../contract-examples/hello-name/define/target/wasm32-unknown-unknown/release\
-     --gas-price 1 \
-     --from "$ACCOUNT_ID" \
-     --session /data/helloname.wasm \
-     --payment /data/helloname.wasm \
-     --nonce 1 \
-     --public-key /keys/system-account/account-public.pem \
-     --private-key /keys/system-account/account-private.pem
-```
-
-As you may notice we make use of the `system-account` for deploys signing. This is temporal until we the add ability to create new custom accounts.
 
 ## Monitoring
 

--- a/hack/docker/template/docker-compose.yml
+++ b/hack/docker/template/docker-compose.yml
@@ -55,7 +55,6 @@ services:
       CL_CASPER_MINT_CODE_PATH: /root/.casperlabs/genesis/system-contracts/mint_token.wasm
       CL_CASPER_POS_CODE_PATH: /root/.casperlabs/genesis/system-contracts/pos.wasm
       CL_CASPER_AUTO_PROPOSE_ENABLED: ${CL_CASPER_AUTO_PROPOSE_ENABLED}
-      CL_CASPER_IGNORE_DEPLOY_SIGNATURE: "true"
     entrypoint:
       - sh
       - -c

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -148,7 +148,7 @@ def deploy_and_propose_expect_no_errors(node, contract):
                                          payment_contract=contract,
                                          from_address=node.genesis_account.public_key_hex,
                                          public_key=node.genesis_account.public_key_path,
-                                         private_key=node.genesis_account.private_key_path) 
+                                         private_key=node.genesis_account.private_key_path)
     r = client.show_deploys(block_hash)[0]
     assert r.is_error is False, f'error_message: {r.error_message}'
 
@@ -211,7 +211,7 @@ def block_hash(node):
     return node.deploy_and_propose(session_contract="test_helloname.wasm", payment_contract="test_helloname.wasm")
 
 block_hash_queries = [
-    ({'block_hash': "9d", 'key': "a91208047c", 'path': "file.xxx", 'key_type': "hash"},
+    ({'block_hash': "9d000000", 'key': "a91208047c", 'path': "file.xxx", 'key_type': "hash"},
      "NOT_FOUND: Cannot find block matching"),
 
     ({                    'key': "a91208047c", 'path': "file.xxx", 'key_type': "hash"},
@@ -377,7 +377,7 @@ def test_deploy_with_higher_nonce(node, contracts: List[str]):
     deploy_and_propose(node, contracts[1], 2)
 
     # The deploy with nonce 3 can be proposed now.
-    block_hash = propose(node)  
+    block_hash = propose(node)
     assert deploy_hash in deploy_hashes(node, block_hash)
 
 

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -251,10 +251,6 @@ approve-genesis-duration = "5minutes"
 # Timestamp for the deploys.
 # deploy-timestamp =
 
-# Ignore while client side support for signing deploys is not in place.
-ignore-deploy-signature = false
-
-
 # Enable auto-proposal of blocks.
 auto-propose-enabled = false
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -235,8 +235,6 @@ class NodeRuntime private[node] (
               conf.grpc.portExternal,
               conf.server.maxMessageSize,
               blockingScheduler,
-              blockApiLock,
-              conf.casper.ignoreDeploySignature,
               maybeApiSslContext
             )
 

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -25,14 +25,13 @@ import monix.reactive.Observable
 
 object GrpcCasperService {
 
-  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef: FinalityDetector: BlockStore: ExecutionEngineService: Validation](
-      ignoreDeploySignature: Boolean
-  ): F[CasperGrpcMonix.CasperService] =
+  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef: FinalityDetector: BlockStore: ExecutionEngineService: Validation]()
+      : F[CasperGrpcMonix.CasperService] =
     BlockAPI.establishMetrics[F] *> Sync[F].delay {
       new CasperGrpcMonix.CasperService {
         override def deploy(request: DeployRequest): Task[Empty] =
           TaskLike[F].toTask {
-            BlockAPI.deploy[F](request.getDeploy, ignoreDeploySignature).map(_ => Empty())
+            BlockAPI.deploy[F](request.getDeploy).map(_ => Empty())
           }
 
         override def getBlockInfo(request: GetBlockInfoRequest): Task[BlockInfo] =

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcDeployService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcDeployService.scala
@@ -29,8 +29,7 @@ object GrpcDeployService {
     path.split("/").filter(_.nonEmpty)
 
   def instance[F[_]: Concurrent: MultiParentCasperRef: Log: Metrics: FinalityDetector: BlockStore: TaskLike: ExecutionEngineService](
-      blockApiLock: Semaphore[F],
-      ignoreDeploySignature: Boolean
+      blockApiLock: Semaphore[F]
   )(
       implicit worker: Scheduler
   ): F[CasperMessageGrpcMonix.DeployService] = {
@@ -39,7 +38,7 @@ object GrpcDeployService {
         Task.defer(TaskLike[F].toTask(task)).executeOn(worker).attemptAndLog
 
       override def doDeploy(d: DeployData): Task[DeployServiceResponse] =
-        defer(BlockAPI.deploy[F](d, ignoreDeploySignature))
+        defer(BlockAPI.deploy[F](d))
 
       override def createBlock(e: Empty): Task[DeployServiceResponse] =
         defer(BlockAPI.createBlock[F](blockApiLock))

--- a/node/src/main/scala/io/casperlabs/node/api/Servers.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Servers.scala
@@ -88,21 +88,14 @@ object Servers {
       port: Int,
       maxMessageSize: Int,
       grpcExecutor: Scheduler,
-      blockApiLock: Semaphore[F],
-      ignoreDeploySignature: Boolean,
       maybeSslContext: Option[SslContext]
   )(implicit scheduler: Scheduler, logId: Log[Id], metricsId: Metrics[Id]): Resource[F, Unit] =
     GrpcServer(
       port = port,
       maxMessageSize = Some(maxMessageSize),
       services = List(
-        // TODO: Phase DeployService out in favor of CasperService.
         (_: Scheduler) =>
-          GrpcDeployService.instance(blockApiLock, ignoreDeploySignature) map {
-            CasperMessageGrpcMonix.bindService(_, grpcExecutor)
-          },
-        (_: Scheduler) =>
-          GrpcCasperService(ignoreDeploySignature) map {
+          GrpcCasperService() map {
             CasperGrpcMonix.bindService(_, grpcExecutor)
           }
       ),

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -302,10 +302,6 @@ private[configuration] final case class Options private (
       gen[Path]("Path to the Wasm file which contains the Proof-of-Stake contract")
 
     @scallop
-    val casperIgnoreDeploySignature =
-      gen[Flag]("Bypass deploy hash and signature validation, for debug purposes.")
-
-    @scallop
     val casperAutoProposeEnabled =
       gen[Flag]("Enable auto-proposal of blocks.")
 

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -81,7 +81,6 @@ approve-genesis = false
 approve-genesis-interval = "1second"
 approve-genesis-duration = "1second"
 deploy-timestamp = 1
-ignore-deploy-signature = false
 auto-propose-enabled = false
 auto-propose-check-interval = "1second"
 auto-propose-max-interval = "1second"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -115,7 +115,6 @@ class ConfigurationSpec
       approveGenesisDuration = FiniteDuration(1, TimeUnit.SECONDS),
       deployTimestamp = 1L.some,
       genesisPath = Paths.get("/tmp/genesis"),
-      ignoreDeploySignature = false,
       autoProposeEnabled = false,
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),


### PR DESCRIPTION
### Overview
The node only checked the deploy signatures when the user was sending them directly to the node, but it implicitly trusted other validators that gossiped blocks would contain valid deploys. A malicious validator could have fabricated deploys for any account.

The PR also removes the `ignore-deploy-signature` setting. The tests support it now, and we don't do the REST interface at the moment. Also not strating the `DeployService` any more.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-652

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
