### PR TITLE
OP-566: bump ffi 0.10.0 -> 0.11.0

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -4,7 +4,7 @@
 name = "add-update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -45,7 +45,7 @@ dependencies = [
 name = "authorized-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -134,7 +134,7 @@ dependencies = [
 name = "bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -186,7 +186,7 @@ name = "casperlabs-engine-core"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
  "casperlabs-engine-wasm-prep 0.1.0",
@@ -210,7 +210,7 @@ dependencies = [
 name = "casperlabs-engine-grpc-server"
 version = "0.5.1"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
@@ -247,7 +247,7 @@ version = "0.2.0"
 dependencies = [
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -265,7 +265,7 @@ dependencies = [
 name = "casperlabs-engine-storage"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
  "casperlabs-engine-shared 0.2.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -298,7 +298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "check-system-contract-urefs-access-rights"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -351,7 +351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "create-purse-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -420,7 +420,7 @@ dependencies = [
 name = "deserialize-error"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -445,49 +445,49 @@ dependencies = [
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "ee-401-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "ee-401-regression-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "ee-441-rng-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "ee-532-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "ee-536-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "ee-539-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -565,21 +565,21 @@ dependencies = [
 name = "get-blocktime"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "get-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "get-caller-subcall"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -766,14 +766,14 @@ dependencies = [
 name = "key-management-thresholds"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "known-urefs"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -818,7 +818,7 @@ dependencies = [
 name = "local-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -850,7 +850,7 @@ dependencies = [
 name = "main-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -877,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -1072,28 +1072,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pos"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "pos-finalize-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "pos-get-payment-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "pos-refund-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -1380,7 +1380,7 @@ dependencies = [
 name = "remove-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ dependencies = [
 name = "revert"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -1588,7 +1588,7 @@ dependencies = [
 name = "test-mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -1862,35 +1862,35 @@ dependencies = [
 name = "transfer-purse-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "transfer-to-account-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "transfer-to-account-02"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
 name = "transfer_to_account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]
@@ -1922,7 +1922,7 @@ dependencies = [
 name = "unbonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]

--- a/execution-engine/contract-ffi/Cargo.toml
+++ b/execution-engine/contract-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-contract-ffi"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."

--- a/long-running-tests/Cargo.lock
+++ b/long-running-tests/Cargo.lock
@@ -223,7 +223,7 @@ name = "shared"
 version = "0.1.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.10.0",
+ "casperlabs-contract-ffi 0.11.0",
 ]
 
 [[package]]

--- a/long-running-tests/Cargo.lock
+++ b/long-running-tests/Cargo.lock
@@ -38,7 +38,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
### Overview
Bumps ffi 0.10.0 -> 0.11.0 in prep for release.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-566

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
