### PR TITLE
NODE-744: Make sequence number assignment consistent with sequence number validation

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -420,7 +420,7 @@ object ProtoUtil {
     val validator = ByteString.copyFrom(pk)
     for {
       latestMessageOpt <- dag.latestMessage(validator)
-      seqNum           = latestMessageOpt.fold(0)(_.validatorBlockSeqNum) + 1
+      seqNum           = latestMessageOpt.fold(-1)(_.validatorBlockSeqNum) + 1
       header = {
         assert(block.header.isDefined, "A block without a header doesn't make sense")
         block.getHeader


### PR DESCRIPTION
### Overview
Fixes the bug where newly bonded validators cannot make blocks.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-744

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
An integration test which would have caught this bug is ticketed to be written: https://casperlabs.atlassian.net/browse/OP-570
