### PR TITLE
CON-444: Add `--payment-path` parameter to `unbond` subcommand.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -52,6 +52,7 @@ object DeployRuntime {
       maybeAmount: Option[Long],
       nonce: Long,
       sessionCode: Option[File],
+      paymentCode: Option[File],
       privateKeyFile: File
   ): F[Unit] = {
     val args: Array[Array[Byte]] = Array(
@@ -61,14 +62,16 @@ object DeployRuntime {
 
     for {
       sessionCode <- readFileOrDefault[F](sessionCode, UNBONDING_WASM_FILE)
-      // currently, sessionCode == paymentCode in order to get some gas limit for the execution
-      paymentCode   = sessionCode.toList.toArray
+      // EE will use hardcoded execution limit if it [EE] is run with a `--use-payment-code` flag
+      // but node will verify payment code's wasm correctness so we have to send valid wasm anyway
+      // to not fail the session code execution even when EE will use hardcoded limit.
+      payment       = paymentCode.map(f => Files.readAllBytes(f.toPath)).getOrElse(sessionCode)
       rawPrivateKey <- readFileAsString[F](privateKeyFile)
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
             sessionCode = sessionCode,
-            paymentCode = paymentCode,
+            paymentCode = payment,
             maybeEitherPublicKey = None,
             maybeEitherPrivateKey = rawPrivateKey.asLeft[PrivateKey].some,
             gasPrice = 10L, // gas price is fixed at the moment for 10:1

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -52,12 +52,14 @@ object Main {
           amount,
           nonce,
           contractCode,
+          paymentCode,
           privateKey
           ) =>
         DeployRuntime.unbond(
           amount,
           nonce,
           contractCode,
+          paymentCode,
           privateKey
         )
       case Bond(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -144,6 +144,7 @@ object Configuration {
           options.unbond.amount.toOption,
           options.unbond.nonce(),
           options.unbond.session.toOption,
+          options.unbond.paymentPath.toOption,
           options.unbond.privateKey()
         )
       case options.bond =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -66,6 +66,7 @@ final case class Unbond(
     amount: Option[Long],
     nonce: Long,
     sessionCode: Option[File],
+    paymentCode: Option[File],
     privateKey: File
 ) extends Configuration
 final case class VisualizeDag(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -305,6 +305,13 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         validate = fileCheck
       )
 
+    val paymentPath =
+      opt[File](
+        descr = "Path to the file with payment code.",
+        validate = fileCheck,
+        required = false
+      )
+
     val nonce = opt[Long](
       descr =
         "Nonce of the account. Sequences deploys from that account. Every new deploy has to use nonce one higher than current account's nonce.",


### PR DESCRIPTION
### Overview
As in the title.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-444

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Currently, execution-engine can be started with `--use-payment-code` that tells EE to either use `paymentCode` as a source of execution limit or hardcoded limit. `--payment-path` is not required but the client can't tell whether it should provide payment code because of the above.