### PR TITLE
NODE-669: Prevent deploy replay by dag traversal

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -473,7 +473,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       orphanedBlockHashes <- blockHashes
                               .filterA { blockHash =>
                                 DagOperations
-                                  .anyDescendingPathExists[F](
+                                  .anyDescendantPathExists[F](
                                     dag,
                                     Set(blockHash),
                                     parentSet

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -406,16 +406,22 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       parents: Seq[Block]
   ): F[Seq[Deploy]] =
     for {
-      orphanedDeploys <- findOrphanedDeploys(dag, parents)
-      pendingDeploys  <- DeployBuffer[F].readPendingHashes
-      // Pending deploys are most likely not in the past, or we'd have to go back indefinitely to
-      // prove they aren't. The EE will ignore them if the nonce is less than the expected,
-      // so it should be fine to include and see what happens.
-      candidatesHashes = orphanedDeploys ++ pendingDeploys
+      // We have re-queued orphan deploys already, so we can just look at pending ones.
+      pendingDeployHashes <- DeployBuffer[F].readPendingHashes
 
-      // Only send the next nonce per account.
+      // Make sure pending deploys have never been processed in the past cone of the new parents.
+      candidateBlockHashes <- filterDeploysNotInPast(dag, parents, pendingDeployHashes)
+
+      // The ones which aren't candidates now can be discarded as duplicates.
+      deploysToDiscard = pendingDeployHashes.toSet -- candidateBlockHashes
+      _ <- DeployBuffer[F]
+            .markAsDiscardedByHashes(deploysToDiscard.toList)
+            .whenA(deploysToDiscard.nonEmpty)
+
+      // Only send the next nonce per account. This will change once the nonce check is removed in the EE
+      // and support for SEQ/PAR blocks is added, then we can send all deploys for the account.
       remaining <- DeployBuffer[F]
-                    .getByHashes(candidatesHashes)
+                    .getByHashes(candidateBlockHashes)
                     .map {
                       _.groupBy(_.getHeader.accountPublicKey).map {
                         case (_, deploys) => deploys.minBy(_.getHeader.nonce)
@@ -437,20 +443,22 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       tips    <- tipHashes.toList.traverse(ProtoUtil.unsafeGetBlock[F])
       merged  <- ExecEngineUtil.merge[F](tips, dag)
       parents = merged.parents
-
-      orphanedDeploys <- findOrphanedDeploys(dag, parents)
-      _               <- DeployBuffer[F].markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
+      // Consider deploys which this node has processed but hasn't finalized yet.
+      processedDeploys <- DeployBuffer[F].readProcessedHashes
+      orphanedDeploys  <- filterDeploysNotInPast(dag, parents, processedDeploys)
+      _                <- DeployBuffer[F].markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
     } yield orphanedDeploys.size
 
-  /** Find orphaned deploys in the processed buffer. */
-  private def findOrphanedDeploys(
+  /** Find deploys which either haven't been processed yet or are in blocks which are
+    * not in the past cone of the chosen parents.
+    */
+  private def filterDeploysNotInPast(
       dag: DagRepresentation[F],
-      parents: Seq[Block]
+      parents: Seq[Block],
+      deployHashes: List[ByteString]
   ): F[List[ByteString]] =
     for {
-      processedDeploysHashes <- DeployBuffer[F].readProcessedHashes
-      parentSet              = parents.map(_.blockHash).toSet
-      deployHashToBlocksMap <- processedDeploysHashes
+      deployHashToBlocksMap <- deployHashes
                                 .traverse { deployHash =>
                                   BlockStorage[F]
                                     .findBlockHashesWithDeployhash(deployHash)
@@ -461,24 +469,26 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       blockHashes = deployHashToBlocksMap.values.flatten.toList.distinct
 
       // Find the blocks from which there's no way through the descendants to reach a tip.
+      parentSet = parents.map(_.blockHash).toSet
       orphanedBlockHashes <- blockHashes
-                              .traverse { blockHash =>
+                              .filterA { blockHash =>
                                 DagOperations
-                                  .bfTraverseF[F, BlockHash](List(blockHash))(
-                                    h => dag.children(h).map(_.toList)
+                                  .anyDescendingPathExists[F](
+                                    dag,
+                                    Set(blockHash),
+                                    parentSet
                                   )
-                                  .find(parentSet)
-                                  .map(blockHash -> _.isEmpty)
+                                  .map(!_)
                               }
-                              .map {
-                                _.filter(_._2).map(_._1).toSet
-                              }
+                              .map(_.toSet)
 
-      orphanedDeploys = deployHashToBlocksMap.collect {
-        case (deployHash, blockHashes) if blockHashes.forall(orphanedBlockHashes) => deployHash
+      deploysNotInPast = deployHashToBlocksMap.collect {
+        case (deployHash, blockHashes)
+            if blockHashes.isEmpty || blockHashes.forall(orphanedBlockHashes) =>
+          deployHash
       }.toList
 
-    } yield orphanedDeploys
+    } yield deploysNotInPast
 
   //TODO: Need to specify SEQ vs PAR type block?
   /** Execute a set of deploys in the context of chosen parents. Compile them into a block if everything goes fine. */

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -352,4 +352,22 @@ object DagOperations {
       )
       .map(_.blockHash)
   }
+
+  /** Check if there's a (possibly empty) path leading from any of the starting points to any of the targets. */
+  def anyPathExists[F[_]: Monad, A](
+      start: Set[A],
+      targets: Set[A]
+  )(neighbours: A => F[List[A]])(
+      implicit k: Key[A]
+  ): F[Boolean] =
+    bfTraverseF[F, A](start.toList)(neighbours).find(targets).map(_.nonEmpty)
+
+  def anyDescendingPathExists[F[_]: MonadThrowable](
+      dag: DagRepresentation[F],
+      ancestors: Set[BlockHash],
+      descendants: Set[BlockHash]
+  ): F[Boolean] =
+    anyPathExists(ancestors, descendants) { blockHash =>
+      dag.children(blockHash).map(_.toList)
+    }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -362,7 +362,8 @@ object DagOperations {
   ): F[Boolean] =
     bfTraverseF[F, A](start.toList)(neighbours).find(targets).map(_.nonEmpty)
 
-  def anyDescendingPathExists[F[_]: MonadThrowable](
+  /** Check if a path in the p-DAG exists from ancestors to descendants (or self). */
+  def anyDescendantPathExists[F[_]: MonadThrowable](
       dag: DagRepresentation[F],
       ancestors: Set[BlockHash],
       descendants: Set[BlockHash]

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -18,6 +18,7 @@ import io.casperlabs.casper.consensus.state
 import io.casperlabs.models.{DeployResult => _}
 import io.casperlabs.shared.Log
 import io.casperlabs.smartcontracts.ExecutionEngineService
+import io.casperlabs.casper.consensus.state.{Key, Value}
 
 case class DeploysCheckpoint(
     preStateHash: StateHash,
@@ -364,8 +365,28 @@ object ExecEngineUtil {
     def parents(b: BlockMetadata): F[List[BlockMetadata]] =
       b.parents.traverse(b => dag.lookup(b).map(_.get))
 
-    def effect(block: BlockMetadata): F[Option[TransformMap]] =
-      BlockStorage[F].getTransforms(block.blockHash)
+    def effect(blockMeta: BlockMetadata): F[Option[TransformMap]] =
+      BlockStorage[F]
+        .get(blockMeta.blockHash)
+        .map(_.map { blockWithTransforms =>
+          val blockHash  = blockWithTransforms.getBlockMessage.blockHash
+          val transforms = blockWithTransforms.transformEntry
+          // To avoid the possibility of duplicate deploys, pretend that a deploy
+          // writes to its own deploy hash, to generate conflicts between blocks
+          // that have the same deploy in their bodies.
+          val deployHashTransforms =
+            blockWithTransforms.getBlockMessage.getBody.deploys.map(_.getDeploy).map { deploy =>
+              val k = Key(Key.Value.Hash(Key.Hash(deploy.deployHash)))
+              val t = Transform(
+                Transform.TransformInstance.Write(
+                  TransformWrite().withValue(Value(Value.Value.BytesValue(blockHash)))
+                )
+              )
+              TransformEntry().withKey(k).withTransform(t)
+            }
+
+          transforms ++ deployHashTransforms
+        })
 
     def toOps(t: TransformMap): OpMap[state.Key] = Op.fromTransforms(t)
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -748,7 +748,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
           blockHashes = deployToBlocksMap.values.flatten.toList
 
           maybeDuplicateBlockHash <- blockHashes.findM[F] { blockHash =>
-                                      DagOperations.anyDescendingPathExists(
+                                      DagOperations.anyDescendantPathExists(
                                         dag,
                                         Set(blockHash),
                                         Set(block.blockHash)

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -783,6 +783,32 @@ class ValidationTest
       } yield postState shouldBe Left(ValidateErrorWrapper(InvalidPreStateHash))
   }
 
+  "deployUniqueness" should "return InvalidRepeatDeploy when a deploy is present in an ancestor" in withStorage {
+    implicit blockStorage => implicit dagStorage =>
+      val contract        = ByteString.copyFromUtf8("some contract")
+      val deploysWithCost = prepareDeploys(Vector(contract), 1)
+      for {
+        genesis <- createBlock[Task](Seq.empty, deploys = deploysWithCost)
+        block   <- createBlock[Task](Seq(genesis.blockHash), deploys = deploysWithCost)
+        dag     <- dagStorage.getRepresentation
+        result  <- ValidationImpl[Task].deployUniqueness(block, dag).attempt
+      } yield result shouldBe Left(ValidateErrorWrapper(InvalidRepeatDeploy))
+  }
+
+  it should "return InvalidRepeatDeploy when a deploy is present in the body twice" in withStorage {
+    implicit blockStorage => implicit dagStorage =>
+      val contract        = ByteString.copyFromUtf8("some contract")
+      val deploysWithCost = prepareDeploys(Vector(contract), 1)
+      for {
+        genesis <- createBlock[Task](
+                    Seq.empty,
+                    deploys = deploysWithCost ++ deploysWithCost
+                  )
+        dag    <- dagStorage.getRepresentation
+        result <- ValidationImpl[Task].deployUniqueness(genesis, dag).attempt
+      } yield result shouldBe Left(ValidateErrorWrapper(InvalidRepeatDeploy))
+  }
+
   it should "return InvalidPostStateHash when postStateHash of block is not correct" in withStorage {
     implicit blockStorage => implicit dagStorage =>
       implicit val executionEngineService: ExecutionEngineService[Task] =

--- a/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/DagOperationsTest.scala
@@ -312,15 +312,15 @@ class DagOperationsTest extends FlatSpec with Matchers with BlockGenerator with 
         } yield result
   }
 
-  "anyDescendingPathExists" should
+  "anyDescendantPathExists" should
     "return whether there is a path from any of the possible ancestor blocks to any of the potential descendants" in withStorage {
     implicit blockStorage => implicit dagStorage =>
-      def anyDescendingPathExists(
+      def anyDescendantPathExists(
           dag: DagRepresentation[Task],
           start: Set[Block],
           targets: Set[Block]
       ) =
-        DagOperations.anyDescendingPathExists[Task](
+        DagOperations.anyDescendantPathExists[Task](
           dag,
           start.map(_.blockHash),
           targets.map(_.blockHash)
@@ -349,19 +349,19 @@ class DagOperationsTest extends FlatSpec with Matchers with BlockGenerator with 
         b7      <- createBlock[Task](Seq(b4.blockHash, b5.blockHash))
         dag     <- dagStorage.getRepresentation
         // self
-        _ <- anyDescendingPathExists(dag, Set(genesis), Set(genesis)) shouldBeF true
+        _ <- anyDescendantPathExists(dag, Set(genesis), Set(genesis)) shouldBeF true
         // any descendant
-        _ <- anyDescendingPathExists(dag, Set(b3), Set(b2, b7)) shouldBeF true
+        _ <- anyDescendantPathExists(dag, Set(b3), Set(b2, b7)) shouldBeF true
         // any ancestor
-        _ <- anyDescendingPathExists(dag, Set(b2, b3), Set(b5)) shouldBeF true
+        _ <- anyDescendantPathExists(dag, Set(b2, b3), Set(b5)) shouldBeF true
         // main parent
-        _ <- anyDescendingPathExists(dag, Set(b4), Set(b7)) shouldBeF true
+        _ <- anyDescendantPathExists(dag, Set(b4), Set(b7)) shouldBeF true
         // secondary parent
-        _ <- anyDescendingPathExists(dag, Set(b5), Set(b7)) shouldBeF true
+        _ <- anyDescendantPathExists(dag, Set(b5), Set(b7)) shouldBeF true
         // not to ancestor
-        _ <- anyDescendingPathExists(dag, Set(b2, b4), Set(b1)) shouldBeF false
+        _ <- anyDescendantPathExists(dag, Set(b2, b4), Set(b1)) shouldBeF false
         // not to sibling
-        _ <- anyDescendingPathExists(dag, Set(b2), Set(b3)) shouldBeF false
+        _ <- anyDescendantPathExists(dag, Set(b2), Set(b3)) shouldBeF false
       } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -460,9 +460,9 @@ object ExecEngineUtilTest {
 
   val other: String = """ """.stripMargin
 
-  def prepareDeploys(v: Vector[ByteString], c: Long): Vector[ProcessedDeploy] = {
-    val genesisDeploys =
-      v.map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis))
-    genesisDeploys.map(d => ProcessedDeploy().withDeploy(d).withCost(c))
+  def prepareDeploys(contracts: Vector[ByteString], cost: Long): Vector[ProcessedDeploy] = {
+    val deploys =
+      contracts.map(ProtoUtil.sourceDeploy(_, System.currentTimeMillis))
+    deploys.map(d => ProcessedDeploy().withDeploy(d).withCost(cost))
   }
 }


### PR DESCRIPTION
### Overview
We want to remove the nonce check, however, the nonce check was our last line of defence against replay attacks. This PR adds checks based on traversing the DAG that checks that the same deploy hash hasn't been included already in the past. A similar thing existed before but now we can do it without going back to Genesis by first consulting the block store to see if we already registered the deploy in any of the existing blocks.

Changes:
- reject a block if any deploy is already in its history
- filter for deploys which aren't in the past during block proposal, discard the ones which are
- consider forks that contain the same block conflicting to avoid merging them as parents

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-669

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
