### PR TITLE
NODE-796: Stored contract options in the Scala client

### DIFF
--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
@@ -9,6 +9,7 @@ import cats.effect.{Sync, Timer}
 import cats.implicits._
 import cats.temp.par._
 import io.casperlabs.client.{DeployRuntime, DeployService}
+import io.casperlabs.client.configuration.Contracts
 import io.casperlabs.crypto.Keys
 import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
 import io.casperlabs.crypto.codec.Base64
@@ -62,8 +63,7 @@ object Benchmarks {
         amount: Long
     ): F[Unit] = DeployRuntime.transfer[F](
       nonce = nonce,
-      sessionCode = None,
-      paymentCode = None,
+      contracts = Contracts.empty,
       senderPublicKey = senderPublicKey,
       senderPrivateKey = senderPrivateKey,
       recipientPublicKeyBase64 = recipientPublicKeyBase64,

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -544,6 +544,8 @@ object ProtoUtil {
         ipc.DeployPayload.Payload.StoredContractHash(ipc.StoredContractHash(hash, code.args))
       case Deploy.Code.Contract.Name(name) =>
         ipc.DeployPayload.Payload.StoredContractName(ipc.StoredContractName(name, code.args))
+      case Deploy.Code.Contract.Uref(uref) =>
+        ipc.DeployPayload.Payload.StoredContractUref(ipc.StoredContractURef(uref, code.args))
       case Deploy.Code.Contract.Empty =>
         ipc.DeployPayload.Payload.Empty
     }

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -12,7 +12,7 @@ import guru.nidi.graphviz.engine._
 import io.casperlabs.casper.consensus
 import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.catscontrib.MonadThrowable
-import io.casperlabs.client.configuration.Streaming
+import io.casperlabs.client.configuration.{Contracts, Streaming}
 import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
 import io.casperlabs.crypto.codec.{Base16, Base64}
 import io.casperlabs.crypto.hash.Blake2b256
@@ -25,10 +25,6 @@ import scala.language.higherKinds
 import scala.util.Try
 
 object DeployRuntime {
-
-  val BONDING_WASM_FILE   = "bonding.wasm"
-  val UNBONDING_WASM_FILE = "unbonding.wasm"
-  val TRANSFER_WASM_FILE  = "transfer_to_account.wasm"
 
   def propose[F[_]: Sync: DeployService](
       exit: Boolean = true,
@@ -51,8 +47,7 @@ object DeployRuntime {
   def unbond[F[_]: Sync: DeployService](
       maybeAmount: Option[Long],
       nonce: Long,
-      sessionCode: Option[File],
-      paymentCode: Option[File],
+      contracts: Contracts,
       privateKeyFile: File
   ): F[Unit] = {
     val args: Array[Array[Byte]] = Array(
@@ -61,13 +56,11 @@ object DeployRuntime {
     val argsSer = serializeArgs(args)
 
     for {
-      sessionCode   <- readFileOrDefault[F](sessionCode, UNBONDING_WASM_FILE)
       rawPrivateKey <- readFileAsString[F](privateKeyFile)
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
-            sessionCode = sessionCode,
-            paymentCode = paymentCode,
+            contracts,
             maybeEitherPublicKey = None,
             maybeEitherPrivateKey = rawPrivateKey.asLeft[PrivateKey].some,
             gasPrice = 10L, // gas price is fixed at the moment for 10:1
@@ -79,21 +72,18 @@ object DeployRuntime {
   def bond[F[_]: Sync: DeployService](
       amount: Long,
       nonce: Long,
-      sessionCode: Option[File],
-      paymentCode: Option[File],
+      contracts: Contracts,
       privateKeyFile: File
   ): F[Unit] = {
     val args: Array[Array[Byte]] = Array(serializeLong(amount))
     val argsSer: Array[Byte]     = serializeArgs(args)
 
     for {
-      sessionCode   <- readFileOrDefault[F](sessionCode, BONDING_WASM_FILE)
       rawPrivateKey <- readFileAsString[F](privateKeyFile)
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
-            sessionCode = sessionCode,
-            paymentCode = paymentCode,
+            contracts,
             maybeEitherPublicKey = None,
             maybeEitherPrivateKey = rawPrivateKey.asLeft[PrivateKey].some,
             gasPrice = 10L, // gas price is fixed at the moment for 10:1
@@ -230,8 +220,7 @@ object DeployRuntime {
 
   def transferCLI[F[_]: Sync: DeployService: FilesAPI](
       nonce: Long,
-      sessionCode: Option[File],
-      paymentCode: Option[File],
+      contracts: Contracts,
       privateKeyFile: File,
       recipientPublicKeyBase64: String,
       amount: Long
@@ -252,8 +241,7 @@ object DeployRuntime {
                   )
       _ <- transfer[F](
             nonce,
-            sessionCode,
-            paymentCode,
+            contracts,
             publicKey,
             privateKey,
             recipientPublicKeyBase64,
@@ -263,8 +251,7 @@ object DeployRuntime {
 
   def transfer[F[_]: Sync: DeployService: FilesAPI](
       nonce: Long,
-      sessionCode: Option[File],
-      paymentCode: Option[File],
+      contracts: Contracts,
       senderPublicKey: PublicKey,
       senderPrivateKey: PrivateKey,
       recipientPublicKeyBase64: String,
@@ -279,13 +266,11 @@ object DeployRuntime {
                     s"Failed to parse base64 encoded account: $recipientPublicKeyBase64"
                   )
                 )
-      sessionCode <- readFileOrDefault[F](sessionCode, TRANSFER_WASM_FILE)
-      args        = serializeArgs(Array(serializeArray(account), serializeLong(amount)))
+      args = serializeArgs(Array(serializeArray(account), serializeLong(amount)))
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
-            sessionCode = sessionCode,
-            paymentCode = paymentCode,
+            contracts,
             maybeEitherPublicKey = senderPublicKey.asRight[String].some,
             maybeEitherPrivateKey = senderPrivateKey.asRight[String].some,
             gasPrice = 10L,
@@ -330,12 +315,14 @@ object DeployRuntime {
       from: ByteString,
       nonce: Long,
       gasPrice: Long,
-      sessionCode: Array[Byte],
-      sessionArguments: Array[Byte],
-      paymentCode: Array[Byte]
+      contracts: Contracts,
+      sessionArguments: Array[Byte]
   ): Deploy = {
-    val session     = ByteString.copyFrom(sessionCode)
-    val payment     = ByteString.copyFrom(paymentCode)
+    // EE will use hardcoded execution limit if it [EE] is run with a `--use-payment-code` flag
+    // but node will verify payment code's wasm correctness so we have to send valid wasm anyway
+    // to not fail the session code execution even when EE will use hardcoded limit.
+    val session     = contracts.session
+    val payment     = if (contracts.payment.isEmpty) contracts.session else contracts.payment
     val sessionArgs = ByteString.copyFrom(sessionArguments)
 
     consensus
@@ -351,8 +338,8 @@ object DeployRuntime {
       .withBody(
         consensus.Deploy
           .Body()
-          .withSession(consensus.Deploy.Code().withWasm(session).withArgs(sessionArgs))
-          .withPayment(consensus.Deploy.Code().withWasm(payment))
+          .withSession(consensus.Deploy.Code(contract = session).withArgs(sessionArgs))
+          .withPayment(consensus.Deploy.Code(contract = payment))
       )
       .withHashes
   }
@@ -380,8 +367,7 @@ object DeployRuntime {
   def deployFileProgram[F[_]: Sync: DeployService](
       from: Option[String],
       nonce: Long,
-      sessionCode: Array[Byte],
-      paymentCode: Option[File],
+      contracts: Contracts,
       maybeEitherPublicKey: Option[Either[String, PublicKey]],
       maybeEitherPrivateKey: Option[Either[String, PrivateKey]],
       gasPrice: Long,
@@ -399,11 +385,6 @@ object DeployRuntime {
       either.fold(Ed25519.tryParsePublicKey, _.some)
     } orElse maybePrivateKey.flatMap(Ed25519.tryToPublic)
 
-    // EE will use hardcoded execution limit if it [EE] is run with a `--use-payment-code` flag
-    // but node will verify payment code's wasm correctness so we have to send valid wasm anyway
-    // to not fail the session code execution even when EE will use hardcoded limit.
-    val payment = paymentCode.map(f => Files.readAllBytes(f.toPath)).getOrElse(sessionCode)
-
     val deploy = for {
       accountPublicKey <- Sync[F].fromOption(
                            from
@@ -413,7 +394,7 @@ object DeployRuntime {
                          )
     } yield {
       val deploy =
-        makeDeploy(accountPublicKey, nonce, gasPrice, sessionCode, sessionArgs, payment)
+        makeDeploy(accountPublicKey, nonce, gasPrice, contracts, sessionArgs)
       (maybePrivateKey, maybePublicKey).mapN(deploy.sign) getOrElse deploy
     }
 
@@ -458,24 +439,6 @@ object DeployRuntime {
 
   private def hash[T <: scalapb.GeneratedMessage](data: T): ByteString =
     ByteString.copyFrom(Blake2b256.hash(data.toByteArray))
-
-  // When not provided fallbacks to the contract version packaged with the client.
-  private def readFileOrDefault[F[_]: Sync](
-      file: Option[File],
-      defaultName: String
-  ): F[Array[Byte]] = {
-    def consumeInputStream(is: InputStream): Array[Byte] = {
-      val baos = new ByteArrayOutputStream()
-      IOUtils.copy(is, baos)
-      baos.toByteArray
-    }
-    Sync[F].delay {
-      file
-        .map(f => Files.readAllBytes(f.toPath))
-        .getOrElse(consumeInputStream(getClass.getClassLoader.getResourceAsStream(defaultName)))
-
-    }
-  }
 
   def readFileAsString[F[_]: Sync](file: File): F[String] = Sync[F].delay {
     new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8)

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -26,6 +26,10 @@ import scala.util.Try
 
 object DeployRuntime {
 
+  val BONDING_WASM_FILE   = "bonding.wasm"
+  val UNBONDING_WASM_FILE = "unbonding.wasm"
+  val TRANSFER_WASM_FILE  = "transfer_to_account.wasm"
+
   def propose[F[_]: Sync: DeployService](
       exit: Boolean = true,
       ignoreOutput: Boolean = false
@@ -60,7 +64,7 @@ object DeployRuntime {
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
-            contracts,
+            contracts.withSessionResource(UNBONDING_WASM_FILE),
             maybeEitherPublicKey = None,
             maybeEitherPrivateKey = rawPrivateKey.asLeft[PrivateKey].some,
             gasPrice = 10L, // gas price is fixed at the moment for 10:1
@@ -83,7 +87,7 @@ object DeployRuntime {
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
-            contracts,
+            contracts.withSessionResource(BONDING_WASM_FILE),
             maybeEitherPublicKey = None,
             maybeEitherPrivateKey = rawPrivateKey.asLeft[PrivateKey].some,
             gasPrice = 10L, // gas price is fixed at the moment for 10:1
@@ -270,7 +274,7 @@ object DeployRuntime {
       _ <- deployFileProgram[F](
             from = None,
             nonce = nonce,
-            contracts,
+            contracts.withSessionResource(TRANSFER_WASM_FILE),
             maybeEitherPublicKey = senderPublicKey.asRight[String].some,
             maybeEitherPrivateKey = senderPrivateKey.asRight[String].some,
             gasPrice = 10L,

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -52,43 +52,37 @@ object Main {
       case Unbond(
           amount,
           nonce,
-          contractCode,
-          paymentCode,
+          contracts,
           privateKey
           ) =>
         DeployRuntime.unbond(
           amount,
           nonce,
-          contractCode,
-          paymentCode,
+          contracts,
           privateKey
         )
       case Bond(
           amount,
           nonce,
-          contractCode,
-          paymentCode,
+          contracts,
           privateKey
           ) =>
         DeployRuntime.bond(
           amount,
           nonce,
-          contractCode,
-          paymentCode,
+          contracts,
           privateKey
         )
       case Transfer(
           amount,
           recipientPublicKeyBase64,
           nonce,
-          contractCode,
-          paymentCode,
+          contracts,
           privateKey
           ) =>
         DeployRuntime.transferCLI(
           nonce,
-          contractCode,
-          paymentCode,
+          contracts,
           privateKey,
           recipientPublicKeyBase64,
           amount
@@ -96,8 +90,7 @@ object Main {
       case Deploy(
           from,
           nonce,
-          sessionCode,
-          paymentCode,
+          contracts,
           maybePublicKey,
           maybePrivateKey,
           gasPrice
@@ -105,8 +98,7 @@ object Main {
         DeployRuntime.deployFileProgram(
           from,
           nonce,
-          Files.readAllBytes(sessionCode.toPath),
-          paymentCode,
+          contracts,
           maybePublicKey.map(
             file =>
               new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PublicKey]
@@ -121,8 +113,7 @@ object Main {
           from,
           publicKey,
           nonce,
-          sessionCode,
-          paymentCode,
+          contracts,
           gasPrice,
           deployPath
           ) =>
@@ -146,9 +137,8 @@ object Main {
             baseAccount,
             nonce,
             gasPrice,
-            Files.readAllBytes(sessionCode.toPath),
-            Array.emptyByteArray,
-            Files.readAllBytes(paymentCode.toPath)
+            contracts,
+            Array.emptyByteArray
           )
           _ <- DeployRuntime.writeDeploy(deploy, deployPath)
         } yield ()

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -23,7 +23,9 @@ final case class ContractOptions(
     // Hash of a stored contract.
     hash: Option[String] = None,
     // Name of a stored contract.
-    name: Option[String] = None
+    name: Option[String] = None,
+    // URef of a stored contract.
+    uref: Option[String] = None
 )
 
 /** Encapsulate reading session and payment contracts from disk or resources
@@ -55,17 +57,21 @@ object Contracts {
       val wasm = ByteString.copyFrom(Files.readAllBytes(f.toPath))
       Contract.Wasm(wasm)
     } orElse {
-      opts.hash.map { h =>
-        Contract.Hash(ByteString.copyFrom(Base16.decode(h)))
+      opts.hash.map { x =>
+        Contract.Hash(ByteString.copyFrom(Base16.decode(x)))
       }
     } orElse {
-      opts.name.map { n =>
-        Contract.Name(n)
+      opts.name.map { x =>
+        Contract.Name(x)
       }
     } orElse {
-      opts.resource.map { n =>
+      opts.uref.map { x =>
+        Contract.Uref(ByteString.copyFrom(Base16.decode(x)))
+      }
+    } orElse {
+      opts.resource.map { x =>
         val wasm =
-          ByteString.copyFrom(consumeInputStream(getClass.getClassLoader.getResourceAsStream(n)))
+          ByteString.copyFrom(consumeInputStream(getClass.getClassLoader.getResourceAsStream(x)))
         Contract.Wasm(wasm)
       }
     } getOrElse {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -146,7 +146,7 @@ object Configuration {
           options.unbond.amount.toOption,
           options.unbond.nonce(),
           options.unbond.session.toOption,
-          options.unbond.paymentPath.toOption,
+          options.unbond.payment.toOption,
           options.unbond.privateKey()
         )
       case options.bond =>
@@ -154,7 +154,7 @@ object Configuration {
           options.bond.amount(),
           options.bond.nonce(),
           options.bond.session.toOption,
-          options.bond.paymentPath.toOption,
+          options.bond.payment.toOption,
           options.bond.privateKey()
         )
       case options.transfer =>
@@ -163,7 +163,7 @@ object Configuration {
           options.transfer.targetAccount(),
           options.transfer.nonce(),
           options.transfer.session.toOption,
-          options.transfer.paymentPath.toOption,
+          options.transfer.payment.toOption,
           options.transfer.privateKey()
         )
       case options.visualizeBlocks =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -42,6 +42,13 @@ object Options {
           "Name of the stored contract (associated with the executing account) to be called in the session."
       )
 
+    val sessionUref =
+      opt[String](
+        required = false,
+        descr = "URef of the stored contract to be called in the session; base16 encoded.",
+        validate = hashCheck
+      )
+
     val payment =
       opt[File](
         name = paymentPathName,
@@ -64,11 +71,20 @@ object Options {
           "Name of the stored contract (associated with the executing account) to be called in the payment."
       )
 
+    val paymentUref =
+      opt[String](
+        required = false,
+        descr = "URef of the stored contract to be called in the payment; base16 encoded.",
+        validate = hashCheck
+      )
+
     addValidation {
       val sessionsProvided =
-        List(session.isDefined, sessionHash.isDefined, sessionName.isDefined).count(identity)
+        List(session.isDefined, sessionHash.isDefined, sessionName.isDefined, sessionUref.isDefined)
+          .count(identity)
       val paymentsProvided =
-        List(payment.isDefined, paymentHash.isDefined, paymentName.isDefined).count(identity)
+        List(payment.isDefined, paymentHash.isDefined, paymentName.isDefined, paymentUref.isDefined)
+          .count(identity)
       if (sessionRequired && sessionsProvided == 0)
         Left("No session contract options provided; please specify exactly one.")
       else if (sessionsProvided > 1)

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -511,7 +511,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         name = "key",
         descr = "Base16 encoding of the base key.",
         required = true,
-        validate = hashCheck
+        validate = hexCheck
       )
 
     val path =

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -11,7 +11,7 @@ import org.rogach.scallop._
 
 object Options {
   val hexCheck: String => Boolean  = _.matches("[0-9a-fA-F]+")
-  val hashCheck: String => Boolean = x => hexCheck(x) && x.length == 32
+  val hashCheck: String => Boolean = x => hexCheck(x) && x.length == 64
 
   val fileCheck: File => Boolean = file =>
     file.exists() && file.canRead && !file.isDirectory && file.isFile

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -65,6 +65,8 @@ message Deploy {
             bytes hash = 3;
             // Name of a stored contract associated with the executing account (uref or hash).
             string name = 4;
+            // URef of a stored contract.
+            bytes uref = 5;
         }
         bytes args = 2; // ABI-encoded arguments
     }


### PR DESCRIPTION
### Overview
Cut down code repetition in the client's way of passing session code and payment code.
Add support for `hash`, `name` and `uref` types of stored contracts to `deploy`, `make-deploy`, `bond`, `unbond` and `transfer`. For example:

```
Subcommand: deploy - Constructs a Deploy and sends it ...
  ...
  -p, --payment  <arg>        Path to the file with payment code.
      --payment-hash  <arg>   Hash of the stored contract to be called in the
                              payment; base16 encoded.
      --payment-name  <arg>   Name of the stored contract (associated with the
                              executing account) to be called in the payment.
      --payment-uref  <arg>   URef of the stored contract to be called in the
                              payment; base16 encoded.
      --private-key  <arg>    Path to the file with account private key
                              (Ed25519)
      --public-key  <arg>     Path to the file with account public key (Ed25519)
  -s, --session  <arg>        Path to the file with session code.
      --session-hash  <arg>   Hash of the stored contract to be called in the
                              session; base16 encoded.
      --session-name  <arg>   Name of the stored contract (associated with the
                              executing account) to be called in the session.
      --session-uref  <arg>   URef of the stored contract to be called in the
                              session; base16 encoded.
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-796

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Added URef in this PR since https://github.com/CasperLabs/CasperLabs/pull/1003 has already been merged.
