### PR TITLE
OP-464: Add integration test for create-deploy, sign-deploy and send-deploy

### DIFF
--- a/integration-testing/test/cl_node/casperlabs_accounts.py
+++ b/integration-testing/test/cl_node/casperlabs_accounts.py
@@ -36,6 +36,14 @@ class Account:
         return self.account_path / self.private_key_filename
 
     @property
+    def public_key_docker_path(self) -> Path:
+        return f"/data/accounts/{self.public_key_filename}"
+
+    @property
+    def private_key_docker_path(self) -> Path:
+        return f"/data/accounts/{self.private_key_filename}"
+
+    @property
     def private_key_filename(self) -> str:
         return f"account-private-{self.file_id}.pem"
 

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -33,9 +33,12 @@ class DockerClient(CasperLabsClient, LoggingMixin):
     def client_type(self) -> str:
         return "docker"
 
-    def invoke_client(self, command: str, decode_stdout: bool = True) -> str:
+    def invoke_client(
+        self, command: str, decode_stdout: bool = True, add_host: bool = True
+    ) -> str:
         volumes = {self.node.host_mount_dir: {"bind": "/data", "mode": "ro"}}
-        command = f"--host {self.node.container_name} {command}"
+        if add_host:
+            command = f"--host {self.node.container_name} {command}"
         self.logger.info(f"COMMAND {command}")
         container = self.docker_client.containers.run(
             image=f"casperlabs/client:{self.node.docker_tag}",

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -36,7 +36,10 @@ class DockerClient(CasperLabsClient, LoggingMixin):
     def invoke_client(
         self, command: str, decode_stdout: bool = True, add_host: bool = True
     ) -> str:
-        volumes = {self.node.host_mount_dir: {"bind": "/data", "mode": "ro"}}
+        volumes = {
+            self.node.host_mount_dir: {"bind": "/data", "mode": "ro"},
+            "/tmp": {"bind": "/tmp", "mode": "rw"},
+        }
         if add_host:
             command = f"--host {self.node.container_name} {command}"
         self.logger.info(f"COMMAND {command}")

--- a/integration-testing/test/cl_node/docker_client.py
+++ b/integration-testing/test/cl_node/docker_client.py
@@ -33,7 +33,7 @@ class DockerClient(CasperLabsClient, LoggingMixin):
     def client_type(self) -> str:
         return "docker"
 
-    def invoke_client(self, command: str) -> str:
+    def invoke_client(self, command: str, decode_stdout: bool = True) -> str:
         volumes = {self.node.host_mount_dir: {"bind": "/data", "mode": "ro"}}
         command = f"--host {self.node.container_name} {command}"
         self.logger.info(f"COMMAND {command}")
@@ -49,7 +49,8 @@ class DockerClient(CasperLabsClient, LoggingMixin):
         )
         r = container.wait()
         status_code = r["StatusCode"]
-        stdout = container.logs(stdout=True, stderr=False).decode("utf-8")
+        stdout_raw = container.logs(stdout=True, stderr=False)
+        stdout = decode_stdout and stdout_raw.decode("utf-8") or stdout_raw
         stderr = container.logs(stdout=False, stderr=True).decode("utf-8")
 
         # TODO: I don't understand why bug if I just call `self.logger.debug` then

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -637,7 +637,7 @@ class CLI:
 
     def expand_args(self, args):
         def _args(args, connection_details=["--host", f"{self.host}", "--port", f"{self.port}"]):
-            return [str(a) for a in [self.cli_cmd] + connection_details + list(args)]
+            return [str(a) for a in connection_details + list(args)]
 
         return '--help' in args and _args(args, []) or _args(args)
 
@@ -663,7 +663,7 @@ class CLI:
         return output
 
     def __call__(self, *args, sleep=0):
-        command_line = self.expand_args(args)
+        command_line = [str(self.cli_cmd)] + self.expand_args(args)
         logging.info(f"EXECUTING []: {command_line}")
         logging.info(f"EXECUTING: {' '.join(command_line)}")
         if sleep:
@@ -679,6 +679,13 @@ class CLI:
                 pass
             raise CLIErrorExit(cp, output)
 
+        return self.parse_output(args[0], binary_output)
+
+
+class DockerCLI(CLI):
+    def __call__(self, *args):
+        command = ' '.join(self.expand_args(args))
+        binary_output = self.node.d_client.invoke_client(command, decode_stdout=False)
         return self.parse_output(args[0], binary_output)
 
 

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -857,46 +857,14 @@ def test_cli_scala_extended_deploy(scala_cli):
                        '--from', account.public_key_hex,
                        '--session', test_contract,
                        '--payment', test_contract)
-    """
-         - Subcommand: make-deploy - Constructs a deploy that can be signed and sent to a node.
-         -   -o, --deploy-path  <arg>   Path to the file where deploy will be saved.
-         -                              Optional, if not provided the deploy will be
-         -                              printed to STDOUT.
-         -   -f, --from  <arg>          The public key of the account which is the context
-         -                              of this deployment, base16 encoded.
-         -   -g, --gas-price  <arg>     The price of gas for this transaction in units
-         -                              dust/gas. Must be positive integer.
-         -   -n, --nonce  <arg>         This allows you to overwrite your own pending
-         -                              transactions that use the same nonce.
-         -       --payment  <arg>       Path to the file with payment code, by default
-         -                              fallbacks to the --session code
-         -   -p, --public-key  <arg>    Path to the file with account public key (Ed25519)
-         -   -s, --session  <arg>       Path to the file with session code
-    """
+
+    logging.info(f"make-deploy => =|{output}|=")
 
     output = scala_cli('sign-deploy',
                        '-i', '/tmp/unsigned.deploy',
                        '-o', '/tmp/signed.deploy',
                        '--private-key', account.private_key_docker_path,
                        '--public-key', account.public_key_docker_path)
-    """
-         - Subcommand: sign-deploy - Cryptographically signs a deploy. The signature is appended to existing approvals.
-         -   -i, --deploy-path  <arg>          Path to the deploy file.
-         -       --private-key  <arg>          Path to the file with account private key
-         -                                     (Ed25519)
-         -       --public-key  <arg>           Path to the file with account public key
-         -                                     (Ed25519)
-         -   -o, --signed-deploy-path  <arg>   Path to the file where signed deploy will be
-         -                                     saved.If not provided, the signed deploy
-         -                                     will be sent to stdout.
-         -   -h, --help                        Show help message
-    """
 
-    output = scala_cli('send-deploy',
-                       '-i', '/tmp/signed.deploy',)
+    output = scala_cli('send-deploy', '-i', '/tmp/signed.deploy',)
     output = output
-
-    """
-         - Subcommand: send-deploy - Deploy a smart contract source file to Casper on an existing running node. The deploy will be packaged and sent as a block to the network depending on the configuration of the Casper instance.
-         -   -i, --deploy-path  <arg>   Path to the file with signed Deploy.
-    """

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -685,6 +685,7 @@ class CLI:
 class DockerCLI(CLI):
     def __call__(self, *args):
         logging.info(f"EXECUTING []: {args}")
+        self.host = self.node.container_name
         command = ' '.join(self.expand_args(args))
         logging.info(f"EXECUTING: {command}")
         binary_output = self.node.d_client.invoke_client(command, decode_stdout=False, add_host=False)


### PR DESCRIPTION
### Overview
This PR adds test for the new CL subcommands: `create-deploy`, `sign-deploy` and `send-deploy`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-464

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
