### PR TITLE
EE-633: introduce ProtocolDataStore

### DIFF
--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -10,13 +10,13 @@ use engine_shared::transform::Transform;
 use crate::error::{self, in_memory};
 use crate::global_state::StateReader;
 use crate::global_state::{commit, CommitResult, History};
+use crate::store::Store;
 use crate::transaction_source::in_memory::{InMemoryEnvironment, InMemoryReadTransaction};
 use crate::transaction_source::{Transaction, TransactionSource};
 use crate::trie::operations::create_hashed_empty_trie;
 use crate::trie::Trie;
 use crate::trie_store::in_memory::InMemoryTrieStore;
 use crate::trie_store::operations::{read, write, ReadResult, WriteResult};
-use crate::trie_store::TrieStore;
 
 /// Represents a "view" of global state at a particular root hash.
 pub struct InMemoryGlobalState {

--- a/execution-engine/engine-storage/src/global_state/lmdb.rs
+++ b/execution-engine/engine-storage/src/global_state/lmdb.rs
@@ -12,13 +12,13 @@ use engine_shared::transform::Transform;
 use crate::error;
 use crate::global_state::StateReader;
 use crate::global_state::{commit, CommitResult, History};
+use crate::store::Store;
 use crate::transaction_source::lmdb::LmdbEnvironment;
 use crate::transaction_source::{Transaction, TransactionSource};
 use crate::trie::operations::create_hashed_empty_trie;
 use crate::trie::Trie;
 use crate::trie_store::lmdb::LmdbTrieStore;
 use crate::trie_store::operations::{read, ReadResult};
-use crate::trie_store::TrieStore;
 
 /// Represents a "view" of global state at a particular root hash.
 pub struct LmdbGlobalState {

--- a/execution-engine/engine-storage/src/lib.rs
+++ b/execution-engine/engine-storage/src/lib.rs
@@ -1,15 +1,19 @@
 #![feature(never_type, result_map_or_else)]
 
-#[cfg(test)]
-use lazy_static::lazy_static;
-
 // modules
 pub mod error;
 pub mod global_state;
 pub mod protocol_data;
+pub mod protocol_data_store;
+pub mod store;
 pub mod transaction_source;
 pub mod trie;
 pub mod trie_store;
+
+#[cfg(test)]
+use lazy_static::lazy_static;
+
+const MAX_DBS: u32 = 2;
 
 #[cfg(test)]
 lazy_static! {
@@ -21,8 +25,3 @@ lazy_static! {
         page_size * 2560
     };
 }
-
-/// TODO: update to reflect semantic versioning
-pub type ProtocolVersion = u64;
-
-const MAX_DBS: u32 = 2;

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -3,7 +3,7 @@ use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 use engine_wasm_prep::wasm_costs::{WasmCosts, WASM_COSTS_SIZE_SERIALIZED};
 
 /// Represents a protocol's data. Intended to be associated with a given protocol version.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProtocolData {
     wasm_costs: WasmCosts,
 }
@@ -36,7 +36,7 @@ impl FromBytes for ProtocolData {
 }
 
 #[cfg(test)]
-mod gens {
+pub(crate) mod gens {
     use proptest::prop_compose;
 
     use engine_wasm_prep::wasm_costs::gens;

--- a/execution-engine/engine-storage/src/protocol_data_store/in_memory.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/in_memory.rs
@@ -1,0 +1,32 @@
+use crate::error::in_memory::Error;
+use crate::protocol_data::ProtocolData;
+use crate::protocol_data_store::{self, ProtocolDataStore, ProtocolVersion};
+use crate::store::Store;
+use crate::transaction_source::in_memory::InMemoryEnvironment;
+
+/// An in-memory protocol data store
+pub struct InMemoryProtocolDataStore {
+    maybe_name: Option<String>,
+}
+
+impl InMemoryProtocolDataStore {
+    pub fn new(_env: &InMemoryEnvironment, maybe_name: Option<&str>) -> Self {
+        let name = maybe_name
+            .map(|name| format!("{}-{}", protocol_data_store::NAME, name))
+            .unwrap_or_else(|| String::from(protocol_data_store::NAME));
+        InMemoryProtocolDataStore {
+            maybe_name: Some(name),
+        }
+    }
+}
+
+impl Store<ProtocolVersion, ProtocolData> for InMemoryProtocolDataStore {
+    type Error = Error;
+    type Handle = Option<String>;
+
+    fn handle(&self) -> Self::Handle {
+        self.maybe_name.to_owned()
+    }
+}
+
+impl ProtocolDataStore for InMemoryProtocolDataStore {}

--- a/execution-engine/engine-storage/src/protocol_data_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/lmdb.rs
@@ -1,0 +1,46 @@
+use lmdb::{Database, DatabaseFlags};
+
+use crate::protocol_data::ProtocolData;
+use crate::protocol_data_store::{ProtocolDataStore, ProtocolVersion};
+use crate::store::Store;
+use crate::transaction_source::lmdb::LmdbEnvironment;
+use crate::{error, protocol_data_store};
+
+/// An LMDB-backed protocol data store.
+///
+/// Wraps [`lmdb::Database`].
+#[derive(Debug, Clone)]
+pub struct LmdbProtocolDataStore {
+    db: Database,
+}
+
+impl LmdbProtocolDataStore {
+    pub fn new(
+        env: &LmdbEnvironment,
+        maybe_name: Option<&str>,
+        flags: DatabaseFlags,
+    ) -> Result<Self, error::Error> {
+        let name = maybe_name
+            .map(|name| format!("{}-{}", protocol_data_store::NAME, name))
+            .unwrap_or_else(|| String::from(protocol_data_store::NAME));
+        let db = env.env().create_db(Some(&name), flags)?;
+        Ok(LmdbProtocolDataStore { db })
+    }
+
+    pub fn open(env: &LmdbEnvironment, name: Option<&str>) -> Result<Self, error::Error> {
+        let db = env.env().open_db(name)?;
+        Ok(LmdbProtocolDataStore { db })
+    }
+}
+
+impl Store<ProtocolVersion, ProtocolData> for LmdbProtocolDataStore {
+    type Error = error::Error;
+
+    type Handle = Database;
+
+    fn handle(&self) -> Self::Handle {
+        self.db
+    }
+}
+
+impl ProtocolDataStore for LmdbProtocolDataStore {}

--- a/execution-engine/engine-storage/src/protocol_data_store/mod.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/mod.rs
@@ -1,0 +1,17 @@
+//! A store for persisting [`ProtocolData`] values at their protocol versions.
+
+pub mod in_memory;
+pub mod lmdb;
+#[cfg(test)]
+mod tests;
+
+use crate::protocol_data::ProtocolData;
+use crate::store::Store;
+
+const NAME: &str = "PROTOCOL_DATA_STORE";
+
+/// TODO: update to reflect semantic versioning
+pub type ProtocolVersion = u64;
+
+/// An entity which persists [`ProtocolData`] values at their protocol versions.
+pub trait ProtocolDataStore: Store<ProtocolVersion, ProtocolData> {}

--- a/execution-engine/engine-storage/src/protocol_data_store/tests/mod.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/tests/mod.rs
@@ -1,0 +1,1 @@
+mod proptests;

--- a/execution-engine/engine-storage/src/protocol_data_store/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/tests/proptests.rs
@@ -1,0 +1,63 @@
+use std::collections::BTreeMap;
+use std::ops::RangeInclusive;
+
+use lmdb::DatabaseFlags;
+use proptest::collection;
+use proptest::num;
+use proptest::prelude::proptest;
+use tempfile;
+
+use crate::protocol_data::{gens, ProtocolData};
+use crate::protocol_data_store::in_memory::InMemoryProtocolDataStore;
+use crate::protocol_data_store::lmdb::LmdbProtocolDataStore;
+use crate::protocol_data_store::ProtocolVersion;
+use crate::store::tests as store_tests;
+use crate::transaction_source::in_memory::InMemoryEnvironment;
+use crate::transaction_source::lmdb::LmdbEnvironment;
+use crate::TEST_MAP_SIZE;
+
+const DEFAULT_MIN_LENGTH: usize = 1;
+const DEFAULT_MAX_LENGTH: usize = 16;
+
+fn get_range() -> RangeInclusive<usize> {
+    let start = option_env!("CL_PROTOCOL_DATA_STORE_TEST_MAP_MIN_LENGTH")
+        .and_then(|s| str::parse::<usize>(s).ok())
+        .unwrap_or(DEFAULT_MIN_LENGTH);
+    let end = option_env!("CL_PROTOCOL_DATA_STORE_TEST_MAP_MAX_LENGTH")
+        .and_then(|s| str::parse::<usize>(s).ok())
+        .unwrap_or(DEFAULT_MAX_LENGTH);
+    RangeInclusive::new(start, end)
+}
+
+fn in_memory_roundtrip_succeeds(inputs: BTreeMap<ProtocolVersion, ProtocolData>) -> bool {
+    let env = InMemoryEnvironment::new();
+    let store = InMemoryProtocolDataStore::new(&env, None);
+
+    store_tests::roundtrip_succeeds(&env, &store, inputs).unwrap()
+}
+
+fn lmdb_roundtrip_succeeds(inputs: BTreeMap<ProtocolVersion, ProtocolData>) -> bool {
+    let tmp_dir = tempfile::tempdir().unwrap();
+    let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), *TEST_MAP_SIZE).unwrap();
+    let store = LmdbProtocolDataStore::new(&env, None, DatabaseFlags::empty()).unwrap();
+
+    let ret = store_tests::roundtrip_succeeds(&env, &store, inputs).unwrap();
+    tmp_dir.close().unwrap();
+    ret
+}
+
+proptest! {
+    #[test]
+    fn prop_in_memory_roundtrip_succeeds(
+        m in collection::btree_map(num::u64::ANY, gens::protocol_data_arb(), get_range())
+    ) {
+        assert!(in_memory_roundtrip_succeeds(m))
+    }
+
+    #[test]
+    fn prop_lmdb_roundtrip_succeeds(
+        m in collection::btree_map(num::u64::ANY, gens::protocol_data_arb(), get_range())
+    ) {
+        assert!(lmdb_roundtrip_succeeds(m))
+    }
+}

--- a/execution-engine/engine-storage/src/store/mod.rs
+++ b/execution-engine/engine-storage/src/store/mod.rs
@@ -1,0 +1,45 @@
+mod store_ext;
+#[cfg(test)]
+pub(crate) mod tests;
+
+use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
+
+pub use self::store_ext::StoreExt;
+use crate::transaction_source::{Readable, Writable};
+
+pub trait Store<K, V> {
+    type Error: From<bytesrepr::Error>;
+
+    type Handle;
+
+    fn handle(&self) -> Self::Handle;
+
+    fn get<T>(&self, txn: &T, key: &K) -> Result<Option<V>, Self::Error>
+    where
+        T: Readable<Handle = Self::Handle>,
+        K: ToBytes,
+        V: FromBytes,
+        Self::Error: From<T::Error>,
+    {
+        let handle = self.handle();
+        match txn.read(handle, &key.to_bytes()?)? {
+            None => Ok(None),
+            Some(value_bytes) => {
+                let value = bytesrepr::deserialize(&value_bytes)?;
+                Ok(Some(value))
+            }
+        }
+    }
+
+    fn put<T>(&self, txn: &mut T, key: &K, value: &V) -> Result<(), Self::Error>
+    where
+        T: Writable<Handle = Self::Handle>,
+        K: ToBytes,
+        V: ToBytes,
+        Self::Error: From<T::Error>,
+    {
+        let handle = self.handle();
+        txn.write(handle, &key.to_bytes()?, &value.to_bytes()?)
+            .map_err(Into::into)
+    }
+}

--- a/execution-engine/engine-storage/src/store/store_ext.rs
+++ b/execution-engine/engine-storage/src/store/store_ext.rs
@@ -1,0 +1,44 @@
+use contract_ffi::bytesrepr::{FromBytes, ToBytes};
+
+use crate::store::Store;
+use crate::transaction_source::{Readable, Writable};
+
+pub trait StoreExt<K, V>: Store<K, V> {
+    fn get_many<'a, T>(
+        &self,
+        txn: &T,
+        keys: impl Iterator<Item = &'a K>,
+    ) -> Result<Vec<Option<V>>, Self::Error>
+    where
+        T: Readable<Handle = Self::Handle>,
+        K: ToBytes + 'a,
+        V: FromBytes,
+        Self::Error: From<T::Error>,
+    {
+        let mut ret: Vec<Option<V>> = Vec::new();
+        for key in keys {
+            let result = self.get(txn, key)?;
+            ret.push(result)
+        }
+        Ok(ret)
+    }
+
+    fn put_many<'a, T>(
+        &self,
+        txn: &mut T,
+        pairs: impl Iterator<Item = (&'a K, &'a V)>,
+    ) -> Result<(), Self::Error>
+    where
+        T: Writable<Handle = Self::Handle>,
+        K: ToBytes + 'a,
+        V: ToBytes + 'a,
+        Self::Error: From<T::Error>,
+    {
+        for (key, value) in pairs {
+            self.put(txn, key, value)?;
+        }
+        Ok(())
+    }
+}
+
+impl<K, V, T: Store<K, V>> StoreExt<K, V> for T {}

--- a/execution-engine/engine-storage/src/store/tests.rs
+++ b/execution-engine/engine-storage/src/store/tests.rs
@@ -1,0 +1,47 @@
+use std::collections::BTreeMap;
+
+use contract_ffi::bytesrepr::{FromBytes, ToBytes};
+
+use crate::store::{Store, StoreExt};
+use crate::transaction_source::{Transaction, TransactionSource};
+
+// should be moved to the `store` module
+fn roundtrip<'a, K, V, X, S>(
+    transaction_source: &'a X,
+    store: &S,
+    items: &BTreeMap<K, V>,
+) -> Result<Vec<Option<V>>, S::Error>
+where
+    K: ToBytes,
+    V: ToBytes + FromBytes,
+    X: TransactionSource<'a, Handle = S::Handle>,
+    S: Store<K, V>,
+    S::Error: From<X::Error>,
+{
+    let mut txn: X::ReadWriteTransaction = transaction_source.create_read_write_txn()?;
+    store.put_many(&mut txn, items.iter())?;
+    let result = store.get_many(&txn, items.keys());
+    txn.commit()?;
+    result
+}
+
+// should be moved to the `store` module
+pub fn roundtrip_succeeds<'a, K, V, X, S>(
+    transaction_source: &'a X,
+    store: &S,
+    items: BTreeMap<K, V>,
+) -> Result<bool, S::Error>
+where
+    K: ToBytes,
+    V: ToBytes + FromBytes + Clone + PartialEq,
+    X: TransactionSource<'a, Handle = S::Handle>,
+    S: Store<K, V>,
+    S::Error: From<X::Error>,
+{
+    let maybe_values: Vec<Option<V>> = roundtrip(transaction_source, store, &items)?;
+    let values = match maybe_values.into_iter().collect::<Option<Vec<V>>>() {
+        Some(values) => values,
+        None => return Ok(false),
+    };
+    Ok(Iterator::eq(items.values(), values.iter()))
+}

--- a/execution-engine/engine-storage/src/trie_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/trie_store/lmdb.rs
@@ -8,6 +8,7 @@
 //! # extern crate lmdb;
 //! # extern crate engine_shared;
 //! # extern crate tempfile;
+//! use casperlabs_engine_storage::store::Store;
 //! use casperlabs_engine_storage::transaction_source::{Transaction, TransactionSource};
 //! use casperlabs_engine_storage::transaction_source::lmdb::LmdbEnvironment;
 //! use casperlabs_engine_storage::trie::{Pointer, PointerBlock, Trie};
@@ -110,11 +111,11 @@
 
 use lmdb::{Database, DatabaseFlags};
 
-use contract_ffi::bytesrepr::{deserialize, FromBytes, ToBytes};
+use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 use engine_shared::newtypes::Blake2bHash;
 
+use crate::store::Store;
 use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::transaction_source::{Readable, Writable};
 use crate::trie::Trie;
 use crate::trie_store::TrieStore;
 use crate::{error, trie_store};
@@ -146,40 +147,23 @@ impl LmdbTrieStore {
     }
 }
 
-impl<K: ToBytes + FromBytes, V: ToBytes + FromBytes> TrieStore<K, V> for LmdbTrieStore {
+impl<K, V> Store<Blake2bHash, Trie<K, V>> for LmdbTrieStore
+where
+    K: ToBytes + FromBytes,
+    V: ToBytes + FromBytes,
+{
     type Error = error::Error;
 
     type Handle = Database;
 
-    fn get<T: Readable>(
-        &self,
-        txn: &T,
-        key: &Blake2bHash,
-    ) -> Result<Option<Trie<K, V>>, Self::Error>
-    where
-        T: Readable<Handle = Self::Handle>,
-        Self::Error: From<T::Error>,
-    {
-        match txn.read(self.db, &key.to_bytes()?)? {
-            None => Ok(None),
-            Some(bytes) => {
-                let trie = deserialize(&bytes)?;
-                Ok(Some(trie))
-            }
-        }
+    fn handle(&self) -> Self::Handle {
+        self.db
     }
+}
 
-    fn put<T: Writable>(
-        &self,
-        txn: &mut T,
-        key: &Blake2bHash,
-        value: &Trie<K, V>,
-    ) -> Result<(), Self::Error>
-    where
-        T: Writable<Handle = Self::Handle>,
-        Self::Error: From<T::Error>,
-    {
-        txn.write(self.db, &key.to_bytes()?, &value.to_bytes()?)
-            .map_err(Into::into)
-    }
+impl<K, V> TrieStore<K, V> for LmdbTrieStore
+where
+    K: ToBytes + FromBytes,
+    V: ToBytes + FromBytes,
+{
 }

--- a/execution-engine/engine-storage/src/trie_store/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/mod.rs
@@ -10,29 +10,10 @@ mod tests;
 
 use engine_shared::newtypes::Blake2bHash;
 
-use crate::transaction_source::{Readable, Writable};
+use crate::store::Store;
 use crate::trie::Trie;
 
 const NAME: &str = "TRIE_STORE";
 
 /// An entity which persists [`Trie`] values at their hashes.
-pub trait TrieStore<K, V> {
-    /// An error which can occur while getting a value out of or putting a value
-    /// into a trie store.
-    type Error;
-
-    /// Represents the underlying entity which is being read from or written to.
-    type Handle;
-
-    /// Returns the [`Trie`] value from the corresponding hash.
-    fn get<T>(&self, txn: &T, key: &Blake2bHash) -> Result<Option<Trie<K, V>>, Self::Error>
-    where
-        T: Readable<Handle = Self::Handle>,
-        Self::Error: From<T::Error>;
-
-    /// Inserts a [`Trie`] value at a given hash.
-    fn put<T>(&self, txn: &mut T, key: &Blake2bHash, value: &Trie<K, V>) -> Result<(), Self::Error>
-    where
-        T: Writable<Handle = Self::Handle>,
-        Self::Error: From<T::Error>;
-}
+pub trait TrieStore<K, V>: Store<Blake2bHash, Trie<K, V>> {}

--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -3,7 +3,7 @@ mod tests;
 
 use std::time::Instant;
 
-use contract_ffi::bytesrepr::{self, ToBytes};
+use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
 use engine_shared::logging::{log_duration, log_metric, GAUGE};
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 
@@ -39,8 +39,8 @@ pub fn read<K, V, T, S, E>(
     key: &K,
 ) -> Result<ReadResult<V>, E>
 where
-    K: ToBytes + Eq + std::fmt::Debug,
-    V: ToBytes,
+    K: ToBytes + FromBytes + Eq + std::fmt::Debug,
+    V: ToBytes + FromBytes,
     T: Readable<Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<T::Error>,
@@ -217,8 +217,8 @@ fn scan<K, V, T, S, E>(
     root: &Trie<K, V>,
 ) -> Result<TrieScan<K, V>, E>
 where
-    K: ToBytes + Clone,
-    V: ToBytes + Clone,
+    K: ToBytes + FromBytes + Clone,
+    V: ToBytes + FromBytes + Clone,
     T: Readable<Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<T::Error>,
@@ -622,8 +622,8 @@ pub fn write<K, V, T, S, E>(
     value: &V,
 ) -> Result<WriteResult, E>
 where
-    K: ToBytes + Clone + Eq + std::fmt::Debug,
-    V: ToBytes + Clone + Eq,
+    K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+    V: ToBytes + FromBytes + Clone + Eq,
     T: Readable<Handle = S::Handle> + Writable<Handle = S::Handle>,
     S: TrieStore<K, V>,
     S::Error: From<T::Error>,

--- a/execution-engine/engine-storage/src/trie_store/tests/concurrent.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/concurrent.rs
@@ -4,13 +4,13 @@ use std::thread;
 use tempfile::tempdir;
 
 use super::TestData;
+use crate::store::Store;
 use crate::transaction_source::in_memory::InMemoryEnvironment;
 use crate::transaction_source::lmdb::LmdbEnvironment;
 use crate::transaction_source::{Transaction, TransactionSource};
 use crate::trie::Trie;
 use crate::trie_store::in_memory::InMemoryTrieStore;
 use crate::trie_store::lmdb::LmdbTrieStore;
-use crate::trie_store::TrieStore;
 use crate::TEST_MAP_SIZE;
 
 #[test]

--- a/execution-engine/engine-storage/src/trie_store/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/proptests.rs
@@ -10,15 +10,13 @@ use contract_ffi::key::Key;
 use contract_ffi::value::Value;
 use engine_shared::newtypes::Blake2bHash;
 
-use super::TestData;
-use crate::transaction_source::{Transaction, TransactionSource};
+use crate::store::tests as store_tests;
 use crate::trie::gens::trie_arb;
 use crate::trie::Trie;
-use crate::trie_store::TrieStore;
 use crate::TEST_MAP_SIZE;
+use std::collections::BTreeMap;
 
 const DEFAULT_MIN_LENGTH: usize = 1;
-
 const DEFAULT_MAX_LENGTH: usize = 4;
 
 fn get_range() -> RangeInclusive<usize> {
@@ -31,66 +29,22 @@ fn get_range() -> RangeInclusive<usize> {
     RangeInclusive::new(start, end)
 }
 
-fn roundtrip<'a, K, V, S, X, E>(
-    store: &S,
-    transaction_source: &'a X,
-    items: &[TestData<K, V>],
-) -> Result<Vec<Option<Trie<K, V>>>, E>
-where
-    K: ToBytes,
-    V: ToBytes,
-    S: TrieStore<K, V>,
-    X: TransactionSource<'a, Handle = S::Handle>,
-    S::Error: From<X::Error>,
-    E: From<S::Error> + From<X::Error>,
-{
-    let mut txn: X::ReadWriteTransaction = transaction_source.create_read_write_txn()?;
-    super::put_many::<_, _, _, _, E>(&mut txn, store, items)?;
-    let keys: Vec<&Blake2bHash> = items.iter().map(|TestData(k, _)| k).collect();
-    let result = super::get_many::<_, _, _, _, E>(&txn, store, &keys);
-    txn.commit()?;
-    result
-}
-
-fn roundtrip_succeeds<'a, S, X, E>(
-    store: &S,
-    transaction_source: &'a X,
-    inputs: Vec<Trie<Key, Value>>,
-) -> bool
-where
-    S: TrieStore<Key, Value>,
-    X: TransactionSource<'a, Handle = S::Handle>,
-    S::Error: From<X::Error>,
-    E: From<S::Error> + From<X::Error> + std::fmt::Debug,
-{
-    let outputs: Vec<Trie<Key, Value>> = {
-        let input_tuples: Vec<TestData<Key, Value>> = inputs
-            .iter()
-            .map(|trie| TestData(Blake2bHash::new(&trie.to_bytes().unwrap()), trie.to_owned()))
-            .collect();
-        roundtrip::<_, _, _, _, E>(store, transaction_source, &input_tuples)
-            .expect("roundtrip failed")
-            .into_iter()
-            .collect::<Option<Vec<Trie<Key, Value>>>>()
-            .expect("one of the outputs was empty")
-    };
-
-    outputs == inputs
-}
-
 fn in_memory_roundtrip_succeeds(inputs: Vec<Trie<Key, Value>>) -> bool {
-    use crate::error::in_memory;
     use crate::transaction_source::in_memory::InMemoryEnvironment;
     use crate::trie_store::in_memory::InMemoryTrieStore;
 
     let env = InMemoryEnvironment::new();
     let store = InMemoryTrieStore::new(&env, None);
 
-    roundtrip_succeeds::<_, _, in_memory::Error>(&store, &env, inputs)
+    let inputs: BTreeMap<Blake2bHash, Trie<Key, Value>> = inputs
+        .into_iter()
+        .map(|trie| (Blake2bHash::new(&trie.to_bytes().unwrap()), trie))
+        .collect();
+
+    store_tests::roundtrip_succeeds(&env, &store, inputs).unwrap()
 }
 
 fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, Value>>) -> bool {
-    use crate::error;
     use crate::transaction_source::lmdb::LmdbEnvironment;
     use crate::trie_store::lmdb::LmdbTrieStore;
 
@@ -98,7 +52,12 @@ fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, Value>>) -> bool {
     let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), *TEST_MAP_SIZE).unwrap();
     let store = LmdbTrieStore::new(&env, None, DatabaseFlags::empty()).unwrap();
 
-    let ret = roundtrip_succeeds::<_, _, error::Error>(&store, &env, inputs);
+    let inputs: BTreeMap<Blake2bHash, Trie<Key, Value>> = inputs
+        .into_iter()
+        .map(|trie| (Blake2bHash::new(&trie.to_bytes().unwrap()), trie))
+        .collect();
+
+    let ret = store_tests::roundtrip_succeeds(&env, &store, inputs).unwrap();
     tmp_dir.close().unwrap();
     ret
 }


### PR DESCRIPTION
### Overview
This PR introduces the `ProtocolDataStore` for storing `ProtocolData` associated with a given `ProtocolVersion`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-633

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Because of the structural similarity between this new trait and the `TrieStore` trait.  It made sense to factor out a common `Store` trait, which nicely allowed for us to be able to write fairly minimal implementations of `ProtocolDataStore` and `TrieStore`.  Similarly, some test code was refactored to avoid duplication.
