### PR TITLE
OP-524: create revert contract

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -1378,6 +1378,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "revert"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.10.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "contract-ffi",
     "contracts/client/bonding",
+    "contracts/client/revert",
     "contracts/client/transfer_to_account",
     "contracts/client/unbonding",
     "contracts/system/mint-token",

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -34,7 +34,7 @@ test:
 	$(CARGO) test $(CARGO_FLAGS) -- --nocapture
 
 .PHONY: test-contracts
-test-contracts: $(SYSTEM_CONTRACTS) $(TEST_CONTRACTS)
+test-contracts: build-contracts
 	$(CARGO) test $(CARGO_FLAGS) -p casperlabs-engine-grpc-server -- --ignored --nocapture
 
 .PHONY: check-format

--- a/execution-engine/contracts/client/revert/Cargo.toml
+++ b/execution-engine/contracts/client/revert/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "revert"
+version = "0.1.0"
+authors = ["Henry Till <henrytill@gmail.com>"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std"]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/client/revert/src/lib.rs
+++ b/execution-engine/contracts/client/revert/src/lib.rs
@@ -1,0 +1,11 @@
+#![no_std]
+#![feature(alloc)]
+
+extern crate contract_ffi;
+
+use contract_ffi::contract_api;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    contract_api::revert(100)
+}

--- a/execution-engine/engine-grpc-server/tests/test_revert.rs
+++ b/execution-engine/engine-grpc-server/tests/test_revert.rs
@@ -1,0 +1,27 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate contract_ffi;
+extern crate engine_core;
+extern crate engine_shared;
+extern crate engine_storage;
+extern crate grpc;
+
+#[allow(dead_code)]
+mod test_support;
+
+use std::collections::HashMap;
+
+use test_support::WasmTestBuilder;
+
+const GENESIS_ADDR: [u8; 32] = [7u8; 32];
+const REVERT_WASM: &str = "revert.wasm";
+const BLOCK_TIME: u64 = 42;
+
+#[ignore]
+#[test]
+fn should_revert() {
+    WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec(GENESIS_ADDR, REVERT_WASM, BLOCK_TIME, 1)
+        .commit()
+        .is_error();
+}


### PR DESCRIPTION
### Overview
This PR adds a simple contract that calls `contract_api::revert` only.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-524

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
