### PR TITLE
EE-449: Add comm/tests for PoS Contract

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -1133,6 +1133,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pos-bonding"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.12.0",
+]
+
+[[package]]
 name = "pos-finalize-payment"
 version = "0.1.0"
 dependencies = [

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -39,6 +39,7 @@ members = [
     "contracts/test/pos-get-payment-purse",
     "contracts/test/pos-finalize-payment",
     "contracts/test/pos-refund-purse",
+    "contracts/test/pos-bonding",
     "contracts/test/remove-associated-key",
     "contracts/test/transfer-purse-to-account",
     "contracts/test/transfer-purse-to-purse",

--- a/execution-engine/contracts/test/pos-bonding/Cargo.toml
+++ b/execution-engine/contracts/test/pos-bonding/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pos-bonding"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "pos_bonding"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["cl_std/std" ]
+
+[dependencies]
+cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![feature(alloc)]
+
+#[macro_use]
+extern crate alloc;
+extern crate cl_std;
+
+use alloc::prelude::*;
+
+use cl_std::contract_api::pointers::{ContractPointer, UPointer};
+use cl_std::contract_api::{
+    call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
+    transfer_from_purse_to_account, transfer_from_purse_to_purse, PurseTransferResult,
+    TransferResult,
+};
+use cl_std::key::Key;
+use cl_std::uref::AccessRights;
+use cl_std::value::account::{PublicKey, PurseId};
+use cl_std::value::U512;
+
+enum Error {
+    GetPosOuterURef = 1000,
+    GetPosInnerURef = 1001,
+    PurseToPurseTransfer = 1002,
+    UnableToSeedAccount = 1003,
+    UnknownCommand = 1004,
+}
+
+fn purse_to_key(p: PurseId) -> Key {
+    Key::URef(p.value())
+}
+
+fn get_pos_contract() -> ContractPointer {
+    let outer: UPointer<Key> = get_uref("pos")
+        .and_then(Key::to_u_ptr)
+        .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
+    if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
+        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+    } else {
+        revert(Error::GetPosOuterURef as u32)
+    }
+}
+
+fn bond(pos: &ContractPointer, amount: &U512, source: PurseId) {
+    call_contract::<_, ()>(
+        pos.clone(),
+        &("bond", *amount, source),
+        &vec![purse_to_key(source)],
+    );
+}
+
+fn unbond(pos: &ContractPointer, amount: Option<U512>) {
+    call_contract::<_, ()>(pos.clone(), &("unbond", amount), &Vec::<Key>::new());
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let pos_pointer = get_pos_contract();
+
+    let command: String = get_arg(0);
+
+    if command == "bond" {
+        // Creates new purse with desired amount based on main purse and sends funds
+
+        let amount = get_arg(1);
+        let p1 = create_purse();
+
+        if transfer_from_purse_to_purse(main_purse(), p1, amount)
+            == PurseTransferResult::TransferError
+        {
+            revert(Error::PurseToPurseTransfer as u32);
+        }
+
+        bond(&pos_pointer, &amount, p1);
+    } else if command == "seed_new_account" {
+        let account: PublicKey = get_arg(1);
+        let amount: U512 = get_arg(2);
+        if transfer_from_purse_to_account(main_purse(), account, amount)
+            == TransferResult::TransferError
+        {
+            revert(Error::UnableToSeedAccount as u32);
+        }
+    } else if command == "unbond" {
+        let maybe_amount: Option<U512> = get_arg(1);
+        unbond(&pos_pointer, maybe_amount);
+    } else {
+        revert(Error::UnknownCommand as u32);
+    }
+}

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -58,7 +58,6 @@ pub extern "C" fn call() {
     let pos_pointer = get_pos_contract();
 
     let command: String = get_arg(0);
-
     if command == "bond" {
         // Creates new purse with desired amount based on main purse and sends funds
 
@@ -72,6 +71,10 @@ pub extern "C" fn call() {
         }
 
         bond(&pos_pointer, &amount, p1);
+    } else if command == "bond-from-main-purse" {
+        let amount = get_arg(1);
+
+        bond(&pos_pointer, &amount, main_purse());
     } else if command == "seed_new_account" {
         let account: PublicKey = get_arg(1);
         let amount: U512 = get_arg(2);

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -44,21 +44,29 @@ fn get_pos_contract() -> ContractPointer {
 fn bond(pos: &ContractPointer, amount: &U512, source: PurseId) {
     call_contract::<_, ()>(
         pos.clone(),
-        &("bond", *amount, source),
+        &(POS_BOND, *amount, source),
         &vec![purse_to_key(source)],
     );
 }
 
 fn unbond(pos: &ContractPointer, amount: Option<U512>) {
-    call_contract::<_, ()>(pos.clone(), &("unbond", amount), &Vec::<Key>::new());
+    call_contract::<_, ()>(pos.clone(), &(POS_UNBOND, amount), &Vec::<Key>::new());
 }
+
+const POS_BOND: &str = "bond";
+const POS_UNBOND: &str = "unbond";
+
+const TEST_BOND: &str = "bond";
+const TEST_BOND_FROM_MAIN_PURSE: &str = "bond-from-main-purse";
+const TEST_SEED_NEW_ACCOUNT: &str = "seed_new_account";
+const TEST_UNBOND: &str = "unbond";
 
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_pointer = get_pos_contract();
 
     let command: String = get_arg(0);
-    if command == "bond" {
+    if command == TEST_BOND {
         // Creates new purse with desired amount based on main purse and sends funds
 
         let amount = get_arg(1);
@@ -71,11 +79,11 @@ pub extern "C" fn call() {
         }
 
         bond(&pos_pointer, &amount, p1);
-    } else if command == "bond-from-main-purse" {
+    } else if command == TEST_BOND_FROM_MAIN_PURSE {
         let amount = get_arg(1);
 
         bond(&pos_pointer, &amount, main_purse());
-    } else if command == "seed_new_account" {
+    } else if command == TEST_SEED_NEW_ACCOUNT {
         let account: PublicKey = get_arg(1);
         let amount: U512 = get_arg(2);
         if transfer_from_purse_to_account(main_purse(), account, amount)
@@ -83,7 +91,7 @@ pub extern "C" fn call() {
         {
             revert(Error::UnableToSeedAccount as u32);
         }
-    } else if command == "unbond" {
+    } else if command == TEST_UNBOND {
         let maybe_amount: Option<U512> = get_arg(1);
         unbond(&pos_pointer, maybe_amount);
     } else {

--- a/execution-engine/engine-grpc-server/tests/test_pos_bonding.rs
+++ b/execution-engine/engine-grpc-server/tests/test_pos_bonding.rs
@@ -1,0 +1,352 @@
+extern crate casperlabs_engine_grpc_server;
+extern crate contract_ffi;
+extern crate engine_core;
+extern crate engine_shared;
+extern crate engine_storage;
+extern crate grpc;
+
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+use contract_ffi::base16;
+use contract_ffi::bytesrepr::ToBytes;
+use contract_ffi::key::Key;
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::account::PurseId;
+use contract_ffi::value::Account;
+use contract_ffi::value::Contract;
+use contract_ffi::value::{Value, U512};
+
+use engine_core::engine_state::genesis::POS_BONDING_PURSE;
+use engine_core::execution::POS_NAME;
+use engine_shared::transform::Transform;
+
+use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+
+#[allow(unused)]
+mod test_support;
+
+const GENESIS_ADDR: [u8; 32] = [6u8; 32];
+const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
+
+fn get_pos_contract(builder: &WasmTestBuilder) -> Contract {
+    let genesis_key = Key::Account(GENESIS_ADDR);
+    let pos_uref: Key = builder
+        .query(None, genesis_key, &[POS_NAME])
+        .and_then(|v| v.try_into().ok())
+        .expect("should find PoS URef");
+
+    builder
+        .query(None, pos_uref, &[])
+        .and_then(|v| v.try_into().ok())
+        .expect("should find PoS Contract")
+}
+
+fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Option<PurseId> {
+    let pos_contract = get_pos_contract(builder);
+
+    pos_contract
+        .urefs_lookup()
+        .get(purse_name)
+        .and_then(Key::as_uref)
+        .map(|u| PurseId::new(*u))
+}
+
+fn get_purse_balance(builder: &WasmTestBuilder, purse_id: PurseId) -> U512 {
+    let mint = builder.get_mint_contract_uref();
+    let purse_bytes = purse_id
+        .value()
+        .addr()
+        .to_bytes()
+        .expect("should be able to serialize purse bytes");
+
+    let balance_mapping_key = Key::local(mint.addr(), &purse_bytes);
+    let balance_uref = builder
+        .query(None, balance_mapping_key, &[])
+        .and_then(|v| v.try_into().ok())
+        .expect("should find balance uref");
+
+    builder
+        .query(None, balance_uref, &[])
+        .and_then(|v| v.try_into().ok())
+        .expect("should parse balance into a U512")
+}
+
+fn get_pos_bonding_purse_balance(builder: &WasmTestBuilder) -> U512 {
+    let purse_id = get_pos_purse_id_by_name(builder, POS_BONDING_PURSE)
+        .expect("should find PoS payment purse");
+    get_purse_balance(builder, purse_id)
+}
+
+fn get_account(builder: &WasmTestBuilder, key: Key) -> Option<Account> {
+    let account_value = builder.query(None, key, &[]).expect("should query account");
+    if let Value::Account(account) = account_value {
+        Some(account)
+    } else {
+        None
+    }
+}
+
+#[ignore]
+#[test]
+fn should_run_successful_bond_and_unbond() {
+    let genesis_account_key = Key::Account(GENESIS_ADDR);
+    let genesis_validators = {
+        let mut result = HashMap::new();
+        result.insert(PublicKey::new([42; 32]), U512::from(50_000));
+        result
+    };
+
+    let result = WasmTestBuilder::default()
+        .run_genesis(GENESIS_ADDR, genesis_validators)
+        .exec_with_args(
+            GENESIS_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+            (String::from("bond"), U512::from(100_000)),
+        )
+        .expect_success()
+        .commit()
+        .finish();
+    let genesis_account =
+        get_account(result.builder(), genesis_account_key).expect("should get account 1");
+
+    let pos = result.builder().get_pos_contract_uref();
+
+    let transforms = &result.builder().get_transforms()[0];
+
+    let pos_transform = &transforms[&pos.into()];
+
+    // Verify that genesis account is in validator queue
+    let add_keys = if let Transform::AddKeys(keys) = pos_transform {
+        keys
+    } else {
+        panic!("pos transform is expected to be of AddKeys variant");
+    };
+
+    let lookup_key = format!("v_{}_{}", base16::encode_lower(&GENESIS_ADDR), 100_000);
+    assert!(add_keys.contains_key(&lookup_key));
+
+    // Gensis validator [42; 32] bonded 50k, and genesis account bonded 100k inside the test contract
+    assert_eq!(
+        get_pos_bonding_purse_balance(result.builder()),
+        U512::from(50_000 + 100_000)
+    );
+
+    // Create new account (from genesis funds) and bond with it
+    let result = WasmTestBuilder::from_result(result)
+        .exec_with_args(
+            GENESIS_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            2,
+            (
+                String::from("seed_new_account"),
+                PublicKey::new(ACCOUNT_1_ADDR),
+                U512::from(1_000_000),
+            ),
+        )
+        .expect_success()
+        .commit()
+        .exec_with_args(
+            ACCOUNT_1_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            1,
+            (String::from("bond"), U512::from(42_000)),
+        )
+        .expect_success()
+        .commit()
+        .finish();
+
+    let account_1_key = Key::Account(ACCOUNT_1_ADDR);
+
+    let account_1 = get_account(result.builder(), account_1_key).expect("should get account 1");
+
+    let pos = result.builder().get_pos_contract_uref();
+
+    let transforms = &result.builder().get_transforms()[1];
+
+    let pos_transform = &transforms[&pos.into()];
+
+    // Verify that genesis account is in validator queue
+    let add_keys = if let Transform::AddKeys(keys) = pos_transform {
+        keys
+    } else {
+        panic!("pos transform is expected to be of AddKeys variant");
+    };
+
+    let lookup_key = format!("v_{}_{}", base16::encode_lower(&ACCOUNT_1_ADDR), 42_000);
+    assert!(add_keys.contains_key(&lookup_key));
+
+    // Gensis validator [42; 32] bonded 50k, and genesis account bonded 100k inside the test contract
+    assert_eq!(
+        get_pos_bonding_purse_balance(result.builder()),
+        U512::from(50_000 + 100_000 + 42_000)
+    );
+
+    //
+    // Stage 2a - Account 1 unbonds by decreasing less than 50% (and is still in the queue)
+    //
+
+    let result = WasmTestBuilder::from_result(result)
+        .exec_with_args(
+            ACCOUNT_1_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            2,
+            (String::from("unbond"), Some(U512::from(20_000))),
+        )
+        .expect_success()
+        .commit()
+        .finish();
+
+    assert_eq!(
+        get_purse_balance(result.builder(), account_1.purse_id()),
+        U512::from(1_000_000 - 42_000 + 20_000)
+    );
+
+    // POS bonding purse is decreased
+    assert_eq!(
+        get_pos_bonding_purse_balance(result.builder()),
+        U512::from(50_000 + 100_000 + 22_000)
+    );
+
+    let pos_contract = get_pos_contract(result.builder());
+
+    let lookup_key = format!("v_{}_{}", base16::encode_lower(&ACCOUNT_1_ADDR), 42_000);
+    assert!(!pos_contract.urefs_lookup().contains_key(&lookup_key));
+
+    let lookup_key = format!("v_{}_{}", base16::encode_lower(&ACCOUNT_1_ADDR), 22_000);
+    // Account 1 is still tracked anymore in the bonding queue with different uref name
+    assert!(pos_contract.urefs_lookup().contains_key(&lookup_key));
+
+    //
+    // Stage 2b - Genesis unbonds by decreasing less than 50% (and is still in the queue)
+    //
+    // Genesis account unbonds less than 50% of his stake
+    let result = WasmTestBuilder::from_result(result)
+        .exec_with_args(
+            GENESIS_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            3,
+            (String::from("unbond"), Some(U512::from(45_000))),
+        )
+        .expect_success()
+        .commit()
+        .finish();
+
+    assert_eq!(
+        get_purse_balance(result.builder(), genesis_account.purse_id()),
+        U512::from(test_support::GENESIS_INITIAL_BALANCE - 1_000_000 - 55_000)
+    );
+
+    // POS bonding purse is further decreased
+    assert_eq!(
+        get_pos_bonding_purse_balance(result.builder()),
+        U512::from(50_000 + 55_000 + 22_000)
+    );
+
+    //
+    // Stage 3a - Fully unbond account1 with Some(TOTAL_AMOUNT)
+    //
+    let result = WasmTestBuilder::from_result(result)
+        .exec_with_args(
+            ACCOUNT_1_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            3,
+            (String::from("unbond"), Some(U512::from(22_000))), // <-- rest of accont1's funds
+        )
+        .expect_success()
+        .commit()
+        .finish();
+
+    assert_eq!(
+        get_purse_balance(result.builder(), account_1.purse_id()),
+        U512::from(1_000_000)
+    );
+
+    // POS bonding purse contains now genesis validator (50k) + genesis account (55k)
+    assert_eq!(
+        get_pos_bonding_purse_balance(result.builder()),
+        U512::from(50_000 + 55_000)
+    );
+
+    let pos_contract = get_pos_contract(result.builder());
+
+    let lookup_key = format!("v_{}_{}", base16::encode_lower(&ACCOUNT_1_ADDR), 22_000);
+    // Account 1 isn't tracked anymore in the bonding queue
+    assert!(!pos_contract.urefs_lookup().contains_key(&lookup_key));
+
+    //
+    // Stage 3b - Fully unbond account1 with Some(TOTAL_AMOUNT)
+    //
+
+    // Genesis account unbonds less than 50% of his stake
+    let result = WasmTestBuilder::from_result(result)
+        .exec_with_args(
+            GENESIS_ADDR,
+            "pos_bonding.wasm",
+            DEFAULT_BLOCK_TIME,
+            4,
+            (String::from("unbond"), None as Option<U512>), // <-- va banque
+        )
+        .expect_success()
+        .commit()
+        .finish();
+
+    // Back to original after funding account1's pursee
+    assert_eq!(
+        get_purse_balance(result.builder(), genesis_account.purse_id()),
+        U512::from(test_support::GENESIS_INITIAL_BALANCE - 1_000_000)
+    );
+
+    // Final balance after two full unbonds is the initial bond valuee
+    assert_eq!(
+        get_pos_bonding_purse_balance(result.builder()),
+        U512::from(50_000)
+    );
+
+    let pos_contract = get_pos_contract(result.builder());
+    let lookup_key = format!("v_{}_{}", base16::encode_lower(&GENESIS_ADDR), 55_000);
+    // Genesis is still tracked anymore in the bonding queue with different uref name
+    assert!(!pos_contract.urefs_lookup().contains_key(&lookup_key));
+
+    //
+    // Final checks on validator queue
+    //
+
+    // Account 1 is still tracked anymore in the bonding queue with any amount suffix
+    assert_eq!(
+        pos_contract
+            .urefs_lookup()
+            .iter()
+            .filter(
+                |(key, _)| key.starts_with(&format!("v_{}", base16::encode_lower(&GENESIS_ADDR)))
+            )
+            .count(),
+        0
+    );
+    assert_eq!(
+        pos_contract
+            .urefs_lookup()
+            .iter()
+            .filter(
+                |(key, _)| key.starts_with(&format!("v_{}", base16::encode_lower(&ACCOUNT_1_ADDR)))
+            )
+            .count(),
+        0
+    );
+    // only genesis validator is still in the queue
+    assert_eq!(
+        pos_contract
+            .urefs_lookup()
+            .iter()
+            .filter(|(key, _)| key.starts_with("v_"))
+            .count(),
+        1
+    );
+}

--- a/execution-engine/engine-grpc-server/tests/test_pos_finalize_payment.rs
+++ b/execution-engine/engine-grpc-server/tests/test_pos_finalize_payment.rs
@@ -11,12 +11,10 @@ use std::convert::TryInto;
 use contract_ffi::bytesrepr::ToBytes;
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{Account, PublicKey, PurseId};
-use contract_ffi::value::contract::Contract;
 use contract_ffi::value::U512;
 
 use engine_core::engine_state::genesis::{POS_PAYMENT_PURSE, POS_REWARDS_PURSE};
 use engine_core::engine_state::{EngineConfig, CONV_RATE};
-use engine_core::execution::POS_NAME;
 
 use test_support::{DeployBuilder, ExecRequestBuilder, WasmTestBuilder, DEFAULT_BLOCK_TIME};
 
@@ -199,7 +197,7 @@ fn get_pos_rewards_purse_balance(builder: &WasmTestBuilder) -> U512 {
 }
 
 fn get_pos_refund_purse(builder: &WasmTestBuilder) -> Option<Key> {
-    let pos_contract = get_pos_contract(builder);
+    let pos_contract = builder.get_pos_contract();
 
     pos_contract
         .urefs_lookup()
@@ -207,21 +205,8 @@ fn get_pos_refund_purse(builder: &WasmTestBuilder) -> Option<Key> {
         .cloned()
 }
 
-fn get_pos_contract(builder: &WasmTestBuilder) -> Contract {
-    let genesis_key = Key::Account(GENESIS_ADDR);
-    let pos_uref: Key = builder
-        .query(None, genesis_key, &[POS_NAME])
-        .and_then(|v| v.try_into().ok())
-        .expect("should find PoS URef");
-
-    builder
-        .query(None, pos_uref, &[])
-        .and_then(|v| v.try_into().ok())
-        .expect("should find PoS Contract")
-}
-
 fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Option<PurseId> {
-    let pos_contract = get_pos_contract(builder);
+    let pos_contract = builder.get_pos_contract();
 
     pos_contract
         .urefs_lookup()

--- a/execution-engine/engine-grpc-server/tests/test_support.rs
+++ b/execution-engine/engine-grpc-server/tests/test_support.rs
@@ -480,6 +480,8 @@ pub struct WasmTestBuilder {
     genesis_transforms: Option<HashMap<contract_ffi::key::Key, Transform>>,
     /// Mint contract uref
     mint_contract_uref: Option<contract_ffi::uref::URef>,
+    /// PoS contract uref
+    pos_contract_uref: Option<contract_ffi::uref::URef>,
 }
 
 impl Default for WasmTestBuilder {
@@ -495,6 +497,7 @@ impl Default for WasmTestBuilder {
             bonded_validators: Vec::new(),
             genesis_account: None,
             mint_contract_uref: None,
+            pos_contract_uref: None,
             genesis_transforms: None,
         }
     }
@@ -523,6 +526,7 @@ impl WasmTestBuilder {
             bonded_validators: result.0.bonded_validators,
             genesis_account: result.0.genesis_account,
             mint_contract_uref: result.0.mint_contract_uref,
+            pos_contract_uref: result.0.pos_contract_uref,
             genesis_transforms: result.0.genesis_transforms,
         }
     }
@@ -539,6 +543,7 @@ impl WasmTestBuilder {
             bonded_validators: Vec::new(),
             genesis_account: None,
             mint_contract_uref: None,
+            pos_contract_uref: None,
             genesis_transforms: None,
         }
     }
@@ -566,8 +571,12 @@ impl WasmTestBuilder {
         let mint_contract_uref = get_mint_contract_uref(&genesis_transforms, &contracts)
             .expect("Unable to get mint contract uref");
 
+        let pos_contract_uref = get_pos_contract_uref(&genesis_transforms, &contracts)
+            .expect("Unable to get pos contract uref");
+
         // Cache mint uref
         self.mint_contract_uref = Some(mint_contract_uref);
+        self.pos_contract_uref = Some(pos_contract_uref);
 
         // Cache the account
         self.genesis_account = Some(
@@ -827,6 +836,11 @@ impl WasmTestBuilder {
     pub fn get_mint_contract_uref(&self) -> contract_ffi::uref::URef {
         self.mint_contract_uref
             .expect("Unable to obtain mint contract uref. Please run genesis first.")
+    }
+
+    pub fn get_pos_contract_uref(&self) -> contract_ffi::uref::URef {
+        self.pos_contract_uref
+            .expect("Unable to obtain pos contract uref. Please run genesis first.")
     }
 
     pub fn get_genesis_transforms(

--- a/execution-engine/engine-grpc-server/tests/test_support.rs
+++ b/execution-engine/engine-grpc-server/tests/test_support.rs
@@ -888,4 +888,36 @@ impl WasmTestBuilder {
             .and_then(|v| v.try_into().ok())
             .expect("should find PoS Contract")
     }
+
+    pub fn get_purse_balance(
+        &self,
+        purse_id: contract_ffi::value::account::PurseId,
+    ) -> contract_ffi::value::uint::U512 {
+        let mint = self.get_mint_contract_uref();
+        let purse_addr = purse_id.value().addr();
+        let purse_bytes = contract_ffi::bytesrepr::ToBytes::to_bytes(&purse_addr)
+            .expect("should be able to serialize purse bytes");
+        let balance_mapping_key = contract_ffi::key::Key::local(mint.addr(), &purse_bytes);
+        let balance_uref = self
+            .query(None, balance_mapping_key, &[])
+            .and_then(|v| v.try_into().ok())
+            .expect("should find balance uref");
+
+        self.query(None, balance_uref, &[])
+            .and_then(|v| v.try_into().ok())
+            .expect("should parse balance into a U512")
+    }
+
+    pub fn get_account(
+        &self,
+        key: contract_ffi::key::Key,
+    ) -> Option<contract_ffi::value::account::Account> {
+        let account_value = self.query(None, key, &[]).expect("should query account");
+
+        if let contract_ffi::value::Value::Account(account) = account_value {
+            Some(account)
+        } else {
+            None
+        }
+    }
 }

--- a/execution-engine/engine-grpc-server/tests/test_support.rs
+++ b/execution-engine/engine-grpc-server/tests/test_support.rs
@@ -26,6 +26,7 @@ use casperlabs_engine_grpc_server::engine_server::mappings::{
 use casperlabs_engine_grpc_server::engine_server::state::{BigInt, ProtocolVersion};
 use engine_core::engine_state::utils::WasmiBytes;
 use engine_core::engine_state::{EngineConfig, EngineState};
+use engine_core::execution::POS_NAME;
 use engine_shared::test_utils;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
@@ -870,5 +871,21 @@ impl WasmTestBuilder {
 
     pub fn finish(&self) -> WasmTestResult {
         WasmTestResult(self.clone())
+    }
+
+    pub fn get_pos_contract(&self) -> contract_ffi::value::contract::Contract {
+        let genesis_account = self
+            .genesis_account
+            .clone()
+            .expect("should run genesis process first");
+        let genesis_key = contract_ffi::key::Key::Account(genesis_account.pub_key());
+        let pos_uref: contract_ffi::key::Key = self
+            .query(None, genesis_key, &[POS_NAME])
+            .and_then(|v| v.try_into().ok())
+            .expect("should find PoS URef");
+
+        self.query(None, pos_uref, &[])
+            .and_then(|v| v.try_into().ok())
+            .expect("should find PoS Contract")
     }
 }


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

This PR adds tests for PoS contract bond/unbond features.

Scenario from the commit description:


    This test consists of different stages:

    - Genesis process starts with a single validator with 50k stake (genesis
      validator.
    - Genesis account bonds with 100k
    - Genesis account seeds account1 with 1M
    - Account 1 bonds with 42k

    Partial unbonds:

    - Account1 unbonds with 20k
    - Genesis account unbonds with 45k

    Full unbonds:

    - Account1 unbond with 22k (total; remaining amount)
    - Genesis account unbonds with "None" (va banque)

    At the end of the test it is verified that the queue contains only
    genesis validator, and the pos bonding purse contains only initial
    amount, where account1's and genesis account's purses contains their
    original amounts.

---

- [x]  PoS is in named URefs of genesis and all new accounts (no tests; this is implicit for each test which tries to access `pos` - in case there is no `pos` every PoS test would fail)
- [x] Bonding requests work properly
- [x] Requests with a purse with insufficient funds fail
- [x] ~Requests bonding 0 amount fail~ MIN/MAX spread is not set, it's a ticketed bug as `0 <= amount <= U512::max_value()` is allowed
- [x] ~Requests with bonding amount too large fail (will need to check what the limit is here, don’t know off the top of my head)~ same as above: MIN/MAX is not set, it's a ticketed bug as `0 <= amount <= U512::max_value()` can be used (although I verified that it doesn't lead to fraud)
- [x] Good bonding requests work and the newly bonded validator is included in the bonded validator set after commit
- [x] Unbonding requests work properly
- [x] Requests from non-bonded accounts fail (in `should_fail_unbonding_validator_without_bonding_first`)
- [x] ~Requests to return more than what was bonded fail~ ticketed bug; can return more than it was bonded; although it doesn't lead to fraud
- [x] If no amount is given then the full stake is returned to the account purse; the validator is not listed any more after commit
- [x] If an amount is given then that amount is returned to the account purse and bond is reduced by that amount; the validator still appears in the bonded validators after commit, but with the updated stake amount


### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-449

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._