### PR TITLE
EE-575 normalize main_purse & rewards_purse keys in Forced Transfer step

### DIFF
--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -175,18 +175,24 @@ impl ExecutionResultBuilder {
 
         let new_balance = account_main_purse_balance - max_payment_cost;
 
-        ops.insert(account_main_purse, Op::Write);
+        let account_main_purse_normalize = account_main_purse.normalize();
+        let rewards_purse_normalize = rewards_purse.normalize();
+
+        ops.insert(account_main_purse_normalize, Op::Write);
         transforms.insert(
-            account_main_purse,
+            account_main_purse_normalize,
             Transform::Write(Value::UInt512(new_balance)),
         );
 
-        ops.insert(rewards_purse, Op::Add);
-        transforms.insert(rewards_purse, Transform::AddUInt512(max_payment_cost));
+        ops.insert(rewards_purse_normalize, Op::Add);
+        transforms.insert(
+            rewards_purse_normalize,
+            Transform::AddUInt512(max_payment_cost),
+        );
 
         let error = error::Error::InsufficientPaymentError;
         let effect = ExecutionEffect::new(ops, transforms);
-        let cost = 0;
+        let cost = (max_payment_cost / CONV_RATE).as_u64();
 
         Some(ExecutionResult::Failure {
             error,

--- a/execution-engine/engine-grpc-server/tests/test_payment_code.rs
+++ b/execution-engine/engine-grpc-server/tests/test_payment_code.rs
@@ -100,7 +100,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
 
 #[ignore]
 #[test]
-fn should_raise_insufficient_payment_when_payment_code_exceeds_gas_limit() {
+fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
     let genesis_public_key = PublicKey::new(GENESIS_ADDR);
     let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
 


### PR DESCRIPTION
This PR fixes the following bug:

In the case of Forced Transfer (Payment Code Step 4 in the Payment code execution specification), the balance urefs of both `account_main_purse` and `rewards_purse` must be `normalized` when added to the exec transforms returned to the caller or attempts to commit the transforms will result in a `CommitResult::KeyNotFound` error being raised due to attempting to read using a non-normalized `Key` 

https://casperlabs.atlassian.net/browse/EE-575

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X]  If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X]  Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

@srinivasreddy42, you may want to rebase off of this branch to continue your testing
