### PR TITLE
NODE-815: Add basic deploy selection strategy.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -4,6 +4,7 @@ import cats.effect.Concurrent
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import io.casperlabs.blockstorage.{BlockStorage, DagRepresentation, DagStorage}
+import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.deploybuffer.DeployBuffer
@@ -67,7 +68,7 @@ sealed abstract class MultiParentCasperInstances {
                     )
     } yield (blockProcessingLock, casperState)
 
-  def fromTransportLayer[F[_]: Concurrent: ConnectionsCell: TransportLayer: Log: Time: Metrics: ErrorHandler: FinalityDetector: BlockStorage: RPConfAsk: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation](
+  def fromTransportLayer[F[_]: Concurrent: ConnectionsCell: TransportLayer: Log: Time: Metrics: ErrorHandler: FinalityDetector: BlockStorage: RPConfAsk: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation: DeploySelection](
       validatorId: Option[ValidatorIdentity],
       genesis: Block,
       genesisPreState: StateHash,
@@ -92,7 +93,7 @@ sealed abstract class MultiParentCasperInstances {
     } yield casper
 
   /** Create a MultiParentCasper instance from the new RPC style gossiping. */
-  def fromGossipServices[F[_]: Concurrent: Log: Time: Metrics: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation](
+  def fromGossipServices[F[_]: Concurrent: Log: Time: Metrics: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation: DeploySelection](
       validatorId: Option[ValidatorIdentity],
       genesis: Block,
       genesisPreState: StateHash,

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -44,7 +44,8 @@ final case class CasperConf(
     autoProposeEnabled: Boolean,
     autoProposeCheckInterval: FiniteDuration,
     autoProposeMaxInterval: FiniteDuration,
-    autoProposeMaxCount: Int
+    autoProposeMaxCount: Int,
+    maxBlockSize: Int
 ) extends SubConfig {
   def chainId = shardId
 }

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -45,7 +45,7 @@ final case class CasperConf(
     autoProposeCheckInterval: FiniteDuration,
     autoProposeMaxInterval: FiniteDuration,
     autoProposeMaxCount: Int,
-    maxBlockSize: Int
+    maxBlockSizeBytes: Int
 ) extends SubConfig {
   def chainId = shardId
 }

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -3,7 +3,7 @@ package io.casperlabs.casper
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
-import io.casperlabs.casper.consensus.state
+import io.casperlabs.casper.consensus.{state, Deploy}
 import io.casperlabs.casper.consensus.state.{Key, ProtocolVersion}
 import io.casperlabs.casper.deploybuffer.DeployBuffer
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.{
@@ -11,7 +11,7 @@ import io.casperlabs.casper.util.execengine.ExecEngineUtil.{
   processDeploys,
   zipDeploysResults
 }
-import io.casperlabs.catscontrib.MonadThrowable
+import io.casperlabs.catscontrib.{Fs2Compiler, MonadThrowable}
 import io.casperlabs.casper.util.execengine.{DeployEffects, Op, ProcessedDeployResult}
 import io.casperlabs.casper.util.execengine.Op.OpMap
 import io.casperlabs.shared.Log
@@ -26,16 +26,18 @@ trait Select[F[_]] {
 object DeploySelection {
 
   trait DeploySelection[F[_]] extends Select[F] {
-    type A = (ByteString, Long, ProtocolVersion, Set[DeployHash])
+    type A = (ByteString, Long, ProtocolVersion, fs2.Stream[F, List[Deploy]])
     type B = List[DeployEffects]
   }
 
   def apply[F[_]](implicit ev: DeploySelection[F]): DeploySelection[F] = ev
 
   private case class IntermediateState(
-      chosen: List[DeployEffects] = List.empty,
+      accumulated: List[DeployEffects] = List.empty,
+      diff: List[DeployEffects] = List.empty,
       accumulatedOps: OpMap[Key] = Map.empty
   ) {
+    def chosen: List[DeployEffects] = accumulated ++ diff
     def effectsCommutativity: (List[DeployEffects], OpMap[state.Key]) =
       (chosen, accumulatedOps)
     def size: Int = chosen.map(_.deploy.serializedSize).sum
@@ -47,56 +49,80 @@ object DeploySelection {
     val ops                  = Op.fromIpcEntry(el.effects.opMap)
     val (accEffects, accOps) = init.effectsCommutativity
     if (accOps ~ ops)
-      init.copy(el :: accEffects, accOps + ops)
+      IntermediateState(el :: accEffects, el :: init.diff, accOps + ops)
     else
       init
   }
 
-  def unsafeCreate[F[_]: MonadThrowable: ExecutionEngineService: DeployBuffer: Log](
+  def unsafeCreate[F[_]: MonadThrowable: ExecutionEngineService: DeployBuffer: Log: Fs2Compiler](
       sizeLimitMB: Int
   ): DeploySelection[F] =
     new DeploySelection[F] {
       override def select(
-          in: (DeployHash, Long, ProtocolVersion, Set[DeployHash])
+          in: (DeployHash, Long, ProtocolVersion, fs2.Stream[F, List[Deploy]])
       ): F[List[DeployEffects]] = {
         val (prestate, blocktime, protocolVersion, hashes) = in
 
-        hashes
-          .grouped(50)
-          .toList
-          .foldM[F, Either[IntermediateState, IntermediateState]](
-            IntermediateState().asRight[IntermediateState]
-          ) {
-            case (stateE, batch) =>
-              val state = stateE.fold(identity, identity)
-              for {
-                deploys <- DeployBuffer[F].getByHashes(batch.toList)
-                dr <- processDeploys[F](
-                       prestate,
-                       blocktime,
-                       deploys,
-                       protocolVersion
-                     )
-                pdr                                = zipDeploysResults(deploys, dr).toList
-                (invalidDeploys, effectfulDeploys) = ProcessedDeployResult.split(pdr)
-                _                                  <- handleInvalidDeploys[F](invalidDeploys)
-              } yield {
-                effectfulDeploys.foldLeftM(state) {
-                  case (accState, element) =>
-                    // newState is either `accState` if `element` doesn't commute,
-                    // or contains `element` if it does.
-                    val newState = commutes(accState, element)
-                    // TODO: Use some base `Block` element to measure the size.
-                    // If size if accumulated deploys is over 90% of the block limit, stop consuming more deploys.
-                    if (newState.size > (0.9 * sizeLimitMB)) {
-                      // foldM will short-circuit for `Left`
-                      // and continue for `Right`
-                      accState.asLeft[IntermediateState]
-                    } else newState.asRight[IntermediateState]
+        def go(
+            state: IntermediateState,
+            stream: fs2.Stream[F, List[Deploy]]
+        ): fs2.Pull[F, List[DeployEffects], Unit] =
+          stream.pull.uncons.flatMap {
+            case Some((chunk, streamTail)) =>
+              // Fold over elements of the chunk, picking deploys that commute,
+              // stop as soon as maximum block size limit is reached.
+              val chunkResults = chunk.toList
+                .foldM[F, Either[IntermediateState, IntermediateState]](
+                  state.asRight[IntermediateState]
+                ) {
+                  case (stateE, batch) =>
+                    val state = stateE.fold(identity, identity)
+                    for {
+                      dr <- processDeploys[F](
+                             prestate,
+                             blocktime,
+                             batch,
+                             protocolVersion
+                           )
+                      pdr                                = zipDeploysResults(batch, dr).toList
+                      (invalidDeploys, effectfulDeploys) = ProcessedDeployResult.split(pdr)
+                      _                                  <- handleInvalidDeploys[F](invalidDeploys)
+                    } yield {
+                      effectfulDeploys.foldLeftM(state) {
+                        case (accState, element) =>
+                          // newState is either `accState` if `element` doesn't commute,
+                          // or contains `element` if it does.
+                          val newState = commutes(accState, element)
+                          // TODO: Use some base `Block` element to measure the size.
+                          // If size if accumulated deploys is over 90% of the block limit, stop consuming more deploys.
+                          if (newState.size > (0.9 * sizeLimitMB)) {
+                            // foldM will short-circuit for `Left`
+                            // and continue for `Right`
+                            accState.asLeft[IntermediateState]
+                          } else newState.asRight[IntermediateState]
+                      }
+                    }
                 }
-              }
+
+              fs2.Pull
+                .eval(chunkResults)
+                .flatMap {
+                  // Block size limit reached. Output whatever was accumulated in the chunk and stop consuming.
+                  case Left(deploys)  => fs2.Pull.output(fs2.Chunk(deploys.diff)) >> fs2.Pull.done
+                  case Right(deploys) =>
+                    // Output what was chosen in the chunk and continue consuming the stream.
+                    fs2.Pull.output(fs2.Chunk(deploys.diff)) >> go(
+                      // We're emptying whatever was accumulated in the previous chunk,
+                      // but we leave the total accumulated state, so we only pick deploys
+                      // that commute with whatever was already chosen.
+                      deploys.copy(diff = List.empty),
+                      streamTail
+                    )
+                }
+            case None => fs2.Pull.done
           }
-          .map(_.fold(_.chosen, _.chosen))
+
+        go(IntermediateState(), hashes).stream.compile.toList.map(_.flatten)
       }
     }
 

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -38,7 +38,7 @@ object DeploySelection {
   ) {
     def effectsCommutativity: (List[DeployEffects], OpMap[state.Key]) =
       (chosen, accumulatedOps)
-    def size: Long = chosen.map(_.deploy.serializedSize).sum.toLong
+    def size: Int = chosen.map(_.deploy.serializedSize).sum
   }
 
   // Appends new element to the intermediate state if it commutes with it.
@@ -53,7 +53,7 @@ object DeploySelection {
   }
 
   def unsafeCreate[F[_]: MonadThrowable: ExecutionEngineService: DeployBuffer: Log](
-      sizeLimitMB: Long
+      sizeLimitMB: Int
   ): DeploySelection[F] =
     new DeploySelection[F] {
       override def select(
@@ -101,7 +101,7 @@ object DeploySelection {
     }
 
   def create[F[_]: Sync: ExecutionEngineService: DeployBuffer: Log](
-      sizeLimitMB: Long
+      sizeLimitMB: Int
   ): F[DeploySelection[F]] =
     Sync[F].delay {
       unsafeCreate[F](sizeLimitMB)

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -60,7 +60,7 @@ object DeploySelection {
   }
 
   def unsafeCreate[F[_]: MonadThrowable: ExecutionEngineService: Fs2Compiler](
-      sizeLimitMB: Int
+      sizeLimitBytes: Int
   ): DeploySelection[F] =
     new DeploySelection[F] {
       override def select(
@@ -96,7 +96,7 @@ object DeploySelection {
                           val newState = accState.addCommuting(element)
                           // TODO: Use some base `Block` element to measure the size.
                           // If size of accumulated deploys is over 90% of the block limit, stop consuming more deploys.
-                          if (newState.size > (0.9 * sizeLimitMB)) {
+                          if (newState.size > (0.9 * sizeLimitBytes)) {
                             // foldM will short-circuit for `Left`
                             // and continue for `Right`
                             accState.asLeft[IntermediateState]

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -59,7 +59,7 @@ object DeploySelection {
     }
   }
 
-  def unsafeCreate[F[_]: MonadThrowable: ExecutionEngineService: Fs2Compiler](
+  def create[F[_]: MonadThrowable: ExecutionEngineService: Fs2Compiler](
       sizeLimitBytes: Int
   ): DeploySelection[F] =
     new DeploySelection[F] {
@@ -130,12 +130,5 @@ object DeploySelection {
 
         go(IntermediateState(), hashes).stream.compile.toList.map(_.flatten)
       }
-    }
-
-  def create[F[_]: Sync: ExecutionEngineService: DeployBuffer: Log](
-      sizeLimitMB: Int
-  ): F[DeploySelection[F]] =
-    Sync[F].delay {
-      unsafeCreate[F](sizeLimitMB)
     }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -1,0 +1,98 @@
+package io.casperlabs.casper
+
+import cats.effect.Sync
+import cats.implicits._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.state
+import io.casperlabs.casper.consensus.state.{Key, ProtocolVersion}
+import io.casperlabs.casper.deploybuffer.DeployBuffer
+import io.casperlabs.casper.util.execengine.ExecEngineUtil.{
+  handleInvalidDeploys,
+  processDeploys,
+  zipDeploysResults
+}
+import io.casperlabs.casper.util.execengine.{DeployEffects, Op, ProcessedDeployResult}
+import io.casperlabs.casper.util.execengine.Op.OpMap
+import io.casperlabs.shared.Log
+import io.casperlabs.smartcontracts.ExecutionEngineService
+
+trait Select[F[_]] {
+  type A
+  type B
+  def select(in: A): F[B]
+}
+
+object DeploySelection {
+
+  trait DeploySelection[F[_]] extends Select[F] {
+    type A = (ByteString, Long, ProtocolVersion, Set[DeployHash])
+    type B = List[DeployEffects]
+  }
+
+  def apply[F[_]](implicit ev: DeploySelection[F]): DeploySelection[F] = ev
+
+  private case class IntermediateState(
+      chosen: List[DeployEffects] = List.empty,
+      accumulatedOps: OpMap[Key] = Map.empty
+  ) {
+    def effectsCommutativity: (List[DeployEffects], OpMap[state.Key]) =
+      (chosen, accumulatedOps)
+    def size: Long = chosen.map(_.deploy.serializedSize).sum.toLong
+  }
+
+  // Appends new element to the intermediate state if it commutes with it.
+  // Otherwise returns initial state.
+  private def commutes(init: IntermediateState, el: DeployEffects): IntermediateState = {
+    val ops                  = Op.fromIpcEntry(el.effects.opMap)
+    val (accEffects, accOps) = init.effectsCommutativity
+    if (accOps ~ ops)
+      init.copy(el :: accEffects, accOps + ops)
+    else
+      init
+  }
+
+  def create[F[_]: Sync: ExecutionEngineService: DeployBuffer: Log](
+      sizeLimitMB: Long
+  ): F[DeploySelection[F]] =
+    Sync[F].delay {
+      new DeploySelection[F] {
+        override def select(
+            in: (DeployHash, Long, ProtocolVersion, Set[DeployHash])
+        ): F[List[DeployEffects]] = {
+          val (prestate, blocktime, protocolVersion, hashes) = in
+
+          hashes
+            .grouped(50)
+            .toList
+            .foldM[F, Either[IntermediateState, IntermediateState]](
+              IntermediateState().asRight[IntermediateState]
+            ) {
+              case (stateE, batch) =>
+                val state = stateE.fold(identity, identity)
+                for {
+                  deploys <- DeployBuffer[F].getByHashes(batch.toList)
+                  dr <- processDeploys[F](
+                         prestate,
+                         blocktime,
+                         deploys,
+                         protocolVersion
+                       )
+                  pdr                                = zipDeploysResults(deploys, dr).toList
+                  (invalidDeploys, effectfulDeploys) = ProcessedDeployResult.split(pdr)
+                  _                                  <- handleInvalidDeploys[F](invalidDeploys)
+                } yield {
+                  effectfulDeploys.foldLeftM(state) {
+                    case (chosenDeploys, element) =>
+                      if ((chosenDeploys.size + element.deploy.serializedSize) > (0.9 * sizeLimitMB)) {
+                        chosenDeploys.asLeft[IntermediateState]
+                      } else {
+                        commutes(chosenDeploys, element).asRight[IntermediateState]
+                      }
+                  }
+                }
+            }
+            .map(_.fold(_.chosen, _.chosen))
+        }
+      }
+    }
+}

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -31,6 +31,7 @@ trait Select[F[_]] {
 object DeploySelection {
 
   trait DeploySelection[F[_]] extends Select[F] {
+    // prestate hash, block time, protocol version, stream of batched deploys.
     type A = (ByteString, Long, ProtocolVersion, fs2.Stream[F, List[Deploy]])
     type B = List[ProcessedDeployResult]
   }
@@ -66,7 +67,7 @@ object DeploySelection {
       override def select(
           in: (DeployHash, Long, ProtocolVersion, fs2.Stream[F, List[Deploy]])
       ): F[List[ProcessedDeployResult]] = {
-        val (prestate, blocktime, protocolVersion, hashes) = in
+        val (prestate, blocktime, protocolVersion, deploys) = in
 
         def go(
             state: IntermediateState,
@@ -128,7 +129,7 @@ object DeploySelection {
             case None => fs2.Pull.done
           }
 
-        go(IntermediateState(), hashes).stream.compile.toList.map(_.flatten)
+        go(IntermediateState(), deploys).stream.compile.toList.map(_.flatten)
       }
     }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -8,6 +8,7 @@ import cats.mtl.FunctorRaise
 import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockStorage, DagRepresentation, DagStorage}
+import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.casper.consensus._
@@ -51,7 +52,7 @@ final case class CasperState(
     equivocationsTracker: Set[EquivocationRecord] = Set.empty[EquivocationRecord]
 )
 
-class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: deploybuffer.DeployBuffer: Validation: Fs2Compiler](
+class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: deploybuffer.DeployBuffer: Validation: Fs2Compiler: DeploySelection](
     statelessExecutor: MultiParentCasperImpl.StatelessExecutor[F],
     broadcaster: MultiParentCasperImpl.Broadcaster[F],
     validatorId: Option[ValidatorIdentity],
@@ -669,7 +670,7 @@ object MultiParentCasperImpl {
   def create[F[_]: Sync: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: DeployBuffer: Validation: Cell[
     ?[_],
     CasperState
-  ]](
+  ]: DeploySelection](
       statelessExecutor: StatelessExecutor[F],
       broadcaster: Broadcaster[F],
       validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -52,7 +52,7 @@ final case class CasperState(
     equivocationsTracker: Set[EquivocationRecord] = Set.empty[EquivocationRecord]
 )
 
-class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: deploybuffer.DeployBuffer: Validation: Fs2Compiler: DeploySelection](
+class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: BlockStorage: DagStorage: ExecutionEngineService: LastFinalizedBlockHashContainer: deploybuffer.DeployBuffer: Validation: Fs2Compiler: DeploySelection](
     statelessExecutor: MultiParentCasperImpl.StatelessExecutor[F],
     broadcaster: MultiParentCasperImpl.Broadcaster[F],
     validatorId: Option[ValidatorIdentity],

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -525,12 +525,6 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: 
         postStateHash,
         bondedValidators,
         deploysForBlock,
-        // We don't have to put InvalidNonce deploys back to the buffer,
-        // as by default buffer is cleared when deploy gets included in
-        // the finalized block. If that strategy ever changes, we will have to
-        // put them back into the buffer explicitly.
-        invalidNonceDeploys,
-        deploysToDiscard,
         protocolVersion
       )                 = result
       dag               <- dag
@@ -564,15 +558,6 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: 
 
         CreateBlockStatus.created(block)
       }
-      // Discard deploys that will never be included because they failed some precondition.
-      // If we traveled back on the DAG (due to orphaned block) and picked a deploy to be included
-      // in the past of the new fork, it wouldn't hit this as the nonce would be what we expect.
-      // Then if a block gets finalized and we remove the deploys it contains, and _then_ one of them
-      // turns up again for some reason, we'll treat it again as a pending deploy and try to include it.
-      // At that point the EE will discard it as the nonce is in the past and we'll drop it here.
-
-      _ <- DeployBuffer[F]
-            .markAsDiscarded(deploysToDiscard.toList.map(_.deploy)) whenA deploysToDiscard.nonEmpty
     } yield status)
       .handleErrorWith {
         case ex @ SmartContractEngineError(error_msg) =>

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -125,21 +125,18 @@ object ExecEngineUtil {
     * they will be rejected.
     *
     * @param deployEffects List of effects that deploy made on the GlobalState.
-    * @param init Initial set of deploy effects with which the rest of input `deployEffects`
-    *             has to commute with.
     *
     * @return List of deploy effects that commute.
     */
   //TODO: Logic for picking the commuting group? Prioritize highest revenue? Try to include as many deploys as possible?
   def findCommutingEffects(
-      deployEffects: Seq[DeployEffects],
-      init: (List[DeployEffects], OpMap[state.Key]) = (List.empty, Map.empty)
+      deployEffects: Seq[DeployEffects]
   ): List[DeployEffects] =
     deployEffects match {
-      case Nil => init._1
+      case Nil => Nil
       case list =>
         val (result, _) =
-          list.foldLeft(init) {
+          list.foldLeft((List.empty[DeployEffects] -> Map.empty[state.Key, Op])) {
             case (unchanged @ (acc, totalOps), next) =>
               val ops = Op.fromIpcEntry(next.effects.opMap)
               if (totalOps ~ ops)

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -39,7 +39,7 @@ object ExecEngineUtil {
       preconditionFailures: List[PreconditionFailure]
   )
 
-  def computeDeploysCheckpoint[F[_]: MonadThrowable: BlockStorage: DeployBuffer: Log: ExecutionEngineService](
+  def computeDeploysCheckpoint[F[_]: MonadThrowable: DeployBuffer: Log: ExecutionEngineService](
       merged: MergeResult[TransformMap, Block],
       hashes: Set[DeployHash],
       blocktime: Long,
@@ -97,7 +97,7 @@ object ExecEngineUtil {
       protocolVersion
     )
 
-  private def processDeploys[F[_]: MonadError[?[_], Throwable]: BlockStorage: ExecutionEngineService](
+  private def processDeploys[F[_]: MonadError[?[_], Throwable]: ExecutionEngineService](
       prestate: StateHash,
       blocktime: Long,
       deploys: Seq[Deploy],

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -8,18 +8,17 @@ import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockMetadata, BlockStorage, DagRepresentation}
 import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper._
-import io.casperlabs.casper.consensus.{Block, Deploy}
+import io.casperlabs.casper.consensus.state.{Key, Value}
+import io.casperlabs.casper.consensus.{Block, Deploy, state}
+import io.casperlabs.casper.deploybuffer.DeployBuffer
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.casper.util.execengine.Op.{OpMap, OpMapAddComm}
 import io.casperlabs.casper.util.{CasperLabsProtocolVersions, DagOperations, ProtoUtil}
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.ipc._
-import io.casperlabs.casper.consensus.state
 import io.casperlabs.models.{DeployResult => _}
 import io.casperlabs.shared.Log
 import io.casperlabs.smartcontracts.ExecutionEngineService
-import io.casperlabs.casper.consensus.state.{Key, ProtocolVersion, Value}
-import io.casperlabs.casper.deploybuffer.DeployBuffer
 
 case class DeploysCheckpoint(
     preStateHash: StateHash,
@@ -45,7 +44,7 @@ object ExecEngineUtil {
   ): F[DeploysCheckpoint] =
     for {
       preStateHash <- computePrestate[F](merged)
-      deployStream = DeployBuffer[F].getByHashes(hashes, chunkSize = 20)
+      deployStream = DeployBuffer[F].getByHashes(hashes)
       pdr <- DeploySelection[F].select(
               (preStateHash, blocktime, protocolVersion, deployStream)
             )

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -45,10 +45,7 @@ object ExecEngineUtil {
   ): F[DeploysCheckpoint] =
     for {
       preStateHash <- computePrestate[F](merged)
-      deployStream = fs2.Stream
-        .fromIterator[F, DeployHash](hashes.toIterator)
-        .chunkLimit(10) // TODO: from config?
-        .flatMap(batch => fs2.Stream.eval(DeployBuffer[F].getByHashes(batch.toList)))
+      deployStream = DeployBuffer[F].getByHashes(hashes, chunkSize = 20)
       pdr <- DeploySelection[F].select(
               (preStateHash, blocktime, protocolVersion, deployStream)
             )

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -9,7 +9,7 @@ import io.casperlabs.blockstorage.{BlockMetadata, BlockStorage, DagRepresentatio
 import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper._
 import io.casperlabs.casper.consensus.state.{Key, Value}
-import io.casperlabs.casper.consensus.{Block, Deploy, state}
+import io.casperlabs.casper.consensus.{state, Block, Deploy}
 import io.casperlabs.casper.deploybuffer.DeployBuffer
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.casper.util.execengine.Op.{OpMap, OpMapAddComm}

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ProcessedDeployResult.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ProcessedDeployResult.scala
@@ -11,13 +11,14 @@ sealed trait DeployEffects extends ProcessedDeployResult {
   val effects: ipc.ExecutionEffect
 }
 
+sealed trait NoEffectsFailure extends ProcessedDeployResult
+
 final case class InvalidNonceDeploy(deploy: Deploy, deployNonce: Long, expectedNonce: Long)
-    extends ProcessedDeployResult
+    extends NoEffectsFailure
 
 // Precondition failures don't have effects or cost.
 // They are errors that we can't charge for (like key not found, key not being an public key of the account).
-final case class PreconditionFailure(deploy: Deploy, errorMessage: String)
-    extends ProcessedDeployResult
+final case class PreconditionFailure(deploy: Deploy, errorMessage: String) extends NoEffectsFailure
 
 // Represents errors during execution of the program.
 // These errors do have effects in the form of increasing account's nonce and execution of payment code.
@@ -52,5 +53,15 @@ object ProcessedDeployResult {
           case ipc.DeployResult.ExecutionResult(None, None, _) => ???
         }
       case ipc.DeployResult(ipc.DeployResult.Value.Empty) => ???
+    }
+
+  def split(l: List[ProcessedDeployResult]): (List[NoEffectsFailure], List[DeployEffects]) =
+    l.foldRight(
+      (List.empty[NoEffectsFailure], List.empty[DeployEffects])
+    ) {
+      case (pdr: DeployEffects, (noEffects, effectful)) =>
+        (noEffects, pdr :: effectful)
+      case (pdr: NoEffectsFailure, (noEffects, effectful)) =>
+        (pdr :: noEffects, effectful)
     }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ProcessedDeployResult.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ProcessedDeployResult.scala
@@ -55,6 +55,9 @@ object ProcessedDeployResult {
       case ipc.DeployResult(ipc.DeployResult.Value.Empty) => ???
     }
 
+  // All the deploys that do not change the global state in a way that can conflict with others:
+  // which can be only`ExecutionError` now as `InvalidNonce` and `PreconditionFailure` has been
+  // filtered out when creating block and when we're validating block it shouldn't include those either.
   def split(l: List[ProcessedDeployResult]): (List[NoEffectsFailure], List[DeployEffects]) =
     l.foldRight(
       (List.empty[NoEffectsFailure], List.empty[DeployEffects])

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -1,0 +1,173 @@
+package io.casperlabs.casper
+
+import cats.implicits._
+import cats.mtl.FunctorRaise
+import com.github.ghik.silencer.silent
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.DeploySelection.DeploySelection
+import io.casperlabs.casper.DeploySelectionTest._
+import io.casperlabs.casper.consensus.Deploy
+import io.casperlabs.casper.consensus.state.{Key, ProtocolVersion, Value}
+import io.casperlabs.casper.deploybuffer.{DeployBuffer, MockDeployBuffer}
+import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
+import io.casperlabs.comm.gossiping.ArbitraryConsensus
+import io.casperlabs.ipc
+import io.casperlabs.ipc.DeployResult.Value.ExecutionResult
+import io.casperlabs.ipc._
+import io.casperlabs.p2p.EffectsTestInstances.LogStub
+import io.casperlabs.shared.Log
+import io.casperlabs.smartcontracts.ExecutionEngineService
+import io.casperlabs.smartcontracts.ExecutionEngineService.CommitResult
+import monix.eval.Task
+import monix.eval.Task._
+import org.scalacheck.Gen
+import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import monix.execution.Scheduler.Implicits.global
+import io.casperlabs.catscontrib.TaskContrib.TaskOps
+import io.casperlabs.catscontrib.MonadThrowable
+import monix.execution.atomic.AtomicInt
+
+import scala.util.Either
+
+@silent("is never used")
+class DeploySelectionTest
+    extends FlatSpec
+    with Matchers
+    with ArbitraryConsensus
+    with GeneratorDrivenPropertyChecks {
+
+  behavior of "DeploySelection"
+
+  implicit val cc = ConsensusConfig()
+
+  implicit val logEff: Log[Task]                = new LogStub[Task]
+  implicit val deployBuffer: DeployBuffer[Task] = MockDeployBuffer.unsafeCreate[Task]()
+
+  val prestate        = ByteString.EMPTY
+  val blocktime       = 0L
+  val protocolVersion = ProtocolVersion(1L)
+
+  val smallBlockSizeMb = 2 * 1024 * 1024
+
+  it should "stop consuming the stream when block size limit is reached" in forAll(
+    Gen.listOf(arbDeploy.arbitrary).suchThat(assertMinSize(smallBlockSizeMb))
+  ) { deploys =>
+    {
+      val expected = deploys
+        .foldLeftM(List.empty[Deploy]) {
+          case (state, element) =>
+            val newState = element :: state
+            if (deploysSize(newState) > (0.9 * smallBlockSizeMb)) {
+              Left(state)
+            } else {
+              Right(newState)
+            }
+        }
+        .fold(identity, identity)
+        .reverse
+
+      assert(deploysSize(expected) < (0.9 * smallBlockSizeMb))
+
+      val countedStream = CountedStream(
+        fs2.Stream
+          .fromIterator[Task, Deploy](deploys.toIterator)
+          .chunkLimit(1) // We don't want to return all elements in one chunk.
+          .map(_.toList) // We want to see if we pull chunks lazily.
+      )
+
+      implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
+
+      val deploySelection: DeploySelection[Task] =
+        DeploySelection.unsafeCreate[Task](smallBlockSizeMb)
+
+      val test = for {
+        selected <- deploySelection
+                     .select((prestate, blocktime, protocolVersion, countedStream.stream))
+                     .map(_.map(_.deploy))
+        // If we will consume whole stream, before condition is met, that's how many
+        // elements we expect to pull from the stream.
+        // Otherwise we expect one more pull than elements, because we have to pull
+        // from the stream first before we decide we're full.
+        expectedPulls = if (expected.size == deploys.size) {
+          expected.size
+        } else expected.size + 1
+        _ <- Task.delay(assert(countedStream.getCount() == expectedPulls))
+      } yield selected should contain theSameElementsAs expected
+
+      test.unsafeRunSync
+    }
+  }
+}
+
+@silent("is never used")
+object DeploySelectionTest {
+  case class CountedStream[F[_], A] private (
+      private val counter: AtomicInt,
+      private val streamPrivate: fs2.Stream[F, A]
+  ) {
+    def stream: fs2.Stream[F, A] = streamPrivate.map { el =>
+      counter.increment()
+      el
+    }
+
+    def getCount(): Int = counter.get()
+  }
+
+  object CountedStream {
+    def apply[F[_], A](stream: fs2.Stream[F, A]): CountedStream[F, A] =
+      CountedStream(AtomicInt(0), stream)
+  }
+
+  def everythingCommutesExec(
+      prestate: ByteString,
+      blockTime: Long,
+      deploys: Seq[DeployItem],
+      version: ProtocolVersion
+  ): Task[Either[Throwable, Seq[DeployResult]]] = {
+    val key = Key(
+      Key.Value.Hash(Key.Hash(ByteString.EMPTY))
+    )
+    val (op, transform) =
+      Op(Op.OpInstance.Read(ReadOp())) ->
+        Transform(Transform.TransformInstance.Identity(TransformIdentity()))
+
+    val transformEntry = TransformEntry(Some(key), Some(transform))
+    val opEntry        = OpEntry(Some(key), Some(op))
+    val effect         = ExecutionEffect(Seq(opEntry), Seq(transformEntry))
+
+    Task.now(
+      deploys
+        .map(
+          _ =>
+            DeployResult(
+              ExecutionResult(ipc.DeployResult.ExecutionResult(Some(effect), None, 10))
+            )
+        )
+        .asRight[Throwable]
+    )
+  }
+
+  def deploysSize(l: List[Deploy]): Int = l.map(_.serializedSize).sum
+
+  def raiseNotImplemented[F[_], A](implicit F: MonadThrowable[F]): F[A] =
+    F.raiseError[A](new IllegalArgumentException("Not implemented in this mock."))
+
+  def assertMinSize(sizeLimitMb: Int)(l: List[Deploy]): Boolean =
+    deploysSize(l) > (sizeLimitMb)
+
+  def eeExecMock[F[_]: MonadThrowable](
+      execFunc: (
+          ByteString,
+          Long,
+          Seq[DeployItem],
+          ProtocolVersion
+      ) => F[Either[Throwable, Seq[DeployResult]]]
+  ): ExecutionEngineService[F] = ExecutionEngineServiceStub.mock(
+    (_, _) => raiseNotImplemented[F, Either[Throwable, GenesisResult]],
+    execFunc,
+    (_, _) => raiseNotImplemented[F, Either[Throwable, CommitResult]],
+    (_, _, _) => raiseNotImplemented[F, Either[Throwable, Value]],
+    _ => raiseNotImplemented[F, Either[String, Unit]]
+  )
+}

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -41,9 +41,6 @@ class DeploySelectionTest
 
   implicit val cc = ConsensusConfig()
 
-  implicit val logEff: Log[Task]                = new LogStub[Task]
-  implicit val deployBuffer: DeployBuffer[Task] = MockDeployBuffer.unsafeCreate[Task]()
-
   val prestate        = ByteString.EMPTY
   val blocktime       = 0L
   val protocolVersion = ProtocolVersion(1L)

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -66,7 +66,7 @@ class DeploySelectionTest
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
 
       val deploySelection: DeploySelection[Task] =
-        DeploySelection.unsafeCreate[Task](smallBlockSizeBytes)
+        DeploySelection.create[Task](smallBlockSizeBytes)
 
       val test = for {
         selected <- deploySelection
@@ -104,7 +104,7 @@ class DeploySelectionTest
       val counter                                   = AtomicInt(0)
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherCommutesExec(counter) _)
       val deploySelection: DeploySelection[Task] =
-        DeploySelection.unsafeCreate[Task](smallBlockSizeBytes)
+        DeploySelection.create[Task](smallBlockSizeBytes)
 
       val test = deploySelection
         .select((prestate, blocktime, protocolVersion, stream))
@@ -125,7 +125,7 @@ class DeploySelectionTest
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
 
       val deploySelection: DeploySelection[Task] =
-        DeploySelection.unsafeCreate[Task](maxBlockSizeMb)
+        DeploySelection.create[Task](maxBlockSizeMb)
 
       val stream = toStreamChunked(cappedDeploys)
 
@@ -154,7 +154,7 @@ class DeploySelectionTest
     val counter                                   = AtomicInt(0)
     implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherInvalidDeploy(counter) _)
     val deploySelection: DeploySelection[Task] =
-      DeploySelection.unsafeCreate[Task](smallBlockSizeBytes)
+      DeploySelection.create[Task](smallBlockSizeBytes)
 
     val test = deploySelection
       .select((prestate, blocktime, protocolVersion, stream))

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -1,32 +1,29 @@
 package io.casperlabs.casper
 
+import cats.effect.Sync
 import cats.implicits._
-import cats.mtl.FunctorRaise
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.DeploySelectionTest._
 import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.consensus.state.{Key, ProtocolVersion, Value}
-import io.casperlabs.casper.deploybuffer.{DeployBuffer, MockDeployBuffer}
-import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
+import io.casperlabs.casper.util.execengine.{DeployEffects, ExecutionEngineServiceStub}
+import io.casperlabs.catscontrib.MonadThrowable
+import io.casperlabs.catscontrib.TaskContrib.TaskOps
 import io.casperlabs.comm.gossiping.ArbitraryConsensus
 import io.casperlabs.ipc
-import io.casperlabs.ipc.DeployResult.Value.ExecutionResult
+import io.casperlabs.ipc.DeployResult.Value.{ExecutionResult, InvalidNonce}
 import io.casperlabs.ipc._
-import io.casperlabs.p2p.EffectsTestInstances.LogStub
-import io.casperlabs.shared.Log
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.smartcontracts.ExecutionEngineService.CommitResult
 import monix.eval.Task
 import monix.eval.Task._
-import org.scalacheck.Gen
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
 import monix.execution.Scheduler.Implicits.global
-import io.casperlabs.catscontrib.TaskContrib.TaskOps
-import io.casperlabs.catscontrib.MonadThrowable
 import monix.execution.atomic.AtomicInt
+import org.scalacheck.Gen
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Either
 
@@ -39,38 +36,31 @@ class DeploySelectionTest
 
   behavior of "DeploySelection"
 
-  implicit val cc = ConsensusConfig()
+  implicit val cc = ConsensusConfig(
+    maxSessionCodeBytes = 500,
+    maxPaymentCodeBytes = 500
+  )
 
   val prestate        = ByteString.EMPTY
   val blocktime       = 0L
   val protocolVersion = ProtocolVersion(1L)
 
-  val smallBlockSizeMb = 2 * 1024 * 1024
+  val smallBlockSizeMb = 5 * 1024
+
+  val sampleDeploy        = sample(arbDeploy.arbitrary)
+  val deploysInSmallBlock = smallBlockSizeMb / sampleDeploy.serializedSize
 
   it should "stop consuming the stream when block size limit is reached" in forAll(
-    Gen.listOf(arbDeploy.arbitrary).suchThat(assertMinSize(smallBlockSizeMb))
+    Gen.listOfN(deploysInSmallBlock * 2, arbDeploy.arbitrary)
   ) { deploys =>
     {
-      val expected = deploys
-        .foldLeftM(List.empty[Deploy]) {
-          case (state, element) =>
-            val newState = element :: state
-            if (deploysSize(newState) > (0.9 * smallBlockSizeMb)) {
-              Left(state)
-            } else {
-              Right(newState)
-            }
-        }
-        .fold(identity, identity)
-        .reverse
+      val expected = takeUnlessTooBig(smallBlockSizeMb)(deploys)
+      assert(expected.size < deploys.size)
 
       assert(deploysSize(expected) < (0.9 * smallBlockSizeMb))
 
       val countedStream = CountedStream(
-        fs2.Stream
-          .fromIterator[Task, Deploy](deploys.toIterator)
-          .chunkLimit(1) // We don't want to return all elements in one chunk.
-          .map(_.toList) // We want to see if we pull chunks lazily.
+        toStreamChunked(deploys)
       )
 
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
@@ -95,6 +85,90 @@ class DeploySelectionTest
       test.unsafeRunSync
     }
   }
+
+  it should "skip elements that don't commute and continue consuming the stream" in forAll(
+    Gen.zip(
+      Gen.listOfN(deploysInSmallBlock * 2, arbDeploy.arbitrary),
+      Gen.listOfN(deploysInSmallBlock * 2, arbDeploy.arbitrary)
+    )
+  ) {
+    case (conflicting, commuting) =>
+      val stream = fs2.Stream
+        .fromIterator(commuting.toIterator)
+        .interleave(fs2.Stream.fromIterator(conflicting.toIterator))
+        .chunkLimit(1)
+        .map(_.toList)
+
+      val cappedEffects = takeUnlessTooBig(smallBlockSizeMb)(commuting)
+
+      val counter                                   = AtomicInt(0)
+      implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherCommutesExec(counter) _)
+      val deploySelection: DeploySelection[Task] =
+        DeploySelection.unsafeCreate[Task](smallBlockSizeMb)
+
+      val test = deploySelection
+        .select((prestate, blocktime, protocolVersion, stream))
+        .map(results => assert(results.map(_.deploy) == cappedEffects))
+
+      test.unsafeRunSync
+  }
+
+  it should "consume the whole stream if all deploys commute and fit block size limit" in forAll(
+    Gen
+      .listOf(arbDeploy.arbitrary),
+    Gen.chooseNum(1 * 1024 * 1024, 3 * 1024 * 1024)
+  ) {
+    case (deploys, maxBlockSizeMb) =>
+      val cappedDeploys = takeUnlessTooBig(maxBlockSizeMb)(deploys)
+      assert(cappedDeploys.size == deploys.size)
+
+      implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
+
+      val deploySelection: DeploySelection[Task] =
+        DeploySelection.unsafeCreate[Task](maxBlockSizeMb)
+
+      val stream = toStreamChunked(cappedDeploys)
+
+      val test = deploySelection
+        .select((prestate, blocktime, protocolVersion, stream))
+        .map(_.map(_.deploy))
+        .map(_ should contain theSameElementsAs cappedDeploys)
+
+      test.unsafeRunSync
+  }
+
+  it should "push NoEffectsFailure elements to output stream" in forAll(
+    Gen.listOfN(deploysInSmallBlock * 2, arbDeploy.arbitrary)
+  ) { deploys =>
+    val (invalid, effects) = {
+      val (invalidIdx, effectsIdx) = deploys.toStream.zipWithIndex.partition {
+        case (_, idx) => idx % 2 == 0
+      }
+      (invalidIdx.map(_._1.deployHash).toSet, effectsIdx.map(_._1).toList)
+    }
+
+    val cappedEffects = takeUnlessTooBig(smallBlockSizeMb)(effects)
+
+    val stream = fs2.Stream.fromIterator(deploys.toIterator).chunkLimit(1).map(_.toList)
+
+    val counter                                   = AtomicInt(0)
+    implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherInvalidDeploy(counter) _)
+    val deploySelection: DeploySelection[Task] =
+      DeploySelection.unsafeCreate[Task](smallBlockSizeMb)
+
+    val test = deploySelection
+      .select((prestate, blocktime, protocolVersion, stream))
+      .map(results => {
+        // Partition the output stream to invalid deploys and commuting deploys.
+        val (invalidDeploys, chosenDeploys) = results.partition(!_.isInstanceOf[DeployEffects])
+        // Assert that all invalid deploys are a subset of the input set of invalid deploys.
+        assert(invalidDeploys.map(_.deploy.deployHash).forall(invalid.contains(_)))
+        // Assert that commuting deploys are as expected.
+        assert(chosenDeploys.map(_.deploy) == cappedEffects)
+      })
+
+    test.unsafeRunSync
+  }
 }
 
 @silent("is never used")
@@ -116,22 +190,86 @@ object DeploySelectionTest {
       CountedStream(AtomicInt(0), stream)
   }
 
-  def everythingCommutesExec(
-      prestate: ByteString,
-      blockTime: Long,
-      deploys: Seq[DeployItem],
-      version: ProtocolVersion
-  ): Task[Either[Throwable, Seq[DeployResult]]] = {
-    val key = Key(
-      Key.Value.Hash(Key.Hash(ByteString.EMPTY))
-    )
+  def toStreamChunked[F[_]: Sync, A](l: List[A], chunkSize: Int = 1): fs2.Stream[F, List[A]] =
+    fs2.Stream.fromIterator[F, A](l.toIterator).chunkLimit(chunkSize).map(_.toList)
+
+  // We need common key to generate conflicts.
+  private val key = Key(
+    Key.Value.Hash(Key.Hash(ByteString.EMPTY))
+  )
+
+  private val readTransform: (OpEntry, TransformEntry) = {
     val (op, transform) =
       Op(Op.OpInstance.Read(ReadOp())) ->
         Transform(Transform.TransformInstance.Identity(TransformIdentity()))
 
     val transformEntry = TransformEntry(Some(key), Some(transform))
     val opEntry        = OpEntry(Some(key), Some(op))
-    val effect         = ExecutionEffect(Seq(opEntry), Seq(transformEntry))
+    (opEntry, transformEntry)
+  }
+
+  private val writeTransform: (OpEntry, TransformEntry) = {
+    val (op, transform) =
+      Op(Op.OpInstance.Write(WriteOp())) ->
+        Transform(
+          Transform.TransformInstance.Write(
+            TransformWrite().withValue(Value(Value.Value.IntValue(10)))
+          )
+        )
+
+    val transformEntry = TransformEntry(Some(key), Some(transform))
+    val opEntry        = OpEntry(Some(key), Some(op))
+    (opEntry, transformEntry)
+  }
+
+  // WARNING: `counter` is thread-safe but not synchronized
+  private def everyOtherInvalidDeploy(counter: AtomicInt)(
+      prestate: ByteString,
+      blockTime: Long,
+      deploys: Seq[DeployItem],
+      version: ProtocolVersion
+  ): Task[Either[Throwable, Seq[DeployResult]]] =
+    Seq
+      .fill(deploys.size) {
+        val counterValue = counter.getAndIncrement()
+        if (counterValue % 2 == 0) {
+          DeployResult(InvalidNonce(ipc.DeployResult.InvalidNonce(0, 0)))
+        } else {
+          val (opEntry, transformEntry) = readTransform
+          val effect                    = ExecutionEffect(Seq(opEntry), Seq(transformEntry))
+          DeployResult(ExecutionResult(ipc.DeployResult.ExecutionResult(Some(effect), None, 10)))
+        }
+      }
+      .asRight[Throwable]
+      .pure[Task]
+
+  // WARNING: `counter` is thread-safe but not synchronized
+  private def everyOtherCommutesExec(counter: AtomicInt)(
+      prestate: ByteString,
+      blockTime: Long,
+      deploys: Seq[DeployItem],
+      version: ProtocolVersion
+  ): Task[Either[Throwable, Seq[DeployResult]]] =
+    Seq
+      .fill(deploys.size) {
+        val counterValue = counter.getAndIncrement()
+        val (opEntry, transformEntry) =
+          if (counterValue % 2 == 0) readTransform
+          else writeTransform
+        val effect = ExecutionEffect(Seq(opEntry), Seq(transformEntry))
+        DeployResult(ExecutionResult(ipc.DeployResult.ExecutionResult(Some(effect), None, 10)))
+      }
+      .asRight[Throwable]
+      .pure[Task]
+
+  private def everythingCommutesExec(
+      prestate: ByteString,
+      blockTime: Long,
+      deploys: Seq[DeployItem],
+      version: ProtocolVersion
+  ): Task[Either[Throwable, Seq[DeployResult]]] = {
+    val (opEntry, transformEntry) = readTransform
+    val effect                    = ExecutionEffect(Seq(opEntry), Seq(transformEntry))
 
     Task.now(
       deploys
@@ -145,15 +283,32 @@ object DeploySelectionTest {
     )
   }
 
-  def deploysSize(l: List[Deploy]): Int = l.map(_.serializedSize).sum
+  private def deploysSize(l: List[Deploy]): Int = l.map(_.serializedSize).sum
 
-  def raiseNotImplemented[F[_], A](implicit F: MonadThrowable[F]): F[A] =
+  private def raiseNotImplemented[F[_], A](implicit F: MonadThrowable[F]): F[A] =
     F.raiseError[A](new IllegalArgumentException("Not implemented in this mock."))
 
-  def assertMinSize(sizeLimitMb: Int)(l: List[Deploy]): Boolean =
+  private def assertMinSize(sizeLimitMb: Int)(l: List[Deploy]): Boolean =
     deploysSize(l) > (sizeLimitMb)
 
-  def eeExecMock[F[_]: MonadThrowable](
+  private def assertMaxSize(sizeLimitMb: Int)(l: List[Deploy]): Boolean =
+    deploysSize(l) < sizeLimitMb
+
+  private def takeUnlessTooBig(sizeLimitMb: Int)(deploys: List[Deploy]): List[Deploy] =
+    deploys
+      .foldLeftM(List.empty[Deploy]) {
+        case (state, element) =>
+          val newState = element :: state
+          if (deploysSize(newState) > (0.9 * sizeLimitMb)) {
+            Left(state)
+          } else {
+            Right(newState)
+          }
+      }
+      .fold(identity, identity)
+      .reverse
+
+  private def eeExecMock[F[_]: MonadThrowable](
       execFunc: (
           ByteString,
           Long,

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -4,6 +4,7 @@ import cats.Monad
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockStorage, IndexedDagStorage}
+import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.casper.consensus._
@@ -856,7 +857,10 @@ class ValidationTest
 
       for {
         implicit0(deployBuffer: DeployBuffer[Task]) <- MockDeployBuffer.create[Task]()
-        _                                           <- deployBuffer.addAsPending(deploys.toList)
+        implicit0(deploySelection: DeploySelection[Task]) <- DeploySelection.create[Task](
+                                                              5 * 1024 * 1024 /* 10MB */
+                                                            )
+        _ <- deployBuffer.addAsPending(deploys.toList)
         deploysCheckpoint <- ExecEngineUtil.computeDeploysCheckpoint[Task](
                               ExecEngineUtil.MergeResult.empty,
                               deploys.map(_.deployHash).toSet,

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -857,9 +857,9 @@ class ValidationTest
 
       for {
         implicit0(deployBuffer: DeployBuffer[Task]) <- MockDeployBuffer.create[Task]()
-        implicit0(deploySelection: DeploySelection[Task]) <- DeploySelection.create[Task](
-                                                              5 * 1024 * 1024 /* 10MB */
-                                                            )
+        implicit0(deploySelection: DeploySelection[Task]) = DeploySelection.create[Task](
+          5 * 1024 * 1024
+        )
         _ <- deployBuffer.addAsPending(deploys.toList)
         deploysCheckpoint <- ExecEngineUtil.computeDeploysCheckpoint[Task](
                               ExecEngineUtil.MergeResult.empty,

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -868,8 +868,6 @@ class ValidationTest
           computedPostStateHash,
           bondedValidators,
           processedDeploys,
-          _,
-          _,
           _
         ) = deploysCheckpoint
         block <- createBlock[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferImplSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferImplSpec.scala
@@ -46,12 +46,13 @@ class DeployBufferImplSpec extends DeployBufferSpec with BeforeAndAfterEach with
   }
   override protected def testFixture(
       test: DeployBuffer[Task] => Task[Unit],
-      timeout: FiniteDuration = 5.seconds
+      timeout: FiniteDuration = 5.seconds,
+      deployBufferChunkSize: Int = 100
   ): Unit = {
     val program = for {
       _            <- Task(cleanupTables())
       _            <- Task(setupTables())
-      deployBuffer <- DeployBufferImpl.create[Task]
+      deployBuffer <- DeployBufferImpl.create[Task](deployBufferChunkSize)
       _            <- test(deployBuffer)
     } yield ()
     program.runSyncUnsafe(timeout)

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
@@ -1,6 +1,5 @@
 package io.casperlabs.casper.deploybuffer
 
-import cats.data.NonEmptyList
 import cats.implicits._
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
@@ -25,7 +24,8 @@ trait DeployBufferSpec
   /* Implement this method in descendants substituting various DeployBuffer implementations */
   protected def testFixture(
       test: DeployBuffer[Task] => Task[Unit],
-      timeout: FiniteDuration = 5.seconds
+      timeout: FiniteDuration = 5.seconds,
+      deployBufferChunkSize: Int = 100
   ): Unit
 
   private implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
@@ -105,7 +105,7 @@ trait DeployBufferSpec
           for {
             _   <- db.addAsPending(pending)
             _   <- db.addAsProcessed(processed)
-            all <- db.getByHashes(deployHashes.toSet, chunkSize = 100).compile.toList
+            all <- db.getByHashes(deployHashes.toSet).compile.toList
             _   = assert(deploys.sortedByHash == all.sortedByHash)
           } yield ()
 

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
@@ -105,7 +105,7 @@ trait DeployBufferSpec
           for {
             _   <- db.addAsPending(pending)
             _   <- db.addAsProcessed(processed)
-            all <- db.getByHashes(deployHashes)
+            all <- db.getByHashes(deployHashes.toSet, chunkSize = 100).compile.toList
             _   = assert(deploys.sortedByHash == all.sortedByHash)
           } yield ()
 

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBuffer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBuffer.scala
@@ -139,9 +139,10 @@ class MockDeployBuffer[F[_]: Sync: Log](
       )
       .flatMap(d => fs2.Stream.fromIterator(d.toIterator))
 
-  override def getByHashes(l: List[ByteString]): F[List[Deploy]] = {
-    val hashesSet = l.toSet
-    (readPending, readProcessed).mapN(_ ++ _).map(_.filter(d => hashesSet.contains(d.deployHash)))
+  override def getByHashes(l: Set[ByteString], chunkSize: Int): fs2.Stream[F, Deploy] = {
+    val deploys =
+      (readPending, readProcessed).mapN(_ ++ _).map(_.filter(d => l.contains(d.deployHash)))
+    fs2.Stream.eval(deploys).flatMap(all => fs2.Stream.fromIterator(all.toIterator))
   }
 
   private def readByStatus(status: Int): F[List[Deploy]] =

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBufferSpec.scala
@@ -10,11 +10,12 @@ import scala.concurrent.duration._
 class MockDeployBufferSpec extends DeployBufferSpec {
   override protected def testFixture(
       test: DeployBuffer[Task] => Task[Unit],
-      timeout: FiniteDuration = 5.seconds
+      timeout: FiniteDuration = 5.seconds,
+      deployBufferChunkSize: Int = 100
   ): Unit =
     (for {
       implicit0(logNOP: Log[Task]) <- Task(new NOPLog[Task])
-      mockDeployBuffer             <- MockDeployBuffer.create[Task]()
+      mockDeployBuffer             <- MockDeployBuffer.create[Task](deployBufferChunkSize)
       _                            <- test(mockDeployBuffer)
     } yield ()).runSyncUnsafe(timeout)
 }

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBufferSpec.scala
@@ -15,7 +15,7 @@ class MockDeployBufferSpec extends DeployBufferSpec {
   ): Unit =
     (for {
       implicit0(logNOP: Log[Task]) <- Task(new NOPLog[Task])
-      mockDeployBuffer             <- MockDeployBuffer.create[Task](deployBufferChunkSize)
+      mockDeployBuffer             <- MockDeployBuffer.create[Task]
       _                            <- test(mockDeployBuffer)
     } yield ()).runSyncUnsafe(timeout)
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -10,6 +10,8 @@ import io.casperlabs.blockstorage.{
   DagRepresentation,
   IndexedDagStorage
 }
+import io.casperlabs.casper.DeploySelection
+import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus._
@@ -94,7 +96,10 @@ object BlockGenerator {
       )
       merged                                   <- ExecEngineUtil.merge[F](parents, dag)
       implicit0(deployBuffer: DeployBuffer[F]) <- MockDeployBuffer.create[F]()
-      _                                        <- deployBuffer.addAsPending(deploys.toList)
+      implicit0(deploySelection: DeploySelection[F]) <- DeploySelection.create[F](
+                                                         5 * 1024 * 1024 /* 10MB */
+                                                       )
+      _ <- deployBuffer.addAsPending(deploys.toList)
       result <- computeDeploysCheckpoint[F](
                  merged,
                  deploys.map(_.deployHash).toSet,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -96,9 +96,9 @@ object BlockGenerator {
       )
       merged                                   <- ExecEngineUtil.merge[F](parents, dag)
       implicit0(deployBuffer: DeployBuffer[F]) <- MockDeployBuffer.create[F]()
-      implicit0(deploySelection: DeploySelection[F]) <- DeploySelection.create[F](
-                                                         5 * 1024 * 1024 /* 10MB */
-                                                       )
+      implicit0(deploySelection: DeploySelection[F]) = DeploySelection.create[F](
+        5 * 1024 * 1024
+      )
       _ <- deployBuffer.addAsPending(deploys.toList)
       result <- computeDeploysCheckpoint[F](
                  merged,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -28,6 +28,7 @@ import io.casperlabs.metrics.Metrics
 import io.casperlabs.p2p.EffectsTestInstances._
 import io.casperlabs.shared.Log.NOPLog
 import io.casperlabs.shared.{Cell, Log, Time}
+import monix.eval.Task
 import monix.tail.Iterant
 
 import scala.collection.immutable.Queue
@@ -75,6 +76,8 @@ class GossipServiceCasperTestNode[F[_]](
 
   implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
   implicit val validation        = HashSetCasperTestNode.makeValidation[F]
+
+  implicit val deploySelection = DeploySelection.unsafeCreate[F](5 * 1024 * 1024)
 
   // `addBlock` called in many ways:
   // - test proposes a block on the node that created it

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -77,7 +77,7 @@ class GossipServiceCasperTestNode[F[_]](
   implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
   implicit val validation        = HashSetCasperTestNode.makeValidation[F]
 
-  implicit val deploySelection = DeploySelection.unsafeCreate[F](5 * 1024 * 1024)
+  implicit val deploySelection = DeploySelection.create[F](5 * 1024 * 1024)
 
   // `addBlock` called in many ways:
   // - test proposes a block on the node that created it

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -37,6 +37,7 @@ import io.casperlabs.p2p.EffectsTestInstances._
 import io.casperlabs.p2p.effects.PacketHandler
 import io.casperlabs.shared.Log.NOPLog
 import io.casperlabs.shared.{Cell, Log, Time}
+import monix.eval.Task
 
 import scala.collection.mutable
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
@@ -93,6 +94,7 @@ class TransportLayerCasperTestNode[F[_]](
 
   implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
   implicit val validation        = HashSetCasperTestNode.makeValidation[F]
+  implicit val deploySelection   = DeploySelection.unsafeCreate[F](5 * 1024 * 1024)
 
   implicit val casperEff: MultiParentCasperImpl[F] =
     new MultiParentCasperImpl[F](

--- a/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/TransportLayerCasperTestNode.scala
@@ -94,7 +94,7 @@ class TransportLayerCasperTestNode[F[_]](
 
   implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
   implicit val validation        = HashSetCasperTestNode.makeValidation[F]
-  implicit val deploySelection   = DeploySelection.unsafeCreate[F](5 * 1024 * 1024)
+  implicit val deploySelection   = DeploySelection.create[F](5 * 1024 * 1024)
 
   implicit val casperEff: MultiParentCasperImpl[F] =
     new MultiParentCasperImpl[F](

--- a/casper/src/test/scala/io/casperlabs/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -126,7 +126,9 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
     }
     implicit val raiseInvalidBlock =
       casper.validation.raiseValidateErrorThroughApplicativeError[Task]
-    implicit val validation = new ValidationImpl[Task]
+    implicit val validation      = new ValidationImpl[Task]
+    implicit val deployBuffer    = MockDeployBuffer.unsafeCreate[Task]()
+    implicit val deploySelection = DeploySelection.unsafeCreate[Task](5 * 1024 * 1024)
   }
 
   "CasperPacketHandler" when {
@@ -139,7 +141,6 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
 
         implicit val lastFinalizedBlockHashContainer =
           NoOpsLastFinalizedBlockHashContainer.create[Task](genesis.blockHash)
-        implicit val deployBuffer = MockDeployBuffer.unsafeCreate[Task]()
         val ref =
           Ref.unsafe[Task, CasperPacketHandlerInternal[Task]](
             new GenesisValidatorHandler[Task](validatorId, chainId, bap)

--- a/casper/src/test/scala/io/casperlabs/casper/util/comm/CasperPacketHandlerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/comm/CasperPacketHandlerSpec.scala
@@ -128,7 +128,7 @@ class CasperPacketHandlerSpec extends WordSpec with Matchers {
       casper.validation.raiseValidateErrorThroughApplicativeError[Task]
     implicit val validation      = new ValidationImpl[Task]
     implicit val deployBuffer    = MockDeployBuffer.unsafeCreate[Task]()
-    implicit val deploySelection = DeploySelection.unsafeCreate[Task](5 * 1024 * 1024)
+    implicit val deploySelection = DeploySelection.create[Task](5 * 1024 * 1024)
   }
 
   "CasperPacketHandler" when {

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -4,7 +4,8 @@ import cats.Id
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockStorage, DagRepresentation}
-import io.casperlabs.casper.consensus
+import io.casperlabs.casper.DeploySelection.DeploySelection
+import io.casperlabs.casper.{consensus, DeploySelection}
 import io.casperlabs.casper.consensus.{state, Block, Bond}
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.helper.BlockGenerator._
@@ -118,7 +119,10 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
     for {
       blocktime                                   <- Task.delay(System.currentTimeMillis)
       implicit0(deployBuffer: DeployBuffer[Task]) <- MockDeployBuffer.create[Task]()
-      _                                           <- deployBuffer.addAsPending(deploy.toList)
+      implicit0(deploySelection: DeploySelection[Task]) <- DeploySelection.create[Task](
+                                                            5 * 1024 * 1024
+                                                          )
+      _ <- deployBuffer.addAsPending(deploy.toList)
       computeResult <- ExecEngineUtil
                         .computeDeploysCheckpoint[Task](
                           ExecEngineUtil.MergeResult.empty,

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -126,7 +126,7 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
                           blocktime,
                           protocolVersion
                         )
-      DeploysCheckpoint(_, _, _, result, _, _, _) = computeResult
+      DeploysCheckpoint(_, _, _, result, _) = computeResult
     } yield result
 
   "computeDeploysCheckpoint" should "aggregate the result of deploying multiple programs within the block" in {

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -119,9 +119,9 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
     for {
       blocktime                                   <- Task.delay(System.currentTimeMillis)
       implicit0(deployBuffer: DeployBuffer[Task]) <- MockDeployBuffer.create[Task]()
-      implicit0(deploySelection: DeploySelection[Task]) <- DeploySelection.create[Task](
-                                                            5 * 1024 * 1024
-                                                          )
+      implicit0(deploySelection: DeploySelection[Task]) = DeploySelection.create[Task](
+        5 * 1024 * 1024
+      )
       _ <- deployBuffer.addAsPending(deploy.toList)
       computeResult <- ExecEngineUtil
                         .computeDeploysCheckpoint[Task](

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -261,6 +261,8 @@ auto-propose-max-interval = "5seconds"
 # Number of deploys to accumulate before proposing.
 auto-propose-max-count = 10
 
+# Maximum block size in MBs
+max-block-size = 10
 
 # io.casperlabs.node.configuration.Configuration.Kamon
 [metrics]

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -261,8 +261,8 @@ auto-propose-max-interval = "5seconds"
 # Number of deploys to accumulate before proposing.
 auto-propose-max-count = 10
 
-# Maximum block size in MBs
-max-block-size = 10
+# Maximum block size in bytes
+max-block-size-bytes = 10485760
 
 # io.casperlabs.node.configuration.Configuration.Kamon
 [metrics]

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -17,20 +17,11 @@ import com.olegpy.meow.effects._
 import doobie.util.transactor.Transactor
 import io.casperlabs.blockstorage.util.fileIO.IOError
 import io.casperlabs.blockstorage.util.fileIO.IOError.RaiseIOError
-import io.casperlabs.blockstorage.{
-  BlockStorage,
-  CachingBlockStorage,
-  DagStorage,
-  FileDagStorage,
-  FileLMDBIndexBlockStorage
-}
+import io.casperlabs.blockstorage.{BlockStorage, CachingBlockStorage, DagStorage, FileDagStorage, FileLMDBIndexBlockStorage}
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper._
 import io.casperlabs.casper.deploybuffer.{DeployBuffer, DeployBufferImpl}
-import io.casperlabs.casper.finality.singlesweep.{
-  FinalityDetector,
-  FinalityDetectorBySingleSweepImpl
-}
+import io.casperlabs.casper.finality.singlesweep.{FinalityDetector, FinalityDetectorBySingleSweepImpl}
 import io.casperlabs.casper.validation.{Validation, ValidationImpl}
 import io.casperlabs.catscontrib.Catscontrib._
 import io.casperlabs.catscontrib.TaskContrib._
@@ -137,8 +128,12 @@ class NodeRuntime private[node] (
                                                             transactEC = dbIOScheduler,
                                                             conf.server.dataDir
                                                           )
+        deployBufferChunkSize = 20 //TODO: Move to config
         implicit0(deployBuffer: DeployBuffer[Effect]) <- Resource
-                                                          .liftF(DeployBufferImpl.create[Effect])
+                                                          .liftF(
+                                                            DeployBufferImpl
+                                                              .create[Effect](deployBufferChunkSize)
+                                                          )
         maybeBootstrap <- Resource.liftF(initPeer[Effect])
 
         implicit0(finalizedBlocksStream: FinalizedBlocksStream[Effect]) <- Resource.liftF(

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -17,11 +17,20 @@ import com.olegpy.meow.effects._
 import doobie.util.transactor.Transactor
 import io.casperlabs.blockstorage.util.fileIO.IOError
 import io.casperlabs.blockstorage.util.fileIO.IOError.RaiseIOError
-import io.casperlabs.blockstorage.{BlockStorage, CachingBlockStorage, DagStorage, FileDagStorage, FileLMDBIndexBlockStorage}
+import io.casperlabs.blockstorage.{
+  BlockStorage,
+  CachingBlockStorage,
+  DagStorage,
+  FileDagStorage,
+  FileLMDBIndexBlockStorage
+}
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper._
 import io.casperlabs.casper.deploybuffer.{DeployBuffer, DeployBufferImpl}
-import io.casperlabs.casper.finality.singlesweep.{FinalityDetector, FinalityDetectorBySingleSweepImpl}
+import io.casperlabs.casper.finality.singlesweep.{
+  FinalityDetector,
+  FinalityDetectorBySingleSweepImpl
+}
 import io.casperlabs.casper.validation.{Validation, ValidationImpl}
 import io.casperlabs.catscontrib.Catscontrib._
 import io.casperlabs.catscontrib.TaskContrib._

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -95,7 +95,7 @@ package object gossiping {
       // TODO: Get from config
       implicit0(deploySelection: DeploySelection[F]) <- Resource.liftF(
                                                          DeploySelection.create[F](
-                                                           10 * 1024 * 1024 /* 10MB */
+                                                           conf.casper.maxBlockSize * 1024 * 1024 /* MB */
                                                          )
                                                        )
 

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -9,6 +9,7 @@ import cats.implicits._
 import cats.temp.par.Par
 import com.google.protobuf.ByteString
 import io.casperlabs.blockstorage.{BlockStorage, DagStorage}
+import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.deploybuffer.DeployBuffer
@@ -90,6 +91,13 @@ package object gossiping {
       downloadManager <- makeDownloadManager(conf, connectToGossip, relaying, validatorId)
 
       genesisApprover <- makeGenesisApprover(conf, connectToGossip, downloadManager)
+
+      // TODO: Get from config
+      implicit0(deploySelection: DeploySelection[F]) <- Resource.liftF(
+                                                         DeploySelection.create[F](
+                                                           10 * 1024 * 1024 /* 10MB */
+                                                         )
+                                                       )
 
       // Make sure MultiParentCasperRef is set before the synchronizer is resumed.
       awaitApproval <- makeFiberResource {

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -92,7 +92,7 @@ package object gossiping {
 
       genesisApprover <- makeGenesisApprover(conf, connectToGossip, downloadManager)
 
-      implicit0(deploySelection: DeploySelection[F]) <- Resource.liftF(
+      implicit0(deploySelection: DeploySelection[F]) <- Resource.pure[F, DeploySelection[F]](
                                                          DeploySelection.create[F](
                                                            conf.casper.maxBlockSizeBytes
                                                          )

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -94,7 +94,7 @@ package object gossiping {
 
       implicit0(deploySelection: DeploySelection[F]) <- Resource.liftF(
                                                          DeploySelection.create[F](
-                                                           conf.casper.maxBlockSize * 1024 * 1024 /* MB */
+                                                           conf.casper.maxBlockSizeBytes
                                                          )
                                                        )
 

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -92,7 +92,6 @@ package object gossiping {
 
       genesisApprover <- makeGenesisApprover(conf, connectToGossip, downloadManager)
 
-      // TODO: Get from config
       implicit0(deploySelection: DeploySelection[F]) <- Resource.liftF(
                                                          DeploySelection.create[F](
                                                            conf.casper.maxBlockSize * 1024 * 1024 /* MB */

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -96,7 +96,7 @@ package object transport {
       // TODO: Get from config
       implicit0(deploySelection: DeploySelection[Effect]) <- DeploySelection
                                                               .create[Effect](
-                                                                10 * 1024 * 1024 /* 10MB */
+                                                                conf.casper.maxBlockSize * 1024 * 1024 /* 10MB */
                                                               )
 
       implicit0(lab: LastApprovedBlock[Task]) <- LastApprovedBlock.of[Task].toEffect

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -11,6 +11,7 @@ import cats.syntax.foldable._
 import cats.syntax.functor._
 import com.github.ghik.silencer.silent
 import io.casperlabs.blockstorage.{BlockStorage, DagStorage}
+import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.LastApprovedBlock.LastApprovedBlock
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper._
@@ -91,6 +92,12 @@ package object transport {
       }
       implicit0(transportEff: TransportLayer[Effect]) = TransportLayer
         .eitherTTransportLayer[Task]
+
+      // TODO: Get from config
+      implicit0(deploySelection: DeploySelection[Effect]) <- DeploySelection
+                                                              .create[Effect](
+                                                                10 * 1024 * 1024 /* 10MB */
+                                                              )
 
       implicit0(lab: LastApprovedBlock[Task]) <- LastApprovedBlock.of[Task].toEffect
 

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -95,7 +95,7 @@ package object transport {
 
       implicit0(deploySelection: DeploySelection[Effect]) <- DeploySelection
                                                               .create[Effect](
-                                                                conf.casper.maxBlockSize * 1024 * 1024 /* MB */
+                                                                conf.casper.maxBlockSizeBytes
                                                               )
 
       implicit0(lab: LastApprovedBlock[Task]) <- LastApprovedBlock.of[Task].toEffect

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -93,10 +93,10 @@ package object transport {
       implicit0(transportEff: TransportLayer[Effect]) = TransportLayer
         .eitherTTransportLayer[Task]
 
-      implicit0(deploySelection: DeploySelection[Effect]) <- DeploySelection
-                                                              .create[Effect](
-                                                                conf.casper.maxBlockSizeBytes
-                                                              )
+      implicit0(deploySelection: DeploySelection[Effect]) = DeploySelection
+        .create[Effect](
+          conf.casper.maxBlockSizeBytes
+        )
 
       implicit0(lab: LastApprovedBlock[Task]) <- LastApprovedBlock.of[Task].toEffect
 

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -93,10 +93,9 @@ package object transport {
       implicit0(transportEff: TransportLayer[Effect]) = TransportLayer
         .eitherTTransportLayer[Task]
 
-      // TODO: Get from config
       implicit0(deploySelection: DeploySelection[Effect]) <- DeploySelection
                                                               .create[Effect](
-                                                                conf.casper.maxBlockSize * 1024 * 1024 /* 10MB */
+                                                                conf.casper.maxBlockSize * 1024 * 1024 /* MB */
                                                               )
 
       implicit0(lab: LastApprovedBlock[Task]) <- LastApprovedBlock.of[Task].toEffect

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -308,6 +308,10 @@ private[configuration] final case class Options private (
       gen[Int]("Number of deploys to accumulate before proposing.")
 
     @scallop
+    val casperMaxBlockSize =
+      gen[Int]("Maximum block size [in MBs].")
+
+    @scallop
     val serverBootstrap =
       gen[Node](
         "Bootstrap casperlabs node address for initial seed.",

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -308,8 +308,8 @@ private[configuration] final case class Options private (
       gen[Int]("Number of deploys to accumulate before proposing.")
 
     @scallop
-    val casperMaxBlockSize =
-      gen[Int]("Maximum block size [in MBs].")
+    val casperMaxBlockSizeBytes =
+      gen[Int]("Maximum block size [in bytes].")
 
     @scallop
     val serverBootstrap =

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -84,6 +84,7 @@ auto-propose-enabled = false
 auto-propose-check-interval = "1second"
 auto-propose-max-interval = "1second"
 auto-propose-max-count = 1
+max-block-size = 10
 
 [blockstorage]
 latest-messages-log-max-size-factor = 1

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -84,7 +84,7 @@ auto-propose-enabled = false
 auto-propose-check-interval = "1second"
 auto-propose-max-interval = "1second"
 auto-propose-max-count = 1
-max-block-size = 10
+max-block-size-bytes = 1
 
 [blockstorage]
 latest-messages-log-max-size-factor = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -117,7 +117,8 @@ class ConfigurationSpec
       autoProposeEnabled = false,
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),
-      autoProposeMaxCount = 1
+      autoProposeMaxCount = 1,
+      maxBlockSizeMBs = 10
     )
     val tls = Tls(
       certificate = Paths.get("/tmp/test"),

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -118,7 +118,7 @@ class ConfigurationSpec
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeMaxCount = 1,
-      maxBlockSizeMBs = 10
+      maxBlockSize = 10
     )
     val tls = Tls(
       certificate = Paths.get("/tmp/test"),

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -118,7 +118,7 @@ class ConfigurationSpec
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeMaxCount = 1,
-      maxBlockSize = 10
+      maxBlockSizeBytes = 1
     )
     val tls = Tls(
       certificate = Paths.get("/tmp/test"),


### PR DESCRIPTION
### Overview
Adds a basic deploy selection strategy with a block size limit. Lazily consumes a stream of `Deploy`s from the `DeployBuffer`, sends it to the EE and collects commuting effects until it reaches the end of the deploy stream or reaches block size limit.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-815

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
