### PR TITLE
NODE-654: Split up node client deploy command.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -363,7 +363,7 @@ object DeployRuntime {
       ignoreOutput = true
     )
 
-  def deploy[F[_]: Sync: DeployService](deployBA: Array[Byte]): F[Unit] =
+  def sendDeploy[F[_]: Sync: DeployService](deployBA: Array[Byte]): F[Unit] =
     gracefulExit {
       for {
         deploy <- Sync[F].fromTry(Try(Deploy.parseFrom(deployBA)))

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -98,7 +98,7 @@ object Main {
           Array.emptyByteArray,
           Files.readAllBytes(paymentCode.toPath)
         )
-        DeployRuntime.saveDeploy(deploy, deployPath)
+        DeployRuntime.writeDeploy(deploy, deployPath)
       }
 
       case Deploy(deploy) =>

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -102,30 +102,9 @@ object Main {
         DeployRuntime.saveDeploy(deploy, deployPath)
       }
 
-      case Deploy(
-          from,
-          nonce,
-          sessionCode,
-          paymentCode,
-          maybePublicKey,
-          maybePrivateKey,
-          gasPrice
-          ) =>
-        DeployRuntime.deployFileProgram(
-          from,
-          nonce,
-          Files.readAllBytes(sessionCode.toPath),
-          Files.readAllBytes(paymentCode.toPath),
-          maybePublicKey.map(
-            file =>
-              new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PublicKey]
-          ),
-          maybePrivateKey.map(
-            file =>
-              new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PrivateKey]
-          ),
-          gasPrice
-        )
+      case Deploy(deploy) =>
+        DeployRuntime.deploy(deploy)
+
       case Sign(deploy, signedDeployOut, publicKey, privateKey) =>
         DeployRuntime.sign(deploy, signedDeployOut, publicKey, privateKey)
 

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -3,13 +3,14 @@ package io.casperlabs.client
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
-import cats.implicits._
 import cats.effect.{Sync, Timer}
+import cats.implicits._
 import cats.temp.par._
 import com.google.protobuf.ByteString
 import io.casperlabs.client.configuration._
 import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
 import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.shared.{FilesAPI, Log, UncaughtExceptionHandler}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -111,22 +112,39 @@ object Main {
         )
       case MakeDeploy(
           from,
+          publicKey,
           nonce,
           sessionCode,
           paymentCode,
           gasPrice,
           deployPath
-          ) => {
-        val deploy = DeployRuntime.makeDeploy(
-          ByteString.copyFrom(Base16.decode(from)),
-          nonce,
-          gasPrice,
-          Files.readAllBytes(sessionCode.toPath),
-          Array.emptyByteArray,
-          Files.readAllBytes(paymentCode.toPath)
-        )
-        DeployRuntime.writeDeploy(deploy, deployPath)
-      }
+          ) =>
+        for {
+          baseAccount <- publicKey match {
+                          case None =>
+                            // This should be safe because we validate that one of --from, --public-key is present.
+                            ByteString.copyFrom(Base16.decode(from.get)).pure[F]
+                          case Some(publicKeyFile) =>
+                            for {
+                              content <- DeployRuntime.readFileAsString[F](publicKeyFile)
+                              publicKey <- Sync[F].fromOption(
+                                            Ed25519.tryParsePublicKey(content),
+                                            new IllegalArgumentException(
+                                              s"Failed to parse public key file ${publicKeyFile.getPath()}"
+                                            )
+                                          )
+                            } yield ByteString.copyFrom(publicKey)
+                        }
+          deploy = DeployRuntime.makeDeploy(
+            baseAccount,
+            nonce,
+            gasPrice,
+            Files.readAllBytes(sessionCode.toPath),
+            Array.emptyByteArray,
+            Files.readAllBytes(paymentCode.toPath)
+          )
+          _ <- DeployRuntime.writeDeploy(deploy, deployPath)
+        } yield ()
 
       case SendDeploy(deploy) =>
         DeployRuntime.sendDeploy(deploy)

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -83,6 +83,25 @@ object Main {
           recipientPublicKeyBase64,
           amount
         )
+      case MakeDeploy(
+          from,
+          nonce,
+          sessionCode,
+          paymentCode,
+          gasPrice,
+          deployPath
+          ) => {
+        val deploy = DeployRuntime.makeDeploy(
+          from,
+          nonce,
+          gasPrice,
+          Files.readAllBytes(sessionCode.toPath),
+          Array.emptyByteArray,
+          Files.readAllBytes(paymentCode.toPath)
+        )
+        DeployRuntime.saveDeploy(deploy, deployPath)
+      }
+
       case Deploy(
           from,
           nonce,

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -107,6 +107,8 @@ object Main {
           ),
           gasPrice
         )
+      case Sign(deploy, signedDeployOut, publicKey, privateKey) =>
+        DeployRuntime.sign(deploy, signedDeployOut, publicKey, privateKey)
 
       case Propose =>
         DeployRuntime.propose()

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -1,13 +1,12 @@
 package io.casperlabs.client
 
-import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 
 import cats.effect.{Sync, Timer}
-import cats.syntax.either._
 import cats.temp.par._
+import com.google.protobuf.ByteString
 import io.casperlabs.client.configuration._
-import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
+import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.shared.{FilesAPI, Log, UncaughtExceptionHandler}
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -92,7 +91,7 @@ object Main {
           deployPath
           ) => {
         val deploy = DeployRuntime.makeDeploy(
-          from,
+          ByteString.copyFrom(Base16.decode(from)),
           nonce,
           gasPrice,
           Files.readAllBytes(sessionCode.toPath),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -14,6 +14,15 @@ final case class ConnectOptions(
 
 sealed trait Configuration
 
+final case class MakeDeploy(
+    from: String,
+    nonce: Long,
+    sessionCode: File,
+    paymentCode: File,
+    gasPrice: Long,
+    deployPath: Option[File]
+) extends Configuration
+
 final case class Deploy(
     from: Option[String],
     nonce: Long,
@@ -96,6 +105,15 @@ object Configuration {
       options.nodeId.toOption
     )
     val conf = options.subcommand.map {
+      case options.makeDeploy =>
+        MakeDeploy(
+          options.makeDeploy.from(),
+          options.makeDeploy.nonce(),
+          options.makeDeploy.session(),
+          options.makeDeploy.payment(),
+          options.makeDeploy.gasPrice(),
+          options.makeDeploy.deployPath.toOption
+        )
       case options.deploy =>
         Deploy(
           options.deploy.from.toOption,

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -1,9 +1,6 @@
 package io.casperlabs.client.configuration
 import java.io.File
 
-import cats.implicits._
-import org.rogach.scallop.ScallopOption
-
 final case class ConnectOptions(
     host: String,
     portExternal: Int,
@@ -22,8 +19,18 @@ final case class MakeDeploy(
     deployPath: Option[File]
 ) extends Configuration
 
-final case class Deploy(
+final case class SendDeploy(
     deploy: Array[Byte]
+) extends Configuration
+
+final case class Deploy(
+    from: Option[String],
+    nonce: Long,
+    sessionCode: File,
+    paymentCode: File,
+    publicKey: Option[File],
+    privateKey: Option[File],
+    gasPrice: Long
 ) extends Configuration
 
 /** Client command to sign a deploy.
@@ -91,6 +98,16 @@ object Configuration {
       options.nodeId.toOption
     )
     val conf = options.subcommand.map {
+      case options.deploy =>
+        Deploy(
+          options.deploy.from.toOption,
+          options.deploy.nonce(),
+          options.deploy.session(),
+          options.deploy.payment.toOption.getOrElse(options.deploy.session()),
+          options.deploy.publicKey.toOption,
+          options.deploy.privateKey.toOption,
+          options.deploy.gasPrice()
+        )
       case options.makeDeploy =>
         MakeDeploy(
           options.makeDeploy.from(),
@@ -100,8 +117,8 @@ object Configuration {
           options.makeDeploy.gasPrice(),
           options.makeDeploy.deployPath.toOption
         )
-      case options.deploy =>
-        Deploy(options.deploy.deployFile())
+      case options.`sendDeploy` =>
+        SendDeploy(options.sendDeploy.deployFile())
       case options.sign =>
         Sign(
           options.sign.deployFile(),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -11,7 +11,8 @@ final case class ConnectOptions(
 sealed trait Configuration
 
 final case class MakeDeploy(
-    from: String,
+    from: Option[String],
+    publicKey: Option[File],
     nonce: Long,
     sessionCode: File,
     paymentCode: File,
@@ -110,7 +111,8 @@ object Configuration {
         )
       case options.makeDeploy =>
         MakeDeploy(
-          options.makeDeploy.from(),
+          options.makeDeploy.from.toOption,
+          options.makeDeploy.publicKey.toOption,
           options.makeDeploy.nonce(),
           options.makeDeploy.session(),
           options.makeDeploy.payment(),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -24,13 +24,7 @@ final case class MakeDeploy(
 ) extends Configuration
 
 final case class Deploy(
-    from: Option[String],
-    nonce: Long,
-    sessionCode: File,
-    paymentCode: File,
-    publicKey: Option[File],
-    privateKey: Option[File],
-    gasPrice: Long
+    deploy: Either[Array[Byte], File]
 ) extends Configuration
 
 /** Client command to sign a deploy.
@@ -116,13 +110,9 @@ object Configuration {
         )
       case options.deploy =>
         Deploy(
-          options.deploy.from.toOption,
-          options.deploy.nonce(),
-          options.deploy.session(),
-          options.deploy.payment.toOption.getOrElse(options.deploy.session()),
-          options.deploy.publicKey.toOption,
-          options.deploy.privateKey.toOption,
-          options.deploy.gasPrice()
+          options.deploy.deployFile.toOption
+            .map(_.asRight[Array[Byte]])
+            .getOrElse(options.deploy.deployStdin().getBytes.asLeft[File])
         )
       case options.sign =>
         Sign(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -119,14 +119,14 @@ object Configuration {
           options.makeDeploy.gasPrice(),
           options.makeDeploy.deployPath.toOption
         )
-      case options.`sendDeploy` =>
-        SendDeploy(options.sendDeploy.deployFile())
-      case options.sign =>
+      case options.sendDeploy =>
+        SendDeploy(options.sendDeploy.deployPath())
+      case options.signDeploy =>
         Sign(
-          options.sign.deployFile(),
-          options.sign.signedDeployPath.toOption,
-          options.sign.publicKey(),
-          options.sign.privateKey()
+          options.signDeploy.deployPath(),
+          options.signDeploy.signedDeployPath.toOption,
+          options.signDeploy.publicKey(),
+          options.signDeploy.privateKey()
         )
       case options.propose =>
         Propose

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -51,6 +51,48 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val fileCheck: File => Boolean = file =>
     file.exists() && file.canRead && !file.isDirectory && file.isFile
 
+  val makeDeploy = new Subcommand("make-deploy") {
+    descr("Constructs a deploy that can be signed and sent to a node.")
+
+    val from = opt[String](
+      descr =
+        "The public key of the account which is the context of this deployment, base16 encoded.",
+      required = true
+    )
+
+    val gasPrice = opt[Long](
+      descr = "The price of gas for this transaction in units dust/gas. Must be positive integer.",
+      validate = _ > 0,
+      required = false,
+      default = 10L.some
+    )
+
+    val nonce = opt[Long](
+      descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
+      validate = _ > 0,
+      required = true
+    )
+
+    val session =
+      opt[File](required = true, descr = "Path to the file with session code", validate = fileCheck)
+
+    val payment =
+      opt[File](
+        required = false,
+        descr = "Path to the file with payment code, by default fallbacks to the --session code",
+        validate = fileCheck
+      )
+
+    val deployPath =
+      opt[File](
+        required = false,
+        descr = "Path to the file where deploy will be saved. " +
+          "Optional, if not provided the deploy will be printed to STDOUT.",
+        short = 'o'
+      )
+  }
+  addSubcommand(makeDeploy)
+
   val deploy = new Subcommand("deploy") {
     descr(
       "Deploy a smart contract source file to Casper on an existing running node. " +

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -115,7 +115,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         "on the configuration of the Casper instance."
     )
 
-    val deployFile = opt[File](
+    val deployPath = opt[File](
       required = false,
       descr = "Path to the file with signed Deploy.",
       validate = fileCheck,
@@ -186,7 +186,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(deploy)
 
-  val sign = new Subcommand("sign") {
+  val signDeploy = new Subcommand("sign-deploy") {
     descr("Cryptographically signs a deploy. The signature is appended to existing approvals.")
 
     val publicKey =
@@ -213,7 +213,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         short = 'o'
       )
 
-    val deployFile =
+    val deployPath =
       opt[File](
         required = false,
         descr = "Path to the deploy file.",
@@ -223,7 +223,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         .orElse(Some(IOUtils.toByteArray(System.in)))
   }
 
-  addSubcommand(sign)
+  addSubcommand(signDeploy)
 
   val propose = new Subcommand("propose") {
     descr(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -94,7 +94,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(makeDeploy)
 
-  val deploy = new Subcommand("deploy") {
+  val sendDeploy = new Subcommand("send-deploy") {
     descr(
       "Deploy a smart contract source file to Casper on an existing running node. " +
         "The deploy will be packaged and sent as a block to the network depending " +
@@ -109,6 +109,66 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     ).map(file => Files.readAllBytes(file.toPath))
       .orElse(Some(IOUtils.toByteArray(System.in)))
 
+  }
+  addSubcommand(sendDeploy)
+
+  val deploy = new Subcommand("deploy") {
+    descr(
+      "Constructs a Deploy and sends it to Casper on an existing running node. " +
+        "The deploy will be packaged and sent as a block to the network depending " +
+        "on the configuration of the Casper instance."
+    )
+
+    val from = opt[String](
+      descr =
+        "The public key of the account which is the context of this deployment, base16 encoded.",
+      required = false
+    )
+
+    val gasLimit =
+      opt[Long](
+        descr =
+          "[Deprecated] The amount of gas to use for the transaction (unused gas is refunded). Must be positive integer.",
+        validate = _ > 0,
+        required = false // Leaving it here for now so old examples don't complain about its presence.
+      )
+
+    val gasPrice = opt[Long](
+      descr = "The price of gas for this transaction in units dust/gas. Must be positive integer.",
+      validate = _ > 0,
+      required = false,
+      default = 10L.some
+    )
+
+    val nonce = opt[Long](
+      descr = "This allows you to overwrite your own pending transactions that use the same nonce.",
+      validate = _ > 0,
+      required = true
+    )
+
+    val session =
+      opt[File](required = true, descr = "Path to the file with session code", validate = fileCheck)
+
+    val payment =
+      opt[File](
+        required = false,
+        descr = "Path to the file with payment code, by default fallbacks to the --session code",
+        validate = fileCheck
+      )
+
+    val publicKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account public key (Ed25519)",
+        validate = fileCheck
+      )
+
+    val privateKey =
+      opt[File](
+        required = false,
+        descr = "Path to the file with account private key (Ed25519)",
+        validate = fileCheck
+      )
   }
   addSubcommand(deploy)
 

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -80,9 +80,9 @@ Success!
 
 ###### Alternative way of creating, signing and deploying contracts
 
-Every account can associate multiple keys with it and give each a weight. Collective weight of signing keys decides whether an action of certain type can be made. In order to collect weight of different associated keys a deploy has to be signed by corresponding private keys. `deploy` command does it all (creates a deploy, signs it an deploys to the node) but doesn't allow for signing with multiple keys. Therefore we split `deploy` into three separate commands:
+Every account can associate multiple keys with it and give each a weight. Collective weight of signing keys decides whether an action of certain type can be made. In order to collect weight of different associated keys a deploy has to be signed by corresponding private keys. `deploy` command does it all (creates a deploy, signs it and deploys to the node) but doesn't allow for signing with multiple keys. Therefore we split `deploy` into three separate commands:
 * `make-deploy` - creates a deploy from input parameters
-* `sign-deploy` - signs a deploy with given private key
+* `sign-deployfuck` - signs a deploy with given private key
 * `send-deploy` - sends a deploy to CasperLabs node
 
 Commands read input deploy from both a file (`-i` flag) and STDIN. They can also write to both file and STDOUT.
@@ -99,7 +99,7 @@ casperlabs-client \
     --nonce 1 \
     --from a1130120d27f6f692545858cc5c284b1ef30fe287caef648b0c405def88f543a
 ``` 
-This will write a deploy in binary format to STDOUT. It's possible to write it to the file, by supplying `-o` argument:
+This will write a deploy in binary format to STDOUT. It's possible to write it to a file, by supplying `-o` argument:
 ```
 casperlabs-client \
     --host localhost \
@@ -127,7 +127,7 @@ casperlabs-client \
     --host localhost \
     send-deploy
 ```
-In the example above there are is no `-i` argument, meaning that signed deploy will be read from STDIN.
+In the example above there is no `-i` argument, meaning that signed deploy will be read from STDIN.
 
 Reading from STDIN and writing to STDOUT allows for piping output from one command to the input of another one (commands are incomplete for better readability):
 ```

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -82,7 +82,7 @@ Success!
 
 Every account can associate multiple keys with it and give each a weight. Collective weight of signing keys decides whether an action of certain type can be made. In order to collect weight of different associated keys a deploy has to be signed by corresponding private keys. `deploy` command does it all (creates a deploy, signs it an deploys to the node) but doesn't allow for signing with multiple keys. Therefore we split `deploy` into three separate commands:
 * `make-deploy` - creates a deploy from input parameters
-* `sign` - signs a deploy with given private key
+* `sign-deploy` - signs a deploy with given private key
 * `send-deploy` - sends a deploy to CasperLabs node
 
 Commands read input deploy from both a file (`-i` flag) and STDIN. They can also write to both file and STDOUT.
@@ -115,7 +115,7 @@ casperlabs-client \
 ```
 casperlabs-client \
     --host localhost \
-    sign \
+    sign-deploy \
     --public-key public-key.pem \
     --private-key private-key.pem
 ```
@@ -131,7 +131,9 @@ In the example above there are is no `-i` argument, meaning that signed deploy w
 
 Reading from STDIN and writing to STDOUT allows for piping output from one command to the input of another one (commands are incomplete for better readability):
 ```
-casperlabs-client make-deploy [arguments] | casperlabs-client sign --private-key [private_key] --public-key [public_key] | casperlabs-client send-deploy
+casperlabs-client make-deploy [arguments] | \
+casperlabs-client sign-deploy --private-key [private_key] --public-key [public_key] | \
+casperlabs-client send-deploy
 ```
 
 For more detailed description, use `--help` flag (`casper-client --help`).

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -78,6 +78,64 @@ You should see the following output:
 Success!
 ```
 
+###### Alternative way of creating, signing and deploying contracts
+
+Every account can associate multiple keys with it and give each a weight. Collective weight of signing keys decides whether an action of certain type can be made. In order to collect weight of different associated keys a deploy has to be signed by corresponding private keys. `deploy` command does it all (creates a deploy, signs it an deploys to the node) but doesn't allow for signing with multiple keys. Therefore we split `deploy` into three separate commands:
+* `make-deploy` - creates a deploy from input parameters
+* `sign` - signs a deploy with given private key
+* `send-deploy` - sends a deploy to CasperLabs node
+
+Commands read input deploy from both a file (`-i` flag) and STDIN. They can also write to both file and STDOUT.
+
+Example usage:
+
+**Creating a deploy**
+```
+casperlabs-client \
+    --host localhost \
+    make-deploy \
+    --session session-code.wasm \
+    --payment payment-code.wasm \
+    --nonce 1 \
+    --from a1130120d27f6f692545858cc5c284b1ef30fe287caef648b0c405def88f543a
+``` 
+This will write a deploy in binary format to STDOUT. It's possible to write it to the file, by supplying `-o` argument:
+```
+casperlabs-client \
+    --host localhost \
+    make-deploy \
+    --session session-code.wasm \
+    --payment payment-code.wasm \
+    --nonce 1 \
+    --from a1130120d27f6f692545858cc5c284b1ef30fe287caef648b0c405def88f543a
+    -o /deploys/deploy_1
+```
+
+**Signing a deploy**
+```
+casperlabs-client \
+    --host localhost \
+    sign \
+    --public-key public-key.pem \
+    --private-key private-key.pem
+```
+This will read a deploy to sign from STDIN and output signed deploy to STDOUT. There are `-i` and `-o` flags for, respectively, reading a deploy from a file and writing signed deploy to a file.
+
+**Sending deploy to the node**
+```
+casperlabs-client \
+    --host localhost \
+    send-deploy
+```
+In the example above there are is no `-i` argument, meaning that signed deploy will be read from STDIN.
+
+Reading from STDIN and writing to STDOUT allows for piping output from one command to the input of another one (commands are incomplete for better readability):
+```
+casperlabs-client make-deploy [arguments] | casperlabs-client sign --private-key [private_key] --public-key [public_key] | casperlabs-client send-deploy
+```
+
+For more detailed description, use `--help` flag (`casper-client --help`).
+
 ##### Step 8: Observe
 
 See the instructions [here](QUERYING.md).


### PR DESCRIPTION
### Overview
Splits node client's `deploy` subcommand into three separate subcommands:
1) `make-deploy` - accepts deploy arguments (session code, payment code, from address, nonce and gas price) and constructs a `Deploy`. Then writes it either to a file or STDOUT.
2) `sign` - accepts key pair and a deploy (deploy can come from a file supplied with `-i` argument or from STDIN), signs it and writes to a file or STDOUT.
3) `send-deploy` - accepts a deploy (either from a file or from STDIN) and then deploys it to the node.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-654

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
This PR isn't adding support for session arguments since it was not yet decided how they are defined in the user-facing API.