### PR TITLE
OP-577: Add --payment-args flag to CLI's deploy command. Support U512 in ABI.

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -109,11 +109,11 @@ class ABI:
                 )
 
         def python_value(typ, value: str):
-            if typ in ("u32", "u64"):
+            if typ in ("u32", "u64", "u512"):
                 return int(value)
             elif typ == "account":
                 return bytearray.fromhex(value)
-            raise ValueError(f"Unknown type {typ}, expected ('u32', 'u64', 'account')")
+            raise ValueError(f"Unknown type {typ}, expected ('u32', 'u64', 'u512', 'account')")
 
         def encode(typ: str, value: str) -> bytes:
             v = python_value(typ, value)
@@ -237,7 +237,7 @@ class CasperLabsClient:
         nonce: int = 0,
         public_key: str = None,
         private_key: str = None,
-        args: bytes = None,
+        session_args: bytes = None,
         payment_args: bytes = None,
     ):
         """
@@ -256,7 +256,8 @@ class CasperLabsClient:
                               transactions that use the same nonce.
         :param public_key:    Path to a file with public key (Ed25519)
         :param private_key:   Path to a file with private key (Ed25519)
-        :param args:          List of ABI encoded arguments
+        :param session_args:  List of ABI encoded arguments of session contract
+        :param payment_args:  List of ABI encoded arguments of payment contract
         :return:              Tuple: (deserialized DeployServiceResponse object, deploy_hash)
         """
 
@@ -296,8 +297,8 @@ class CasperLabsClient:
         # args must go to payment as well for now cause otherwise we'll get GASLIMIT error:
         # https://github.com/CasperLabs/CasperLabs/blob/dev/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala#L463
         body = consensus.Deploy.Body(
-            session=read_code(session, args),
-            payment=read_code(payment, payment == session and args or payment_args),
+            session=read_code(session, session_args),
+            payment=read_code(payment, payment == session and session_args or payment_args),
         )
 
         account_public_key = public_key and read_pem_key(public_key)
@@ -560,7 +561,7 @@ def deploy_command(casperlabs_client, args):
         nonce=args.nonce,
         public_key=args.public_key or None,
         private_key=args.private_key or None,
-        args=args.args and ABI.args_from_json(args.args) or None,
+        session_args=args.session_args and ABI.args_from_json(args.session_args) or None,
         payment_args=args.payment_args and ABI.args_from_json(args.payment_args) or None,
     )
     _, deploy_hash = casperlabs_client.deploy(**kwargs)
@@ -684,8 +685,8 @@ def main():
                        [('-n', '--nonce'), dict(required=True, type=int, help='This allows you to overwrite your own pending transactions that use the same nonce.')],
                        [('-p', '--payment'), dict(required=False, type=str, default=None, help='Path to the file with payment code, by default fallbacks to the --session code')],
                        [('-s', '--session'), dict(required=True, type=str, help='Path to the file with session code')],
-                       [('--args',), dict(required=False, type=str, help='JSON encoded list of args, e.g.: [{"u32":1024},{"u64":12}]')],
-                       [('--payment-args',), dict(required=False, type=str, help="""JSON encoded list of payment code's args, e.g.: [{"u64":10000}]""")],
+                       [('--session-args',), dict(required=False, type=str, help='JSON encoded list of session args, e.g.: [{"u32":1024},{"u64":12}]')],
+                       [('--payment-args',), dict(required=False, type=str, help="""JSON encoded list of payment args, e.g.: [{"u512":100000}]""")],
                        [('--private-key',), dict(required=True, type=str, help='Path to the file with account public key (Ed25519)')],
                        [('--public-key',), dict(required=True, type=str, help='Path to the file with account private key (Ed25519)')]])
 

--- a/integration-testing/contracts/Cargo.toml
+++ b/integration-testing/contracts/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "subcall-revert-test/define",
     "transfer_to_account",
     "test_args/u32",
+    "test_args/u512",
     "test_args/multi",
     "bonding/call",
     "unbonding/call",

--- a/integration-testing/contracts/test_args/u512/Cargo.lock
+++ b/integration-testing/contracts/test_args/u512/Cargo.lock
@@ -6,11 +6,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "binascii"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "bitflags"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -22,7 +17,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -38,9 +33,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.10.0"
+version = "0.8.0"
 dependencies = [
- "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,13 +58,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combined-contracts-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -125,24 +112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "get-caller-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "get-caller-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "it_common"
-version = "0.1.0"
-
-[[package]]
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,20 +120,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "libc"
 version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "list-known-urefs-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "list-known-urefs-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
 
 [[package]]
 name = "memory_units"
@@ -255,7 +210,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -377,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.8"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -415,119 +370,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "test-bonding-call"
+name = "test_args"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-call-hello-name"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-counter-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-counter-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-direct-revert-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-direct-revert-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-mailing-list-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-mailing-list-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-store-hello-name"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-subcall-revert-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-subcall-revert-define"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test-unbonding-call"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test_args_multi"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test_args_u32"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test_args_u512"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
-]
-
-[[package]]
-name = "test_combined_contracts_call"
-version = "0.1.0"
-
-[[package]]
-name = "transfer_to_account"
-version = "0.1.0"
-dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.8.0",
 ]
 
 [[package]]
@@ -601,7 +447,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
-"checksum binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dc96c09fe0e8441b8e0e8afa1a64f11a1994f3f146008175eccdfe67f7c0330"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "91721a6330935673395a0607df4d49a9cb90ae12d259f1b3e0a3f6e1d486872e"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
@@ -610,7 +455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
+"checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
@@ -640,7 +485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-"checksum regex-syntax 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "9b01330cce219c1c6b2e209e5ed64ccd587ae5c67bed91c0b49eecf02ae40e21"
+"checksum regex-syntax 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d76410686f9e3a17f06128962e0ecc5755870bb890c34820c7af7f1db2e1d48"
 "checksum rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "403bb3a286107a04825a5f82e1270acc1e14028d3d554d7a1e08914549575ab8"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"

--- a/integration-testing/contracts/test_args/u512/Cargo.toml
+++ b/integration-testing/contracts/test_args/u512/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "test_args_u512"
+version = "0.1.0"
+authors = ["Piotr Kuchta <piotr@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "test_args_u512"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std" ]
+
+[dependencies]
+cl_std = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/test_args/u512/src/lib.rs
+++ b/integration-testing/contracts/test_args/u512/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![feature(alloc, cell_update)]
+
+extern crate alloc;
+extern crate cl_std;
+
+use cl_std::contract_api::{get_arg, revert};
+use cl_std::value::{U512};
+
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let number: U512 = get_arg(0);
+
+    // I do this silly looping because I don't know how to convert U512 to a native Rust int.
+    for i in 0..1025 {
+        if number == U512::from(i) {
+            revert(i);
+        }
+    }
+}

--- a/integration-testing/test/cl_node/docker_node.py
+++ b/integration-testing/test/cl_node/docker_node.py
@@ -299,7 +299,7 @@ class DockerNode(LoggingDockerBase):
                 payment_contract="transfer_to_account.wasm",
                 public_key=public_key_path,
                 private_key=private_key_path,
-                args=self.p_client.abi.args_from_json(args_json),
+                session_args=self.p_client.abi.args_from_json(args_json),
             )
 
         deploy_hash_hex = deploy_hash_bytes.hex()
@@ -354,7 +354,7 @@ class DockerNode(LoggingDockerBase):
             payment_contract=payment_contract,
             public_key=from_account.public_key_path,
             private_key=from_account.private_key_path,
-            args=self.p_client.abi.args_from_json(json_args),
+            session_args=self.p_client.abi.args_from_json(json_args),
         )
 
         deploy_hash_hex = deploy_hash_bytes.hex()

--- a/integration-testing/test/cl_node/python_client.py
+++ b/integration-testing/test/cl_node/python_client.py
@@ -43,7 +43,8 @@ class PythonClient(CasperLabsClient, LoggingMixin):
         payment_contract: Optional[str] = None,
         private_key: Optional[str] = None,
         public_key: Optional[str] = None,
-        args: list = None,
+        session_args: list = None,
+        payment_args: list = None,
     ) -> str:
 
         assert session_contract is not None
@@ -77,7 +78,8 @@ class PythonClient(CasperLabsClient, LoggingMixin):
                 deploy_nonce,
                 public_key,
                 private_key,
-                args,
+                session_args,
+                payment_args,
             )
             return r
         except Exception:

--- a/integration-testing/test/test_python_client.py
+++ b/integration-testing/test/test_python_client.py
@@ -59,7 +59,7 @@ def test_deploy_with_args(one_node_network, genesis_public_signing_key):
                 session=wasm,
                 public_key=resource("accounts/account-public-genesis.pem"),
                 private_key=resource("accounts/account-private-genesis.pem"),
-                args=ABI.args([encode(number)]),
+                session_args=ABI.args([encode(number)]),
                 nonce=nonce,
             )
             nonce += 1
@@ -90,7 +90,7 @@ def test_deploy_with_args(one_node_network, genesis_public_signing_key):
         public_key=resource("accounts/account-public-genesis.pem"),
         private_key=resource("accounts/account-private-genesis.pem"),
 
-        args=ABI.args([ABI.account(bytes.fromhex(account_hex)), ABI.u32(number)]),
+        session_args=ABI.args([ABI.account(bytes.fromhex(account_hex)), ABI.u32(number)]),
         nonce=nonce,
     )
     logging.info(f"DEPLOY RESPONSE: {response} deploy_hash: {deploy_hash.hex()}")

--- a/integration-testing/test/test_python_client.py
+++ b/integration-testing/test/test_python_client.py
@@ -38,9 +38,11 @@ def genesis_public_signing_key():
 
 def test_deploy_with_args(one_node_network, genesis_public_signing_key):
     """
-    Deploys test contracts that does:
+    Deploys test contracts that do:
 
-        revert(get_arg(0)); for u32
+        revert(get_arg(0)); // for u32 and u512
+
+    and
 
         revert(sum(address_bytes[u8; 32]) + u32); for multiple argument test.
 
@@ -50,49 +52,48 @@ def test_deploy_with_args(one_node_network, genesis_public_signing_key):
     client = node.p_client.client
 
     nonce = 1
-    wasm = resource("test_args_u32.wasm")
-    for number in [12, 256, 1024]:
-        response, deploy_hash = client.deploy(
-            payment=wasm,
-            session=wasm,
-            public_key=resource("accounts/account-public-genesis.pem"),
-            private_key=resource("accounts/account-private-genesis.pem"),
-            args=ABI.args([ABI.u32(number)]),
-            nonce=nonce,
-        )
-        nonce += 1
-        logging.info(f"DEPLOY RESPONSE: {response} deploy_hash: {deploy_hash.hex()}")
+    for wasm, encode in [(resource("test_args_u32.wasm"), ABI.u32), (resource("test_args_u512.wasm"), ABI.u512)]:
+        for number in [1, 12, 256, 1024]:
+            response, deploy_hash = client.deploy(
+                payment=wasm,
+                session=wasm,
+                public_key=resource("accounts/account-public-genesis.pem"),
+                private_key=resource("accounts/account-private-genesis.pem"),
+                args=ABI.args([encode(number)]),
+                nonce=nonce,
+            )
+            nonce += 1
+            logging.info(f"DEPLOY RESPONSE: {response} deploy_hash: {deploy_hash.hex()}")
 
-        response = client.propose()
-        # Need to convert to hex string from bytes
-        block_hash = response.block_hash.hex()
+            response = client.propose()
+            # Need to convert to hex string from bytes
+            block_hash = response.block_hash.hex()
 
-        for deploy_info in client.showDeploys(block_hash):
-            assert deploy_info.is_error is True
-            assert deploy_info.error_message == f"Exit code: {number}"
+            for deploy_info in client.showDeploys(block_hash):
+                assert deploy_info.is_error is True
+                assert deploy_info.error_message == f"Exit code: {number}"
 
-            # Test show_deploy
-            d = client.showDeploy(deploy_info.deploy.deploy_hash.hex())
-            assert deploy_info.deploy.deploy_hash == d.deploy.deploy_hash
+                # Test show_deploy
+                d = client.showDeploy(deploy_info.deploy.deploy_hash.hex())
+                assert deploy_info.deploy.deploy_hash == d.deploy.deploy_hash
 
-    # Testing multiple args without rebuilding network.
+            logging.info(f"NONCE ===================== {nonce}")
+
     wasm = resource("test_args_multi.wasm")
     account_hex = "0101010102020202030303030404040405050505060606060707070708080808"
     number = 1000
     total_sum = sum([1, 2, 3, 4, 5, 6, 7, 8]) * 4 + number
-
-    json_args = json.dumps([{"account": account_hex}, {"u32": number}])
 
     response, deploy_hash = client.deploy(
         payment=wasm,
         session=wasm,
         public_key=resource("accounts/account-public-genesis.pem"),
         private_key=resource("accounts/account-private-genesis.pem"),
-        args=ABI.args_from_json(json_args),
+
+        args=ABI.args([ABI.account(bytes.fromhex(account_hex)), ABI.u32(number)]),
         nonce=nonce,
     )
     logging.info(f"DEPLOY RESPONSE: {response} deploy_hash: {deploy_hash.hex()}")
-
     response = client.propose()
 
     block_hash = response.block_hash.hex()
@@ -107,3 +108,4 @@ def test_deploy_with_args(one_node_network, genesis_public_signing_key):
 
     for blockInfo in client.showBlocks(10):
         assert blockInfo.status.stats.block_size_bytes > 0
+

--- a/integration-testing/test/test_python_client.py
+++ b/integration-testing/test/test_python_client.py
@@ -47,6 +47,12 @@ def test_deploy_with_args(one_node_network, genesis_public_signing_key):
         revert(sum(address_bytes[u8; 32]) + u32); for multiple argument test.
 
     Tests args get correctly encoded and decoded in the contract.
+
+    Test expects the test contracts test_args_u32.wasm and test_args_u512.wasm
+    to deserialize correctly their arguments and then call revert with value
+    of the argument (converted to a Rust native int, as expected by revert).
+    If the test contracts don't fail or if their exit code is different
+    than expected, the test will fail.
     """
     node = one_node_network.docker_nodes[0]
     client = node.p_client.client


### PR DESCRIPTION
### Overview
This PR allows to pass payment contract's arguments on command line (Python CLI).

Also, it adds support for U512 type to ABI, as the `standard-payment` introduced in #928 accepts argument of this type.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-577

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Note, proper testing of passing args to payment contract will be possible once #928 is merged.
