### PR TITLE
EE-579: Removed motes_transferred_in_payment.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -525,18 +525,12 @@ object ProtoUtil {
   // We are hardcoding exchange rate for DEV NET at 10:1
   // (1 gas costs you 10 motes).
   // Later, post DEV NET, conversion rate will be part of a deploy.
-  val GAS_PRICE     = 10L
-  val PAYMENT_MOTES = 1000000000L
+  val GAS_PRICE = 10L
 
   def deployDataToEEDeploy(d: Deploy): ipc.Deploy = ipc.Deploy(
     address = d.getHeader.accountPublicKey,
     session = d.getBody.session.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
     payment = d.getBody.payment.map { case Deploy.Code(code, args) => ipc.DeployCode(code, args) },
-    // The new data type doesn't have a limit field. Remove this once payment is implemented.
-    motesTransferredInPayment =
-      if (d.getBody.getPayment.code.isEmpty || d.getBody.getPayment.code == d.getBody.getSession.code) {
-        sys.env.get("CL_DEFAULT_PAYMENT_MOTES").map(_.toLong).getOrElse(PAYMENT_MOTES)
-      } else 0L,
     gasPrice = GAS_PRICE,
     nonce = d.getHeader.nonce,
     authorizationKeys = d.approvals.map(_.approverPublicKey)

--- a/execution-engine/engine-grpc-server/tests/test_support.rs
+++ b/execution-engine/engine-grpc-server/tests/test_support.rs
@@ -108,7 +108,6 @@ impl DeployBuilder {
 impl Default for DeployBuilder {
     fn default() -> Self {
         let mut deploy = Deploy::new();
-        deploy.set_motes_transferred_in_payment(1_000_000_000);
         deploy.set_gas_price(1);
         DeployBuilder { deploy }
     }
@@ -181,7 +180,6 @@ pub fn get_protocol_version() -> ProtocolVersion {
 pub fn get_mock_deploy() -> Deploy {
     let mut deploy = Deploy::new();
     deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
-    deploy.set_motes_transferred_in_payment(1000);
     deploy.set_gas_price(1);
     deploy.set_nonce(1);
     let mut deploy_code = DeployCode::new();

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -15,11 +15,11 @@ message Bond {
 }
 
 message Deploy {
+    reserved 5;
     // Public key of the account which is the context of the execution.
     bytes address = 1; // length 32 bytes
     DeployCode session = 3;
     DeployCode payment = 4;
-    uint64 motes_transferred_in_payment = 5; // in units of Motes -- someday this will come from running payment code
     uint64 gas_price = 6; // in units of Mote / Gas
     uint64 nonce = 7;
     // Public keys used to sign this deploy, to be checked against the keys


### PR DESCRIPTION
### Overview
EE now calculates it's own gas limit (constant) when payments are disabled. This PR just removes the node code and the field we no longer use.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-579

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
