### PR TITLE
NODE-707: Remove key checks in node

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -195,43 +195,32 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
         s"Deploy ${PrettyPrinter.buildString(d.deployHash)} has no signatures."
       ) *> false.pure[F]
     } else {
-      for {
-        signatoriesVerified <- d.approvals.toList
-                                .traverse { a =>
-                                  signatureVerifiers(a.getSignature.sigAlgorithm)
-                                    .map { verify =>
-                                      Try {
-                                        verify(
-                                          d.deployHash.toByteArray,
-                                          Signature(a.getSignature.sig.toByteArray),
-                                          PublicKey(a.approverPublicKey.toByteArray)
-                                        )
-                                      } match {
-                                        case Success(true) =>
-                                          true.pure[F]
-                                        case _ =>
-                                          Log[F].warn(
-                                            s"Signature of deploy ${PrettyPrinter.buildString(d.deployHash)} is invalid."
-                                          ) *> false.pure[F]
-                                      }
-                                    } getOrElse {
-                                    Log[F].warn(
-                                      s"Signature algorithm ${a.getSignature.sigAlgorithm} of deploy ${PrettyPrinter
-                                        .buildString(d.deployHash)} is unsupported."
-                                    ) *> false.pure[F]
-                                  }
-                                }
-                                .map(_.forall(identity))
-        keysMatched = d.approvals.toList.exists { a =>
-          a.approverPublicKey == d.getHeader.accountPublicKey
+      d.approvals.toList
+        .traverse { a =>
+          signatureVerifiers(a.getSignature.sigAlgorithm)
+            .map { verify =>
+              Try {
+                verify(
+                  d.deployHash.toByteArray,
+                  Signature(a.getSignature.sig.toByteArray),
+                  PublicKey(a.approverPublicKey.toByteArray)
+                )
+              } match {
+                case Success(true) =>
+                  true.pure[F]
+                case _ =>
+                  Log[F].warn(
+                    s"Signature of deploy ${PrettyPrinter.buildString(d.deployHash)} is invalid."
+                  ) *> false.pure[F]
+              }
+            } getOrElse {
+            Log[F].warn(
+              s"Signature algorithm ${a.getSignature.sigAlgorithm} of deploy ${PrettyPrinter
+                .buildString(d.deployHash)} is unsupported."
+            ) *> false.pure[F]
+          }
         }
-        _ <- Log[F]
-              .warn(
-                s"Signatories of deploy ${PrettyPrinter.buildString(d.deployHash)} don't contain at least one signature with key equal to public key: ${PrettyPrinter
-                  .buildString(d.getHeader.accountPublicKey)}"
-              )
-              .whenA(!keysMatched)
-      } yield signatoriesVerified && keysMatched
+        .map(_.forall(identity))
     }
 
   def blockSender(block: BlockSummary)(implicit bs: BlockStorage[F]): F[Boolean] =

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -229,18 +229,6 @@ class ValidationTest
     Validation[Task].deploySignature(deploy) shouldBeF true
   }
 
-  it should "return false if its public key doesn't contained in approvals" in withoutStorage {
-    val genDeploy = for {
-      d            <- arbitrary[consensus.Deploy]
-      approvalKeys <- genAccountKeys
-      signature    = approvalKeys.sign(d.deployHash)
-    } yield d.withApprovals(
-      List(Approval().withApproverPublicKey(approvalKeys.publicKey).withSignature(signature))
-    )
-    val deploy = sample(genDeploy)
-    Validation[Task].deploySignature(deploy) shouldBeF false
-  }
-
   it should "return false if a key in an approval is empty" in withoutStorage {
     val genDeploy = for {
       d <- arbitrary[consensus.Deploy]


### PR DESCRIPTION
### Overview
This PR removes the validation check in Node for requiring from deploys having at least one key in its approvals matching to deploy's account public key.

Basically, reverts changes of the #730.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-707

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I'm not sure if the ticket is still actual because it says: "This check should be removed when the core components of EE-275 is complete". And EE-275 PR was closed and not merged: https://github.com/CasperLabs/CasperLabs/pull/677