### PR TITLE
NODE-765 and NODE-795: Fixing and improving benchmarking client

### DIFF
--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
@@ -7,7 +7,6 @@ import java.nio.file.StandardOpenOption
 import cats._
 import cats.effect.{Sync, Timer}
 import cats.implicits._
-import cats.temp.par._
 import io.casperlabs.client.{DeployRuntime, DeployService}
 import io.casperlabs.crypto.Keys
 import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
@@ -22,13 +21,13 @@ object Benchmarks {
   /** Each round consists of many token transfer deploys from different accounts to single recipient
     * TODO: Remove Sync
     *  */
-  def run[F[_]: Log: DeployService: Par: Timer: FilesAPI: Monad: Sync](
+  def run[F[_]: Log: DeployService: Timer: FilesAPI: Monad: Sync](
       outputStats: File,
       initialFundsPrivateKeyFile: File,
       initialFundsPublicKeyFile: File,
       accountsNum: Int = 250,
       roundsNum: Int = 100,
-      approximateTransferCost: Long = 100000
+      approximateTransferCost: Long = 10000000
   ): F[Unit] = {
     // TODO: Probably can cause overflow problems, for the time being it can stay as is.
     val initialFundsPerAccount = roundsNum * approximateTransferCost
@@ -106,7 +105,7 @@ object Benchmarks {
     def oneRoundTransfer(nonce: Long): F[Unit] =
       for {
         _ <- Log[F].info("Sending deploys...")
-        _ <- senders.parTraverse {
+        _ <- senders.traverse {
               case (sk, pk) =>
                 send(
                   nonce = nonce,

--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Main.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Main.scala
@@ -1,22 +1,22 @@
 package io.casperlabs.benchmarks
+
 import cats.effect.{Sync, Timer}
-import cats.temp.par._
 import io.casperlabs.benchmarks.Options.Configuration
 import io.casperlabs.benchmarks.Options.Configuration._
 import io.casperlabs.client.{DeployService, GrpcDeployService}
 import io.casperlabs.shared.{FilesAPI, Log, UncaughtExceptionHandler}
 import monix.eval.Task
-import monix.execution.Scheduler
+import monix.execution.{ExecutionModel, Scheduler}
 import scala.concurrent.duration._
 
 object Main {
   implicit val log: Log[Task] = Log.log
 
   def main(args: Array[String]): Unit = {
-    implicit val scheduler: Scheduler = Scheduler.computation(
-      Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 4),
-      "node-runner",
-      reporter = new UncaughtExceptionHandler(shutdownTimeout = 5.seconds)
+    implicit val scheduler: Scheduler = Scheduler.io(
+      "benchmarking-io",
+      reporter = new UncaughtExceptionHandler(shutdownTimeout = 5.seconds),
+      executionModel = ExecutionModel.SynchronousExecution
     )
 
     val exec =
@@ -24,8 +24,9 @@ object Main {
         maybeConf <- Task(Configuration.parse(args))
         _ <- maybeConf.fold(Log[Task].error("Couldn't parse CLI args into configuration")) {
               case (conn, conf) =>
-                implicit val deployService: GrpcDeployService = new GrpcDeployService(conn)
-                implicit val filesAPI: FilesAPI[Task]         = FilesAPI.create[Task]
+                implicit val deployService: GrpcDeployService =
+                  new GrpcDeployService(conn, scheduler)
+                implicit val filesAPI: FilesAPI[Task] = FilesAPI.create[Task]
                 program[Task](conf).doOnFinish(_ => Task(deployService.close()))
             }
       } yield ()
@@ -33,7 +34,7 @@ object Main {
     exec.runSyncUnsafe()
   }
 
-  def program[F[_]: Sync: DeployService: Timer: FilesAPI: Log: Par](
+  def program[F[_]: Sync: DeployService: Timer: FilesAPI: Log](
       configuration: Configuration
   ): F[Unit] =
     configuration match {

--- a/build.sbt
+++ b/build.sbt
@@ -559,7 +559,8 @@ lazy val benchmarks = (project in file("benchmarks"))
         ExecCmd("ENTRYPOINT", "bin/casperlabs-benchmarks"),
         ExecCmd("CMD", "run")
       )
-    }
+    },
+    libraryDependencies ++= commonDependencies
   )
   .dependsOn(client)
 

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -34,10 +34,16 @@ object DeployRuntime {
       exit: Boolean = true,
       ignoreOutput: Boolean = false
   ): F[Unit] =
-    gracefulExit(DeployService[F].propose().map(_.map(r => s"Response: $r")), exit, ignoreOutput)
+    gracefulExit(
+      DeployService[F]
+        .propose()
+        .map(_.map(hash => s"Response: Success! Block $hash created and added.")),
+      exit,
+      ignoreOutput
+    )
 
   def showBlock[F[_]: Sync: DeployService](hash: String): F[Unit] =
-    gracefulExit(DeployService[F].showBlock(hash))
+    gracefulExit(DeployService[F].showBlock(hash).map(_.map(Printer.printToUnicodeString)))
 
   def showDeploys[F[_]: Sync: DeployService](hash: String): F[Unit] =
     gracefulExit(DeployService[F].showDeploys(hash))

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.client
 import io.casperlabs.casper.consensus
+import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.consensus.state.Value
 import simulacrum.typeclass
 
@@ -8,7 +9,7 @@ import scala.util.Either
 @typeclass trait DeployService[F[_]] {
   def deploy(d: consensus.Deploy): F[Either[Throwable, String]]
   def propose(): F[Either[Throwable, String]]
-  def showBlock(blockHash: String): F[Either[Throwable, String]]
+  def showBlock(blockHash: String): F[Either[Throwable, BlockInfo]]
   def showDeploys(blockHash: String): F[Either[Throwable, String]]
   def showDeploy(blockHash: String): F[Either[Throwable, String]]
   def showBlocks(depth: Int): F[Either[Throwable, String]]

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -1,43 +1,35 @@
 package io.casperlabs.client
 
+import java.io.Closeable
+import java.security.KeyStore
+import java.util.concurrent.{ThreadFactory, TimeUnit}
+
 import cats.Id
 import cats.data.StateT
-import cats.implicits._
 import cats.mtl.implicits._
-import java.io.Closeable
-import java.util.concurrent.TimeUnit
-import java.security.KeyStore
-
-import javax.net.ssl._
-import com.google.protobuf.ByteString
-import com.google.protobuf.empty.Empty
-import io.casperlabs.crypto.codec.Base16
-import io.casperlabs.crypto.util.HostnameTrustManager
 import io.casperlabs.casper.consensus
 import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
 import io.casperlabs.casper.consensus.state.Value
-import io.casperlabs.graphz
-import io.casperlabs.node.api.casper.{
-  CasperGrpcMonix,
-  DeployRequest,
-  GetBlockInfoRequest,
-  GetBlockStateRequest,
-  GetDeployInfoRequest,
-  StateQuery,
-  StreamBlockDeploysRequest,
-  StreamBlockInfosRequest
-}
-import io.casperlabs.node.api.control.{ControlGrpcMonix, ProposeRequest}
 import io.casperlabs.client.configuration.ConnectOptions
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.crypto.util.HostnameTrustManager
+import io.casperlabs.graphz
+import io.casperlabs.node.api.casper._
+import io.casperlabs.node.api.control.{ControlGrpcMonix, ProposeRequest}
 import io.grpc.ManagedChannel
-import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
-import io.grpc.netty.{GrpcSslContexts, NegotiationType}
+import io.grpc.netty.{GrpcSslContexts, NegotiationType, NettyChannelBuilder}
+import io.netty.channel.DefaultEventLoopGroup
+import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.handler.ssl.util.SimpleTrustManagerFactory
+import javax.net.ssl._
 import monix.eval.Task
+import monix.execution.Scheduler
 
 import scala.util.Either
 
-class GrpcDeployService(conn: ConnectOptions) extends DeployService[Task] with Closeable {
+class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
+    extends DeployService[Task]
+    with Closeable {
   private val DefaultMaxMessageSize = 256 * 1024 * 1024
 
   private var externalConnected = false
@@ -47,6 +39,8 @@ class GrpcDeployService(conn: ConnectOptions) extends DeployService[Task] with C
     var builder = NettyChannelBuilder
       .forAddress(conn.host, port)
       .maxInboundMessageSize(DefaultMaxMessageSize)
+      .eventLoopGroup(new NioEventLoopGroup(0, scheduler))
+      .executor(scheduler)
 
     builder = conn.nodeId match {
       case Some(hash) =>

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -102,16 +102,12 @@ class GrpcDeployService(conn: ConnectOptions) extends DeployService[Task] with C
   def propose(): Task[Either[Throwable, String]] =
     controlServiceStub
       .propose(ProposeRequest())
-      .map { response =>
-        val hash = Base16.encode(response.blockHash.toByteArray)
-        s"Success! Block $hash created and added."
-      }
+      .map(response => Base16.encode(response.blockHash.toByteArray))
       .attempt
 
-  def showBlock(hash: String): Task[Either[Throwable, String]] =
+  def showBlock(hash: String): Task[Either[Throwable, BlockInfo]] =
     casperServiceStub
       .getBlockInfo(GetBlockInfoRequest(hash, BlockInfo.View.FULL))
-      .map(Printer.printToUnicodeString(_))
       .attempt
 
   def showDeploy(hash: String): Task[Either[Throwable, String]] =

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -32,8 +32,9 @@ object Main {
         maybeConf <- Task(Configuration.parse(args))
         _ <- maybeConf.fold(Log[Task].error("Couldn't parse CLI args into configuration")) {
               case (conn, conf) =>
-                implicit val deployService: GrpcDeployService = new GrpcDeployService(conn)
-                implicit val filesAPI: FilesAPI[Task]         = FilesAPI.create[Task]
+                implicit val deployService: GrpcDeployService =
+                  new GrpcDeployService(conn, scheduler)
+                implicit val filesAPI: FilesAPI[Task] = FilesAPI.create[Task]
                 program[Task](conf).doOnFinish(_ => Task(deployService.close()))
             }
       } yield ()


### PR DESCRIPTION
### Overview
Fixes 2 bugs and adds 1 improvement.

Bugs:
* Accounts weren't created properly. We have to create 251 accounts and since we have `nonce` and they created from the single initial account then all of them need to be created block-by-block
* Recently benchmarking started failing with the next error `INTERNAL: Task monix.eval.internal.TaskShift$Register$$anon$1@4eda23cd rejected from java.util.concurrent.ThreadPoolExecutor@19ffe528[Running, pool size = 64, active threads = 64, queued tasks = 0, completed tasks = 4060]
`. You can read about the problem and solution in this ticket: https://casperlabs.atlassian.net/browse/NODE-795

Improvement:
* Ensure that each `propose` successfully processed all deploys and didn't discard any of them. Stop benchmarking otherwise.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-765
https://casperlabs.atlassian.net/browse/NODE-795

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._