### PR TITLE
OP-608: fix drone links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 * [Sign your commits](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4390963/Signing+Commits)
 * [Code Review Process](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4161628/Code+Review+Process)
 * [Github Workflow](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/4128974/Github+Forking+Workflows)
-* We use [Drone CI](http://drone.casperlabs.io/) for unit testing. We require passage of unit tests to merge PRs. To start this automated testing in a PR, please assure you have an account with Travis based on your GitHub account.
+* We use [Drone CI](https://drone-auto.casperlabs.io/) for unit testing. We require passage of unit tests to merge PRs. To start this automated testing in a PR, please assure you have an account with Travis based on your GitHub account.
 * Information about setting up your development environment and the structure of the CasperLabs GitHub repository is available in [CasperLabs/README.md](https://github.com/CasperLabs/CasperLabs/blob/master/README.md).
 
 If you're picking up someone else's pull request, then whatever you

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -9,7 +9,7 @@ _Add the link here. Create a ticket and link it here if one does not exist._
 - [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
 - [ ] If this PR adds a new feature, it includes tests related to this feature.
 - [ ] You assigned one person to review this PR.
-- [ ] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.
+- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
 
 ### Notes
 _Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._


### PR DESCRIPTION
### Overview
Updates links to point to autoscaler

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-608

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](http://drone.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
