### PR TITLE
NO-TICKET: Make ArgParser explicit for single arg.

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/argsparser.rs
+++ b/execution-engine/contract-ffi/src/contract_api/argsparser.rs
@@ -11,16 +11,13 @@ pub trait ArgsParser {
     fn parse(&self) -> Result<Vec<Vec<u8>>, Error>;
 }
 
+impl ArgsParser for () {
+    fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
+        Ok(Vec::new())
+    }
+}
+
 macro_rules! impl_argsparser_tuple {
-    ( $name:ident ) => (
-        impl<$name: ToBytes> ArgsParser for $name {
-            #[allow(non_snake_case)]
-            fn parse(&self) -> Result<Vec<Vec<u8>>, Error> {
-                let $name = self;
-                Ok(vec![ToBytes::to_bytes($name)?])
-            }
-        }
-    );
     ( $($name:ident)+) => (
         impl<$($name: ToBytes),*> ArgsParser for ($($name,)*) {
             #[allow(non_snake_case)]

--- a/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
@@ -47,7 +47,7 @@ pub extern "C" fn pay() {
     };
 
     let payment_purse: PurseId =
-        contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE), &vec![]);
+        contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE,), &vec![]);
 
     if let PurseTransferResult::TransferError =
         contract_api::transfer_from_purse_to_purse(main_purse, payment_purse, amount)

--- a/execution-engine/contracts/client/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment/src/lib.rs
@@ -42,7 +42,7 @@ pub extern "C" fn call() {
     };
 
     let payment_purse: PurseId =
-        contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE), &vec![]);
+        contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE,), &vec![]);
 
     if let PurseTransferResult::TransferError =
         contract_api::transfer_from_purse_to_purse(main_purse, payment_purse, amount)

--- a/execution-engine/contracts/test/get-phase-payment/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase-payment/src/lib.rs
@@ -34,7 +34,7 @@ fn standard_payment(amount: U512) {
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
 
     let payment_purse: PurseId =
-        contract_api::call_contract(pos_contract, &(GET_PAYMENT_PURSE), &vec![]);
+        contract_api::call_contract(pos_contract, &(GET_PAYMENT_PURSE,), &vec![]);
 
     if let PurseTransferResult::TransferError =
         contract_api::transfer_from_purse_to_purse(main_purse, payment_purse, amount)

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -33,7 +33,7 @@ fn set_refund_purse(pos: &ContractPointer, p: &PurseId) {
 }
 
 fn get_payment_purse(pos: &ContractPointer) -> PurseId {
-    contract_api::call_contract(pos.clone(), &"get_payment_purse", &Vec::new())
+    contract_api::call_contract(pos.clone(), &("get_payment_purse",), &Vec::new())
 }
 
 fn submit_payment(pos: &ContractPointer, amount: U512) {

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -38,7 +38,7 @@ pub extern "C" fn call() {
     let source_purse = contract_api::main_purse();
     let payment_amount: U512 = 100.into();
     let payment_purse: PurseId =
-        contract_api::call_contract(pos_pointer, &"get_payment_purse", &Vec::new());
+        contract_api::call_contract(pos_pointer, &("get_payment_purse",), &Vec::new());
 
     // can deposit
     if let PurseTransferResult::TransferError =

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -36,11 +36,11 @@ fn set_refund_purse(pos: &ContractPointer, p: &PurseId) {
 }
 
 fn get_refund_purse(pos: &ContractPointer) -> Option<PurseId> {
-    contract_api::call_contract(pos.clone(), &"get_refund_purse", &Vec::new())
+    contract_api::call_contract(pos.clone(), &("get_refund_purse",), &Vec::new())
 }
 
 fn get_payment_purse(pos: &ContractPointer) -> PurseId {
-    contract_api::call_contract(pos.clone(), &"get_payment_purse", &Vec::new())
+    contract_api::call_contract(pos.clone(), &("get_payment_purse",), &Vec::new())
 }
 
 fn submit_payment(pos: &ContractPointer, amount: U512) {

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -711,7 +711,7 @@ where
     /// Calls the "create" method on the mint contract at the given mint contract key
     fn mint_create(&mut self, mint_contract_key: Key) -> Result<PurseId, Error> {
         let args_bytes = {
-            let args = "create";
+            let args = ("create",);
             ArgsParser::parse(&args).and_then(|args| args.to_bytes())?
         };
 

--- a/execution-engine/engine-grpc-server/tests/regression_test_ee_441.rs
+++ b/execution-engine/engine-grpc-server/tests/regression_test_ee_441.rs
@@ -34,7 +34,7 @@ fn do_pass(pass: &str) -> (URef, URef) {
             "ee_441_rng_state.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            pass.to_string(),
+            (pass.to_string(),),
         )
         .expect_success()
         .commit()

--- a/execution-engine/engine-grpc-server/tests/regression_test_ee_460.rs
+++ b/execution-engine/engine-grpc-server/tests/regression_test_ee_460.rs
@@ -24,7 +24,7 @@ fn should_run_ee_460_no_side_effects_on_error_regression() {
             "ee_460_regression.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            U512::max_value(),
+            (U512::max_value(),),
         )
         .expect_success()
         .commit()

--- a/execution-engine/engine-grpc-server/tests/regression_test_ee_468.rs
+++ b/execution-engine/engine-grpc-server/tests/regression_test_ee_468.rs
@@ -24,7 +24,7 @@ fn should_not_fail_deserializing() {
             "deserialize_error.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            GENESIS_ADDR,
+            (GENESIS_ADDR,),
         )
         .commit()
         .is_error();

--- a/execution-engine/engine-grpc-server/tests/regression_test_ee_572.rs
+++ b/execution-engine/engine-grpc-server/tests/regression_test_ee_572.rs
@@ -85,7 +85,7 @@ fn should_run_ee_572_regression() {
             CONTRACT_ESCALATE,
             DEFAULT_BLOCK_TIME,
             1,
-            contract,
+            (contract,),
         )
         .get_exec_response(3)
         .expect("should have a response")

--- a/execution-engine/engine-grpc-server/tests/test_associated_keys.rs
+++ b/execution-engine/engine-grpc-server/tests/test_associated_keys.rs
@@ -31,7 +31,7 @@ fn should_manage_associated_key() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .expect_success()
         .commit()
@@ -40,7 +40,7 @@ fn should_manage_associated_key() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            GENESIS_ADDR,
+            (GENESIS_ADDR,),
         )
         .expect_success()
         .commit();
@@ -67,7 +67,7 @@ fn should_manage_associated_key() {
             "remove_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             2,
-            GENESIS_ADDR,
+            (GENESIS_ADDR,),
         )
         .expect_success()
         .commit();

--- a/execution-engine/engine-grpc-server/tests/test_authorized_keys.rs
+++ b/execution-engine/engine-grpc-server/tests/test_authorized_keys.rs
@@ -138,7 +138,7 @@ fn should_raise_deploy_authorization_failure() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(key_1),
+            (PublicKey::new(key_1),),
         )
         .expect_success()
         .commit()
@@ -147,7 +147,7 @@ fn should_raise_deploy_authorization_failure() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             2,
-            PublicKey::new(key_2),
+            (PublicKey::new(key_2),),
         )
         .expect_success()
         .commit()
@@ -156,7 +156,7 @@ fn should_raise_deploy_authorization_failure() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             3,
-            PublicKey::new(key_3),
+            (PublicKey::new(key_3),),
         )
         .expect_success()
         .commit()
@@ -303,7 +303,7 @@ fn should_authorize_deploy_with_multiple_keys() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(key_1),
+            (PublicKey::new(key_1),),
         )
         .expect_success()
         .commit()
@@ -312,7 +312,7 @@ fn should_authorize_deploy_with_multiple_keys() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             2,
-            PublicKey::new(key_2),
+            (PublicKey::new(key_2),),
         )
         .expect_success()
         .commit()
@@ -349,7 +349,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
             "add_update_associated_key.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(key_1),
+            (PublicKey::new(key_1),),
         )
         .expect_success()
         .commit()

--- a/execution-engine/engine-grpc-server/tests/test_get_blocktime.rs
+++ b/execution-engine/engine-grpc-server/tests/test_get_blocktime.rs
@@ -26,7 +26,7 @@ fn should_run_get_blocktime_contract() {
             "get_blocktime.wasm",
             block_time,
             1,
-            block_time, // passing this to contract to test assertion
+            (block_time,), // passing this to contract to test assertion
         )
         .commit()
         .expect_success();

--- a/execution-engine/engine-grpc-server/tests/test_get_caller.rs
+++ b/execution-engine/engine-grpc-server/tests/test_get_caller.rs
@@ -26,7 +26,7 @@ fn should_run_get_caller_contract() {
             "get_caller.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(GENESIS_ADDR),
+            (PublicKey::new(GENESIS_ADDR),),
         )
         .commit()
         .expect_success();
@@ -38,7 +38,7 @@ fn should_run_get_caller_contract() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .commit()
         .expect_success()
@@ -47,7 +47,7 @@ fn should_run_get_caller_contract() {
             "get_caller.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(ACCOUNT_1_ADDR),
+            (PublicKey::new(ACCOUNT_1_ADDR),),
         )
         .commit()
         .expect_success();
@@ -63,7 +63,7 @@ fn should_run_get_caller_subcall_contract() {
             "get_caller_subcall.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(GENESIS_ADDR),
+            (PublicKey::new(GENESIS_ADDR),),
         )
         .commit()
         .expect_success();
@@ -75,7 +75,7 @@ fn should_run_get_caller_subcall_contract() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .commit()
         .expect_success()
@@ -84,7 +84,7 @@ fn should_run_get_caller_subcall_contract() {
             "get_caller_subcall.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            PublicKey::new(ACCOUNT_1_ADDR),
+            (PublicKey::new(ACCOUNT_1_ADDR),),
         )
         .commit()
         .expect_success();

--- a/execution-engine/engine-grpc-server/tests/test_get_phase.rs
+++ b/execution-engine/engine-grpc-server/tests/test_get_phase.rs
@@ -27,8 +27,8 @@ fn should_run_get_phase_contract() {
     let exec_request = {
         let deploy = DeployBuilder::new()
             .with_address(GENESIS_ADDR)
-            .with_session_code("get_phase.wasm", Phase::Session)
-            .with_payment_code("get_phase_payment.wasm", Phase::Payment)
+            .with_session_code("get_phase.wasm", (Phase::Session,))
+            .with_payment_code("get_phase_payment.wasm", (Phase::Payment,))
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
             .build();

--- a/execution-engine/engine-grpc-server/tests/test_key_management_thresholds.rs
+++ b/execution-engine/engine-grpc-server/tests/test_key_management_thresholds.rs
@@ -26,7 +26,7 @@ fn should_verify_key_management_permission_with_low_weight() {
             "key_management_thresholds.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            String::from("init"),
+            (String::from("init"),),
         )
         .expect_success()
         .commit()
@@ -36,7 +36,7 @@ fn should_verify_key_management_permission_with_low_weight() {
             DEFAULT_BLOCK_TIME,
             2,
             // This test verifies that any other error than PermissionDenied would revert
-            String::from("test-permission-denied"),
+            (String::from("test-permission-denied"),),
         )
         .expect_success()
         .commit();
@@ -52,7 +52,7 @@ fn should_verify_key_management_permission_with_sufficient_weight() {
             "key_management_thresholds.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            String::from("init"),
+            (String::from("init"),),
         )
         .expect_success()
         .commit()
@@ -62,7 +62,7 @@ fn should_verify_key_management_permission_with_sufficient_weight() {
             DEFAULT_BLOCK_TIME,
             2,
             // This test verifies that all key management operations succeed
-            String::from("test-key-mgmnt-succeed"),
+            (String::from("test-key-mgmnt-succeed"),),
             vec![
                 PublicKey::new(GENESIS_ADDR),
                 // Key [42; 32] is created in init stage

--- a/execution-engine/engine-grpc-server/tests/test_main_purse.rs
+++ b/execution-engine/engine-grpc-server/tests/test_main_purse.rs
@@ -35,7 +35,7 @@ fn should_run_main_purse_contract_genesis_account() {
             "main_purse.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            genesis_account.purse_id(),
+            (genesis_account.purse_id(),),
         )
         .expect_success()
         .commit();
@@ -55,7 +55,7 @@ fn should_run_main_purse_contract_account_1() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .expect_success()
         .commit();
@@ -72,7 +72,7 @@ fn should_run_main_purse_contract_account_1() {
             "main_purse.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            account_1.purse_id(),
+            (account_1.purse_id(),),
         )
         .expect_success()
         .commit();

--- a/execution-engine/engine-grpc-server/tests/test_payment_code.rs
+++ b/execution-engine/engine-grpc-server/tests/test_payment_code.rs
@@ -39,7 +39,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, U512::from(MAX_PAYMENT - 1)),
             )
-            .with_payment_code("standard_payment.wasm", U512::from(MAX_PAYMENT))
+            .with_payment_code("standard_payment.wasm", (U512::from(MAX_PAYMENT),))
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
             .build();
@@ -62,7 +62,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
         let deploy = DeployBuilder::new()
             .with_address(ACCOUNT_1_ADDR)
             .with_session_code("revert.wasm", ())
-            .with_payment_code("standard_payment.wasm", U512::from(MAX_PAYMENT - 1))
+            .with_payment_code("standard_payment.wasm", (U512::from(MAX_PAYMENT - 1),))
             .with_authorization_keys(&[account_1_public_key])
             .with_nonce(1)
             .build();
@@ -113,7 +113,7 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, U512::from(1)),
             )
-            .with_payment_code("standard_payment.wasm", U512::from(1))
+            .with_payment_code("standard_payment.wasm", (U512::from(1),))
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
             .build();
@@ -198,7 +198,7 @@ fn should_raise_insufficient_payment_when_payment_code_fails() {
     let exec_request = {
         let deploy = DeployBuilder::new()
             .with_address(genesis_addr)
-            .with_payment_code("revert.wasm", payment_purse_amount)
+            .with_payment_code("revert.wasm", (payment_purse_amount,))
             .with_session_code(
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, transferred_amount),
@@ -289,7 +289,7 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
     let exec_request = {
         let deploy = DeployBuilder::new()
             .with_address(genesis_addr)
-            .with_payment_code("standard_payment.wasm", U512::from(payment_purse_amount))
+            .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             .with_session_code(
                 "endless_loop.wasm",
                 (account_1_public_key, U512::from(transferred_amount)),
@@ -334,7 +334,7 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
     let exec_request = {
         let deploy = DeployBuilder::new()
             .with_address(genesis_addr)
-            .with_payment_code("standard_payment.wasm", U512::from(payment_purse_amount))
+            .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             .with_session_code("endless_loop.wasm", ())
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
@@ -433,7 +433,7 @@ fn should_correctly_charge_when_session_code_fails() {
     let exec_request = {
         let deploy = DeployBuilder::new()
             .with_address(genesis_addr)
-            .with_payment_code("standard_payment.wasm", U512::from(payment_purse_amount))
+            .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             .with_session_code(
                 "revert.wasm",
                 (account_1_public_key, U512::from(transferred_amount)),
@@ -534,7 +534,7 @@ fn should_correctly_charge_when_session_code_succeeds() {
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, U512::from(transferred_amount)),
             )
-            .with_payment_code("standard_payment.wasm", U512::from(payment_purse_amount))
+            .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
             .build();

--- a/execution-engine/engine-grpc-server/tests/test_pos_finalize_payment.rs
+++ b/execution-engine/engine-grpc-server/tests/test_pos_finalize_payment.rs
@@ -37,7 +37,7 @@ fn initialize() -> WasmTestBuilder {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            SYSTEM_ADDR,
+            (SYSTEM_ADDR,),
         )
         .expect_success()
         .commit()
@@ -46,7 +46,7 @@ fn initialize() -> WasmTestBuilder {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             2,
-            ACCOUNT_ADDR,
+            (ACCOUNT_ADDR,),
         )
         .expect_success()
         .commit();

--- a/execution-engine/engine-grpc-server/tests/test_pos_get_payment_purse.rs
+++ b/execution-engine/engine-grpc-server/tests/test_pos_get_payment_purse.rs
@@ -40,7 +40,7 @@ fn should_run_get_payment_purse_contract_account_1() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .expect_success()
         .commit()

--- a/execution-engine/engine-grpc-server/tests/test_pos_refund_purse.rs
+++ b/execution-engine/engine-grpc-server/tests/test_pos_refund_purse.rs
@@ -53,7 +53,7 @@ fn transfer(builder: &mut WasmTestBuilder, address: [u8; 32], amount: U512) {
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, amount),
             )
-            .with_payment_code("standard_payment.wasm", U512::from(MAX_PAYMENT))
+            .with_payment_code("standard_payment.wasm", (U512::from(MAX_PAYMENT),))
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
             .build();
@@ -74,7 +74,7 @@ fn refund_tests(builder: &mut WasmTestBuilder, address: [u8; 32]) {
         let deploy = DeployBuilder::new()
             .with_address(address)
             .with_session_code("do_nothing.wasm", ())
-            .with_payment_code("pos_refund_purse.wasm", U512::from(MAX_PAYMENT))
+            .with_payment_code("pos_refund_purse.wasm", (U512::from(MAX_PAYMENT),))
             .with_authorization_keys(&[public_key])
             .with_nonce(1)
             .build();

--- a/execution-engine/engine-grpc-server/tests/test_preconditions.rs
+++ b/execution-engine/engine-grpc-server/tests/test_preconditions.rs
@@ -38,7 +38,7 @@ fn should_raise_precondition_invalid_nonce() {
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, U512::from(42)),
             )
-            .with_payment_code("standard_payment.wasm", U512::from(10_000_000))
+            .with_payment_code("standard_payment.wasm", (U512::from(10_000_000),))
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(invalid_nonce)
             .build();
@@ -100,7 +100,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
                 (account_1_public_key, U512::from(transferred_amount)),
             )
             .with_address(nonexistent_account_addr)
-            .with_payment_code("standard_payment.wasm", U512::from(payment_purse_amount))
+            .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             .with_authorization_keys(&[PublicKey::new(nonexistent_account_addr)])
             .with_nonce(0)
             .build();
@@ -182,7 +182,7 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
                 "transfer_purse_to_account.wasm",
                 (account_1_public_key, U512::from(transferred_amount)),
             )
-            .with_payment_code("standard_payment.wasm", U512::from(payment_purse_amount))
+            .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             // invalid authorization key to force error
             .with_authorization_keys(&[PublicKey::new(nonexistent_account_addr)])
             .with_nonce(0)

--- a/execution-engine/engine-grpc-server/tests/test_stored_contract_exec.rs
+++ b/execution-engine/engine-grpc-server/tests/test_stored_contract_exec.rs
@@ -106,7 +106,7 @@ fn should_exec_non_stored_code() {
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
@@ -168,7 +168,7 @@ fn should_exec_stored_code_by_hash() {
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
@@ -229,7 +229,7 @@ fn should_exec_stored_code_by_hash() {
                 stored_payment_contract_hash
                     .expect("hash should exist")
                     .to_vec(),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(2)
@@ -293,7 +293,7 @@ fn should_exec_stored_code_by_named_hash() {
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
@@ -333,7 +333,7 @@ fn should_exec_stored_code_by_named_hash() {
             )
             .with_stored_payment_named_key(
                 STANDARD_PAYMENT_CONTRACT_NAME,
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(2)
@@ -397,7 +397,7 @@ fn should_exec_stored_code_by_named_uref() {
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
@@ -438,7 +438,7 @@ fn should_exec_stored_code_by_named_uref() {
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(2)
@@ -502,7 +502,7 @@ fn should_exec_payment_and_session_stored_code() {
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(1)
@@ -534,7 +534,7 @@ fn should_exec_payment_and_session_stored_code() {
             )
             .with_stored_payment_named_key(
                 STANDARD_PAYMENT_CONTRACT_NAME,
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(2)
@@ -566,7 +566,7 @@ fn should_exec_payment_and_session_stored_code() {
             )
             .with_stored_payment_named_key(
                 STANDARD_PAYMENT_CONTRACT_NAME,
-                U512::from(payment_purse_amount),
+                (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[genesis_public_key])
             .with_nonce(3)
@@ -628,7 +628,7 @@ fn should_produce_same_transforms_as_exec() {
                 )
                 .with_payment_code(
                     &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                    U512::from(payment_purse_amount),
+                    (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[genesis_public_key])
                 .with_nonce(1)
@@ -657,7 +657,7 @@ fn should_produce_same_transforms_as_exec() {
                 )
                 .with_payment_code(
                     &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                    U512::from(payment_purse_amount),
+                    (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[genesis_public_key])
                 .with_nonce(1)
@@ -699,7 +699,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 .with_session_code(&format!("{}_stored.wasm", name), ())
                 .with_payment_code(
                     &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                    U512::from(payment_purse_amount),
+                    (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[genesis_public_key])
                 .with_nonce(nonce)
@@ -744,7 +744,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                     stored_payment_contract_hash
                         .expect("hash should exist")
                         .to_vec(),
-                    U512::from(payment_purse_amount),
+                    (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[genesis_public_key])
                 .with_nonce(3)
@@ -770,7 +770,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 .with_session_code("do_nothing.wasm", ())
                 .with_payment_code(
                     &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                    U512::from(payment_purse_amount),
+                    (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[genesis_public_key])
                 .with_nonce(nonce)
@@ -788,7 +788,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 )
                 .with_payment_code(
                     &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
-                    U512::from(payment_purse_amount),
+                    (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[genesis_public_key])
                 .with_nonce(3)

--- a/execution-engine/engine-grpc-server/tests/test_system_contract_urefs_access_rights.rs
+++ b/execution-engine/engine-grpc-server/tests/test_system_contract_urefs_access_rights.rs
@@ -27,7 +27,7 @@ fn should_have_read_only_access_to_system_contract_urefs() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .commit()
         .exec(

--- a/execution-engine/engine-grpc-server/tests/test_transfer.rs
+++ b/execution-engine/engine-grpc-server/tests/test_transfer.rs
@@ -134,7 +134,7 @@ fn should_transfer_to_account() {
         genesis_hash,
         DEFAULT_BLOCK_TIME,
         1,
-        ACCOUNT_1_ADDR,
+        (ACCOUNT_1_ADDR,),
         vec![PublicKey::new(GENESIS_ADDR)],
     );
 
@@ -222,7 +222,7 @@ fn should_transfer_from_account_to_account() {
         genesis_hash,
         DEFAULT_BLOCK_TIME,
         1,
-        ACCOUNT_1_ADDR,
+        (ACCOUNT_1_ADDR,),
         vec![PublicKey::new(GENESIS_ADDR)],
     );
 
@@ -384,7 +384,7 @@ fn should_transfer_to_existing_account() {
         genesis_hash,
         DEFAULT_BLOCK_TIME,
         1,
-        ACCOUNT_1_ADDR,
+        (ACCOUNT_1_ADDR,),
         vec![PublicKey::new(GENESIS_ADDR)],
     );
 
@@ -515,7 +515,7 @@ fn should_fail_when_insufficient_funds() {
         genesis_hash,
         DEFAULT_BLOCK_TIME,
         1,
-        ACCOUNT_1_ADDR,
+        (ACCOUNT_1_ADDR,),
         vec![PublicKey::new(GENESIS_ADDR)],
     );
 
@@ -646,7 +646,7 @@ fn should_create_purse() {
         genesis_hash,
         DEFAULT_BLOCK_TIME,
         1,
-        ACCOUNT_1_ADDR,
+        (ACCOUNT_1_ADDR,),
         vec![PublicKey::new(GENESIS_ADDR)],
     );
 
@@ -723,7 +723,7 @@ fn should_transfer_total_amount() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_1_ADDR,
+            (ACCOUNT_1_ADDR,),
         )
         .expect_success()
         .commit()
@@ -733,7 +733,7 @@ fn should_transfer_total_amount() {
             "transfer_to_account_01.wasm",
             DEFAULT_BLOCK_TIME,
             1,
-            ACCOUNT_2_ADDR,
+            (ACCOUNT_2_ADDR,),
         )
         .commit()
         .expect_success();

--- a/integration-testing/contracts/counter/call/src/lib.rs
+++ b/integration-testing/contracts/counter/call/src/lib.rs
@@ -20,11 +20,11 @@ pub extern "C" fn call() {
 
     let _result: () = {
         let arg = "inc";
-        call_contract( pointer.clone(), &arg, &Vec::new())
+        call_contract(pointer.clone(), &(arg,), &Vec::new())
     };
 
     let _value: i32 = {
         let arg = "get";
-        call_contract(pointer, &arg, &Vec::new())
+        call_contract(pointer, &(arg,), &Vec::new())
     };
 }

--- a/integration-testing/contracts/finalize-payment/src/lib.rs
+++ b/integration-testing/contracts/finalize-payment/src/lib.rs
@@ -26,7 +26,7 @@ fn set_refund_purse(pos: &ContractPointer, p: &PurseId) {
 }
 
 fn get_payment_purse(pos: &ContractPointer) -> PurseId {
-    contract_api::call_contract(pos.clone(), &"get_payment_purse", &Vec::new())
+    contract_api::call_contract(pos.clone(), &("get_payment_purse",), &Vec::new())
 }
 
 fn submit_payment(pos: &ContractPointer, amount: U512) {

--- a/integration-testing/contracts/hello-name/call/src/lib.rs
+++ b/integration-testing/contracts/hello-name/call/src/lib.rs
@@ -22,7 +22,7 @@ pub extern "C" fn call() {
     };
 
     let arg = "World";
-    let result: String = call_contract(pointer, &arg, &Vec::new());
+    let result: String = call_contract(pointer, &(arg,), &Vec::new());
     assert_eq!("Hello, World", result);
 
     //store the result at a uref so it can be seen as an effect on the global state

--- a/integration-testing/contracts/mailing-list/call/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/call/src/lib.rs
@@ -22,7 +22,7 @@ pub extern "C" fn call() {
     let method = "sub";
     let name = "CasperLabs";
     let args = (method, name);
-    match call_contract(pointer.clone(), &args, &Vec::new()){
+    match call_contract(pointer.clone(), &args, &Vec::new()) {
         Some(sub_key) => {
             let key_name = "mail_feed";
             add_uref(key_name, &sub_key);

--- a/integration-testing/contracts/payment-purse/src/lib.rs
+++ b/integration-testing/contracts/payment-purse/src/lib.rs
@@ -22,7 +22,7 @@ pub extern "C" fn call() {
     let account: PublicKey = contract_api::get_arg(0);
     let payment_amount: U512 = U512::from(contract_api::get_arg::<u32>(1));
     let payment_purse: PurseId =
-        contract_api::call_contract(pos_pointer, &"get_payment_purse", &Vec::new());
+        contract_api::call_contract(pos_pointer, &("get_payment_purse",), &Vec::new());
 
     // can deposit
     if let PurseTransferResult::TransferError =

--- a/integration-testing/contracts/refund-purse/src/lib.rs
+++ b/integration-testing/contracts/refund-purse/src/lib.rs
@@ -25,7 +25,7 @@ fn set_refund_purse(pos: &ContractPointer, p: &PurseId) {
 }
 
 fn get_refund_purse(pos: &ContractPointer) -> Option<PurseId> {
-    contract_api::call_contract(pos.clone(), &"get_refund_purse", &Vec::new())
+    contract_api::call_contract(pos.clone(), &("get_refund_purse",), &Vec::new())
 }
 
 #[no_mangle]

--- a/integration-testing/contracts/standard-payment/src/lib.rs
+++ b/integration-testing/contracts/standard-payment/src/lib.rs
@@ -42,7 +42,7 @@ pub extern "C" fn call() {
     };
 
     let payment_purse: PurseId =
-        contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE), &vec![]);
+        contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE,), &vec![]);
 
     if let PurseTransferResult::TransferError =
         contract_api::transfer_from_purse_to_purse(main_purse, payment_purse, amount)


### PR DESCRIPTION
For quite some time now ArgParser supported a single element to be
treated as a list of arguments with a single element. While it's not
wrong in principle, lack for explicit meaning of that caused whole lot
of troubles that are hard to catch. For example:

```
fn foo(block_hash: [u8; 32], args: impl ArgParser);
```

Both calls would be valid:

```
foo([1; 32], [2; 32]);
```

and

```
foo([2; 32], [1; 32]);
```

And a source of confusion where arguments called contains different
value than expected (i.e. while refactoring, when order of elements
might change).

This change makes the single argument case for `ArgParser` explicit so
you're required to pass single argument as a one element tuple.

```
foo([1;32], [2; 32]); // wrong
foo([1;32], ([2; 32],)); // correct
```

### Overview
_Provide a brief description of what this PR does, and why it's needed._

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
