### PR TITLE
OP-573 test that non-existent accounts are a precondition failure

### DIFF
--- a/integration-testing/test/test_non_account_precondition_failure.py
+++ b/integration-testing/test/test_non_account_precondition_failure.py
@@ -1,11 +1,11 @@
 import pytest
 
 from test.cl_node.casperlabs_accounts import Account
-from test.cl_node.common import HELLO_NAME_CONTRACT
+from test.cl_node.common import HELLO_NAME_CONTRACT, PAYMENT_CONTRACT, MAX_PAYMENT_ABI
 
 
-def test_non_account_precondition_failure(one_node_network):
-    node = one_node_network.docker_nodes[0]
+def test_non_account_precondition_failure(trillion_payment_node_network):
+    node = trillion_payment_node_network.docker_nodes[0]
 
     # Getting a non-existent account
     non_existent_account = Account(300)
@@ -16,7 +16,8 @@ def test_non_account_precondition_failure(one_node_network):
         public_key=non_existent_account.public_key_path,
         private_key=non_existent_account.private_key_path,
         session_contract=HELLO_NAME_CONTRACT,
-        payment_contract=HELLO_NAME_CONTRACT,
+        payment_contract=PAYMENT_CONTRACT,
+        payment_args=MAX_PAYMENT_ABI,
     )
 
     # Will have InternalError as no deploys to propose

--- a/integration-testing/test/test_non_account_precondition_failure.py
+++ b/integration-testing/test/test_non_account_precondition_failure.py
@@ -1,3 +1,5 @@
+import pytest
+
 from test.cl_node.casperlabs_accounts import Account
 from test.cl_node.common import HELLO_NAME_CONTRACT
 
@@ -8,11 +10,19 @@ def test_non_account_precondition_failure(one_node_network):
     # Getting a non-existent account
     non_existent_account = Account(300)
 
-    result = node.p_client.deploy(
+    # Deploy will return hash, but not stay in buffer for proposes.
+    _, deploy_hash = node.p_client.deploy(
         from_address=non_existent_account.public_key_hex,
         public_key=non_existent_account.public_key_path,
         private_key=non_existent_account.private_key_path,
         session_contract=HELLO_NAME_CONTRACT,
         payment_contract=HELLO_NAME_CONTRACT,
     )
-    print(result)
+
+    # Will have InternalError as no deploys to propose
+    with pytest.raises(Exception) as e:
+        _ = node.p_client.propose()
+
+    # Verify reason for propose failure
+    assert e.typename == "InternalError"
+    assert str(e.value) == "StatusCode.OUT_OF_RANGE: No new deploys."

--- a/integration-testing/test/test_non_account_precondition_failure.py
+++ b/integration-testing/test/test_non_account_precondition_failure.py
@@ -10,7 +10,7 @@ def test_non_account_precondition_failure(trillion_payment_node_network):
     # Getting a non-existent account
     non_existent_account = Account(300)
 
-    # Deploy will return hash, but not stay in buffer for proposes.
+    # Client returns deploy hash, but will not stay in buffer for proposes.
     _, deploy_hash = node.p_client.deploy(
         from_address=non_existent_account.public_key_hex,
         public_key=non_existent_account.public_key_path,

--- a/integration-testing/test/test_non_account_precondition_failure.py
+++ b/integration-testing/test/test_non_account_precondition_failure.py
@@ -1,0 +1,18 @@
+from test.cl_node.casperlabs_accounts import Account
+from test.cl_node.common import HELLO_NAME_CONTRACT
+
+
+def test_non_account_precondition_failure(one_node_network):
+    node = one_node_network.docker_nodes[0]
+
+    # Getting a non-existent account
+    non_existent_account = Account(300)
+
+    result = node.p_client.deploy(
+        from_address=non_existent_account.public_key_hex,
+        public_key=non_existent_account.public_key_path,
+        private_key=non_existent_account.private_key_path,
+        session_contract=HELLO_NAME_CONTRACT,
+        payment_contract=HELLO_NAME_CONTRACT,
+    )
+    print(result)


### PR DESCRIPTION
Add integration test that non-existent accounts are a precondition failure.

https://casperlabs.atlassian.net/browse/OP-573

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

