### PR TITLE
NODE-773: New argument types in the API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,7 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 	rm -rf $(DIR_OUT)
 	mkdir -p $(DIR_OUT)
 	# First the pure data packages, so it doesn't create empty _pb_service.d.ts files.
+	# Then the service we'll invoke.
 	./hack/build/docker-buildenv.sh "\
 		protoc \
 				-I=$(DIR_IN) \
@@ -222,16 +223,13 @@ cargo/clean: $(shell find . -type f -name "Cargo.toml" | grep -v target | awk '{
 			$(DIR_IN)/google/protobuf/empty.proto \
 			$(DIR_IN)/io/casperlabs/casper/consensus/consensus.proto \
 			$(DIR_IN)/io/casperlabs/casper/consensus/info.proto \
-			$(DIR_IN)/io/casperlabs/casper/consensus/state.proto \
-		"
-	# Now the service we'll invoke.
-	./hack/build/docker-buildenv.sh "\
-	protoc \
-	    -I=$(DIR_IN) \
-		--plugin=protoc-gen-ts=./explorer/grpc/node_modules/ts-protoc-gen/bin/protoc-gen-ts \
-		--js_out=import_style=commonjs,binary:$(DIR_OUT) \
-		--ts_out=service=true:$(DIR_OUT) \
-		$(DIR_IN)/io/casperlabs/node/api/casper.proto \
+			$(DIR_IN)/io/casperlabs/casper/consensus/state.proto ; \
+		protoc \
+				-I=$(DIR_IN) \
+			--plugin=protoc-gen-ts=./explorer/grpc/node_modules/ts-protoc-gen/bin/protoc-gen-ts \
+			--js_out=import_style=commonjs,binary:$(DIR_OUT) \
+			--ts_out=service=true:$(DIR_OUT) \
+			$(DIR_IN)/io/casperlabs/node/api/casper.proto \
 		"
 	# Annotations were only required for the REST gateway. Remove them from Typescript.
 	for f in $(DIR_OUT)/io/casperlabs/node/api/casper_pb* ; do \

--- a/build.sbt
+++ b/build.sbt
@@ -132,9 +132,7 @@ lazy val casper = (project in file("casper"))
     shared         % "compile->compile;test->test",
     smartContracts % "compile->compile;test->test",
     crypto,
-    models,
-    client,
-    benchmarks
+    models
   )
 
 lazy val comm = (project in file("comm"))

--- a/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
@@ -160,13 +160,13 @@ object LegacyConversions {
         protocol
           .DeployCode()
           .withCode(deploy.getBody.getSession.getWasm)
-          .withArgs(deploy.getBody.getSession.args)
+          .withArgs(deploy.getBody.getSession.abiArgs)
       )
       .withPayment(
         protocol
           .DeployCode()
           .withCode(deploy.getBody.getPayment.getWasm)
-          .withArgs(deploy.getBody.getPayment.args)
+          .withArgs(deploy.getBody.getPayment.abiArgs)
       )
       .withGasLimit(gasLimit) // New version doesn't have it.
       .withGasPrice(deploy.getHeader.gasPrice)
@@ -182,13 +182,13 @@ object LegacyConversions {
         consensus.Deploy
           .Code()
           .withWasm(deploy.getSession.code)
-          .withArgs(deploy.getSession.args)
+          .withAbiArgs(deploy.getSession.args)
       )
       .withPayment(
         consensus.Deploy
           .Code()
           .withWasm(deploy.getPayment.code)
-          .withArgs(deploy.getPayment.args)
+          .withAbiArgs(deploy.getPayment.args)
       )
 
     val header = consensus.Deploy

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -304,8 +304,8 @@ class MultiParentCasperImpl[F[_]: Bracket[?[_], Throwable]: Log: Metrics: Time: 
   def deploy(deploy: Deploy): F[Either[Throwable, Unit]] = validatorId match {
     case Some(_) =>
       (deploy.getBody.session, deploy.getBody.payment) match {
-        case (None, _) | (_, None) | (Some(Deploy.Code(_, Deploy.Code.Contract.Empty)), _) |
-            (_, Some(Deploy.Code(_, Deploy.Code.Contract.Empty))) =>
+        case (None, _) | (_, None) | (Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty)), _) |
+            (_, Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty))) =>
           new IllegalArgumentException(s"Deploy was missing session and/or payment code.")
             .asLeft[Unit]
             .pure[F]

--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -120,11 +120,12 @@ object Genesis {
       blessedTerms: List[Deploy]
   ): F[BlockMsgWithTransform] =
     for {
-      _ <- Log[F].debug(s"Processing ${blessedTerms.size} blessed contracts...")
+      _         <- Log[F].debug(s"Processing ${blessedTerms.size} blessed contracts...")
+      eeDeploys <- blessedTerms.traverse(deployDataToEEDeploy[F](_))
       genesisResult <- MonadError[F, Throwable].rethrow(
                         ExecutionEngineService[F]
                           .runGenesis(
-                            blessedTerms.map(deployDataToEEDeploy),
+                            eeDeploys,
                             CasperLabsProtocolVersions.thresholdsVersionMap.fromBlock(
                               initial
                             )

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -528,33 +528,50 @@ object ProtoUtil {
   // Later, post DEV NET, conversion rate will be part of a deploy.
   val GAS_PRICE = 10L
 
-  def deployDataToEEDeploy(d: Deploy): ipc.DeployItem = ipc.DeployItem(
-    address = d.getHeader.accountPublicKey,
-    session = d.getBody.session.map(deployCodeToDeployPayload),
-    payment = d.getBody.payment.map(deployCodeToDeployPayload),
-    gasPrice = GAS_PRICE,
-    nonce = d.getHeader.nonce,
-    authorizationKeys = d.approvals.map(_.approverPublicKey)
-  )
+  def deployDataToEEDeploy[F[_]: MonadThrowable](d: Deploy): F[ipc.DeployItem] = {
+    def toPayload(maybeCode: Option[Deploy.Code]): F[Option[ipc.DeployPayload]] =
+      maybeCode match {
+        case None       => none[ipc.DeployPayload].pure[F]
+        case Some(code) => (deployCodeToDeployPayload[F](code).map(Some(_)))
+      }
 
-  def deployCodeToDeployPayload(code: Deploy.Code): ipc.DeployPayload = {
-    val args: ByteString = if (code.args.nonEmpty) {
-      ByteString.copyFrom(Abi.args(code.args.map(_.getValue: Abi.Serializable[_]): _*))
-    } else code.abiArgs
-
-    val payload = code.contract match {
-      case Deploy.Code.Contract.Wasm(wasm) =>
-        ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(wasm, args))
-      case Deploy.Code.Contract.Hash(hash) =>
-        ipc.DeployPayload.Payload.StoredContractHash(ipc.StoredContractHash(hash, args))
-      case Deploy.Code.Contract.Name(name) =>
-        ipc.DeployPayload.Payload.StoredContractName(ipc.StoredContractName(name, args))
-      case Deploy.Code.Contract.Uref(uref) =>
-        ipc.DeployPayload.Payload.StoredContractUref(ipc.StoredContractURef(uref, args))
-      case Deploy.Code.Contract.Empty =>
-        ipc.DeployPayload.Payload.Empty
+    for {
+      session <- toPayload(d.getBody.session)
+      payment <- toPayload(d.getBody.payment)
+    } yield {
+      ipc.DeployItem(
+        address = d.getHeader.accountPublicKey,
+        session = session,
+        payment = payment,
+        gasPrice = GAS_PRICE,
+        nonce = d.getHeader.nonce,
+        authorizationKeys = d.approvals.map(_.approverPublicKey)
+      )
     }
-    ipc.DeployPayload(payload)
+  }
+
+  def deployCodeToDeployPayload[F[_]: MonadThrowable](code: Deploy.Code): F[ipc.DeployPayload] = {
+    val argsF: F[ByteString] = if (code.args.nonEmpty) {
+      MonadThrowable[F]
+        .fromTry(Abi.args(code.args.map(_.getValue: Abi.Serializable[_]): _*))
+        .map(ByteString.copyFrom(_))
+    } else code.abiArgs.pure[F]
+
+    argsF.map { args =>
+      val payload = code.contract match {
+        case Deploy.Code.Contract.Wasm(wasm) =>
+          ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(wasm, args))
+        case Deploy.Code.Contract.Hash(hash) =>
+          ipc.DeployPayload.Payload.StoredContractHash(ipc.StoredContractHash(hash, args))
+        case Deploy.Code.Contract.Name(name) =>
+          ipc.DeployPayload.Payload.StoredContractName(ipc.StoredContractName(name, args))
+        case Deploy.Code.Contract.Uref(uref) =>
+          ipc.DeployPayload.Payload.StoredContractUref(ipc.StoredContractURef(uref, args))
+        case Deploy.Code.Contract.Empty =>
+          ipc.DeployPayload.Payload.Empty
+      }
+      ipc.DeployPayload(payload)
+    }
   }
 
   def dependenciesHashesOf(b: Block): List[BlockHash] = {

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -539,13 +539,13 @@ object ProtoUtil {
   def deployCodeToDeployPayload(code: Deploy.Code): ipc.DeployPayload = {
     val payload = code.contract match {
       case Deploy.Code.Contract.Wasm(wasm) =>
-        ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(wasm, code.args))
+        ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(wasm, code.abiArgs))
       case Deploy.Code.Contract.Hash(hash) =>
-        ipc.DeployPayload.Payload.StoredContractHash(ipc.StoredContractHash(hash, code.args))
+        ipc.DeployPayload.Payload.StoredContractHash(ipc.StoredContractHash(hash, code.abiArgs))
       case Deploy.Code.Contract.Name(name) =>
-        ipc.DeployPayload.Payload.StoredContractName(ipc.StoredContractName(name, code.args))
+        ipc.DeployPayload.Payload.StoredContractName(ipc.StoredContractName(name, code.abiArgs))
       case Deploy.Code.Contract.Uref(uref) =>
-        ipc.DeployPayload.Payload.StoredContractUref(ipc.StoredContractURef(uref, code.args))
+        ipc.DeployPayload.Payload.StoredContractUref(ipc.StoredContractURef(uref, code.abiArgs))
       case Deploy.Code.Contract.Empty =>
         ipc.DeployPayload.Payload.Empty
     }

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -538,25 +538,8 @@ object ProtoUtil {
   )
 
   def deployCodeToDeployPayload(code: Deploy.Code): ipc.DeployPayload = {
-    import Deploy.Arg.Value.Value
-    def toAbi(arg: Deploy.Arg): Abi.Serializable[_] =
-      arg.getValue.value match {
-        case Value.Empty | Value.Key(state.Key(state.Key.Value.Empty)) =>
-          throw new java.lang.IllegalArgumentException(
-            "Optional and empty deploy arguments are not supported yet!"
-          )
-        case Value.IntValue(x)    => Abi.toBytes(x)
-        case Value.LongValue(x)   => Abi.toBytes(x)
-        case Value.BytesValue(x)  => Abi.toBytes(x.toByteArray)
-        case Value.IntList(x)     => Abi.toBytes(x.values)
-        case Value.StringValue(x) => Abi.toBytes(x)
-        case Value.StringList(x)  => Abi.toBytes(x.values)
-        case Value.BigInt(_)      => ???
-        case Value.Key(x)         => Abi.toBytes(x)
-      }
-
     val args: ByteString = if (code.args.nonEmpty) {
-      ByteString.copyFrom(Abi.args(code.args.map(toAbi): _*))
+      ByteString.copyFrom(Abi.args(code.args.map(_.getValue: Abi.Serializable[_]): _*))
     } else code.abiArgs
 
     val payload = code.contract match {

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -541,7 +541,10 @@ object ProtoUtil {
     import Deploy.Arg.Value.Value
     def toAbi(arg: Deploy.Arg): Abi.Serializable[_] =
       arg.getValue.value match {
-        case Value.Empty          => Abi.none
+        case Value.Empty | Value.Key(state.Key(state.Key.Value.Empty)) =>
+          throw new java.lang.IllegalArgumentException(
+            "Optional and empty deploy arguments are not supported yet!"
+          )
         case Value.IntValue(x)    => Abi.toBytes(x)
         case Value.LongValue(x)   => Abi.toBytes(x)
         case Value.BytesValue(x)  => Abi.toBytes(x.toByteArray)
@@ -549,7 +552,7 @@ object ProtoUtil {
         case Value.StringValue(x) => Abi.toBytes(x)
         case Value.StringList(x)  => Abi.toBytes(x.values)
         case Value.BigInt(_)      => ???
-        case Value.Key(_)         => ???
+        case Value.Key(x)         => Abi.toBytes(x)
       }
 
     val args: ByteString = if (code.args.nonEmpty) {

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -546,8 +546,8 @@ object ProtoUtil {
         case Value.LongValue(x)   => Abi.toBytes(x)
         case Value.BytesValue(x)  => Abi.toBytes(x.toByteArray)
         case Value.IntList(x)     => Abi.toBytes(x.values)
-        case Value.StringValue(_) => ???
-        case Value.StringList(_)  => ???
+        case Value.StringValue(x) => Abi.toBytes(x)
+        case Value.StringList(x)  => Abi.toBytes(x.values)
         case Value.BigInt(_)      => ???
         case Value.Key(_)         => ???
       }

--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/BlockApproverProtocol.scala
@@ -180,10 +180,10 @@ object BlockApproverProtocol {
       protocolVersion = CasperLabsProtocolVersions.thresholdsVersionMap.versionAt(
         postState.blockNumber
       )
+      eeDeploys <- EitherT.liftF(deploys.toList.traverse(ProtoUtil.deployDataToEEDeploy[F](_)))
       genesisResult <- EitherT(
                         ExecutionEngineService[F].runGenesis(
-                          deploys
-                            .map(ProtoUtil.deployDataToEEDeploy),
+                          eeDeploys,
                           protocolVersion
                         )
                       ).leftMap(_.getMessage)

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -348,7 +348,7 @@ object DeployRuntime {
       .withBody(
         consensus.Deploy
           .Body()
-          .withSession(consensus.Deploy.Code(contract = session).withArgs(sessionArgs))
+          .withSession(consensus.Deploy.Code(contract = session).withAbiArgs(sessionArgs))
           .withPayment(consensus.Deploy.Code(contract = payment))
       )
       .withHashes

--- a/explorer/grpc/package-lock.json
+++ b/explorer/grpc/package-lock.json
@@ -23,9 +23,9 @@
       "integrity": "sha512-CA9hsySZVo9371qEHjHZtYxV2cFtVj5Wj/ZHi8ooEsrtm4vOnl9Y9HmyYWk9q+05d7K3rdoAE0j3MVEFVvtQtg=="
     },
     "google-protobuf": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.8.0.tgz",
-      "integrity": "sha512-tx39PTc//HaIT7K/baUF/8JYLGDozEi1e4xwPP1qSx3InP78cNpbSJpxiDsDMwj77qNOndVBDXnn7oi9zKxZew==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.9.1.tgz",
+      "integrity": "sha512-tkz7SVwBktFbqFK3teXFUY/VM57+mbUgV9bSD+sZH1ocHJ7uk7BfEWMRdU24dd0ciUDokreA7ghH2fYFIczQdw==",
       "dev": true
     },
     "ts-protoc-gen": {

--- a/explorer/server/src/lib/Contracts.ts
+++ b/explorer/server/src/lib/Contracts.ts
@@ -31,7 +31,7 @@ export class Contract {
 
     const code = new Deploy.Code();
     code.setWasm(this.contractWasm);
-    code.setArgs(args);
+    code.setAbiArgs(args);
 
     const body = new Deploy.Body();
     body.setSession(code);

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -327,7 +327,7 @@ class CasperLabsClient:
 
         def read_code(file_name: str, abi_encoded_args: bytes = None):
             return consensus.Deploy.Code(
-                wasm=read_binary(file_name), args=abi_encoded_args
+                wasm=read_binary(file_name), abi_args=abi_encoded_args
             )
 
         def sign(data: bytes):

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package io.casperlabs.casper.consensus;
 
+import "io/casperlabs/casper/consensus/state.proto";
+
 // Signature over for example a deploy or a block. The location of the public key depends
 // on the subject; for example if it's a block then the key is actually part of the data
 // that needs to be signed over.
@@ -68,7 +70,28 @@ message Deploy {
             // URef of a stored contract.
             bytes uref = 5;
         }
-        bytes args = 2; // ABI-encoded arguments
+        // Deprecated, use `args` instead.
+        bytes abi_args = 2; // ABI-encoded arguments
+        // Keyword arguments. Note that while the execution engine works with the original
+        // positional argument passing style, the order of the arguments matters.
+        repeated Arg args = 6;
+    }
+
+    message Arg {
+        string name = 1;
+        Value value = 3;
+
+        // Subset of cases in `state.Value` that can be used as input for contract calls.
+        message Value {
+            int32 int_value = 1;
+            bytes bytes_value = 2;
+            state.IntList int_list = 3;
+            string string_value = 4;
+            state.StringList string_list = 7;
+            state.BigInt big_int = 9;
+            state.Key key = 10;
+            uint64 long_value = 12;
+        }
     }
 }
 

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -79,18 +79,20 @@ message Deploy {
 
     message Arg {
         string name = 1;
-        Value value = 3;
+        Value value = 2;
 
         // Subset of cases in `state.Value` that can be used as input for contract calls.
         message Value {
-            int32 int_value = 1;
-            bytes bytes_value = 2;
-            state.IntList int_list = 3;
-            string string_value = 4;
-            state.StringList string_list = 7;
-            state.BigInt big_int = 9;
-            state.Key key = 10;
-            uint64 long_value = 12;
+            oneof value {
+                int32 int_value = 1;
+                bytes bytes_value = 2;
+                state.IntList int_list = 3;
+                string string_value = 4;
+                state.StringList string_list = 7;
+                state.BigInt big_int = 9;
+                state.Key key = 10;
+                uint64 long_value = 12;
+            }
         }
     }
 }

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -79,19 +79,22 @@ message Deploy {
 
     message Arg {
         string name = 1;
+        // Note that until the EE doesn't support kwargs directly, missing an Empty values are
+        // not allowed because they would be ambiguous.
         Value value = 2;
-
         // Subset of cases in `state.Value` that can be used as input for contract calls.
         message Value {
             oneof value {
-                int32 int_value = 1;
+                // Explicitly mark a value as Some or None in the ABI.
+                Value optional_value = 1;
                 bytes bytes_value = 2;
-                state.IntList int_list = 3;
-                string string_value = 4;
-                state.StringList string_list = 7;
-                state.BigInt big_int = 9;
-                state.Key key = 10;
-                uint64 long_value = 12;
+                int32 int_value = 3;
+                state.IntList int_list = 4;
+                string string_value = 5;
+                state.StringList string_list = 6;
+                uint64 long_value = 7;
+                state.BigInt big_int = 8;
+                state.Key key = 9;
             }
         }
     }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -2,7 +2,7 @@ package io.casperlabs.smartcontracts
 import simulacrum.typeclass
 import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets
-import io.casperlabs.casper.consensus.state.Key
+import io.casperlabs.casper.consensus.state.{BigInt, Key}
 import io.casperlabs.casper.consensus.Deploy
 
 @typeclass
@@ -59,6 +59,10 @@ object Abi {
     }
   }
 
+  implicit val `BigInt => ABI` = instance[BigInt] { x =>
+    Abi.toBytes(x.value) ++ Abi.toBytes(x.bitWidth)
+  }
+
   implicit def `Option => ABI`[T: Abi] = instance[Option[T]] { x =>
     x.fold(Array[Byte](0))(Array[Byte](1) ++ Abi.toBytes(_))
   }
@@ -88,7 +92,7 @@ object Abi {
       case Value.StringValue(x) => Abi.toBytes(x)
       case Value.StringList(x)  => Abi.toBytes(x.values)
       case Value.LongValue(x)   => Abi.toBytes(x)
-      case Value.BigInt(_)      => ???
+      case Value.BigInt(x)      => Abi.toBytes(x)
       case Value.Key(x)         => Abi.toBytes(x)
     }
   }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -37,11 +37,17 @@ object Abi {
   }
 
   implicit val `Bytes => ABI` = instance[Array[Byte]] { x =>
-    Abi[Int].toBytes(x.length) ++ x
+    Abi.toBytes(x.length) ++ x
   }
 
+  implicit def `Option => ABI`[T: Abi] = instance[Option[T]] { x =>
+    x.fold(Array[Byte](0))(Array[Byte](1) ++ Abi.toBytes(_))
+  }
+
+  def toBytes[T: Abi](x: T): Array[Byte] = Abi[T].toBytes(x)
+
   def args(args: Serializable[_]*): Array[Byte] = {
-    val bytes = args.flatMap(_.toBytes)
-    Abi[Int].toBytes(bytes.length) ++ bytes
+    val bytes = args.flatMap(x => Abi.toBytes(x.toBytes))
+    Abi.toBytes(args.length) ++ bytes
   }
 }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -50,8 +50,8 @@ object Abi {
 
   implicit val `Key => ABI` = instance[Key] { x =>
     x.value match {
-      case Key.Value.Hash(x)    => Array[Byte](0) ++ Abi.toBytes(x.hash.toByteArray)
-      case Key.Value.Address(x) => Array[Byte](1) ++ Abi.toBytes(x.account.toByteArray)
+      case Key.Value.Address(x) => Array[Byte](0) ++ Abi.toBytes(x.account.toByteArray)
+      case Key.Value.Hash(x)    => Array[Byte](1) ++ Abi.toBytes(x.hash.toByteArray)
       case Key.Value.Uref(x)    => Array[Byte](2) ++ Abi.toBytes(x.uref.toByteArray)
       case Key.Value.Local(x)   => Array[Byte](3) ++ Abi.toBytes(x.hash.toByteArray)
       case Key.Value.Empty =>

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.smartcontracts
 import simulacrum.typeclass
 import java.nio.{ByteBuffer, ByteOrder}
+import java.nio.charset.StandardCharsets
 
 @typeclass
 trait Abi[T] {
@@ -38,6 +39,11 @@ object Abi {
 
   implicit val `Bytes => ABI` = instance[Array[Byte]] { x =>
     Abi.toBytes(x.length) ++ x
+  }
+
+  implicit val `String => ABI` = instance[String] { x =>
+    val bytes = x.getBytes(StandardCharsets.UTF_8)
+    Abi.toBytes(bytes.length) ++ bytes
   }
 
   implicit def `Option => ABI`[T: Abi] = instance[Option[T]] { x =>

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -44,6 +44,13 @@ object Abi {
     x.fold(Array[Byte](0))(Array[Byte](1) ++ Abi.toBytes(_))
   }
 
+  implicit def `Seq => ABI`[T: Abi] = instance[Seq[T]] { xs =>
+    Abi.toBytes(xs.length) ++ xs.flatMap(Abi.toBytes(_))
+  }
+
+  // All None values are the same.
+  val none = Abi.toBytes(None: Option[Int])
+
   def toBytes[T: Abi](x: T): Array[Byte] = Abi[T].toBytes(x)
 
   def args(args: Serializable[_]*): Array[Byte] = {

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -4,14 +4,15 @@ import java.nio.{ByteBuffer, ByteOrder}
 import java.nio.charset.StandardCharsets
 import io.casperlabs.casper.consensus.state.{BigInt, Key}
 import io.casperlabs.casper.consensus.Deploy
+import scala.util.{Failure, Success, Try}
 
 @typeclass
 trait Abi[T] {
-  def toBytes(x: T): Array[Byte]
+  def toBytes(x: T): Try[Array[Byte]]
 }
 
 object Abi {
-  def instance[T](to: T => Array[Byte]) = new Abi[T] {
+  def instance[T](to: T => Try[Array[Byte]]) = new Abi[T] {
     override def toBytes(x: T) = to(x)
   }
 
@@ -23,20 +24,30 @@ object Abi {
     implicit def fromValue[T: Abi](value: T) = Serializable(value)
   }
 
+  private implicit class TryOps[T](val ta: Try[Array[Byte]]) extends AnyVal {
+    def ++(b: Array[Byte]): Try[Array[Byte]]          = ta.map(a => a ++ b)
+    def ++(tb: => Try[Array[Byte]]): Try[Array[Byte]] = for { a <- ta; b <- tb } yield (a ++ b)
+    def ++:(b: Array[Byte]): Try[Array[Byte]]         = ta.map(a => b ++ a)
+  }
+
   implicit val `Int => ABI` = instance[Int] { x =>
-    ByteBuffer
-      .allocate(4)
-      .order(ByteOrder.LITTLE_ENDIAN)
-      .putInt(x)
-      .array()
+    Success(
+      ByteBuffer
+        .allocate(4)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt(x)
+        .array()
+    )
   }
 
   implicit val `Long => ABI` = instance[Long] { x =>
-    ByteBuffer
-      .allocate(8)
-      .order(ByteOrder.LITTLE_ENDIAN)
-      .putLong(x)
-      .array()
+    Success(
+      ByteBuffer
+        .allocate(8)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putLong(x)
+        .array()
+    )
   }
 
   implicit val `Bytes => ABI` = instance[Array[Byte]] { x =>
@@ -50,12 +61,12 @@ object Abi {
 
   implicit val `Key => ABI` = instance[Key] { x =>
     x.value match {
-      case Key.Value.Address(x) => Array[Byte](0) ++ Abi.toBytes(x.account.toByteArray)
-      case Key.Value.Hash(x)    => Array[Byte](1) ++ Abi.toBytes(x.hash.toByteArray)
-      case Key.Value.Uref(x)    => Array[Byte](2) ++ Abi.toBytes(x.uref.toByteArray)
-      case Key.Value.Local(x)   => Array[Byte](3) ++ Abi.toBytes(x.hash.toByteArray)
+      case Key.Value.Address(x) => Array[Byte](0) ++: Abi.toBytes(x.account.toByteArray)
+      case Key.Value.Hash(x)    => Array[Byte](1) ++: Abi.toBytes(x.hash.toByteArray)
+      case Key.Value.Uref(x)    => Array[Byte](2) ++: Abi.toBytes(x.uref.toByteArray)
+      case Key.Value.Local(x)   => Array[Byte](3) ++: Abi.toBytes(x.hash.toByteArray)
       case Key.Value.Empty =>
-        throw new java.lang.IllegalArgumentException("Cannot serialize empty Key to ABI.")
+        Failure(new java.lang.IllegalArgumentException("Cannot serialize empty Key to ABI."))
     }
   }
 
@@ -70,15 +81,15 @@ object Abi {
     val unsignedLittleEndian = bytes.dropWhile(_ == 0.toByte).reverse
     // For some reason the BigInt expects the length of bytes to be in a 1 sized array,
     // instead of the usual 4.
-    Abi.toBytes(unsignedLittleEndian).take(1) ++ unsignedLittleEndian
+    Abi.toBytes(unsignedLittleEndian).map(_.take(1) ++ unsignedLittleEndian)
   }
 
   implicit def `Option => ABI`[T: Abi] = instance[Option[T]] { x =>
-    x.fold(Array[Byte](0))(Array[Byte](1) ++ Abi.toBytes(_))
+    x.fold(Try(Array[Byte](0)))(Array[Byte](1) ++: Abi.toBytes(_))
   }
 
   implicit def `Seq => ABI`[T: Abi] = instance[Seq[T]] { xs =>
-    Abi.toBytes(xs.length) ++ xs.flatMap(Abi.toBytes(_))
+    xs.foldLeft(Abi.toBytes(xs.length))(_ ++ Abi.toBytes(_))
   }
 
   // All None values are the same.
@@ -91,8 +102,10 @@ object Abi {
         // If kwargs were supported by the EE side we could treat Value.Empty as None,
         // but with positional arguments we can't as it would possibly lead to data corruption
         // if the EE for example expects a Long but we send just a single byte.
-        throw new java.lang.IllegalArgumentException(
-          "Empty deploy arguments are not supported yet, use the `optional_value` variant!"
+        Failure(
+          new java.lang.IllegalArgumentException(
+            "Empty deploy arguments are not supported yet, use the `optional_value` variant!"
+          )
         )
       case Value.OptionalValue(x) =>
         if (x.value.isEmpty) Abi.none else Abi.toBytes(Option(x))
@@ -107,10 +120,10 @@ object Abi {
     }
   }
 
-  def toBytes[T: Abi](x: T): Array[Byte] = Abi[T].toBytes(x)
+  def toBytes[T: Abi](x: T): Try[Array[Byte]] = Abi[T].toBytes(x)
 
-  def args(args: Serializable[_]*): Array[Byte] = {
-    val bytes = args.flatMap(x => Abi.toBytes(x.toBytes))
-    Abi.toBytes(args.length) ++ bytes
-  }
+  def args(args: Serializable[_]*): Try[Array[Byte]] =
+    args.foldLeft(Abi.toBytes(args.length)) {
+      case (acc, arg) => acc ++ arg.toBytes.flatMap(Abi.toBytes(_))
+    }
 }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/Abi.scala
@@ -1,0 +1,47 @@
+package io.casperlabs.smartcontracts
+import simulacrum.typeclass
+import java.nio.{ByteBuffer, ByteOrder}
+
+@typeclass
+trait Abi[T] {
+  def toBytes(x: T): Array[Byte]
+}
+
+object Abi {
+  def instance[T](to: T => Array[Byte]) = new Abi[T] {
+    override def toBytes(x: T) = to(x)
+  }
+
+  /** Helper class to be used with `Abi.args(...)` */
+  case class Serializable[T](value: T)(implicit ev: Abi[T]) {
+    def toBytes = ev.toBytes(value)
+  }
+  object Serializable {
+    implicit def fromValue[T: Abi](value: T) = Serializable(value)
+  }
+
+  implicit val `Int => ABI` = instance[Int] { x =>
+    ByteBuffer
+      .allocate(4)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putInt(x)
+      .array()
+  }
+
+  implicit val `Long => ABI` = instance[Long] { x =>
+    ByteBuffer
+      .allocate(8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putLong(x)
+      .array()
+  }
+
+  implicit val `Bytes => ABI` = instance[Array[Byte]] { x =>
+    Abi[Int].toBytes(x.length) ++ x
+  }
+
+  def args(args: Serializable[_]*): Array[Byte] = {
+    val bytes = args.flatMap(_.toBytes)
+    Abi[Int].toBytes(bytes.length) ++ bytes
+  }
+}

--- a/smart-contracts/src/test/scala/io/casperlabs/smartcontracts/AbiSpec.scala
+++ b/smart-contracts/src/test/scala/io/casperlabs/smartcontracts/AbiSpec.scala
@@ -1,0 +1,71 @@
+package io.casperlabs.smartcontracts
+import org.scalatest._
+
+class AbiSpec extends FlatSpec with Matchers {
+  def wrap(bytes: Array[Byte]): java.nio.ByteBuffer = {
+    val buffer = java.nio.ByteBuffer.allocate(bytes.length).order(java.nio.ByteOrder.LITTLE_ENDIAN)
+    buffer.put(bytes)
+    buffer.flip() // Otherwise UnderflowException.
+    buffer
+  }
+
+  behavior of "Abi"
+
+  it should "serialize Long as 64 bits using little endiannes" in {
+    val value = 1234567890L
+    val bytes = Abi.toBytes(value)
+    bytes should have size (64 / 8)
+    wrap(bytes).getLong() shouldBe value
+  }
+
+  it should "serialize Array[Byte] as size ++ content using little endiannes" in {
+    val value = Array.range(0, 32).map(_.toByte)
+    val bytes = Abi.toBytes(value)
+    bytes should have size (4 + 32)
+    bytes(0) shouldBe 32
+    bytes(1) shouldBe 0
+    bytes(4) shouldBe value(0)
+    bytes(35) shouldBe value(31)
+  }
+
+  it should "serialize multiple args with size ++ concatentation of parts" in {
+    val a      = Array.range(0, 32).map(_.toByte)
+    val b      = 500000L
+    val bytes  = Abi.args(a, b)
+    val buffer = wrap(bytes)
+    buffer.get(0) shouldBe 2
+    buffer.get(1) shouldBe 0
+    buffer.get(4) shouldBe 36
+    buffer.get(5) shouldBe 0
+    buffer.get(8) shouldBe 32
+    buffer.get(44) shouldBe 8
+    Array.range(12, 12 + 32).map(buffer.get) shouldBe a
+    buffer.getLong(48) shouldBe b
+  }
+
+  it should "work with the hardcoded example" in {
+    val a      = Array.fill(32)(1.toByte)
+    val b      = 67305985L
+    val result = Abi.args(a, b)
+    val expected = Array[Byte](
+      2, 0, 0, 0,  // number of args
+      36, 0, 0, 0, // length of `a` serialized as an arg
+      32, 0, 0, 0, // length of contents of `a`
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      1,                     // contents of `a`
+      8, 0, 0, 0,            // length of `b` serialized as an arg
+      1, 2, 3, 4, 0, 0, 0, 0 // bytes of `b` itself
+    )
+    result shouldBe expected
+  }
+
+  it should "serialize Some as 1 ++ value" in {
+    val bytes = Abi.toBytes(Option(67305985L))
+    bytes shouldBe Array[Byte](1, 1, 2, 3, 4, 0, 0, 0, 0)
+  }
+
+  it should "serialize None as 0" in {
+    val bytes = Abi.toBytes(None: Option[Int])
+    bytes shouldBe Array[Byte](0)
+  }
+}

--- a/smart-contracts/src/test/scala/io/casperlabs/smartcontracts/AbiSpec.scala
+++ b/smart-contracts/src/test/scala/io/casperlabs/smartcontracts/AbiSpec.scala
@@ -13,14 +13,14 @@ class AbiSpec extends FlatSpec with Matchers {
 
   it should "serialize Long as 64 bits using little endiannes" in {
     val value = 1234567890L
-    val bytes = Abi.toBytes(value)
+    val bytes = Abi.toBytes(value).get
     bytes should have size (64 / 8)
     wrap(bytes).getLong() shouldBe value
   }
 
   it should "serialize Array[Byte] as size ++ content using little endiannes" in {
     val value = Array.range(0, 32).map(_.toByte)
-    val bytes = Abi.toBytes(value)
+    val bytes = Abi.toBytes(value).get
     bytes should have size (4 + 32)
     bytes(0) shouldBe 32
     bytes(1) shouldBe 0
@@ -31,7 +31,7 @@ class AbiSpec extends FlatSpec with Matchers {
   it should "serialize multiple args with size ++ concatentation of parts" in {
     val a      = Array.range(0, 32).map(_.toByte)
     val b      = 500000L
-    val bytes  = Abi.args(a, b)
+    val bytes  = Abi.args(a, b).get
     val buffer = wrap(bytes)
     buffer.get(0) shouldBe 2
     buffer.get(1) shouldBe 0
@@ -46,7 +46,7 @@ class AbiSpec extends FlatSpec with Matchers {
   it should "work with the hardcoded example" in {
     val a      = Array.fill(32)(1.toByte)
     val b      = 67305985L
-    val result = Abi.args(a, b)
+    val result = Abi.args(a, b).get
     val expected = Array[Byte](
       2, 0, 0, 0,  // number of args
       36, 0, 0, 0, // length of `a` serialized as an arg
@@ -60,12 +60,12 @@ class AbiSpec extends FlatSpec with Matchers {
   }
 
   it should "serialize Some as 1 ++ value" in {
-    val bytes = Abi.toBytes(Option(67305985L))
+    val bytes = Abi.toBytes(Option(67305985L)).get
     bytes shouldBe Array[Byte](1, 1, 2, 3, 4, 0, 0, 0, 0)
   }
 
   it should "serialize None as 0" in {
-    val bytes = Abi.toBytes(None: Option[Int])
+    val bytes = Abi.toBytes(None: Option[Int]).get
     bytes shouldBe Array[Byte](0)
   }
 }


### PR DESCRIPTION
### Overview
Renames the current `Deploy.Code.args` to `Deploy.Code.abi_args` and adds a new `args` field with type type `repeated Deploy.Code.Arg`. Each `Arg` has a name and a value, which are a subset of the `state.Value` options, except `Account` and `Contract`. 

I added an explicit `optional_value` variant to capture whether a field is intentionally None or Some. If we had support for kwargs, then the Rust side could differentiate between an empty Value or one that is just there in the args, but without explicit Some designation, without risking data corruption. For now empty values are rejected.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-773

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I was just guessing with some of the data types' ABI rules.
