### PR TITLE
NODE-755: Postpone fetching whole `Deploy` entries until it's necessary.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -414,15 +414,13 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       candidatesHashes = orphanedDeploys ++ pendingDeploys
 
       // Only send the next nonce per account.
-      remaining <- if (candidatesHashes.isEmpty) List.empty[Deploy].pure[F]
-                  else
-                    DeployBuffer[F]
-                      .getByHashes(NonEmptyList.fromListUnsafe(candidatesHashes))
-                      .map {
-                        _.groupBy(_.getHeader.accountPublicKey).map {
-                          case (_, deploys) => deploys.minBy(_.getHeader.nonce)
-                        }.toSeq
-                      }
+      remaining <- DeployBuffer[F]
+                    .getByHashes(candidatesHashes)
+                    .map {
+                      _.groupBy(_.getHeader.accountPublicKey).map {
+                        case (_, deploys) => deploys.minBy(_.getHeader.nonce)
+                      }.toSeq
+                    }
     } yield remaining
 
   /** If another node proposed a block which orphaned something proposed by this node,

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -1,6 +1,6 @@
 package io.casperlabs.casper
 
-import cats.data.EitherT
+import cats.data.{EitherT, NonEmptyList}
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Bracket, Resource, Sync}
 import cats.implicits._
@@ -407,19 +407,22 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
   ): F[Seq[Deploy]] =
     for {
       orphanedDeploys <- findOrphanedDeploys(dag, parents)
-      pendingDeploys  <- DeployBuffer[F].readPending
+      pendingDeploys  <- DeployBuffer[F].readPendingHashes
       // Pending deploys are most likely not in the past, or we'd have to go back indefinitely to
       // prove they aren't. The EE will ignore them if the nonce is less than the expected,
       // so it should be fine to include and see what happens.
-      candidates = orphanedDeploys ++ pendingDeploys
+      candidatesHashes = orphanedDeploys ++ pendingDeploys
 
       // Only send the next nonce per account.
-      remaining = candidates
-        .groupBy(_.getHeader.accountPublicKey)
-        .map {
-          case (_, deploys) => deploys.minBy(_.getHeader.nonce)
-        }
-        .toSeq
+      remaining <- if (candidatesHashes.isEmpty) List.empty[Deploy].pure[F]
+                  else
+                    DeployBuffer[F]
+                      .getByHashes(NonEmptyList.fromListUnsafe(candidatesHashes))
+                      .map {
+                        _.groupBy(_.getHeader.accountPublicKey).map {
+                          case (_, deploys) => deploys.minBy(_.getHeader.nonce)
+                        }.toSeq
+                      }
     } yield remaining
 
   /** If another node proposed a block which orphaned something proposed by this node,
@@ -438,26 +441,26 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       parents = merged.parents
 
       orphanedDeploys <- findOrphanedDeploys(dag, parents)
-      _               <- DeployBuffer[F].markAsPending(orphanedDeploys) whenA orphanedDeploys.nonEmpty
+      _               <- DeployBuffer[F].markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
     } yield orphanedDeploys.size
 
   /** Find orphaned deploys in the processed buffer. */
   private def findOrphanedDeploys(
       dag: DagRepresentation[F],
       parents: Seq[Block]
-  ): F[List[Deploy]] =
+  ): F[List[ByteString]] =
     for {
-      processedDeploys <- DeployBuffer[F].readProcessed
-      parentSet        = parents.map(_.blockHash).toSet
-      deployToBlocksMap <- processedDeploys
-                            .traverse { deploy =>
-                              BlockStorage[F]
-                                .findBlockHashesWithDeployhash(deploy.deployHash)
-                                .map(deploy -> _)
-                            }
-                            .map(_.toMap)
+      processedDeploysHashes <- DeployBuffer[F].readProcessedHashes
+      parentSet              = parents.map(_.blockHash).toSet
+      deployHashToBlocksMap <- processedDeploysHashes
+                                .traverse { deployHash =>
+                                  BlockStorage[F]
+                                    .findBlockHashesWithDeployhash(deployHash)
+                                    .map(deployHash -> _)
+                                }
+                                .map(_.toMap)
 
-      blockHashes = deployToBlocksMap.values.flatten.toList.distinct
+      blockHashes = deployHashToBlocksMap.values.flatten.toList.distinct
 
       // Find the blocks from which there's no way through the descendants to reach a tip.
       orphanedBlockHashes <- blockHashes
@@ -473,8 +476,8 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
                                 _.filter(_._2).map(_._1).toSet
                               }
 
-      orphanedDeploys = deployToBlocksMap.collect {
-        case (deploy, blockHashes) if blockHashes.forall(orphanedBlockHashes) => deploy
+      orphanedDeploys = deployHashToBlocksMap.collect {
+        case (deployHash, blockHashes) if blockHashes.forall(orphanedBlockHashes) => deployHash
       }.toList
 
     } yield orphanedDeploys

--- a/casper/src/main/scala/io/casperlabs/casper/deploybuffer/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/deploybuffer/DeployBuffer.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper.deploybuffer
 
 import cats._
+import cats.data.NonEmptyList
 import cats.effect._
 import cats.implicits._
 import com.google.protobuf.ByteString
@@ -76,6 +77,8 @@ import scala.concurrent.duration.FiniteDuration
   def getPendingOrProcessed(hash: ByteString): F[Option[Deploy]]
 
   def sizePendingOrProcessed(): F[Long]
+
+  def getByHashes(l: NonEmptyList[ByteString]): F[List[Deploy]]
 }
 
 class DeployBufferImpl[F[_]: Metrics: Time: Bracket[?[_], Throwable]](
@@ -253,6 +256,11 @@ class DeployBufferImpl[F[_]: Metrics: Time: Bracket[?[_], Throwable]](
       .query[Deploy]
       .option
       .transact(xa)
+
+  override def getByHashes(l: NonEmptyList[ByteString]): F[List[Deploy]] = {
+    val q = fr"SELECT data FROM deploys WHERE " ++ Fragments.in(fr"hash", l) // "hash IN (…)"
+    q.query.to[List].transact(xa)
+  }
 }
 
 object DeployBufferImpl {

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
@@ -102,7 +102,7 @@ trait DeployBufferSpec
           for {
             _   <- db.addAsPending(pending)
             _   <- db.addAsProcessed(processed)
-            all <- db.getByHashes(NonEmptyList.fromListUnsafe(deployHashes))
+            all <- db.getByHashes(deployHashes)
             _   = assert(deploys.sortedByHash == all.sortedByHash)
           } yield ()
 

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBuffer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBuffer.scala
@@ -1,7 +1,6 @@
 package io.casperlabs.casper.deploybuffer
 
 import cats.Monad
-import cats.data.NonEmptyList
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.implicits._
@@ -115,8 +114,8 @@ class MockDeployBuffer[F[_]: Monad: Log](
 
   override def readPendingHashes: F[List[ByteString]] = readPending.map(_.map(_.deployHash))
 
-  override def getByHashes(l: NonEmptyList[ByteString]): F[List[Deploy]] = {
-    val hashesSet = l.toList.toSet
+  override def getByHashes(l: List[ByteString]): F[List[Deploy]] = {
+    val hashesSet = l.toSet
     (readPending, readProcessed).mapN(_ ++ _).map(_.filter(d => hashesSet.contains(d.deployHash)))
   }
 


### PR DESCRIPTION
### Overview
This PR tries to fix an OOM error we experienced when running "long-running tests". Instead of reading the whole `Deploy` type we fetch hashes, collect orphaned deploys based on that, and fetch whole `Deploy` entries just before creating a proposal.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-755

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I thought about adding a `nonce` column to `deploys` table and performing `JOIN` + `GROUP BY` + `SORT BY` + `LIMIT 1` in the SQLite itself but I didn't decide to do it as we want to move away from nonces anyway in the near future so the additional migrations seemed unjustified.
I also thought about streaming deploys from the DB, instead of returning them as a list, but when constructing a proposal (or finding conflict-free deploys) we need a list anyway so that didn't seem like a justified choice either.