### PR TITLE
NODE-764: Block processing timing metrics.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -51,7 +51,7 @@ final case class CasperState(
     equivocationsTracker: Set[EquivocationRecord] = Set.empty[EquivocationRecord]
 )
 
-class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: deploybuffer.DeployBuffer: Validation](
+class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: deploybuffer.DeployBuffer: Validation](
     statelessExecutor: MultiParentCasperImpl.StatelessExecutor[F],
     broadcaster: MultiParentCasperImpl.Broadcaster[F],
     validatorId: Option[ValidatorIdentity],
@@ -64,7 +64,8 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
 
   import MultiParentCasperImpl._
 
-  private implicit val logSource: LogSource = LogSource(this.getClass)
+  implicit val logSource     = LogSource(this.getClass)
+  implicit val metricsSource = CasperMetricsSource
 
   //TODO pull out
   implicit val functorRaiseInvalidBlock = validation.raiseValidateErrorThroughApplicativeError[F]
@@ -84,41 +85,40 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
     ) =
       Resource
         .make(blockProcessingLock.acquire)(_ => blockProcessingLock.release)
-        .use(
-          _ =>
-            for {
-              dag       <- dag
-              blockHash = block.blockHash
-              inDag     <- dag.contains(blockHash)
-              inBuffer <- Cell[F, CasperState].read
-                           .map(casperState => casperState.blockBuffer.contains(blockHash))
-              attempts <- if (inDag) {
-                           Log[F]
-                             .info(
-                               s"Block ${PrettyPrinter.buildString(blockHash)} has already been processed by another thread."
-                             ) *>
-                             List(block -> BlockStatus.processed).pure[F]
-                         } else if (inBuffer) {
-                           // Waiting for dependencies to become available.
-                           Log[F]
-                             .info(
-                               s"Block ${PrettyPrinter.buildString(blockHash)} is already in the buffer."
-                             ) *>
-                             List(block -> BlockStatus.processing).pure[F]
-                         } else {
-                           // This might be the first time we see this block, or it may not have been added to the state
-                           // because it was an IgnorableEquivocation, but then we saw a child and now we got it again.
-                           internalAddBlock(block, dag, validateAndAddBlock)
-                         }
-              // This method could just return the block hashes it created,
-              // but for now it does gossiping as well. The methods return the full blocks
-              // because for missing blocks it's not yet saved to the database.
-              _ <- attempts.traverse {
-                    case (attemptedBlock, status) =>
-                      broadcaster.networkEffects(attemptedBlock, status)
-                  }
-            } yield attempts.head._2
-        )
+        .use { _ =>
+          for {
+            dag       <- dag
+            blockHash = block.blockHash
+            inDag     <- dag.contains(blockHash)
+            inBuffer <- Cell[F, CasperState].read
+                         .map(casperState => casperState.blockBuffer.contains(blockHash))
+            attempts <- if (inDag) {
+                         Log[F]
+                           .info(
+                             s"Block ${PrettyPrinter.buildString(blockHash)} has already been processed by another thread."
+                           ) *>
+                           List(block -> BlockStatus.processed).pure[F]
+                       } else if (inBuffer) {
+                         // Waiting for dependencies to become available.
+                         Log[F]
+                           .info(
+                             s"Block ${PrettyPrinter.buildString(blockHash)} is already in the buffer."
+                           ) *>
+                           List(block -> BlockStatus.processing).pure[F]
+                       } else {
+                         // This might be the first time we see this block, or it may not have been added to the state
+                         // because it was an IgnorableEquivocation, but then we saw a child and now we got it again.
+                         internalAddBlock(block, dag, validateAndAddBlock)
+                       }
+            // This method could just return the block hashes it created,
+            // but for now it does gossiping as well. The methods return the full blocks
+            // because for missing blocks it's not yet saved to the database.
+            _ <- attempts.traverse {
+                  case (attemptedBlock, status) =>
+                    broadcaster.networkEffects(attemptedBlock, status)
+                }
+          } yield attempts.head._2
+        }
 
     val handleInvalidTimestamp =
       (_: Option[StatelessExecutor.Context], dag: DagRepresentation[F], block: Block) =>
@@ -150,7 +150,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
           DagRepresentation[F],
           Block
       ) => F[(BlockStatus, DagRepresentation[F])]
-  ): F[List[(Block, BlockStatus)]] =
+  ): F[List[(Block, BlockStatus)]] = Metrics[F].timer("addBlock") {
     for {
       lastFinalizedBlockHash <- LastFinalizedBlockHashContainer[F].get
       (status, updatedDag) <- validateAndAddBlock(
@@ -184,58 +184,62 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       // Remove any deploys from the buffer which are in finalized blocks.
       _ <- removeFinalizedDeploys(updatedDag)
     } yield (block, status) :: furtherAttempts
-
-  private def updateLastFinalizedBlock(dag: DagRepresentation[F]): F[Unit] = {
-
-    /** Go from the last finalized block and visit all children that can be finalized now.
-      * Remove all of the deploys that are in any of them as they won't have to be attempted again. */
-    def loop(acc: BlockHash): F[BlockHash] =
-      for {
-        childrenHashes <- dag
-                           .children(acc)
-                           .map(_.toList)
-        finalizedChildren <- childrenHashes.filterA(isGreaterThanFaultToleranceThreshold(dag, _))
-        newFinalizedBlock <- if (finalizedChildren.isEmpty) {
-                              acc.pure[F]
-                            } else {
-                              finalizedChildren.traverse(loop).map(_.head)
-                            }
-      } yield newFinalizedBlock
-
-    for {
-      lastFinalizedBlockHash        <- LastFinalizedBlockHashContainer[F].get
-      updatedLastFinalizedBlockHash <- loop(lastFinalizedBlockHash)
-      _                             <- LastFinalizedBlockHashContainer[F].set(updatedLastFinalizedBlockHash)
-      _ <- Log[F].info(
-            s"New last finalized block hash is ${PrettyPrinter.buildString(updatedLastFinalizedBlockHash)}."
-          )
-    } yield ()
   }
+
+  private def updateLastFinalizedBlock(dag: DagRepresentation[F]): F[Unit] =
+    Metrics[F].timer("updateLastFinalizedBlock") {
+
+      /** Go from the last finalized block and visit all children that can be finalized now.
+        * Remove all of the deploys that are in any of them as they won't have to be attempted again. */
+      def loop(acc: BlockHash): F[BlockHash] =
+        for {
+          childrenHashes <- dag
+                             .children(acc)
+                             .map(_.toList)
+          finalizedChildren <- childrenHashes.filterA(isGreaterThanFaultToleranceThreshold(dag, _))
+          newFinalizedBlock <- if (finalizedChildren.isEmpty) {
+                                acc.pure[F]
+                              } else {
+                                finalizedChildren.traverse(loop).map(_.head)
+                              }
+        } yield newFinalizedBlock
+
+      for {
+        lastFinalizedBlockHash        <- LastFinalizedBlockHashContainer[F].get
+        updatedLastFinalizedBlockHash <- loop(lastFinalizedBlockHash)
+        _                             <- LastFinalizedBlockHashContainer[F].set(updatedLastFinalizedBlockHash)
+        _ <- Log[F].info(
+              s"New last finalized block hash is ${PrettyPrinter.buildString(updatedLastFinalizedBlockHash)}."
+            )
+      } yield ()
+    }
 
   /** Remove deploys from the buffer which are included in block that are finalized. */
   private def removeFinalizedDeploys(dag: DagRepresentation[F]): F[Unit] =
-    for {
-      deployHashes <- DeployBuffer[F].readProcessedHashes
-      blockHashes <- deployHashes
-                      .traverse { deployHash =>
-                        BlockStorage[F]
-                          .findBlockHashesWithDeployhash(deployHash)
-                      }
-                      .map(_.flatten.distinct)
+    Metrics[F].timer("removeFinalizedDeploys") {
+      for {
+        deployHashes <- DeployBuffer[F].readProcessedHashes
+        blockHashes <- deployHashes
+                        .traverse { deployHash =>
+                          BlockStorage[F]
+                            .findBlockHashesWithDeployhash(deployHash)
+                        }
+                        .map(_.flatten.distinct)
 
-      finalizedBlockHashes <- blockHashes.filterA(isFinalized(dag, _))
+        finalizedBlockHashes <- blockHashes.filterA(isFinalized(dag, _))
 
-      _ <- finalizedBlockHashes.traverse { blockHash =>
-            removeDeploysInBlock(blockHash) flatMap { removed =>
-              Log[F]
-                .info(
-                  s"Removed $removed deploys from deploy history as we finalized block ${PrettyPrinter
-                    .buildString(blockHash)}"
-                )
-                .whenA(removed > 0L)
+        _ <- finalizedBlockHashes.traverse { blockHash =>
+              removeDeploysInBlock(blockHash) flatMap { removed =>
+                Log[F]
+                  .info(
+                    s"Removed $removed deploys from deploy history as we finalized block ${PrettyPrinter
+                      .buildString(blockHash)}"
+                  )
+                  .whenA(removed > 0L)
+              }
             }
-          }
-    } yield ()
+      } yield ()
+    }
 
   // CON-86 will implement a 2nd pass that will calculate the threshold for secondary parents;
   // right now the FinalityDetector only works for main parents. When it's fixed remove this part.
@@ -344,7 +348,9 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
 
   /** Return the list of tips. */
   def estimator(dag: DagRepresentation[F]): F[IndexedSeq[BlockHash]] =
-    Estimator.tips[F](dag, genesis.blockHash)
+    Metrics[F].timer("estimator") {
+      Estimator.tips[F](dag, genesis.blockHash)
+    }
 
   /*
    * Logic:
@@ -361,44 +367,46 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
    */
   def createBlock: F[CreateBlockStatus] = validatorId match {
     case Some(ValidatorIdentity(publicKey, privateKey, sigAlgorithm)) =>
-      for {
-        dag       <- dag
-        tipHashes <- estimator(dag).map(_.toVector)
-        tips      <- tipHashes.traverse(ProtoUtil.unsafeGetBlock[F])
-        merged    <- ExecEngineUtil.merge[F](tips, dag)
-        parents   = merged.parents
-        _ <- Log[F].info(
-              s"${parents.size} parents out of ${tipHashes.size} latest blocks will be used."
-            )
-        remaining        <- remainingDeploys(dag, parents)
-        bondedValidators = bonds(parents.head).map(_.validatorPublicKey).toSet
-        //We ensure that only the justifications given in the block are those
-        //which are bonded validators in the chosen parent. This is safe because
-        //any latest message not from a bonded validator will not change the
-        //final fork-choice.
-        latestMessages   <- dag.latestMessages
-        bondedLatestMsgs = latestMessages.filter { case (v, _) => bondedValidators.contains(v) }
-        justifications   = toJustification(bondedLatestMsgs)
-        rank             = ProtoUtil.calculateRank(bondedLatestMsgs.values.toSeq)
-        protocolVersion  = CasperLabsProtocolVersions.thresholdsVersionMap.versionAt(rank)
-        proposal <- if (remaining.nonEmpty || parents.length > 1) {
-                     createProposal(
-                       parents,
-                       merged,
-                       remaining,
-                       justifications,
-                       protocolVersion
-                     )
-                   } else {
-                     CreateBlockStatus.noNewDeploys.pure[F]
-                   }
-        signedBlock <- proposal match {
-                        case Created(block) =>
-                          signBlock[F](block, dag, publicKey, privateKey, sigAlgorithm)
-                            .map(Created.apply(_): CreateBlockStatus)
-                        case _ => proposal.pure[F]
-                      }
-      } yield signedBlock
+      Metrics[F].timer("createBlock") {
+        for {
+          dag       <- dag
+          tipHashes <- estimator(dag).map(_.toVector)
+          tips      <- tipHashes.traverse(ProtoUtil.unsafeGetBlock[F])
+          merged    <- ExecEngineUtil.merge[F](tips, dag)
+          parents   = merged.parents
+          _ <- Log[F].info(
+                s"${parents.size} parents out of ${tipHashes.size} latest blocks will be used."
+              )
+          remaining        <- remainingDeploys(dag, parents)
+          bondedValidators = bonds(parents.head).map(_.validatorPublicKey).toSet
+          //We ensure that only the justifications given in the block are those
+          //which are bonded validators in the chosen parent. This is safe because
+          //any latest message not from a bonded validator will not change the
+          //final fork-choice.
+          latestMessages   <- dag.latestMessages
+          bondedLatestMsgs = latestMessages.filter { case (v, _) => bondedValidators.contains(v) }
+          justifications   = toJustification(bondedLatestMsgs)
+          rank             = ProtoUtil.calculateRank(bondedLatestMsgs.values.toSeq)
+          protocolVersion  = CasperLabsProtocolVersions.thresholdsVersionMap.versionAt(rank)
+          proposal <- if (remaining.nonEmpty || parents.length > 1) {
+                       createProposal(
+                         parents,
+                         merged,
+                         remaining,
+                         justifications,
+                         protocolVersion
+                       )
+                     } else {
+                       CreateBlockStatus.noNewDeploys.pure[F]
+                     }
+          signedBlock <- proposal match {
+                          case Created(block) =>
+                            signBlock[F](block, dag, publicKey, privateKey, sigAlgorithm)
+                              .map(Created.apply(_): CreateBlockStatus)
+                          case _ => proposal.pure[F]
+                        }
+        } yield signedBlock
+      }
     case None => CreateBlockStatus.readOnlyMode.pure[F]
   }
 
@@ -412,7 +420,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
   private def remainingDeploys(
       dag: DagRepresentation[F],
       parents: Seq[Block]
-  ): F[Seq[Deploy]] =
+  ): F[Seq[Deploy]] = Metrics[F].timer("remainingDeploys") {
     for {
       // We have re-queued orphan deploys already, so we can just look at pending ones.
       pendingDeployHashes <- DeployBuffer[F].readPendingHashes
@@ -436,6 +444,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
                       }.toSeq
                     }
     } yield remaining
+  }
 
   /** If another node proposed a block which orphaned something proposed by this node,
     * and we still have these deploys in the `processedDeploys` buffer then put them
@@ -444,7 +453,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
   private def requeueOrphanedDeploys(
       dag: DagRepresentation[F],
       tipHashes: IndexedSeq[BlockHash]
-  ): F[Int] =
+  ): F[Int] = Metrics[F].timer("requeueOrphanedDeploys") {
     for {
       // We actually need the tips which can be merged, the ones which we'd build on if we
       // attempted to create a new block.
@@ -456,6 +465,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       orphanedDeploys  <- filterDeploysNotInPast(dag, parents, processedDeploys)
       _                <- DeployBuffer[F].markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
     } yield orphanedDeploys.size
+  }
 
   /** Find deploys which either haven't been processed yet or are in blocks which are
     * not in the past cone of the chosen parents.
@@ -501,7 +511,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       deploys: Seq[Deploy],
       justifications: Seq[Justification],
       protocolVersion: ProtocolVersion
-  ): F[CreateBlockStatus] =
+  ): F[CreateBlockStatus] = Metrics[F].timer("createProposal") {
     (for {
       now <- Time[F].currentMillis
       result <- ExecEngineUtil
@@ -562,7 +572,8 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
       // turns up again for some reason, we'll treat it again as a pending deploy and try to include it.
       // At that point the EE will discard it as the nonce is in the past and we'll drop it here.
 
-      _ <- DeployBuffer[F].markAsDiscarded(deploysToDiscard.toList.map(_.deploy)) whenA deploysToDiscard.nonEmpty
+      _ <- DeployBuffer[F]
+            .markAsDiscarded(deploysToDiscard.toList.map(_.deploy)) whenA deploysToDiscard.nonEmpty
     } yield status)
       .handleErrorWith {
         case ex @ SmartContractEngineError(error_msg) =>
@@ -574,6 +585,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
             .error(s"Critical error encountered while processing deploys: ${ex.getMessage}", ex)
             .as(CreateBlockStatus.internalDeployError(ex))
       }
+  }
 
   // MultiParentCasper Exposes the block DAG to those who need it.
   def dag: F[DagRepresentation[F]] =
@@ -670,7 +682,7 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Time: FinalityD
 
 object MultiParentCasperImpl {
 
-  def create[F[_]: Sync: Log: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation: Cell[
+  def create[F[_]: Sync: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation: Cell[
     ?[_],
     CasperState
   ]](
@@ -702,6 +714,7 @@ object MultiParentCasperImpl {
   ) {
     //TODO pull out
     implicit val functorRaiseInvalidBlock = validation.raiseValidateErrorThroughApplicativeError[F]
+    implicit val metricsSource            = CasperMetricsSource
 
     /* Execute the block to get the effects then do some more validation.
      * Save the block if everything checks out.
@@ -711,95 +724,96 @@ object MultiParentCasperImpl {
         maybeContext: Option[StatelessExecutor.Context],
         dag: DagRepresentation[F],
         block: Block
-    )(implicit state: Cell[F, CasperState]): F[(BlockStatus, DagRepresentation[F])] = {
-      val validationStatus = (for {
-        _ <- Log[F].info(
-              s"Attempting to add ${PrettyPrinter.buildString(block)} to the DAG."
-            )
-        hashPrefix = PrettyPrinter.buildString(block.blockHash)
-        _ <- Validation[F].blockFull(
-              block,
-              dag,
-              chainId,
-              maybeContext.map(_.genesis)
-            )
-        casperState <- Cell[F, CasperState].read
-        // Confirm the parents are correct (including checking they commute) and capture
-        // the effect needed to compute the correct pre-state as well.
-        _ <- Log[F].debug(s"Validating the parents of $hashPrefix")
-        merged <- maybeContext.fold(
-                   ExecEngineUtil.MergeResult
-                     .empty[ExecEngineUtil.TransformMap, Block]
-                     .pure[F]
-                 ) { ctx =>
-                   Validation[F]
-                     .parents(block, ctx.genesis.blockHash, dag)
-                 }
-        _            <- Log[F].debug(s"Computing the pre-state hash of $hashPrefix")
-        preStateHash <- ExecEngineUtil.computePrestate[F](merged)
-        _            <- Log[F].debug(s"Computing the effects for $hashPrefix")
-        blockEffects <- ExecEngineUtil
-                         .effectsForBlock[F](block, preStateHash)
-                         .recoverWith {
-                           case NonFatal(ex) =>
-                             Log[F].error(
-                               s"Could not calculate effects for block ${PrettyPrinter
-                                 .buildString(block)}: $ex",
-                               ex
-                             ) *>
-                               FunctorRaise[F, InvalidBlock].raise(InvalidTransaction)
-                         }
-        gasSpent = block.getBody.deploys.foldLeft(0L) { case (acc, next) => acc + next.cost }
-        _ <- Metrics[F]
-              .incrementCounter("gas_spent", gasSpent)(CasperMetricsSource)
-        _ <- Log[F].debug(s"Validating the transactions in $hashPrefix")
-        _ <- Validation[F].transactions(
-              block,
-              preStateHash,
-              blockEffects
-            )
-        _ <- maybeContext.fold(().pure[F]) { ctx =>
-              EquivocationDetector
-                .checkNeglectedEquivocationsWithUpdate[F](
-                  block,
-                  ctx.genesis
-                )
-            }
-        _ <- Log[F].debug(s"Validating neglection for $hashPrefix")
-        _ <- Validation[F]
-              .neglectedInvalidBlock(
-                block,
-                casperState.invalidBlockTracker
+    )(implicit state: Cell[F, CasperState]): F[(BlockStatus, DagRepresentation[F])] =
+      Metrics[F].timer("validateAndAddBlock") {
+        val validationStatus = (for {
+          _ <- Log[F].info(
+                s"Attempting to add ${PrettyPrinter.buildString(block)} to the DAG."
               )
-        _ <- Log[F].debug(s"Checking equivocation for $hashPrefix")
-        _ <- EquivocationDetector.checkEquivocations[F](casperState.dependencyDag, block, dag)
-        _ <- Log[F].debug(s"Block effects calculated for $hashPrefix")
-      } yield blockEffects).attempt
-
-      validationStatus.flatMap {
-        case Right(effects) =>
-          addEffects(Valid, block, effects, dag).tupleLeft(Valid)
-
-        case Left(DropErrorWrapper(invalid)) =>
-          // These exceptions are coming from the validation checks that used to happen outside attemptAdd,
-          // the ones that returned boolean values.
-          (invalid: BlockStatus, dag).pure[F]
-
-        case Left(ValidateErrorWrapper(invalid)) =>
-          addEffects(invalid, block, Seq.empty, dag)
-            .tupleLeft(invalid)
-
-        case Left(unexpected) =>
-          for {
-            _ <- Log[F].error(
-                  s"Unexpected exception during validation of the block ${PrettyPrinter
-                    .buildString(block.blockHash)}",
-                  unexpected
+          hashPrefix = PrettyPrinter.buildString(block.blockHash)
+          _ <- Validation[F].blockFull(
+                block,
+                dag,
+                chainId,
+                maybeContext.map(_.genesis)
+              )
+          casperState <- Cell[F, CasperState].read
+          // Confirm the parents are correct (including checking they commute) and capture
+          // the effect needed to compute the correct pre-state as well.
+          _ <- Log[F].debug(s"Validating the parents of $hashPrefix")
+          merged <- maybeContext.fold(
+                     ExecEngineUtil.MergeResult
+                       .empty[ExecEngineUtil.TransformMap, Block]
+                       .pure[F]
+                   ) { ctx =>
+                     Validation[F]
+                       .parents(block, ctx.genesis.blockHash, dag)
+                   }
+          _            <- Log[F].debug(s"Computing the pre-state hash of $hashPrefix")
+          preStateHash <- ExecEngineUtil.computePrestate[F](merged)
+          _            <- Log[F].debug(s"Computing the effects for $hashPrefix")
+          blockEffects <- ExecEngineUtil
+                           .effectsForBlock[F](block, preStateHash)
+                           .recoverWith {
+                             case NonFatal(ex) =>
+                               Log[F].error(
+                                 s"Could not calculate effects for block ${PrettyPrinter
+                                   .buildString(block)}: $ex",
+                                 ex
+                               ) *>
+                                 FunctorRaise[F, InvalidBlock].raise(InvalidTransaction)
+                           }
+          gasSpent = block.getBody.deploys.foldLeft(0L) { case (acc, next) => acc + next.cost }
+          _ <- Metrics[F]
+                .incrementCounter("gas_spent", gasSpent)
+          _ <- Log[F].debug(s"Validating the transactions in $hashPrefix")
+          _ <- Validation[F].transactions(
+                block,
+                preStateHash,
+                blockEffects
+              )
+          _ <- maybeContext.fold(().pure[F]) { ctx =>
+                EquivocationDetector
+                  .checkNeglectedEquivocationsWithUpdate[F](
+                    block,
+                    ctx.genesis
+                  )
+              }
+          _ <- Log[F].debug(s"Validating neglection for $hashPrefix")
+          _ <- Validation[F]
+                .neglectedInvalidBlock(
+                  block,
+                  casperState.invalidBlockTracker
                 )
-            _ <- unexpected.raiseError[F, BlockStatus]
-          } yield (UnexpectedBlockException(unexpected), dag)
+          _ <- Log[F].debug(s"Checking equivocation for $hashPrefix")
+          _ <- EquivocationDetector.checkEquivocations[F](casperState.dependencyDag, block, dag)
+          _ <- Log[F].debug(s"Block effects calculated for $hashPrefix")
+        } yield blockEffects).attempt
+
+        validationStatus.flatMap {
+          case Right(effects) =>
+            addEffects(Valid, block, effects, dag).tupleLeft(Valid)
+
+          case Left(DropErrorWrapper(invalid)) =>
+            // These exceptions are coming from the validation checks that used to happen outside attemptAdd,
+            // the ones that returned boolean values.
+            (invalid: BlockStatus, dag).pure[F]
+
+          case Left(ValidateErrorWrapper(invalid)) =>
+            addEffects(invalid, block, Seq.empty, dag)
+              .tupleLeft(invalid)
+
+          case Left(unexpected) =>
+            for {
+              _ <- Log[F].error(
+                    s"Unexpected exception during validation of the block ${PrettyPrinter
+                      .buildString(block.blockHash)}",
+                    unexpected
+                  )
+              _ <- unexpected.raiseError[F, BlockStatus]
+            } yield (UnexpectedBlockException(unexpected), dag)
+        }
       }
-    }
 
     // TODO: Handle slashing
     /** Either store the block with its transformation,
@@ -932,8 +946,10 @@ object MultiParentCasperImpl {
   object StatelessExecutor {
     case class Context(genesis: Block, lastFinalizedBlockHash: BlockHash)
 
-    def establishMetrics[F[_]: Metrics]: F[Unit] =
-      Metrics[F].incrementCounter("gas_spent", 0L)(CasperMetricsSource)
+    def establishMetrics[F[_]: Metrics]: F[Unit] = {
+      implicit val src = CasperMetricsSource
+      Metrics[F].incrementCounter("gas_spent", 0L)
+    }
 
     def create[F[_]: MonadThrowable: Time: Log: BlockStorage: DagStorage: ExecutionEngineService: Metrics: DeployBuffer: Validation: FinalityDetector: LastFinalizedBlockHashContainer](
         chainId: String


### PR DESCRIPTION
### Overview
Adds timers for most of the methods that participate in block processing.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-764

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
The following metrics were added:
```
# TYPE casperlabs_casper_createProposal_seconds histogram
# TYPE casperlabs_casper_estimator_seconds histogram
# TYPE casperlabs_casper_createBlock_seconds histogram
# TYPE casperlabs_casper_validateAndAddBlock_seconds histogram
# TYPE casperlabs_casper_updateLastFinalizedBlock_seconds histogram
# TYPE casperlabs_casper_remainingDeploys_seconds histogram
# TYPE casperlabs_casper_removeFinalizedDeploys_seconds histogram
# TYPE casperlabs_casper_requeueOrphanedDeploys_seconds histogram
# TYPE casperlabs_casper_addBlock_seconds histogram
```

