### PR TITLE
NODE-809: Force shutdown in uncaught exception handler.

### DIFF
--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Main.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Main.scala
@@ -7,6 +7,7 @@ import io.casperlabs.client.{DeployService, GrpcDeployService}
 import io.casperlabs.shared.{FilesAPI, Log, UncaughtExceptionHandler}
 import monix.eval.Task
 import monix.execution.Scheduler
+import scala.concurrent.duration._
 
 object Main {
   implicit val log: Log[Task] = Log.log
@@ -15,7 +16,7 @@ object Main {
     implicit val scheduler: Scheduler = Scheduler.computation(
       Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 4),
       "node-runner",
-      reporter = UncaughtExceptionHandler
+      reporter = new UncaughtExceptionHandler(shutdownTimeout = 5.seconds)
     )
 
     val exec =

--- a/build.sbt
+++ b/build.sbt
@@ -131,7 +131,8 @@ lazy val casper = (project in file("casper"))
     shared         % "compile->compile;test->test",
     smartContracts % "compile->compile;test->test",
     crypto,
-    models
+    models,
+    client
   )
 
 lazy val comm = (project in file("comm"))

--- a/build.sbt
+++ b/build.sbt
@@ -132,7 +132,8 @@ lazy val casper = (project in file("casper"))
     smartContracts % "compile->compile;test->test",
     crypto,
     models,
-    client
+    client,
+    benchmarks
   )
 
 lazy val comm = (project in file("comm"))

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -14,6 +14,7 @@ import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.shared.{FilesAPI, Log, UncaughtExceptionHandler}
 import monix.eval.Task
 import monix.execution.Scheduler
+import scala.concurrent.duration._
 
 object Main {
 
@@ -23,7 +24,7 @@ object Main {
     implicit val scheduler: Scheduler = Scheduler.computation(
       Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
       "node-runner",
-      reporter = UncaughtExceptionHandler
+      reporter = new UncaughtExceptionHandler(shutdownTimeout = 5.seconds)
     )
 
     val exec =

--- a/comm/src/main/scala/io/casperlabs/comm/transport/TcpTransportLayer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/TcpTransportLayer.scala
@@ -274,7 +274,11 @@ class TcpTransportLayer(
     cell.modify { s =>
       val parallelism = Math.max(Runtime.getRuntime.availableProcessors(), 2)
       val queueScheduler =
-        Scheduler.fixedPool("tl-dispatcher", parallelism, reporter = UncaughtExceptionHandler)
+        Scheduler.fixedPool(
+          "tl-dispatcher",
+          parallelism,
+          reporter = new UncaughtExceptionHandler(1.minute)
+        )
       for {
         server <- initQueue(s.server) {
                    Task.delay {

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -19,11 +19,14 @@ object Main {
 
   implicit val log: Log[Task] = effects.log
 
+  implicit val uncaughtExceptionHandler = new UncaughtExceptionHandler(shutdownTimeout = 1.minute)
+
   def main(args: Array[String]): Unit = {
+
     implicit val scheduler: Scheduler = Scheduler.computation(
       Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
       "node-runner",
-      reporter = UncaughtExceptionHandler
+      reporter = uncaughtExceptionHandler
     )
 
     val exec: Task[Unit] =

--- a/shared/src/main/scala/io/casperlabs/shared/RuntimeOps.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/RuntimeOps.scala
@@ -1,0 +1,21 @@
+package io.casperlabs.shared
+
+import java.util.{Timer, TimerTask}
+import scala.concurrent.duration.FiniteDuration
+
+trait RuntimeOps {
+
+  /** Try exiting normally, but if it doesn't work use the more forceful option.  */
+  def exitOrHalt(status: Int, timeout: FiniteDuration): Unit =
+    try {
+      val timer = new Timer()
+      timer.schedule(new TimerTask() {
+        override def run(): Unit =
+          Runtime.getRuntime.halt(status)
+      }, timeout.toMillis)
+      System.exit(status)
+    } catch {
+      case _: Throwable =>
+        Runtime.getRuntime.halt(status)
+    }
+}

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -2,8 +2,11 @@ package io.casperlabs.shared
 
 import cats.Id
 import monix.execution.UncaughtExceptionReporter
+import scala.concurrent.duration.FiniteDuration
 
-object UncaughtExceptionHandler extends UncaughtExceptionReporter {
+class UncaughtExceptionHandler(shutdownTimeout: FiniteDuration)
+    extends UncaughtExceptionReporter
+    with RuntimeOps {
   private implicit val logSource: LogSource = LogSource(this.getClass)
   private val log: Log[Id]                  = Log.logId
 
@@ -13,7 +16,7 @@ object UncaughtExceptionHandler extends UncaughtExceptionReporter {
       case _: VirtualMachineError | _: LinkageError =>
         // To flush logs
         Thread.sleep(1000)
-        sys.exit(1)
+        exitOrHalt(1, shutdownTimeout)
       case _ =>
     }
   }


### PR DESCRIPTION
### Overview
Couldn't reproduce it locally yet, but the node still won't shut down after an OutOfMemory error. This PR changes the error handler to force it if it doesn't happen after a minute.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-809

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
