### PR TITLE
NO-TICKET: Fix 'hash sum mismatch' error during 'apt-get update'

### DIFF
--- a/hack/docker/test-node.Dockerfile
+++ b/hack/docker/test-node.Dockerfile
@@ -3,7 +3,7 @@ FROM casperlabs/node:latest
 # Using iproute2 for network simulation with `tc`.
 # iptables can also be used to block individual ports.
 # Double update due to: Could not open file /var/lib/apt/lists/deb.debian.org_debian_dists_stretch-backports_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
-RUN (apt-get update || apt-get update) && apt-get install -yq iproute2 iptables curl sed nmap
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && (apt-get update || apt-get update) && apt-get install -yq iproute2 iptables curl sed nmap
 
 COPY .genesis/system-contracts /opt/docker/system-contracts
 ENV CL_CASPER_MINT_CODE_PATH /opt/docker/system-contracts/mint_token.wasm

--- a/integration-testing/Dockerfile
+++ b/integration-testing/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6.8-slim
 
 LABEL MAINTAINER="CasperLabs, LLC. <info@casperlabs.io>"
 
-RUN apt-get update && apt-get install -y gcc unzip curl sudo
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -y gcc unzip curl sudo
 RUN curl -OL https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip
 RUN unzip protoc-3.2.0-linux-x86_64.zip -d protoc3 && sudo mv protoc3/bin/* /usr/local/bin/
 RUN sudo mv protoc3/include/* /usr/local/include/ && ln -s /protoc3/bin/protoc /usr/bin/protoc

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-jre-slim
 
-RUN apt-get update && apt-get install -yq openssl
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* && apt-get update && apt-get install -yq openssl
 LABEL MAINTAINER="CasperLabs, LLC. <info@casperlabs.io>"
 
 USER root


### PR DESCRIPTION
### Overview
Previously I always experienced the next problem during `make docker-build/node` and `make docker-build/integration-testing`: `Hash sum mismatch`.

This PR solves the problem using this article: https://blog.packagecloud.io/eng/2016/09/27/fixing-apt-hash-sum-mismatch-consistent-apt-repositories/

### Which JIRA ticket does this PR relate to?
This is an unticketed PR

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._