### PR TITLE
EE-579: ignore motes_transferred_in_payment and gas_price fields

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -42,6 +42,9 @@ pub const CONV_RATE: u64 = 10;
 
 pub const SYSTEM_ACCOUNT_ADDR: [u8; 32] = [0u8; 32];
 
+const DEFAULT_MOTES_TRANSFERRED_IN_PAYMENT: u64 = 1_000_000_000;
+const DEFAULT_GAS_PRICE: u64 = 10;
+
 #[derive(Debug)]
 pub struct EngineState<H> {
     config: EngineConfig,
@@ -121,7 +124,6 @@ where
         blocktime: BlockTime,
         nonce: u64,
         prestate_hash: Blake2bHash,
-        gas_limit: u64,
         protocol_version: u64,
         correlation_id: CorrelationId,
         executor: &E,
@@ -198,6 +200,8 @@ where
         // If payment logic is turned off, execute only session code
         if !(self.config.use_payment_code()) {
             // DEPLOY WITH NO PAYMENT
+
+            let gas_limit = DEFAULT_MOTES_TRANSFERRED_IN_PAYMENT / DEFAULT_GAS_PRICE;
 
             // Session code execution
             let session_result = executor.exec(

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -42,8 +42,7 @@ pub const CONV_RATE: u64 = 10;
 
 pub const SYSTEM_ACCOUNT_ADDR: [u8; 32] = [0u8; 32];
 
-const DEFAULT_MOTES_TRANSFERRED_IN_PAYMENT: u64 = 1_000_000_000;
-const DEFAULT_GAS_PRICE: u64 = 10;
+const DEFAULT_SESSION_MOTES: u64 = 1_000_000_000;
 
 #[derive(Debug)]
 pub struct EngineState<H> {
@@ -201,7 +200,7 @@ where
         if !(self.config.use_payment_code()) {
             // DEPLOY WITH NO PAYMENT
 
-            let gas_limit = DEFAULT_MOTES_TRANSFERRED_IN_PAYMENT / DEFAULT_GAS_PRICE;
+            let gas_limit = DEFAULT_SESSION_MOTES / CONV_RATE;
 
             // Session code execution
             let session_result = executor.exec(

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -551,9 +551,6 @@ where
             };
 
             let nonce = deploy.nonce;
-            // TODO: is the rounding in this division ok?
-            let gas_limit =
-                (deploy.motes_transferred_in_payment as u64) / (deploy.gas_price as u64);
             let protocol_version = protocol_version.value;
             engine_state
                 .run_deploy(
@@ -566,7 +563,6 @@ where
                     blocktime,
                     nonce,
                     prestate_hash,
-                    gas_limit,
                     protocol_version,
                     correlation_id,
                     executor,


### PR DESCRIPTION
### Overview
This PR adds a short-term change to derive gas limit from hard-coded defaults rather than the `Deploy` message when the EE is launched without `--use-payment-code`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-579

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
