### PR TITLE
EE-532: Accounts which could not be found should be marked as precondition failure

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -470,6 +470,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ee-532-regression"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.10.0",
+]
+
+[[package]]
 name = "ee-536-regression"
 version = "0.1.0"
 dependencies = [

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "contracts/test/ee-441-rng-state",
     "contracts/test/ee-539-regression",
     "contracts/test/ee-536-regression",
+    "contracts/test/ee-532-regression",
     "contracts/test/get-blocktime",
     "contracts/test/get-caller",
     "contracts/test/get-caller-subcall",

--- a/execution-engine/contracts/test/ee-532-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-532-regression/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ee-532-regression"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "ee_532_regression"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std"]
+
+[dependencies]
+cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-532-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-532-regression/src/lib.rs
@@ -1,0 +1,10 @@
+#![no_std]
+#![feature(alloc, cell_update)]
+
+extern crate alloc;
+extern crate cl_std;
+
+#[no_mangle]
+pub extern "C" fn call() {
+    // Does nothing
+}

--- a/execution-engine/engine-core/src/execution.rs
+++ b/execution-engine/engine-core/src/execution.rs
@@ -1503,12 +1503,19 @@ impl Executor<Module> for WasmiExecutor {
             on_fail_charge!(instance_and_memory(parity_module.clone(), protocol_version));
         #[allow(unreachable_code)]
         let validated_key = on_fail_charge!(Validated::new(acct_key, Validated::valid));
-        let value = on_fail_charge! {
-            match tc.borrow_mut().get(correlation_id, &validated_key) {
-                Ok(None) => Err(Error::KeyNotFound(acct_key)),
-                Err(error) => Err(error.into()),
-                Ok(Some(value)) => Ok(value)
+
+        let value = match tc.borrow_mut().get(correlation_id, &validated_key) {
+            Ok(None) => {
+                return ExecutionResult::precondition_failure(
+                    ::engine_state::error::Error::AuthorizationError,
+                )
             }
+            Err(error) => {
+                return ExecutionResult::precondition_failure(
+                    ::engine_state::error::Error::ExecError(error.into()),
+                )
+            }
+            Ok(Some(value)) => value,
         };
 
         let mut account = match value {

--- a/execution-engine/engine-grpc-server/tests/regression_test_ee_532.rs
+++ b/execution-engine/engine-grpc-server/tests/regression_test_ee_532.rs
@@ -1,0 +1,46 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate contract_ffi;
+extern crate engine_core;
+extern crate engine_shared;
+extern crate engine_storage;
+extern crate grpc;
+
+use std::collections::HashMap;
+
+use engine_core::engine_state::error;
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(dead_code)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+const UNKNOWN_ADDR: [u8; 32] = [42u8; 32];
+
+#[ignore]
+#[test]
+fn should_run_ee_532_get_uref_regression_test() {
+    // This test runs a contract that's after every call extends the same key with more data
+    let result = WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, HashMap::new())
+        .exec(
+            UNKNOWN_ADDR,
+            "ee_532_regression.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+        )
+        .commit()
+        .finish();
+    let deploy_result = result
+        .builder()
+        .get_exec_response(0)
+        .expect("should have exec response")
+        .get_success()
+        .get_deploy_results()
+        .get(0)
+        .expect("should have at least one deploy result");
+
+    assert!(deploy_result.has_precondition_failure());
+    let message = deploy_result.get_precondition_failure().get_message();
+
+    assert_eq!(message, format!("{}", error::Error::AuthorizationError))
+}


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

Instead of execution error, missing key is raising a precondition failure of type `AuthorizationError` for consistency with an error where passed authorization keys are missing on the account.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-532

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
