### PR TITLE
NODE-774: Don't use infinite timeout to clear resources during shutdown.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -356,7 +356,7 @@ class NodeRuntime private[node] (
       _ <- log.info("Goodbye.")
     } yield ()
     // Run the release synchronously so that we can see the final message.
-    task.unsafeRunSync(scheduler)
+    task.runSyncUnsafe(1.minute)
   }
 
   private def addShutdownHook(release: Effect[Unit]): Task[Unit] =


### PR DESCRIPTION
### Overview
Node logged OutOfMemory error and tried to shut down but the resource deallocation seems to keep it alive because we never see the "Goodbye!" message. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-774

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
It would take longer to figure out which resource is keeping the thread alive, but using an infinite timeout is anyway wrong. This fix might at least alert the operator faster that the node is actually down. We should use the `/metrics` endpoint as well for health checking.
