### PR TITLE
NODE-775: Change connection pool size to 1

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -65,6 +65,12 @@ class NodeRuntime private[node] (
     Scheduler.fixedPool("loop", 4, reporter = UncaughtExceptionHandler)
   private[this] val blockingScheduler =
     Scheduler.cached("blocking-io", 4, 64, reporter = UncaughtExceptionHandler)
+
+  private[this] val dbConnScheduler =
+    Scheduler.cached("db-conn", 1, 64, reporter = UncaughtExceptionHandler)
+  private[this] val dbIOScheduler =
+    Scheduler.cached("db-io", 1, Int.MaxValue, reporter = UncaughtExceptionHandler)
+
   private implicit val concurrentEffectForEffect: ConcurrentEffect[Effect] =
     catsConcurrentEffectForEffect(
       scheduler
@@ -123,7 +129,8 @@ class NodeRuntime private[node] (
                                                                             )
         //TODO: We may want to adjust threading model for better performance
         implicit0(doobieTransactor: Transactor[Effect]) <- effects.doobieTransactor(
-                                                            blockingScheduler,
+                                                            connectEC = dbConnScheduler,
+                                                            transactEC = dbIOScheduler,
                                                             conf.server.dataDir
                                                           )
         implicit0(deployBuffer: DeployBuffer[Effect]) <- Resource

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -124,7 +124,6 @@ class NodeRuntime private[node] (
         //TODO: We may want to adjust threading model for better performance
         implicit0(doobieTransactor: Transactor[Effect]) <- effects.doobieTransactor(
                                                             blockingScheduler,
-                                                            blockingScheduler,
                                                             conf.server.dataDir
                                                           )
         implicit0(deployBuffer: DeployBuffer[Effect]) <- Resource


### PR DESCRIPTION
### Overview
Replaces the `HikariTransactor` with the simpler one just based on the JDBC driver to see if the SQLITE_BUSY is because of the connection pool size.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-775

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
