### PR TITLE
EE-583: Make contract-ffi a consistent alias for all crates

### DIFF
--- a/execution-engine/contracts/client/transfer-to-account/Cargo.toml
+++ b/execution-engine/contracts/client/transfer-to-account/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/client/transfer-to-account/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{self, TransferResult};
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
+use contract_ffi::contract_api::{self, TransferResult};
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
 
 /// Executes mote transfer to supplied public key.
 /// Transfers the requested amount.

--- a/execution-engine/contracts/system/mint-token/Cargo.toml
+++ b/execution-engine/contracts/system/mint-token/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/system/mint-token/src/capabilities.rs
+++ b/execution-engine/contracts/system/mint-token/src/capabilities.rs
@@ -1,11 +1,11 @@
 use core::convert::TryFrom;
 use core::marker::PhantomData;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::UPointer;
-use cl_std::key::Key;
-use cl_std::uref::{AccessRights, URef};
-use cl_std::value::Value;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::value::Value;
 
 /// Trait representing the ability to read a value. Use case: a key
 /// for the blockdag global state (`UPointer`) is obviously Readable,

--- a/execution-engine/contracts/system/mint-token/src/internal_purse_id.rs
+++ b/execution-engine/contracts/system/mint-token/src/internal_purse_id.rs
@@ -1,6 +1,6 @@
-use cl_std::contract_api;
-use cl_std::system_contracts::mint::purse_id::PurseIdError;
-use cl_std::uref::URef;
+use contract_ffi::contract_api;
+use contract_ffi::system_contracts::mint::purse_id::PurseIdError;
+use contract_ffi::uref::URef;
 
 pub struct WithdrawId([u8; 32]);
 

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -3,7 +3,7 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 mod capabilities;
 
@@ -18,11 +18,11 @@ mod mint;
 use alloc::string::String;
 use core::convert::TryInto;
 
-use cl_std::contract_api;
-use cl_std::key::Key;
-use cl_std::system_contracts::mint::error::Error;
-use cl_std::uref::{AccessRights, URef};
-use cl_std::value::U512;
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+use contract_ffi::system_contracts::mint::error::Error;
+use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::value::U512;
 
 use capabilities::{ARef, RAWRef};
 use internal_purse_id::{DepositId, WithdrawId};

--- a/execution-engine/contracts/system/mint-token/src/mint.rs
+++ b/execution-engine/contracts/system/mint-token/src/mint.rs
@@ -1,7 +1,7 @@
-use cl_std::value::U512;
+use contract_ffi::value::U512;
 
 use capabilities::{Addable, Readable, Writable};
-use cl_std::system_contracts::mint::error::Error;
+use contract_ffi::system_contracts::mint::error::Error;
 
 pub trait Mint<A, RW>
 where
@@ -41,7 +41,7 @@ mod tests {
     use core::cell::{Cell, RefCell};
     use core::ops::Add;
 
-    use cl_std::value::U512;
+    use contract_ffi::value::U512;
 
     use capabilities::{Addable, Readable, Writable};
     use mint::{Error, Mint};

--- a/execution-engine/contracts/system/pos/Cargo.toml
+++ b/execution-engine/contracts/system/pos/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/system/pos/src/error.rs
+++ b/execution-engine/contracts/system/pos/src/error.rs
@@ -1,6 +1,6 @@
 use core::result;
 
-use cl_std::contract_api;
+use contract_ffi::contract_api;
 
 #[derive(Debug, PartialEq)]
 // TODO: Split this up into user errors vs. system errors.

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -11,12 +11,12 @@ mod stakes;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use cl_std::contract_api;
-use cl_std::execution::Phase;
-use cl_std::key::Key;
-use cl_std::uref::{AccessRights, URef};
-use cl_std::value::account::{BlockTime, PublicKey, PurseId};
-use cl_std::value::U512;
+use contract_ffi::contract_api;
+use contract_ffi::execution::Phase;
+use contract_ffi::key::Key;
+use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::value::account::{BlockTime, PublicKey, PurseId};
+use contract_ffi::value::U512;
 
 use crate::error::{Error, PurseLookupError, Result, ResultExt};
 use crate::queue::{QueueEntry, QueueLocal, QueueProvider};
@@ -342,7 +342,7 @@ mod tests {
     use std::cell::RefCell;
     use std::iter;
 
-    use cl_std::value::{
+    use contract_ffi::value::{
         account::{BlockTime, PublicKey},
         U512,
     };

--- a/execution-engine/contracts/system/pos/src/queue.rs
+++ b/execution-engine/contracts/system/pos/src/queue.rs
@@ -2,10 +2,10 @@ use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::result;
 
-use cl_std::bytesrepr::{self, FromBytes, ToBytes};
-use cl_std::contract_api;
-use cl_std::value::account::{BlockTime, PublicKey};
-use cl_std::value::{Value, U512};
+use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
+use contract_ffi::contract_api;
+use contract_ffi::value::account::{BlockTime, PublicKey};
+use contract_ffi::value::{Value, U512};
 
 use crate::error::{Error, Result};
 
@@ -176,8 +176,8 @@ impl ToBytes for Queue {
 
 #[cfg(test)]
 mod tests {
-    use cl_std::value::account::{BlockTime, PublicKey};
-    use cl_std::value::U512;
+    use contract_ffi::value::account::{BlockTime, PublicKey};
+    use contract_ffi::value::U512;
 
     use crate::error::Error;
     use crate::queue::{Queue, QueueEntry};

--- a/execution-engine/contracts/system/pos/src/stakes.rs
+++ b/execution-engine/contracts/system/pos/src/stakes.rs
@@ -2,9 +2,9 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::String;
 use core::fmt::Write;
 
-use cl_std::contract_api;
-use cl_std::key::Key;
-use cl_std::value::{account::PublicKey, U512};
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+use contract_ffi::value::{account::PublicKey, U512};
 
 use crate::error::{Error, Result};
 
@@ -184,7 +184,7 @@ impl Stakes {
 
 #[cfg(test)]
 mod tests {
-    use cl_std::value::{account::PublicKey, U512};
+    use contract_ffi::value::{account::PublicKey, U512};
 
     use crate::error::Error;
     use crate::stakes::Stakes;

--- a/execution-engine/contracts/system/test-mint-token/Cargo.toml
+++ b/execution-engine/contracts/system/test-mint-token/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/system/test-mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/test-mint-token/src/lib.rs
@@ -3,13 +3,13 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::String;
 
-use cl_std::contract_api;
-use cl_std::key::Key;
-use cl_std::value::U512;
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+use contract_ffi::value::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/add-update-associated-key/Cargo.toml
+++ b/execution-engine/contracts/test/add-update-associated-key/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/add-update-associated-key/src/lib.rs
+++ b/execution-engine/contracts/test/add-update-associated-key/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::value::account::{PublicKey, Weight};
+use contract_ffi::contract_api;
+use contract_ffi::value::account::{PublicKey, Weight};
 
 const INIT_WEIGHT: u8 = 1;
 const MOD_WEIGHT: u8 = 2;

--- a/execution-engine/contracts/test/authorized-keys/Cargo.toml
+++ b/execution-engine/contracts/test/authorized-keys/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/authorized-keys/src/lib.rs
+++ b/execution-engine/contracts/test/authorized-keys/src/lib.rs
@@ -2,9 +2,9 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
-use cl_std::contract_api::{add_associated_key, get_arg, revert, set_action_threshold};
-use cl_std::value::account::{ActionType, AddKeyFailure, PublicKey, Weight};
+extern crate contract_ffi;
+use contract_ffi::contract_api::{add_associated_key, get_arg, revert, set_action_threshold};
+use contract_ffi::value::account::{ActionType, AddKeyFailure, PublicKey, Weight};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/check-system-contract-urefs-access-rights/Cargo.toml
+++ b/execution-engine/contracts/test/check-system-contract-urefs-access-rights/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/check-system-contract-urefs-access-rights/src/lib.rs
+++ b/execution-engine/contracts/test/check-system-contract-urefs-access-rights/src/lib.rs
@@ -2,11 +2,11 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::list_known_urefs;
-use cl_std::key::Key;
-use cl_std::uref::URef;
+use contract_ffi::contract_api::list_known_urefs;
+use contract_ffi::key::Key;
+use contract_ffi::uref::URef;
 
 #[allow(clippy::redundant_closure)]
 #[no_mangle]

--- a/execution-engine/contracts/test/create-purse-01/Cargo.toml
+++ b/execution-engine/contracts/test/create-purse-01/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/create-purse-01/src/lib.rs
+++ b/execution-engine/contracts/test/create-purse-01/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::uref::{AccessRights, URef};
-use cl_std::value::account::PurseId;
+use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::value::account::PurseId;
 
 // This value was acquired by observing the output of an execution of this contract
 // made by ACCOUNT_1.
@@ -19,7 +19,7 @@ pub extern "C" fn call() {
     let expected_purse_id =
         PurseId::new(URef::new(EXPECTED_UREF_BYTES, AccessRights::READ_ADD_WRITE));
 
-    let actual_purse_id = cl_std::contract_api::create_purse();
+    let actual_purse_id = contract_ffi::contract_api::create_purse();
 
     assert_eq!(actual_purse_id, expected_purse_id);
 }

--- a/execution-engine/contracts/test/deserialize-error/Cargo.toml
+++ b/execution-engine/contracts/test/deserialize-error/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/deserialize-error/src/lib.rs
+++ b/execution-engine/contracts/test/deserialize-error/src/lib.rs
@@ -4,17 +4,17 @@
 #[macro_use]
 extern crate alloc;
 
-extern crate cl_std;
+extern crate contract_ffi;
 extern crate core;
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::vec::Vec;
 
-use cl_std::bytesrepr::ToBytes;
-use cl_std::contract_api;
-use cl_std::contract_api::argsparser::ArgsParser;
-use cl_std::contract_api::pointers::ContractPointer;
-use cl_std::key::Key;
+use contract_ffi::bytesrepr::ToBytes;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::argsparser::ArgsParser;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn do_nothing() {

--- a/execution-engine/contracts/test/do-nothing/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/do-nothing/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 #![feature(alloc)]
 
-extern crate cl_std;
+extern crate contract_ffi;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-221-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-221-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-221-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-221-regression/src/lib.rs
@@ -3,10 +3,10 @@
 
 extern crate alloc;
 
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{add_uref, get_uref, new_uref};
-use cl_std::key::Key;
+use contract_ffi::contract_api::{add_uref, get_uref, new_uref};
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-401-regression-call/Cargo.toml
+++ b/execution-engine/contracts/test/ee-401-regression-call/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
@@ -2,13 +2,13 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::String;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::uref::URef;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::uref::URef;
 
 const CONTRACT_HASH: [u8; 32] = [
     94, 95, 50, 162, 218, 237, 110, 252, 109, 151, 87, 89, 218, 215, 97, 65, 124, 183, 21, 252,

--- a/execution-engine/contracts/test/ee-401-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-401-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-401-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression/src/lib.rs
@@ -3,13 +3,13 @@
 
 extern crate alloc;
 
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::ContractPointer;
 
 #[no_mangle]
 pub extern "C" fn hello_ext() {

--- a/execution-engine/contracts/test/ee-441-rng-state/Cargo.toml
+++ b/execution-engine/contracts/test/ee-441-rng-state/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
+++ b/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
@@ -3,17 +3,17 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::ContractPointer;
-use cl_std::contract_api::{add_uref, get_arg, new_uref};
-use cl_std::key::Key;
-use cl_std::uref::URef;
-use cl_std::value::U512;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{add_uref, get_arg, new_uref};
+use contract_ffi::key::Key;
+use contract_ffi::uref::URef;
+use contract_ffi::value::U512;
 
 #[no_mangle]
 pub extern "C" fn do_nothing() {

--- a/execution-engine/contracts/test/ee-460-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-460-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-460-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-460-regression/src/lib.rs
@@ -3,11 +3,11 @@
 
 extern crate alloc;
 
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, transfer_to_account, TransferResult};
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
+use contract_ffi::contract_api::{get_arg, transfer_to_account, TransferResult};
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-532-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-532-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-532-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-532-regression/src/lib.rs
@@ -2,7 +2,7 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-536-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-536-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-536-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-536-regression/src/lib.rs
@@ -2,12 +2,12 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{
+use contract_ffi::contract_api::{
     add_associated_key, remove_associated_key, revert, set_action_threshold, update_associated_key,
 };
-use cl_std::value::account::{
+use contract_ffi::value::account::{
     ActionType, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight,
 };
 

--- a/execution-engine/contracts/test/ee-539-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-539-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-539-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-539-regression/src/lib.rs
@@ -3,10 +3,10 @@
 
 extern crate alloc;
 
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{add_associated_key, get_arg, revert, set_action_threshold};
-use cl_std::value::account::{ActionType, PublicKey, Weight};
+use contract_ffi::contract_api::{add_associated_key, get_arg, revert, set_action_threshold};
+use contract_ffi::value::account::{ActionType, PublicKey, Weight};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-549-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-549-regression/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-549-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-549-regression/src/lib.rs
@@ -3,11 +3,11 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::key::Key;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::key::Key;
 
 const POS_CONTRACT_NAME: &str = "pos";
 const SET_REFUND_PURSE: &str = "set_refund_purse";

--- a/execution-engine/contracts/test/ee-572-regression-create/Cargo.toml
+++ b/execution-engine/contracts/test/ee-572-regression-create/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
@@ -3,16 +3,16 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
 use core::clone::Clone;
 use core::convert::Into;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::UPointer;
-use cl_std::key::Key;
-use cl_std::uref::{AccessRights, URef};
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::uref::{AccessRights, URef};
 
 const DATA: &str = "data";
 const CONTRACT_NAME: &str = "create";

--- a/execution-engine/contracts/test/ee-572-regression-escalate/Cargo.toml
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
@@ -2,15 +2,15 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::key::Key;
-use cl_std::uref::{AccessRights, URef};
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::key::Key;
+use contract_ffi::uref::{AccessRights, URef};
 
 const CONTRACT_POINTER: u32 = 0;
 

--- a/execution-engine/contracts/test/get-blocktime/Cargo.toml
+++ b/execution-engine/contracts/test/get-blocktime/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/get-blocktime/src/lib.rs
+++ b/execution-engine/contracts/test/get-blocktime/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::value::account::BlockTime;
+use contract_ffi::contract_api;
+use contract_ffi::value::account::BlockTime;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/get-caller-subcall/Cargo.toml
+++ b/execution-engine/contracts/test/get-caller-subcall/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
@@ -2,12 +2,12 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::collections::btree_map::BTreeMap;
 use alloc::prelude::Vec;
-use cl_std::contract_api;
-use cl_std::value::account::PublicKey;
+use contract_ffi::contract_api;
+use contract_ffi::value::account::PublicKey;
 
 #[no_mangle]
 pub extern "C" fn check_caller_ext() {

--- a/execution-engine/contracts/test/get-caller/Cargo.toml
+++ b/execution-engine/contracts/test/get-caller/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/get-caller/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::value::account::PublicKey;
+use contract_ffi::contract_api;
+use contract_ffi::value::account::PublicKey;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/get-phase-payment/Cargo.toml
+++ b/execution-engine/contracts/test/get-phase-payment/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/get-phase-payment/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase-payment/src/lib.rs
@@ -3,14 +3,14 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::pointers::UPointer;
-use cl_std::contract_api::{self, PurseTransferResult};
-use cl_std::execution::Phase;
-use cl_std::key::Key;
-use cl_std::value::account::PurseId;
-use cl_std::value::U512;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::execution::Phase;
+use contract_ffi::key::Key;
+use contract_ffi::value::account::PurseId;
+use contract_ffi::value::U512;
 
 const POS_CONTRACT_NAME: &str = "pos";
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";

--- a/execution-engine/contracts/test/get-phase/Cargo.toml
+++ b/execution-engine/contracts/test/get-phase/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/get-phase/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 #![feature(alloc)]
 
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::execution::Phase;
+use contract_ffi::contract_api;
+use contract_ffi::execution::Phase;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/key-management-thresholds/Cargo.toml
+++ b/execution-engine/contracts/test/key-management-thresholds/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
+++ b/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
@@ -2,15 +2,15 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::String;
 
-use cl_std::contract_api::{
+use contract_ffi::contract_api::{
     add_associated_key, get_arg, remove_associated_key, revert, set_action_threshold,
     update_associated_key,
 };
-use cl_std::value::account::{
+use contract_ffi::value::account::{
     ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
     Weight,
 };

--- a/execution-engine/contracts/test/known-urefs/Cargo.toml
+++ b/execution-engine/contracts/test/known-urefs/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/known-urefs/src/lib.rs
+++ b/execution-engine/contracts/test/known-urefs/src/lib.rs
@@ -2,15 +2,15 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::String;
 
-use cl_std::contract_api::{
+use contract_ffi::contract_api::{
     add, add_uref, get_uref, has_uref, list_known_urefs, new_uref, read, remove_uref, revert, write,
 };
-use cl_std::key::Key;
-use cl_std::value::U512;
+use contract_ffi::key::Key;
+use contract_ffi::value::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/local-state/Cargo.toml
+++ b/execution-engine/contracts/test/local-state/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/local-state/src/lib.rs
+++ b/execution-engine/contracts/test/local-state/src/lib.rs
@@ -2,9 +2,9 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 use alloc::string::{String, ToString};
-use cl_std::contract_api::{read_local, write_local};
+use contract_ffi::contract_api::{read_local, write_local};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/main-purse/Cargo.toml
+++ b/execution-engine/contracts/test/main-purse/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/main-purse/src/lib.rs
+++ b/execution-engine/contracts/test/main-purse/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::value::account::PurseId;
+use contract_ffi::contract_api;
+use contract_ffi::value::account::PurseId;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/pos-bonding/Cargo.toml
+++ b/execution-engine/contracts/test/pos-bonding/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -3,20 +3,20 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::prelude::*;
 
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::contract_api::{
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{
     call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
     transfer_from_purse_to_account, transfer_from_purse_to_purse, PurseTransferResult,
     TransferResult,
 };
-use cl_std::key::Key;
-use cl_std::uref::AccessRights;
-use cl_std::value::account::{PublicKey, PurseId};
-use cl_std::value::U512;
+use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
+use contract_ffi::value::account::{PublicKey, PurseId};
+use contract_ffi::value::U512;
 
 enum Error {
     GetPosOuterURef = 1000,

--- a/execution-engine/contracts/test/pos-finalize-payment/Cargo.toml
+++ b/execution-engine/contracts/test/pos-finalize-payment/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -3,16 +3,16 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::contract_api::{self, PurseTransferResult};
-use cl_std::key::Key;
-use cl_std::uref::AccessRights;
-use cl_std::value::account::{PublicKey, PurseId};
-use cl_std::value::U512;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
+use contract_ffi::value::account::{PublicKey, PurseId};
+use contract_ffi::value::U512;
 
 enum Error {
     GetPosOuterURef = 1,

--- a/execution-engine/contracts/test/pos-get-payment-purse/Cargo.toml
+++ b/execution-engine/contracts/test/pos-get-payment-purse/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -2,16 +2,16 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::contract_api::{self, PurseTransferResult};
-use cl_std::key::Key;
-use cl_std::uref::AccessRights;
-use cl_std::value::account::PurseId;
-use cl_std::value::uint::U512;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
+use contract_ffi::value::account::PurseId;
+use contract_ffi::value::uint::U512;
 
 enum Error {
     GetPosOuterURef = 1,

--- a/execution-engine/contracts/test/pos-refund-purse/Cargo.toml
+++ b/execution-engine/contracts/test/pos-refund-purse/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -3,16 +3,16 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::contract_api::{self, PurseTransferResult};
-use cl_std::key::Key;
-use cl_std::uref::AccessRights;
-use cl_std::value::account::PurseId;
-use cl_std::value::U512;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
+use contract_ffi::value::account::PurseId;
+use contract_ffi::value::U512;
 
 enum Error {
     GetPosOuterURef = 1,

--- a/execution-engine/contracts/test/remove-associated-key/Cargo.toml
+++ b/execution-engine/contracts/test/remove-associated-key/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/remove-associated-key/src/lib.rs
+++ b/execution-engine/contracts/test/remove-associated-key/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::value::account::PublicKey;
+use contract_ffi::contract_api;
+use contract_ffi::value::account::PublicKey;
 
 const REMOVE_FAIL: u32 = 1;
 

--- a/execution-engine/contracts/test/transfer-purse-to-account/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-purse-to-account/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
@@ -3,12 +3,12 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api;
-use cl_std::key::Key;
-use cl_std::value::account::{PublicKey, PurseId};
-use cl_std::value::U512;
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+use contract_ffi::value::account::{PublicKey, PurseId};
+use contract_ffi::value::U512;
 
 const TRANSFER_RESULT_UREF_NAME: &str = "transfer_result";
 const MAIN_PURSE_FINAL_BALANCE_UREF_NAME: &str = "final_balance";

--- a/execution-engine/contracts/test/transfer-purse-to-purse/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
@@ -3,16 +3,16 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::string::String;
-use cl_std::contract_api::{
+use contract_ffi::contract_api::{
     add_uref, create_purse, get_arg, get_balance, get_uref, has_uref, main_purse, new_uref, revert,
     transfer_from_purse_to_purse,
 };
-use cl_std::key::Key;
-use cl_std::value::account::PurseId;
-use cl_std::value::U512;
+use contract_ffi::key::Key;
+use contract_ffi::value::account::PurseId;
+use contract_ffi::value::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/transfer-to-account-01/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-to-account-01/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/transfer-to-account-01/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-to-account-01/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, TransferResult};
-use cl_std::value::U512;
+use contract_ffi::contract_api::{get_arg, TransferResult};
+use contract_ffi::value::U512;
 
 const TRANSFER_AMOUNT: u32 = 1000;
 
@@ -14,7 +14,7 @@ pub extern "C" fn call() {
     let public_key = get_arg(0);
     let amount = U512::from(TRANSFER_AMOUNT);
 
-    let result = cl_std::contract_api::transfer_to_account(public_key, amount);
+    let result = contract_ffi::contract_api::transfer_to_account(public_key, amount);
 
     assert_ne!(result, TransferResult::TransferError);
 }

--- a/execution-engine/contracts/test/transfer-to-account-02/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-to-account-02/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/transfer-to-account-02/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-to-account-02/src/lib.rs
@@ -2,11 +2,11 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::TransferResult;
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
+use contract_ffi::contract_api::TransferResult;
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
 
 const ACCOUNT_2_ADDR: [u8; 32] = [2u8; 32];
 const TRANSFER_AMOUNT: u32 = 750;
@@ -16,7 +16,7 @@ pub extern "C" fn call() {
     let public_key = PublicKey::new(ACCOUNT_2_ADDR);
     let amount = U512::from(TRANSFER_AMOUNT);
 
-    let result = cl_std::contract_api::transfer_to_account(public_key, amount);
+    let result = contract_ffi::contract_api::transfer_to_account(public_key, amount);
 
     assert_ne!(result, TransferResult::TransferError);
 }

--- a/explorer/contracts/faucet/Cargo.toml
+++ b/explorer/contracts/faucet/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/explorer/contracts/faucet/src/lib.rs
+++ b/explorer/contracts/faucet/src/lib.rs
@@ -2,11 +2,11 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, read_local, revert, transfer_to_account, TransferResult, write_local};
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
+use contract_ffi::contract_api::{get_arg, read_local, revert, transfer_to_account, TransferResult, write_local};
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
 
 const TRANSFER_AMOUNT: u32 = 10_000_000;
 

--- a/explorer/contracts/transfer/Cargo.toml
+++ b/explorer/contracts/transfer/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/explorer/contracts/transfer/src/lib.rs
+++ b/explorer/contracts/transfer/src/lib.rs
@@ -2,11 +2,11 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, revert, transfer_to_account, TransferResult};
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
+use contract_ffi::contract_api::{get_arg, revert, transfer_to_account, TransferResult};
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
 
 /// Executes token transfer to supplied public key.
 /// Transfers the requested amount.

--- a/integration-testing/contracts/Cargo.lock
+++ b/integration-testing/contracts/Cargo.lock
@@ -238,6 +238,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pos-bonding"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.12.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/integration-testing/contracts/bonding/call/Cargo.toml
+++ b/integration-testing/contracts/bonding/call/Cargo.toml
@@ -9,4 +9,4 @@ name = "test_bondingcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/bonding/call/src/lib.rs
+++ b/integration-testing/contracts/bonding/call/src/lib.rs
@@ -3,14 +3,14 @@
 
 #[macro_use]
 extern crate alloc;
-//extern crate cl_std;
+//extern crate contract_ffi;
 
-extern crate common;
-use common::contract_api;
-use common::contract_api::pointers::UPointer;
-use common::key::Key;
-use common::value::uint::U512;
-use common::contract_api::{call_contract, PurseTransferResult, get_uref, transfer_from_purse_to_purse, revert};
+extern crate contract_ffi;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::value::uint::U512;
+use contract_ffi::contract_api::{call_contract, PurseTransferResult, get_uref, transfer_from_purse_to_purse, revert};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/combined-contracts/define/Cargo.toml
+++ b/integration-testing/contracts/combined-contracts/define/Cargo.toml
@@ -9,4 +9,4 @@ name = "test_combinedcontractsdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/combined-contracts/define/src/lib.rs
+++ b/integration-testing/contracts/combined-contracts/define/src/lib.rs
@@ -3,16 +3,16 @@
 #[macro_use]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use common::contract_api::*;
-use common::contract_api::pointers::UPointer;
-use common::key::Key;
-use common::uref::URef;
+use contract_ffi::contract_api::*;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::uref::URef;
 
 fn hello_name(name: &str) -> String {
     let mut result = String::from("Hello, ");

--- a/integration-testing/contracts/counter/call/Cargo.toml
+++ b/integration-testing/contracts/counter/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_countercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/counter/call/src/lib.rs
+++ b/integration-testing/contracts/counter/call/src/lib.rs
@@ -4,10 +4,10 @@
 extern crate alloc;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::{call_contract, revert, get_uref};
-use common::contract_api::pointers::ContractPointer;
-use common::key::Key;
+extern crate contract_ffi;
+use contract_ffi::contract_api::{call_contract, revert, get_uref};
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/counter/define/Cargo.toml
+++ b/integration-testing/contracts/counter/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_counterdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/counter/define/src/lib.rs
+++ b/integration-testing/contracts/counter/define/src/lib.rs
@@ -6,10 +6,10 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::*;
-use common::contract_api::pointers::UPointer;
-use common::key::Key;
+extern crate contract_ffi;
+use contract_ffi::contract_api::*;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn counter_ext() {

--- a/integration-testing/contracts/direct-revert-test/call/Cargo.toml
+++ b/integration-testing/contracts/direct-revert-test/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_direct_revert_call"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/direct-revert-test/call/src/lib.rs
+++ b/integration-testing/contracts/direct-revert-test/call/src/lib.rs
@@ -2,8 +2,8 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
-use common::contract_api::revert;
+extern crate contract_ffi;
+use contract_ffi::contract_api::revert;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/direct-revert-test/define/Cargo.toml
+++ b/integration-testing/contracts/direct-revert-test/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_direct_revert_define"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/direct-revert-test/define/src/lib.rs
+++ b/integration-testing/contracts/direct-revert-test/define/src/lib.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-extern crate common;
+extern crate contract_ffi;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/err-transfer-to-account/Cargo.toml
+++ b/integration-testing/contracts/err-transfer-to-account/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/err-transfer-to-account/src/lib.rs
+++ b/integration-testing/contracts/err-transfer-to-account/src/lib.rs
@@ -3,11 +3,11 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
-use cl_std::contract_api::{get_arg, revert, TransferResult};
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
+use contract_ffi::contract_api::{get_arg, revert, TransferResult};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/finalize-payment/Cargo.toml
+++ b/integration-testing/contracts/finalize-payment/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/finalize-payment/src/lib.rs
+++ b/integration-testing/contracts/finalize-payment/src/lib.rs
@@ -3,15 +3,15 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::contract_api::{self, PurseTransferResult};
-use cl_std::key::Key;
-use cl_std::value::account::{PublicKey, PurseId};
-use cl_std::value::U512;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::key::Key;
+use contract_ffi::value::account::{PublicKey, PurseId};
+use contract_ffi::value::U512;
 
 fn purse_to_key(p: &PurseId) -> Key {
     Key::URef(p.value())

--- a/integration-testing/contracts/get-caller/call/Cargo.toml
+++ b/integration-testing/contracts/get-caller/call/Cargo.toml
@@ -8,5 +8,4 @@ name = "getcallercall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/get-caller/call/src/lib.rs
+++ b/integration-testing/contracts/get-caller/call/src/lib.rs
@@ -2,12 +2,12 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
-use common::contract_api::pointers::ContractPointer;
-use common::contract_api::{call_contract, get_uref, revert};
-use common::key::Key;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{call_contract, get_uref, revert};
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/get-caller/define/Cargo.toml
+++ b/integration-testing/contracts/get-caller/define/Cargo.toml
@@ -8,5 +8,4 @@ name = "getcallerdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/get-caller/define/src/lib.rs
+++ b/integration-testing/contracts/get-caller/define/src/lib.rs
@@ -2,11 +2,11 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::collections::btree_map::BTreeMap;
-use common::contract_api::{get_caller, store_function, add_uref};
-use common::value::account::PublicKey;
+use contract_ffi::contract_api::{get_caller, store_function, add_uref};
+use contract_ffi::value::account::PublicKey;
 
 fn test_get_caller() {
     // Assumes that will be called using test framework genesis account with

--- a/integration-testing/contracts/hello-name/call/Cargo.toml
+++ b/integration-testing/contracts/hello-name/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_helloworld"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/hello-name/call/src/lib.rs
+++ b/integration-testing/contracts/hello-name/call/src/lib.rs
@@ -2,14 +2,14 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use common::contract_api::pointers::ContractPointer;
-use common::contract_api::{add_uref, call_contract, get_uref, new_uref, revert};
-use common::key::Key;
-use common::value::Value;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{add_uref, call_contract, get_uref, new_uref, revert};
+use contract_ffi::key::Key;
+use contract_ffi::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/hello-name/define/Cargo.toml
+++ b/integration-testing/contracts/hello-name/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_helloname"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/hello-name/define/src/lib.rs
+++ b/integration-testing/contracts/hello-name/define/src/lib.rs
@@ -6,8 +6,8 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::{add_uref, get_arg, ret, store_function};
+extern crate contract_ffi;
+use contract_ffi::contract_api::{add_uref, get_arg, ret, store_function};
 
 fn hello_name(name: &str) -> String {
     let mut result = String::from("Hello, ");

--- a/integration-testing/contracts/key_management/add_associated_key/Cargo.toml
+++ b/integration-testing/contracts/key_management/add_associated_key/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/key_management/add_associated_key/src/lib.rs
+++ b/integration-testing/contracts/key_management/add_associated_key/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, revert, add_associated_key};
-use cl_std::value::account::{PublicKey, Weight};
+use contract_ffi::contract_api::{get_arg, revert, add_associated_key};
+use contract_ffi::value::account::{PublicKey, Weight};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/key_management/remove_associated_key/Cargo.toml
+++ b/integration-testing/contracts/key_management/remove_associated_key/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/key_management/remove_associated_key/src/lib.rs
+++ b/integration-testing/contracts/key_management/remove_associated_key/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, remove_associated_key, revert};
-use cl_std::value::account::PublicKey;
+use contract_ffi::contract_api::{get_arg, remove_associated_key, revert};
+use contract_ffi::value::account::PublicKey;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/key_management/update_associated_key/Cargo.toml
+++ b/integration-testing/contracts/key_management/update_associated_key/Cargo.toml
@@ -10,8 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/key_management/update_associated_key/src/lib.rs
+++ b/integration-testing/contracts/key_management/update_associated_key/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, revert, update_associated_key};
-use cl_std::value::account::{PublicKey, Weight};
+use contract_ffi::contract_api::{get_arg, revert, update_associated_key};
+use contract_ffi::value::account::{PublicKey, Weight};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/list-known-urefs/call/Cargo.toml
+++ b/integration-testing/contracts/list-known-urefs/call/Cargo.toml
@@ -8,5 +8,4 @@ name = "listknownurefscall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/list-known-urefs/call/src/lib.rs
+++ b/integration-testing/contracts/list-known-urefs/call/src/lib.rs
@@ -2,12 +2,12 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
-use common::contract_api::pointers::ContractPointer;
-use common::contract_api::{call_contract, get_uref, revert};
-use common::key::Key;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{call_contract, get_uref, revert};
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/list-known-urefs/define/Cargo.toml
+++ b/integration-testing/contracts/list-known-urefs/define/Cargo.toml
@@ -8,5 +8,4 @@ name = "listknownurefsdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/list-known-urefs/define/src/lib.rs
+++ b/integration-testing/contracts/list-known-urefs/define/src/lib.rs
@@ -2,14 +2,14 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::borrow::ToOwned;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
-use common::contract_api::{add_uref, get_uref, list_known_urefs, new_uref, store_function, revert};
-use common::key::Key;
-use common::value::Value;
+use contract_ffi::contract_api::{add_uref, get_uref, list_known_urefs, new_uref, store_function, revert};
+use contract_ffi::key::Key;
+use contract_ffi::value::Value;
 use core::iter;
 
 #[no_mangle]

--- a/integration-testing/contracts/mailing-list/call/Cargo.toml
+++ b/integration-testing/contracts/mailing-list/call/Cargo.toml
@@ -8,5 +8,4 @@ name = "test_mailinglistcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/mailing-list/call/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/call/src/lib.rs
@@ -5,10 +5,10 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::pointers::*;
-use common::contract_api::*;
-use common::key::Key;
+extern crate contract_ffi;
+use contract_ffi::contract_api::pointers::*;
+use contract_ffi::contract_api::*;
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/mailing-list/define/Cargo.toml
+++ b/integration-testing/contracts/mailing-list/define/Cargo.toml
@@ -8,5 +8,4 @@ name = "test_mailinglistdefine"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
-
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/mailing-list/define/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/define/src/lib.rs
@@ -7,11 +7,11 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-extern crate common;
-use common::contract_api::*;
-use common::contract_api::pointers::UPointer;
-use common::key::Key;
-use common::uref::URef;
+extern crate contract_ffi;
+use contract_ffi::contract_api::*;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::uref::URef;
 
 fn get_list_key(name: &str) -> UPointer<Vec<String>> {
     get_uref(name).unwrap().to_u_ptr().unwrap()

--- a/integration-testing/contracts/payment-purse/Cargo.toml
+++ b/integration-testing/contracts/payment-purse/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/payment-purse/src/lib.rs
+++ b/integration-testing/contracts/payment-purse/src/lib.rs
@@ -2,15 +2,15 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
-use cl_std::value::account::PublicKey;
-use cl_std::contract_api::pointers::UPointer;
-use cl_std::contract_api::{self, PurseTransferResult};
-use cl_std::key::Key;
-use cl_std::value::account::PurseId;
-use cl_std::value::uint::U512;
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::{self, PurseTransferResult};
+use contract_ffi::key::Key;
+use contract_ffi::value::account::PurseId;
+use contract_ffi::value::uint::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/pos-bonding/Cargo.toml
+++ b/integration-testing/contracts/pos-bonding/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/pos-bonding/src/lib.rs
+++ b/integration-testing/contracts/pos-bonding/src/lib.rs
@@ -3,20 +3,20 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::prelude::*;
 
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::contract_api::{
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{
     call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
     transfer_from_purse_to_account, transfer_from_purse_to_purse, PurseTransferResult,
     TransferResult,
 };
-use cl_std::key::Key;
-use cl_std::uref::AccessRights;
-use cl_std::value::account::{PublicKey, PurseId};
-use cl_std::value::U512;
+use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
+use contract_ffi::value::account::{PublicKey, PurseId};
+use contract_ffi::value::U512;
 
 enum Error {
     GetPosOuterURef = 1000,

--- a/integration-testing/contracts/refund-purse/Cargo.toml
+++ b/integration-testing/contracts/refund-purse/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/refund-purse/src/lib.rs
+++ b/integration-testing/contracts/refund-purse/src/lib.rs
@@ -3,14 +3,14 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use cl_std::contract_api;
-use cl_std::contract_api::pointers::{ContractPointer, UPointer};
-use cl_std::key::Key;
-use cl_std::value::account::PurseId;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::key::Key;
+use contract_ffi::value::account::PurseId;
 
 fn purse_to_key(p: &PurseId) -> Key {
     Key::URef(p.value())

--- a/integration-testing/contracts/set_key_thresholds/Cargo.toml
+++ b/integration-testing/contracts/set_key_thresholds/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std"]
+std = ["contract-ffi/std"]
 
 [dependencies]
-cl_std = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }
+contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/set_key_thresholds/src/lib.rs
+++ b/integration-testing/contracts/set_key_thresholds/src/lib.rs
@@ -2,9 +2,9 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
-use cl_std::contract_api::{get_arg, revert, set_action_threshold};
-use cl_std::value::account::{ActionType, Weight};
+extern crate contract_ffi;
+use contract_ffi::contract_api::{get_arg, revert, set_action_threshold};
+use contract_ffi::value::account::{ActionType, Weight};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/subcall-revert-test/call/Cargo.toml
+++ b/integration-testing/contracts/subcall-revert-test/call/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_subcall_revert_call"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/subcall-revert-test/call/src/lib.rs
+++ b/integration-testing/contracts/subcall-revert-test/call/src/lib.rs
@@ -2,12 +2,12 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use alloc::vec::Vec;
-use common::contract_api::pointers::ContractPointer;
-use common::contract_api::{call_contract, get_uref, revert};
-use common::key::Key;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{call_contract, get_uref, revert};
+use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/subcall-revert-test/define/Cargo.toml
+++ b/integration-testing/contracts/subcall-revert-test/define/Cargo.toml
@@ -8,4 +8,4 @@ name = "test_subcall_revert_define"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/subcall-revert-test/define/src/lib.rs
+++ b/integration-testing/contracts/subcall-revert-test/define/src/lib.rs
@@ -4,8 +4,8 @@
 extern crate alloc;
 use alloc::collections::BTreeMap;
 
-extern crate common;
-use common::contract_api::*;
+extern crate contract_ffi;
+use contract_ffi::contract_api::*;
 
 #[no_mangle]
 pub extern "C" fn revert_test_ext() {

--- a/integration-testing/contracts/test_args/multi/Cargo.toml
+++ b/integration-testing/contracts/test_args/multi/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/test_args/multi/src/lib.rs
+++ b/integration-testing/contracts/test_args/multi/src/lib.rs
@@ -2,9 +2,9 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, revert};
+use contract_ffi::contract_api::{get_arg, revert};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/test_args/u32/Cargo.toml
+++ b/integration-testing/contracts/test_args/u32/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/test_args/u32/src/lib.rs
+++ b/integration-testing/contracts/test_args/u32/src/lib.rs
@@ -2,9 +2,9 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, revert};
+use contract_ffi::contract_api::{get_arg, revert};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/integration-testing/contracts/test_args/u512/Cargo.toml
+++ b/integration-testing/contracts/test_args/u512/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/test_args/u512/src/lib.rs
+++ b/integration-testing/contracts/test_args/u512/src/lib.rs
@@ -2,10 +2,10 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::contract_api::{get_arg, revert};
-use cl_std::value::{U512};
+use contract_ffi::contract_api::{get_arg, revert};
+use contract_ffi::value::{U512};
 
 
 #[no_mangle]

--- a/integration-testing/contracts/transfer_to_account/Cargo.toml
+++ b/integration-testing/contracts/transfer_to_account/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["cl_std/std" ]
+std = ["contract-ffi/std" ]
 
 [dependencies]
-cl_std = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }
+contract-ffi = { path = "../../../execution-engine/contract-ffi", package = "casperlabs-contract-ffi" }

--- a/integration-testing/contracts/transfer_to_account/src/lib.rs
+++ b/integration-testing/contracts/transfer_to_account/src/lib.rs
@@ -3,11 +3,11 @@
 #![feature(alloc, cell_update)]
 
 extern crate alloc;
-extern crate cl_std;
+extern crate contract_ffi;
 
-use cl_std::value::account::PublicKey;
-use cl_std::value::U512;
-use cl_std::contract_api::{get_arg, revert, TransferResult};
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::U512;
+use contract_ffi::contract_api::{get_arg, revert, TransferResult};
 
 #[no_mangle]
 pub extern "C" fn call() {
@@ -17,13 +17,9 @@ pub extern "C" fn call() {
     let public_key = PublicKey::new(account_addr);
     let amount = U512::from(transfer_amount);
 
-    let result = cl_std::contract_api::transfer_to_account(public_key, amount);
+    let result = contract_ffi::contract_api::transfer_to_account(public_key, amount);
 
     if result == TransferResult::TransferError {
         revert(1);
     }
 }
-
-
-
-

--- a/integration-testing/contracts/unbonding/call/Cargo.toml
+++ b/integration-testing/contracts/unbonding/call/Cargo.toml
@@ -9,4 +9,4 @@ name = "test_unbondingcall"
 crate-type = ["cdylib"]
 
 [dependencies]
-common = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/integration-testing/contracts/unbonding/call/src/lib.rs
+++ b/integration-testing/contracts/unbonding/call/src/lib.rs
@@ -4,11 +4,11 @@
 #[macro_use]
 extern crate alloc;
 
-extern crate common;
-use common::contract_api;
-use common::contract_api::pointers::UPointer;
-use common::key::Key;
-use common::value::uint::U512;
+extern crate contract_ffi;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::key::Key;
+use contract_ffi::value::uint::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/long-running-tests/shared/Cargo.toml
+++ b/long-running-tests/shared/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 
 [dependencies]
 binascii = "0.1.2"
-common = { package = "casperlabs-contract-ffi", path = "../../execution-engine/contract-ffi" }
+contract-ffi = {package = "casperlabs-contract-ffi", path = "../../execution-engine/contract-ffi" }

--- a/long-running-tests/shared/src/lib.rs
+++ b/long-running-tests/shared/src/lib.rs
@@ -2,13 +2,13 @@
 #![feature(alloc)]
 
 extern crate alloc;
-extern crate common;
+extern crate contract_ffi;
 
 use binascii::ConvertError;
-use common::contract_api;
-use common::contract_api::TransferResult;
-use common::value::account::PublicKey;
-use common::value::uint::U512;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::TransferResult;
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::uint::U512;
 
 fn parse_public_key(hex: &[u8]) -> Result<PublicKey, ConvertError> {
     let mut buff = [0u8; 32];


### PR DESCRIPTION
### Overview
This changes all `cl_std` and `common` aliases of `casperlabs-contract-ffi` to `contract-ffi` for consistency.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-583

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.