### PR TITLE
OP-228 Fixed test_refund_after_session_code_error

### DIFF
--- a/integration-testing/test/test_execution_cost.py
+++ b/integration-testing/test/test_execution_cost.py
@@ -242,7 +242,6 @@ def test_refund_after_session_code_error(payment_node_network):
         account_address=GENESIS_ACCOUNT.public_key_hex, block_hash=deploy_hash
     )
 
-    # This assert is failing; And could not get lesser balance than original balance.
     expected_sum = later_balance + motes
     assert genesis_init_balance == expected_sum
 


### PR DESCRIPTION
Fixed test_refund_after_session_code_error test which was disabled.

https://casperlabs.atlassian.net/browse/OP-228

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

