### PR TITLE
FIX: Generate TypeScript gRPC with Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,22 +213,26 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 	rm -rf $(DIR_OUT)
 	mkdir -p $(DIR_OUT)
 	# First the pure data packages, so it doesn't create empty _pb_service.d.ts files.
-	protoc \
-	    -I=$(DIR_IN) \
-		--plugin=protoc-gen-ts=./explorer/grpc/node_modules/ts-protoc-gen/bin/protoc-gen-ts \
-		--js_out=import_style=commonjs,binary:$(DIR_OUT) \
-		--ts_out=service=false:$(DIR_OUT) \
-		$(DIR_IN)/google/protobuf/empty.proto \
-		$(DIR_IN)/io/casperlabs/casper/consensus/consensus.proto \
-		$(DIR_IN)/io/casperlabs/casper/consensus/info.proto \
-		$(DIR_IN)/io/casperlabs/casper/consensus/state.proto
+	./hack/build/docker-buildenv.sh "\
+		protoc \
+				-I=$(DIR_IN) \
+			--plugin=protoc-gen-ts=./explorer/grpc/node_modules/ts-protoc-gen/bin/protoc-gen-ts \
+			--js_out=import_style=commonjs,binary:$(DIR_OUT) \
+			--ts_out=service=false:$(DIR_OUT) \
+			$(DIR_IN)/google/protobuf/empty.proto \
+			$(DIR_IN)/io/casperlabs/casper/consensus/consensus.proto \
+			$(DIR_IN)/io/casperlabs/casper/consensus/info.proto \
+			$(DIR_IN)/io/casperlabs/casper/consensus/state.proto \
+		"
 	# Now the service we'll invoke.
+	./hack/build/docker-buildenv.sh "\
 	protoc \
 	    -I=$(DIR_IN) \
 		--plugin=protoc-gen-ts=./explorer/grpc/node_modules/ts-protoc-gen/bin/protoc-gen-ts \
 		--js_out=import_style=commonjs,binary:$(DIR_OUT) \
 		--ts_out=service=true:$(DIR_OUT) \
-		$(DIR_IN)/io/casperlabs/node/api/casper.proto
+		$(DIR_IN)/io/casperlabs/node/api/casper.proto \
+		"
 	# Annotations were only required for the REST gateway. Remove them from Typescript.
 	for f in $(DIR_OUT)/io/casperlabs/node/api/casper_pb* ; do \
 		sed -n '/google_api_annotations_pb/!p' $$f > $$f.tmp ; \

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -2,11 +2,12 @@
 
 ### Prerequisites
 
-* Java Development Kit (JDK), version 11 
+* Java Development Kit (JDK), version 11
   * We recommend using the [OpenJDK](https://openjdk.java.net)
 * [protoc](https://github.com/protocolbuffers/protobuf/releases), version 3.6.1 or greater
 * [sbt](https://www.scala-sbt.org/download.html)
 * [rustup](https://www.rust-lang.org/tools/install)
+* [npm](https://github.com/nodesource/distributions#installation-instructions)
 
 ### Instructions
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -7,7 +7,6 @@
 * [protoc](https://github.com/protocolbuffers/protobuf/releases), version 3.6.1 or greater
 * [sbt](https://www.scala-sbt.org/download.html)
 * [rustup](https://www.rust-lang.org/tools/install)
-* [npm](https://github.com/nodesource/distributions#installation-instructions)
 
 ### Instructions
 


### PR DESCRIPTION
### Overview
I tried to make `npm` optional by [wrapping](https://github.com/CasperLabs/CasperLabs/blob/dev/Makefile#L409) commands with the Docker image, but because I already had it installed I didn't know that the the step [generating](https://github.com/CasperLabs/CasperLabs/blob/dev/Makefile#L207) TypeScript from protobuf also needs it.

This PR wraps that step with `docker-buildenv.sh` as well so `npm` install is optional.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
