### PR TITLE
NODE-776: Fix the waiting on the initial sync.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -505,7 +505,9 @@ package object gossiping {
       isInitialRef: Ref[F, Boolean]
   ): Resource[F, Synchronizer[F]] = Resource.liftF {
     for {
-      _ <- SynchronizerImpl.establishMetrics[F]
+      _         <- SynchronizerImpl.establishMetrics[F]
+      isInitial <- isInitialRef.get
+      _         <- Log[F].info(s"Creating synchronizer in initial mode: $isInitial")
       underlying <- SynchronizerImpl[F](
                      connectToGossip,
                      new SynchronizerImpl.Backend[F] {
@@ -633,7 +635,13 @@ package object gossiping {
                       )
                     }
       _ <- makeFiberResource {
-            awaitApproved >> initialSync.sync() >> isInitialRef.set(false)
+            for {
+              _         <- awaitApproved
+              awaitSync <- initialSync.sync()
+              _         <- awaitSync
+              _         <- isInitialRef.set(false)
+              _         <- Log[F].info("Initial synchronization complete.")
+            } yield ()
           }
     } yield ()
 


### PR DESCRIPTION
### Overview
There was a bug in the way we tried to wait for the initial synchronization, which meant that instead of allowing it to be up to 1 million blocks it immediately reverted the status to where it only allows up to 1000 depth.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-776

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
