### PR TITLE
NODE-758: Try to bump timeouts

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferImplSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferImplSpec.scala
@@ -44,15 +44,17 @@ class DeployBufferImplSpec extends DeployBufferSpec with BeforeAndAfterEach with
         .locations(new Location("classpath:db/migration"))
     conf.load()
   }
-
-  override protected def testFixture(test: DeployBuffer[Task] => Task[Unit]): Unit = {
+  override protected def testFixture(
+      test: DeployBuffer[Task] => Task[Unit],
+      timeout: FiniteDuration = 5.seconds
+  ): Unit = {
     val program = for {
       _            <- Task(cleanupTables())
       _            <- Task(setupTables())
       deployBuffer <- DeployBufferImpl.create[Task]
       _            <- test(deployBuffer)
     } yield ()
-    program.runSyncUnsafe(5.seconds)
+    program.runSyncUnsafe(timeout)
   }
 
   private def setupTables(): Unit = flyway.migrate()

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
@@ -23,7 +23,10 @@ trait DeployBufferSpec
     with GeneratorDrivenPropertyChecks {
 
   /* Implement this method in descendants substituting various DeployBuffer implementations */
-  protected def testFixture(test: DeployBuffer[Task] => Task[Unit]): Unit
+  protected def testFixture(
+      test: DeployBuffer[Task] => Task[Unit],
+      timeout: FiniteDuration = 5.seconds
+  ): Unit
 
   private implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
@@ -258,42 +261,47 @@ trait DeployBufferSpec
     }
 
     "cleanupDiscarded" should {
-      "delete discarded deploys only older than 'now - expirationPeriod'" in testFixture { db =>
-        val first  = sample(arbDeploy.arbitrary)
-        val second = sample(arbDeploy.arbitrary)
-        for {
-          _ <- db.addAsPending(List(first, second))
-          _ <- db.markAsDiscarded(List(first))
-          _ <- Task.sleep(1.second)
-          _ <- db.markAsDiscarded(List(second))
-          _ <- db.cleanupDiscarded(expirationPeriod = 500.millis).foreachL(_ shouldBe 1)
-          _ <- Task.sleep(1.second)
-          _ <- db.cleanupDiscarded(expirationPeriod = 500.millis).foreachL(_ shouldBe 1)
-          _ <- Task.sleep(1.second)
-          _ <- db.cleanupDiscarded(expirationPeriod = 500.millis).foreachL(_ shouldBe 0)
-        } yield ()
-      }
+      "delete discarded deploys only older than 'now - expirationPeriod'" in testFixture(
+        { db =>
+          val first  = sample(arbDeploy.arbitrary)
+          val second = sample(arbDeploy.arbitrary)
+          for {
+            _ <- db.addAsPending(List(first, second))
+            _ <- db.markAsDiscarded(List(first))
+            _ <- Task.sleep(2.seconds)
+            _ <- db.markAsDiscarded(List(second))
+            _ <- db.cleanupDiscarded(expirationPeriod = 1.second).foreachL(_ shouldBe 1)
+            _ <- Task.sleep(2.seconds)
+            _ <- db.cleanupDiscarded(expirationPeriod = 1.second).foreachL(_ shouldBe 1)
+            _ <- Task.sleep(2.seconds)
+            _ <- db.cleanupDiscarded(expirationPeriod = 1.second).foreachL(_ shouldBe 0)
+          } yield ()
+        },
+        timeout = 15.seconds
+      )
     }
 
     "markAsDiscarded(duration)" should {
-      "mark only pending deploys were added more than 'now - expirationPeriod' time ago" in testFixture {
-        db =>
+      "mark only pending deploys were added more than 'now - expirationPeriod' time ago" in testFixture(
+        { db =>
           val first  = sample(arbDeploy.arbitrary)
           val second = sample(arbDeploy.arbitrary)
           for {
             _ <- db.addAsPending(List(first))
             _ <- db.pendingNum.foreachL(_ shouldBe 1)
-            _ <- Task.sleep(1.second)
+            _ <- Task.sleep(2.seconds)
             _ <- db.addAsProcessed(List(second))
             _ <- db.markAsPending(List(second))
             _ <- db.pendingNum.foreachL(_ shouldBe 2)
-            _ <- db.markAsDiscarded(expirationPeriod = 500.millis)
+            _ <- db.markAsDiscarded(expirationPeriod = 1.second)
             _ <- db.pendingNum.foreachL(_ shouldBe 1)
-            _ <- Task.sleep(1.second)
-            _ <- db.markAsDiscarded(expirationPeriod = 500.millis)
+            _ <- Task.sleep(2.seconds)
+            _ <- db.markAsDiscarded(expirationPeriod = 1.second)
             _ <- db.pendingNum.foreachL(_ shouldBe 0)
           } yield ()
-      }
+        },
+        timeout = 15.seconds
+      )
     }
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBufferSpec.scala
@@ -8,10 +8,13 @@ import monix.execution.schedulers.CanBlock.permit
 import scala.concurrent.duration._
 
 class MockDeployBufferSpec extends DeployBufferSpec {
-  override protected def testFixture(test: DeployBuffer[Task] => Task[Unit]): Unit =
+  override protected def testFixture(
+      test: DeployBuffer[Task] => Task[Unit],
+      timeout: FiniteDuration = 5.seconds
+  ): Unit =
     (for {
       implicit0(logNOP: Log[Task]) <- Task(new NOPLog[Task])
       mockDeployBuffer             <- MockDeployBuffer.create[Task]()
       _                            <- test(mockDeployBuffer)
-    } yield ()).runSyncUnsafe(5.seconds)
+    } yield ()).runSyncUnsafe(timeout)
 }


### PR DESCRIPTION
### Overview
Tries to fix non-det `DeployBufferSpec` CI failures by bumping timeouts. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-758

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I ran the CI twice and it succeeds it both cases. 