### PR TITLE
STOR-104: the created block's rank should be calculated from justification's rank.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -123,6 +123,11 @@ object ProtoUtil {
               }
     } yield block
 
+  def calculateRank(justificationMsgs: Seq[BlockMetadata]): Long =
+    1L + justificationMsgs.foldLeft(-1L) {
+      case (acc, blockMetadata) => math.max(acc, blockMetadata.rank)
+    }
+
   def creatorJustification(block: Block): Option[Justification] =
     creatorJustification(block.getHeader)
 

--- a/casper/src/test/scala/io/casperlabs/casper/FinalityDetectorTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/FinalityDetectorTest.scala
@@ -62,12 +62,14 @@ class FinalityDetectorTest
           b2 <- createBlock[Task](
                  Seq(b1.blockHash),
                  v1,
-                 bonds
+                 bonds,
+                 HashMap(v1 -> b1.blockHash)
                )
           b3 <- createBlock[Task](
                  Seq(b1.blockHash),
                  v2,
-                 bonds
+                 bonds,
+                 HashMap(v1 -> b1.blockHash)
                )
           b4 <- createBlock[Task](
                  Seq(b2.blockHash),
@@ -104,7 +106,7 @@ class FinalityDetectorTest
           lowestLevelZeroMsgs = levelZeroMsgs.flatMap {
             case (_, msgs) => msgs.lastOption.map(_.blockHash)
           }.toSet
-          _ = lowestLevelZeroMsgs shouldBe Set(b2.blockHash, b3.blockHash)
+          _ = lowestLevelZeroMsgs shouldBe Set(b1.blockHash, b3.blockHash)
           _ <- dag.justificationToBlocks(b2.blockHash) shouldBeF Some(Set(b4.blockHash))
           _ <- dag.justificationToBlocks(b3.blockHash) shouldBeF Some(
                 Set(b4.blockHash, b5.blockHash)
@@ -148,7 +150,7 @@ class FinalityDetectorTest
           _                              = blockLevels(b2.blockHash).blockLevel shouldBe (0)
           _                              = blockLevels(b3.blockHash).blockLevel shouldBe (0)
           _                              = blockLevels(b4.blockHash).blockLevel shouldBe (1)
-          _                              = blockLevels(b5.blockHash).blockLevel shouldBe (0)
+          _                              = blockLevels(b5.blockHash).blockLevel shouldBe (1)
           _                              = blockLevels(b6.blockHash).blockLevel shouldBe (1)
           _                              = blockLevels(b7.blockHash).blockLevel shouldBe (1)
           _                              = blockLevels(b8.blockHash).blockLevel shouldBe (2)

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -507,6 +507,7 @@ class ValidationTest
                    _ <- Validation[Task].parents(b3, genesisBlockHash, dag)
                    _ <- Validation[Task].parents(b4, genesisBlockHash, dag)
                    _ <- Validation[Task].parents(b5, genesisBlockHash, dag)
+                   _ <- Validation[Task].parents(b6, genesisBlockHash, dag)
 
                    // Not valid
                    _ <- Validation[Task].parents(b7, genesisBlockHash, dag).attempt

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -399,7 +399,7 @@ class ValidationTest
   it should "return false for non-sequential numbering" in withStorage {
     implicit blockStorage => implicit dagStorage =>
       for {
-        _     <- createChain[Task](2)
+        _     <- createChainWithRoundRobinValidators[Task](2, 2)
         block <- dagStorage.lookupByIdUnsafe(1)
         dag   <- dagStorage.getRepresentation
         _ <- ValidationImpl[Task]
@@ -480,15 +480,16 @@ class ValidationTest
                     creator = validators(validator),
                     bonds = bonds,
                     deploys = Seq(deploy),
-                    justifications = latestMessages(justifications)
+                    justifications = latestMessages(justifications),
+                    addParentsToJustifications = false
                   )
         } yield block
 
       for {
         b0  <- createBlock[Task](Seq.empty, bonds = bonds)
-        b1  <- createValidatorBlock[Task](Seq(b0), Seq.empty, 0)
-        b2  <- createValidatorBlock[Task](Seq(b0), Seq.empty, 1)
-        b3  <- createValidatorBlock[Task](Seq(b0), Seq.empty, 2)
+        b1  <- createValidatorBlock[Task](Seq(b0), Seq(b0), 0)
+        b2  <- createValidatorBlock[Task](Seq(b0), Seq(b0), 1)
+        b3  <- createValidatorBlock[Task](Seq(b0), Seq(b0), 2)
         b4  <- createValidatorBlock[Task](Seq(b1), Seq(b1), 0)
         b5  <- createValidatorBlock[Task](Seq(b3, b2, b1), Seq(b1, b2, b3), 1)
         b6  <- createValidatorBlock[Task](Seq(b5, b4), Seq(b1, b4, b5), 0)

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
@@ -169,19 +169,18 @@ class BlocksResponseAPITest
   it should "return until depth" in withStorage { implicit blockStorage => implicit dagStorage =>
     /**
       * The Dag looks like
-			*
-			* rank
       *
-			*  4          b8
-			*           /
-			*  3     b6 ----   b7
+      *
+      *  4          b8
+      *           /
+      *  3     b6 ----   b7
       *                x
-			*  2          b5  b4
-			*           /    /
-			*  1     b3   b2
+      *  2          b5  b4
+      *           /    /
+      *  1     b3   b2
       *         \   |
       *  0       genesis
-			*
+      *
       */
     for {
       genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
@@ -1,17 +1,17 @@
 package io.casperlabs.casper.api
 
-import cats.Id
 import cats.effect.Sync
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
-import io.casperlabs.blockstorage.{BlockStorage, IndexedDagStorage}
+import io.casperlabs.casper._
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus._
-import io.casperlabs.casper.{genesis, _}
 import io.casperlabs.casper.helper._
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
+import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.p2p.EffectsTestInstances.LogStub
+import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockMsgWithTransform
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
@@ -167,6 +167,22 @@ class BlocksResponseAPITest
   }
 
   it should "return until depth" in withStorage { implicit blockStorage => implicit dagStorage =>
+    /**
+      * The Dag looks like
+			*
+			* rank
+      *
+			*  4          b8
+			*           /
+			*  3     b6 ----   b7
+      *                x
+			*  2          b5  b4
+			*           /    /
+			*  1     b3   b2
+      *         \   |
+      *  0       genesis
+			*
+      */
     for {
       genesis <- createBlock[Task](Seq(), ByteString.EMPTY, bonds)
       b2 <- createBlock[Task](
@@ -217,17 +233,22 @@ class BlocksResponseAPITest
                        HashMap.empty[BlockHash, BlockMsgWithTransform],
                        tips
                      )
-      logEff                 = new LogStub[Task]
-      casperRef              <- MultiParentCasperRef.of[Task]
-      _                      <- casperRef.set(casperEffect)
-      finalityDetectorEffect = new FinalityDetectorInstancesImpl[Task]()(Sync[Task], logEff)
-      blocksResponse <- BlockAPI.showBlocks[Task](2)(
-                         Sync[Task],
-                         casperRef,
-                         logEff,
-                         finalityDetectorEffect,
-                         blockStorage
-                       )
-    } yield blocksResponse.length should be(2) // TODO: Switch to 3 when we implement block height correctly
+      implicit0(logEff: Log[Task])                     = new LogStub[Task]
+      implicit0(casperRef: MultiParentCasperRef[Task]) <- MultiParentCasperRef.of[Task]
+      _                                                <- casperRef.set(casperEffect)
+      implicit0(finalityDetectorEffect: FinalityDetector[Task]) = new FinalityDetectorInstancesImpl[
+        Task
+      ]()
+      blocksWithRankBelow1 <- BlockAPI.showBlocks[Task](1)
+      _                    = blocksWithRankBelow1.length shouldBe 1
+      blocksWithRankBelow2 <- BlockAPI.showBlocks[Task](2)
+      _                    = blocksWithRankBelow2.length shouldBe 3
+      blocksWithRankBelow3 <- BlockAPI.showBlocks[Task](3)
+      _                    = blocksWithRankBelow3.length shouldBe 5
+      blocksWithRankBelow4 <- BlockAPI.showBlocks[Task](4)
+      _                    = blocksWithRankBelow4.length shouldBe 7
+      blocksWithRankBelow5 <- BlockAPI.showBlocks[Task](5)
+      result               = blocksWithRankBelow5.length shouldBe 8
+    } yield result
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -116,7 +116,7 @@ trait BlockGenerator {
       body = Block.Body().withDeploys(deploys)
       dag  <- IndexedDagStorage[F].getRepresentation
       // add parensHashList to justifications so that we can avoid passing parameter justification
-      updatedJustifications <- if (justifications.nonEmpty || !addParentsToJustifications) {
+      updatedJustifications <- if (!addParentsToJustifications) {
                                 justifications.pure[F]
                               } else {
                                 parentsHashList.toList.foldLeftM(justifications) {

--- a/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
@@ -58,7 +58,7 @@ class DagOperationsTest extends FlatSpec with Matchers with BlockGenerator with 
                 .children(b.blockHash)
                 .flatMap(_.toList.traverse(l => dag.lookup(l).map(_.get)))
           }
-          result <- stream.toList.map(_.map(_.rank) shouldBe List(0, 1, 2, 3, 4, 5, 6, 7))
+          result <- stream.toList.map(_.map(_.rank) shouldBe List(0, 1, 2, 2, 3, 3, 4, 4))
         } yield result
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
@@ -30,25 +30,29 @@ class DagOperationsTest extends FlatSpec with Matchers with BlockGenerator with 
         /*
          * DAG Looks like this:
          *
-         *        b6   b7
-         *       |  \ /  \
-         *       |   b4  b5
-         *       |    \ /
-         *       b2    b3
+         *       b6      b7
+         *       |  \ /  |
+         *       |  b4   b5
+         *       |     \ |
+         *       b2      b3
          *         \  /
          *          b1
          *           |
          *         genesis
          */
+        val v1 = generateValidator("v1")
+        val v2 = generateValidator("v2")
+        val v3 = generateValidator("v3")
+
         for {
           genesis <- createBlock[Task](Seq.empty)
-          b1      <- createBlock[Task](Seq(genesis.blockHash))
-          b2      <- createBlock[Task](Seq(b1.blockHash))
-          b3      <- createBlock[Task](Seq(b1.blockHash))
-          b4      <- createBlock[Task](Seq(b3.blockHash))
-          b5      <- createBlock[Task](Seq(b3.blockHash))
-          b6      <- createBlock[Task](Seq(b2.blockHash, b4.blockHash))
-          b7      <- createBlock[Task](Seq(b4.blockHash, b5.blockHash))
+          b1      <- createBlock[Task](Seq(genesis.blockHash), v2)
+          b2      <- createBlock[Task](Seq(b1.blockHash), v1)
+          b3      <- createBlock[Task](Seq(b1.blockHash), v3)
+          b4      <- createBlock[Task](Seq(b3.blockHash), v2)
+          b5      <- createBlock[Task](Seq(b3.blockHash), v3)
+          b6      <- createBlock[Task](Seq(b2.blockHash, b4.blockHash), v1)
+          b7      <- createBlock[Task](Seq(b4.blockHash, b5.blockHash), v3)
 
           implicit0(dagTopoOrderingAsc: Ordering[BlockMetadata]) = DagOperations.blockTopoOrderingAsc
           dag                                                    <- dagStorage.getRepresentation

--- a/storage/src/test/scala/io/casperlabs/blockstorage/IndexedDagStorage.scala
+++ b/storage/src/test/scala/io/casperlabs/blockstorage/IndexedDagStorage.scala
@@ -40,19 +40,8 @@ final class IndexedDagStorage[F[_]: Monad](
       justificationMsgs <- header.justifications.toList
                             .traverse(j => dag.lookup(j.latestBlockHash))
                             .map(_.flatten)
-      parentMsg <- header.parentHashes.toList
-                    .traverse(b => dag.lookup(b))
-                    .map(_.flatten)
-      maxRank = if (justificationMsgs.nonEmpty) {
-        justificationMsgs.foldLeft(-1L) {
-          case (acc, b) => math.max(b.rank, acc)
-        }
-      } else {
-        // Caution: here is different from PROD
-        // If there are no justifications, then maxRank = max {rank of parent}
-        parentMsg.foldLeft(-1L) {
-          case (acc, b) => math.max(b.rank, acc)
-        }
+      maxRank = justificationMsgs.foldLeft(-1L) {
+        case (acc, b) => math.max(b.rank, acc)
       }
       rank = maxRank + 1
       nextCreatorSeqNum <- dag


### PR DESCRIPTION
### Overview
When creating a block in the test, if we provide justifications, then its rank is max{rank of justifications} + 1, if not, then its rank is max{rank of parent} + 1. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/STOR-104

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
