### PR TITLE
NO-TICK Bump version to 0.4.0 for PyPi publish.

### DIFF
--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -168,7 +168,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.3.13",
+    version="0.4.0",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",


### PR DESCRIPTION
Bumped Python Client Version to 0.4.0 to test PyPi publish of latest client.

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.
