### PR TITLE
EE-542: PoS set_refund_purse function

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -1065,6 +1065,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pos-refund-purse"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.10.0",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "contracts/test/local-state",
     "contracts/test/main-purse",
     "contracts/test/pos-get-payment-purse",
+    "contracts/test/pos-refund-purse",
     "contracts/test/remove-associated-key",
     "contracts/test/transfer-purse-to-account",
     "contracts/test/transfer-purse-to-purse",

--- a/execution-engine/contracts/system/pos/src/error.rs
+++ b/execution-engine/contracts/system/pos/src/error.rs
@@ -22,6 +22,7 @@ pub enum Error {
     PaymentPurseKeyUnexpectedType,
     BondingPurseNotFound,
     BondingPurseKeyUnexpectedType,
+    RefundPurseKeyUnexpectedType,
     // TODO: Put these in their own enum, and wrap them separately in `BondingError` and
     // `UnbondingError`.
     QueueNotStoredAsByteArray,
@@ -52,6 +53,7 @@ impl Into<u32> for Error {
             Error::PaymentPurseKeyUnexpectedType => 0x100 + 3,
             Error::BondingPurseNotFound => 0x100 + 4,
             Error::BondingPurseKeyUnexpectedType => 0x100 + 5,
+            Error::RefundPurseKeyUnexpectedType => 0x100 + 6,
             Error::QueueNotStoredAsByteArray => 0x200,
             Error::QueueDeserializationFailed => 0x200 + 1,
             Error::QueueDeserializationExtraBytes => 0x200 + 2,

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -149,10 +149,6 @@ fn set_refund(purse_id: URef) {
     contract_api::add_uref(REFUND_PURSE_KEY, &Key::URef(purse_id));
 }
 
-fn unset_refund() {
-    contract_api::remove_uref(REFUND_PURSE_KEY);
-}
-
 fn get_refund_purse() -> Option<PurseId> {
     match get_purse_id(REFUND_PURSE_KEY) {
         Ok(purse_id) => Some(purse_id),
@@ -247,7 +243,6 @@ pub extern "C" fn call() {
             let purse_id: PurseId = contract_api::get_arg(1);
             set_refund(purse_id.value());
         }
-        "unset_refund_purse" => unset_refund(),
         "get_refund_purse" => {
             // We purposely choose to remove the access rights so that we do not
             // accidentally give rights for a purse to some contract that is not

--- a/execution-engine/contracts/test/pos-refund-purse/Cargo.toml
+++ b/execution-engine/contracts/test/pos-refund-purse/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pos-refund-purse"
+version = "0.1.0"
+authors = ["Michael Birch <birchmd@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "pos_refund_purse"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std" ]
+
+[dependencies]
+cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -1,0 +1,90 @@
+#![no_std]
+#![feature(alloc)]
+
+#[macro_use]
+extern crate alloc;
+extern crate cl_std;
+
+use alloc::vec::Vec;
+
+use cl_std::contract_api;
+use cl_std::contract_api::pointers::{ContractPointer, UPointer};
+use cl_std::key::Key;
+use cl_std::value::account::PurseId;
+
+fn purse_to_key(p: &PurseId) -> Key {
+    Key::URef(p.value())
+}
+
+fn set_refund_purse(pos: &ContractPointer, p: &PurseId) {
+    contract_api::call_contract::<_, ()>(
+        pos.clone(),
+        &("set_refund_purse", *p),
+        &vec![purse_to_key(p)],
+    );
+}
+
+fn unset_refund_purse(pos: &ContractPointer) {
+    contract_api::call_contract::<_, ()>(pos.clone(), &"unset_refund_purse", &Vec::new());
+}
+
+fn get_refund_purse(pos: &ContractPointer) -> Option<PurseId> {
+    contract_api::call_contract(pos.clone(), &"get_refund_purse", &Vec::new())
+}
+
+fn create_purse(mint: &ContractPointer) -> PurseId {
+    contract_api::call_contract(mint.clone(), &"create", &Vec::new())
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
+    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_pointer = pos_contract.to_c_ptr().unwrap();
+
+    let mint_public: UPointer<Key> = contract_api::get_uref("mint").unwrap().to_u_ptr().unwrap();
+    let mint_contract: Key = contract_api::read(mint_public);
+    let mint_pointer = mint_contract.to_c_ptr().unwrap();
+
+    let p1 = create_purse(&mint_pointer);
+    let p2 = create_purse(&mint_pointer);
+
+    // get_refund_purse should return None before setting it
+    let refund_result = get_refund_purse(&pos_pointer);
+    if refund_result.is_some() {
+        contract_api::revert(1);
+    }
+
+    // it should return Some(x) after calling set_refund_purse(x)
+    set_refund_purse(&pos_pointer, &p1);
+    let refund_purse = match get_refund_purse(&pos_pointer) {
+        None => contract_api::revert(2),
+        Some(x) if x.value().addr() == p1.value().addr() => x.value(),
+        Some(_) => contract_api::revert(3),
+    };
+
+    // the returned purse should not have any access rights
+    if refund_purse.is_addable() || refund_purse.is_writeable() || refund_purse.is_readable() {
+        contract_api::revert(4)
+    }
+
+    // get_refund_purse should return correct value after setting a second time
+    set_refund_purse(&pos_pointer, &p2);
+    match get_refund_purse(&pos_pointer) {
+        None => contract_api::revert(5),
+        Some(x) if x.value().addr() == p2.value().addr() => (),
+        Some(_) => contract_api::revert(6),
+    }
+
+    // it should return None again after calling unset_refund_purse
+    unset_refund_purse(&pos_pointer);
+    if get_refund_purse(&pos_pointer).is_some() {
+        contract_api::revert(7);
+    }
+
+    // unset_refund_purse is idempotent
+    unset_refund_purse(&pos_pointer);
+    if get_refund_purse(&pos_pointer).is_some() {
+        contract_api::revert(8);
+    }
+}

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -28,22 +28,14 @@ fn get_refund_purse(pos: &ContractPointer) -> Option<PurseId> {
     contract_api::call_contract(pos.clone(), &"get_refund_purse", &Vec::new())
 }
 
-fn create_purse(mint: &ContractPointer) -> PurseId {
-    contract_api::call_contract(mint.clone(), &"create", &Vec::new())
-}
-
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = pos_contract.to_c_ptr().unwrap();
 
-    let mint_public: UPointer<Key> = contract_api::get_uref("mint").unwrap().to_u_ptr().unwrap();
-    let mint_contract: Key = contract_api::read(mint_public);
-    let mint_pointer = mint_contract.to_c_ptr().unwrap();
-
-    let p1 = create_purse(&mint_pointer);
-    let p2 = create_purse(&mint_pointer);
+    let p1 = contract_api::create_purse();
+    let p2 = contract_api::create_purse();
 
     // get_refund_purse should return None before setting it
     let refund_result = get_refund_purse(&pos_pointer);

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -24,10 +24,6 @@ fn set_refund_purse(pos: &ContractPointer, p: &PurseId) {
     );
 }
 
-fn unset_refund_purse(pos: &ContractPointer) {
-    contract_api::call_contract::<_, ()>(pos.clone(), &"unset_refund_purse", &Vec::new());
-}
-
 fn get_refund_purse(pos: &ContractPointer) -> Option<PurseId> {
     contract_api::call_contract(pos.clone(), &"get_refund_purse", &Vec::new())
 }
@@ -74,17 +70,5 @@ pub extern "C" fn call() {
         None => contract_api::revert(5),
         Some(x) if x.value().addr() == p2.value().addr() => (),
         Some(_) => contract_api::revert(6),
-    }
-
-    // it should return None again after calling unset_refund_purse
-    unset_refund_purse(&pos_pointer);
-    if get_refund_purse(&pos_pointer).is_some() {
-        contract_api::revert(7);
-    }
-
-    // unset_refund_purse is idempotent
-    unset_refund_purse(&pos_pointer);
-    if get_refund_purse(&pos_pointer).is_some() {
-        contract_api::revert(8);
     }
 }

--- a/execution-engine/engine-grpc-server/tests/test_pos_refund_purse.rs
+++ b/execution-engine/engine-grpc-server/tests/test_pos_refund_purse.rs
@@ -1,0 +1,50 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate contract_ffi;
+extern crate engine_core;
+extern crate engine_shared;
+extern crate engine_storage;
+extern crate grpc;
+
+use std::collections::HashMap;
+
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(unused)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
+
+#[ignore]
+#[test]
+fn should_run_pos_refund_purse_contract_genesis_account() {
+    WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec(GENESIS_ADDR, "pos_refund_purse.wasm", DEFAULT_BLOCK_TIME, 1)
+        .expect_success()
+        .commit();
+}
+
+#[ignore]
+#[test]
+fn should_run_pos_refund_purse_contract_account_1() {
+    WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec_with_args(
+            GENESIS_ADDR,
+            "transfer_to_account_01.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+            ACCOUNT_1_ADDR,
+        )
+        .expect_success()
+        .commit()
+        .exec(
+            ACCOUNT_1_ADDR,
+            "pos_refund_purse.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+        )
+        .expect_success()
+        .commit();
+}


### PR DESCRIPTION
### Overview
`set_refund_purse` is needed for payment code. The other functions were mostly for ease of testing and could perhaps be useful to users with more complex payment code logic.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-542

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
