### PR TITLE
ECO-101: Display justification lines on hover.

### DIFF
--- a/explorer/server/README.md
+++ b/explorer/server/README.md
@@ -31,6 +31,14 @@ ln -s ../../grpc/generated grpc
 
 Run unit tests, for example to check the contract ABI serialization format.
 
+## Environment variables
+
+You can start the server in once console and the UI in another, the UI will proxy the requests to the backend, and also get the configuration from the `config.js` file served by the backend.
+
+There are some environment variables that can come handy:
+* `UI_GRPC_URL`: By default this is empty, or pointing at the local docker setup, but you can set it to any environment to test the UI locally agains the remote `grpcwebproxy` insteance.
+* `AUTH_MOCK_ENABLED`: By setting it to `true` you can work offline and be automatically logged in with a test user to create accounts and use the faucet.
+
 ## Useful links:
 * https://facebook.github.io/create-react-app/docs/deployment
 * https://www.fullstackreact.com/articles/using-create-react-app-with-a-server/

--- a/explorer/ui/src/styles/custom.scss
+++ b/explorer/ui/src/styles/custom.scss
@@ -50,3 +50,16 @@ button.link:hover {
 button.icon-button {
   color: inherit;
 }
+
+div.svg-container {
+  position: relative;
+}
+div.svg-hint {
+  position: absolute;
+  bottom: 0;
+  display: none;
+  opacity: 0.75;
+  background-color: #666666;
+  color: white;
+  padding: 5px;
+}


### PR DESCRIPTION
### Overview
During debugging it would have been useful to see justifications as well as parents. This PR changes the mouseover action to reveal the justifications of a block with dashed lines (unless they are parents) and also makes the link to the main parent even thicker to make it stand out more.
![image](https://user-images.githubusercontent.com/2684603/62633908-d54fff00-b92c-11e9-8e3c-d8b49ddf5e6d.png)

Also moves the "title" that appears with the block details to the bottom of the graph so it doesn't block the view:
![image](https://user-images.githubusercontent.com/2684603/62637489-6fb34100-b933-11e9-896b-c046c59f6e91.png)


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-101

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
