### PR TITLE
EE-509: Check thresholds before performing account action

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -756,6 +756,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "key-management-thresholds"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.10.0",
+]
+
+[[package]]
 name = "known-urefs"
 version = "0.1.0"
 dependencies = [

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "contracts/test/transfer-purse-to-purse",
     "contracts/test/transfer-to-account-01",
     "contracts/test/transfer-to-account-02",
+    "contracts/test/key-management-thresholds",
     "engine-core",
     "engine-grpc-server",
     "engine-metrics-scraper",

--- a/execution-engine/contracts/test/key-management-thresholds/Cargo.toml
+++ b/execution-engine/contracts/test/key-management-thresholds/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "key-management-thresholds"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "key_management_thresholds"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std" ]
+
+[dependencies]
+cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
+++ b/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
@@ -1,0 +1,70 @@
+#![no_std]
+#![feature(alloc, cell_update)]
+
+extern crate alloc;
+extern crate cl_std;
+
+use alloc::string::String;
+
+use cl_std::contract_api::{
+    add_associated_key, get_arg, remove_associated_key, revert, set_action_threshold,
+    update_associated_key,
+};
+use cl_std::value::account::{
+    ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
+    Weight,
+};
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let stage: String = get_arg(0);
+    if stage == "init" {
+        // executed with weight >= 1
+        add_associated_key(PublicKey::new([42; 32]), Weight::new(100))
+            .unwrap_or_else(|_| revert(100));
+        // this key will be used to test permission denied when removing keys with low total weight
+        add_associated_key(PublicKey::new([43; 32]), Weight::new(1))
+            .unwrap_or_else(|_| revert(101));
+        add_associated_key(PublicKey::new([1; 32]), Weight::new(1)).unwrap_or_else(|_| revert(102));
+        set_action_threshold(ActionType::KeyManagement, Weight::new(101))
+            .unwrap_or_else(|_| revert(103));
+    } else if stage == "test-permission-denied" {
+        // Has to be executed with keys of total weight < 255
+        match add_associated_key(PublicKey::new([44; 32]), Weight::new(1)) {
+            Ok(_) => revert(200),
+            Err(AddKeyFailure::PermissionDenied) => {}
+            Err(_) => revert(201),
+        }
+
+        match update_associated_key(PublicKey::new([43; 32]), Weight::new(2)) {
+            Ok(_) => revert(300),
+            Err(UpdateKeyFailure::PermissionDenied) => {}
+            Err(_) => revert(301),
+        }
+        match remove_associated_key(PublicKey::new([43; 32])) {
+            Ok(_) => revert(400),
+            Err(RemoveKeyFailure::PermissionDenied) => {}
+            Err(_) => revert(401),
+        }
+
+        match set_action_threshold(ActionType::KeyManagement, Weight::new(255)) {
+            Ok(_) => revert(500),
+            Err(SetThresholdFailure::PermissionDeniedError) => {}
+            Err(_) => revert(501),
+        }
+    } else if stage == "test-key-mgmnt-succeed" {
+        // Has to be executed with keys of total weight >= 254
+        add_associated_key(PublicKey::new([44; 32]), Weight::new(1))
+            .unwrap_or_else(|_| revert(600));
+        // Updates [43;32] key weight created in init stage
+        update_associated_key(PublicKey::new([44; 32]), Weight::new(2))
+            .unwrap_or_else(|_| revert(601));
+        // Removes [43;32] key created in init stage
+        remove_associated_key(PublicKey::new([44; 32])).unwrap_or_else(|_| revert(602));
+        // Sets action threshodl
+        set_action_threshold(ActionType::KeyManagement, Weight::new(100))
+            .unwrap_or_else(|_| revert(603));
+    } else {
+        revert(1)
+    }
+}

--- a/execution-engine/engine-core/src/runtime_context.rs
+++ b/execution-engine/engine-core/src/runtime_context.rs
@@ -614,6 +614,15 @@ where
             return Err(AddKeyFailure::PermissionDenied.into());
         }
 
+        if !self
+            .account()
+            .can_manage_keys_with(&self.authorization_keys)
+        {
+            // Exit early if authorization keys weight doesn't exceed required
+            // key management threshold
+            return Err(AddKeyFailure::PermissionDenied.into());
+        }
+
         // Converts an account's public key into a URef
         let key = Key::Account(self.account().pub_key());
 
@@ -640,6 +649,15 @@ where
         // Check permission to modify associated keys
         if self.base_key() != Key::Account(self.account().pub_key()) {
             // Exit early with error to avoid mutations
+            return Err(RemoveKeyFailure::PermissionDenied.into());
+        }
+
+        if !self
+            .account()
+            .can_manage_keys_with(&self.authorization_keys)
+        {
+            // Exit early if authorization keys weight doesn't exceed required
+            // key management threshold
             return Err(RemoveKeyFailure::PermissionDenied.into());
         }
 
@@ -676,6 +694,15 @@ where
             return Err(UpdateKeyFailure::PermissionDenied.into());
         }
 
+        if !self
+            .account()
+            .can_manage_keys_with(&self.authorization_keys)
+        {
+            // Exit early if authorization keys weight doesn't exceed required
+            // key management threshold
+            return Err(UpdateKeyFailure::PermissionDenied.into());
+        }
+
         // Converts an account's public key into a URef
         let key = Key::Account(self.account().pub_key());
 
@@ -706,6 +733,15 @@ where
         // Check permission to modify associated keys
         if self.base_key() != Key::Account(self.account().pub_key()) {
             // Exit early with error to avoid mutations
+            return Err(SetThresholdFailure::PermissionDeniedError.into());
+        }
+
+        if !self
+            .account()
+            .can_manage_keys_with(&self.authorization_keys)
+        {
+            // Exit early if authorization keys weight doesn't exceed required
+            // key management threshold
             return Err(SetThresholdFailure::PermissionDeniedError.into());
         }
 

--- a/execution-engine/engine-grpc-server/tests/test_key_management_thresholds.rs
+++ b/execution-engine/engine-grpc-server/tests/test_key_management_thresholds.rs
@@ -1,0 +1,74 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate contract_ffi;
+extern crate engine_core;
+extern crate engine_shared;
+extern crate engine_storage;
+extern crate grpc;
+
+use std::collections::HashMap;
+
+use contract_ffi::value::account::PublicKey;
+
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(dead_code)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+
+#[ignore]
+#[test]
+fn should_verify_key_management_permission_with_low_weight() {
+    WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec_with_args(
+            GENESIS_ADDR,
+            "key_management_thresholds.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+            String::from("init"),
+        )
+        .expect_success()
+        .commit()
+        .exec_with_args(
+            GENESIS_ADDR,
+            "key_management_thresholds.wasm",
+            DEFAULT_BLOCK_TIME,
+            2,
+            // This test verifies that any other error than PermissionDenied would revert
+            String::from("test-permission-denied"),
+        )
+        .expect_success()
+        .commit();
+}
+
+#[ignore]
+#[test]
+fn should_verify_key_management_permission_with_sufficient_weight() {
+    WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec_with_args(
+            GENESIS_ADDR,
+            "key_management_thresholds.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+            String::from("init"),
+        )
+        .expect_success()
+        .commit()
+        .exec_with_args_and_keys(
+            GENESIS_ADDR,
+            "key_management_thresholds.wasm",
+            DEFAULT_BLOCK_TIME,
+            2,
+            // This test verifies that all key management operations succeed
+            String::from("test-key-mgmnt-succeed"),
+            vec![
+                PublicKey::new(GENESIS_ADDR),
+                // Key [42; 32] is created in init stage
+                PublicKey::new([42; 32]),
+            ],
+        )
+        .expect_success()
+        .commit();
+}


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

Adds checks if total weights of authorization keys passed to deployment is greater or equal to the key management thresholds. Raises PermissionDenied otherwise. Contains an integration test to prove permission denied is raised with insufficient weight, and a test case that proves increasing weight of keys will make key management methods succeed. And some unit tests to support this feature.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-509

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._

Discovered another bug while developing integration tests: https://casperlabs.atlassian.net/browse/EE-550