### PR TITLE
NODE-756: Fix sync width check depth.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/SynchronizerImpl.scala
@@ -315,7 +315,7 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     */
   private def notTooWide(syncState: SyncState): EitherT[F, SyncError, Unit] = {
     // Dependencies can be scattered across many different ranks and still be at the same
-    // distance when measaured in hops along the j-DAG, so to use the "bonding per rank"
+    // distance when measured in hops along the j-DAG, so to use the "bonding per rank"
     // limit we need to have a different estimate for the number of depth as in ranks.
     // The max-min rank distance could be faked, but we can perhaps get an estimate by just
     // seeing how many different values we observed so far.

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -82,7 +82,7 @@ trait ArbitraryConsensus {
   def numValidators: Int = 10
 
   protected lazy val randomAccounts   = sample(Gen.listOfN(numAccounts, genAccountKeys))
-  protected lazy val randomValidators = sample(Gen.listOfN(numAccounts, genAccountKeys))
+  protected lazy val randomValidators = sample(Gen.listOfN(numValidators, genKey))
 
   implicit val arbNode: Arbitrary[Node] = Arbitrary {
     for {
@@ -131,7 +131,7 @@ trait ArbitraryConsensus {
       bodyHash           <- genHash
       preStateHash       <- genHash
       postStateHash      <- genHash
-      validatorPublicKey <- genKey
+      validatorPublicKey <- Gen.oneOf(randomValidators)
     } yield {
       Block
         .Header()


### PR DESCRIPTION
### Overview
The way the recently added "max bonding rate per rank" parameter works was at odds with the depth calculation in the synchronizer. Depth was based on distance, which I forgot was also following justifications that can be scattered across many different ranks. 

Say we have 2 validators; if we request a slice of the DAG with depth 5, the two validators' latest messages can be so much apart that we can get 10 different ranks, if it was like `A1 B1 A2 B2 A3 B3 A4 B4 A5 B6 B7 B8 B9 B10`. A5 and B9 are both at distance 1 from B10, but A5 will bring along B1 as well. At that point we see 15 blocks, while we only expected one from each validator at each rank, which is just 2*5. 

The PR changes the depth estimate to be based on the number of ranks in the DAG. One again it's just an estimate to detect abnormally wide feeds that would try to fill up the memory, not a realistic number.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-756

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
