### PR TITLE
NODE-754: Set Hikari's connection `autoCommit` property to false.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -6,6 +6,7 @@ import cats._
 import cats.effect._
 import cats.implicits._
 import cats.mtl._
+import doobie.free.connection
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
 import doobie.util.transactor.Transactor
@@ -109,10 +110,16 @@ package object effects {
         transactEC = transactionEC
       )
       .map(
-        xa =>
+        xa => {
           // Foreign keys support must be enabled explicitly in SQLite
           // https://www.sqlite.org/foreignkeys.html#fk_enable
           Transactor.before
             .set(xa, sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before.get(xa))
+          // `autoCommit=true` is a default for Hikari; doobie sets `autoCommit=false`.
+          // From doobie's docs:
+          // * - Auto-commit will be set to `false`;
+          // * - the transaction will `commit` on success and `rollback` on failure;
+          Transactor.before.modify(xa, _ >> connection.setAutoCommit(false))
+        }
       )
 }

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -113,13 +113,13 @@ package object effects {
         xa => {
           // Foreign keys support must be enabled explicitly in SQLite
           // https://www.sqlite.org/foreignkeys.html#fk_enable
-          Transactor.before
+          val mxa = Transactor.before
             .set(xa, sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before.get(xa))
           // `autoCommit=true` is a default for Hikari; doobie sets `autoCommit=false`.
           // From doobie's docs:
           // * - Auto-commit will be set to `false`;
           // * - the transaction will `commit` on success and `rollback` on failure;
-          Transactor.before.modify(xa, _ >> connection.setAutoCommit(false))
+          Transactor.before.modify(mxa, _ >> connection.setAutoCommit(false))
         }
       )
 }


### PR DESCRIPTION
### Overview

Doobie handles commiting (and rolling back) transactions we don't
need to set that in Hikari. This will silence loggings we have seen:
> HikariPool-1 - Reset (autoCommit) on …

since that was logged when connection's and txn pool's `autoCommit` properties differed.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-754

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
