### PR TITLE
NODE-653: kwargs in Scala client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -430,7 +430,8 @@ lazy val client = (project in file("client"))
       scallop,
       grpcNetty,
       graphvizJava,
-      apacheCommons
+      apacheCommons,
+      scalapbCirce
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "io.casperlabs.client",

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -81,7 +81,7 @@ object DeployRuntime {
 
   // This is true for any array but I didn't want to go as far as writing type classes.
   // Binary format of an array is constructed from:
-  // length (u64/integer in binary) ++ bytes
+  // length (u32/integer in binary) ++ bytes
   private def serializeArray(ba: Array[Byte]): Array[Byte] = {
     val serLen = serializeInt(ba.length)
     serLen ++ ba

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -139,7 +139,7 @@ object Main {
             nonce,
             gasPrice,
             contracts,
-            Array.emptyByteArray
+            sessionArgs = Nil
           )
           _ <- DeployRuntime.writeDeploy(deploy, deployPath)
         } yield ()

--- a/client/src/main/scala/io/casperlabs/client/configuration/Args.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Args.scala
@@ -17,17 +17,17 @@ import scalapb.descriptors.{FieldDescriptor, PByteString, PMessage, PValue, Scal
 import scala.util.Try
 import com.google.protobuf.descriptor.FieldDescriptorProto.Type.TYPE_BYTES
 
-case class Args(args: Seq[Arg]) {
-  // Convert from JSON string to args.
-  implicit val valueConverter = implicitly[ValueConverter[String]].flatMap { _ =>
-    ???
-  }
-}
+case class Args(args: Seq[Arg])
 
 object Args {
+  // Convert from JSON string to args.
+  implicit val valueConverter: ValueConverter[Args] =
+    implicitly[ValueConverter[String]].flatMap { json =>
+      Args.fromJson(json).map(args => Some(Args(args)))
+    }
+
   // Override the format of `bytes` to be Base16.
   // https://github.com/scalapb-json/scalapb-circe/blob/0.2.x/shared/src/main/scala/scalapb_circe/JsonFormat.scala
-
   val parser = new Parser(
     preservingProtoFieldNames = true
   ) {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Args.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Args.scala
@@ -1,0 +1,67 @@
+package io.casperlabs.client.configuration
+
+import cats._
+import cats.implicits._
+import cats.syntax.either._
+import com.google.protobuf.wrappers
+import com.google.protobuf.ByteString
+import com.google.protobuf.descriptor.FieldDescriptorProto
+import io.casperlabs.casper.consensus.Deploy.Arg
+import io.casperlabs.crypto.codec.Base16
+import io.circe.Json
+import org.rogach.scallop._
+import scalapb_circe.{JsonFormat, Parser, Printer}
+import scalapb_json.JsonFormatException
+import scalapb.GeneratedMessageCompanion
+import scalapb.descriptors.{FieldDescriptor, PByteString, PMessage, PValue, ScalaType}
+import scala.util.Try
+import com.google.protobuf.descriptor.FieldDescriptorProto.Type.TYPE_BYTES
+
+case class Args(args: Seq[Arg]) {
+  // Convert from JSON string to args.
+  implicit val valueConverter = implicitly[ValueConverter[String]].flatMap { _ =>
+    ???
+  }
+}
+
+object Args {
+  // Override the format of `bytes` to be Base16.
+  // https://github.com/scalapb-json/scalapb-circe/blob/0.2.x/shared/src/main/scala/scalapb_circe/JsonFormat.scala
+
+  val parser = new Parser(
+    preservingProtoFieldNames = true
+  ) {
+    override def parseSingleValue(
+        containerCompanion: GeneratedMessageCompanion[_],
+        fd: FieldDescriptor,
+        value: Json
+    ): PValue =
+      fd.scalaType match {
+        case ScalaType.ByteString =>
+          value.asString match {
+            case Some(s) =>
+              PByteString(ByteString.copyFrom(Base16.decode(s)))
+            case None =>
+              throw new JsonFormatException(
+                s"Unexpected value ($value) for field ${fd.asProto.getName} of ${fd.containingMessage.name}"
+              )
+          }
+        case _ =>
+          super.parseSingleValue(containerCompanion, fd, value)
+      }
+  }
+
+  // Parse JSON formatted arguments using the Proto3 JSON format.
+  def fromJson(s: String): Either[String, List[Arg]] =
+    for {
+      json <- io.circe.parser.parse(s).leftMap(_.message)
+      arr  <- json.as[List[Json]].leftMap(_.message)
+      args <- arr
+               .map { js =>
+                 Try(parser.fromJson[Arg](js)).toEither.leftMap(_.getMessage)
+               }
+               .toList
+               .sequence
+    } yield args
+
+}

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -68,7 +68,12 @@ object Contracts {
 
   val empty = Contracts(CodeOptions.empty, CodeOptions.empty)
 
-  /** Produce a Deploy.Code DTO from the options. */
+  /** Produce a Deploy.Code DTO from the options.
+    * 'defaultArgs' can be used by specialized commands such as `transfer` and `unbond`
+    * to pass arguments they captured via dedicated CLI options, e.g. `--amount`, but
+    * if the user sends explicit arguments via `--session-args` or `--payment-args`
+    * they take precedence. This allows overriding the built-in contracts with custom ones.
+    */
   private def toCode(opts: CodeOptions, defaultArgs: Seq[Arg]): Code = {
     val contract = opts.file.map { f =>
       val wasm = ByteString.copyFrom(Files.readAllBytes(f.toPath))

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -49,6 +49,13 @@ object Options {
         validate = hashCheck
       )
 
+    val sessionArgs =
+      opt[Args](
+        required = false,
+        descr =
+          "JSON encoded session contract arguments, e.g. [{'name': 'amount', 'value': {'long_value': 123456}}]"
+      )
+
     val payment =
       opt[File](
         name = paymentPathName,
@@ -76,6 +83,13 @@ object Options {
         required = false,
         descr = "URef of the stored contract to be called in the payment; base16 encoded.",
         validate = hashCheck
+      )
+
+    val paymentArgs =
+      opt[Args](
+        required = false,
+        descr =
+          "JSON encoded payment contract arguments, e.g. [{'name': 'amount', 'value': {'long_value': 123456}}]"
       )
 
     addValidation {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -53,7 +53,7 @@ object Options {
       opt[Args](
         required = false,
         descr =
-          "JSON encoded session contract arguments, e.g. [{'name': 'amount', 'value': {'long_value': 123456}}]"
+          "JSON encoded list of Deploy.Arg protobuf messages for the session, e.g. [{'name': 'amount', 'value': {'long_value': 123456}}]"
       )
 
     val payment =
@@ -89,7 +89,7 @@ object Options {
       opt[Args](
         required = false,
         descr =
-          "JSON encoded payment contract arguments, e.g. [{'name': 'amount', 'value': {'long_value': 123456}}]"
+          "JSON encoded list of Deploy.Arg protobuf messages for the payment, e.g. [{'name': 'amount', 'value': {'long_value': 123456}}]"
       )
 
     addValidation {

--- a/client/src/test/scala/io/casperlabs/client/configuration/ArgsSpec.scala
+++ b/client/src/test/scala/io/casperlabs/client/configuration/ArgsSpec.scala
@@ -1,0 +1,36 @@
+package io.casperlabs.client.configuration
+
+import org.scalatest._
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.casper.consensus.Deploy.Arg
+import com.google.protobuf.ByteString
+
+class ArgsSpec extends FlatSpec with Matchers {
+  behavior of "Args"
+
+  it should "parse JSON arguments" in {
+    val amount  = 123456L
+    val account = Array.range(0, 32).map(_.toByte)
+    val json    = s"""
+    [
+      {"name": "amount", "value": {"long_value": ${amount}}},
+      {"name": "account", "value": {"bytes_value": "${Base16.encode(account)}"}},
+      {"name": "purse_id", "value": {"optional_value": {}}}
+    ]
+    """
+
+    Args.fromJson(json) match {
+      case Left(error) =>
+        fail(error)
+      case Right(args) =>
+        args should have size 3
+        args(0) shouldBe Arg("amount").withValue(Arg.Value(Arg.Value.Value.LongValue(amount)))
+        args(1) shouldBe Arg("account").withValue(
+          Arg.Value(Arg.Value.Value.BytesValue(ByteString.copyFrom(account)))
+        )
+        args(2) shouldBe Arg("purse_id").withValue(
+          Arg.Value(Arg.Value.Value.OptionalValue(Arg.Value(Arg.Value.Value.Empty)))
+        )
+    }
+  }
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val catsVersion    = "1.6.0"
   val catsMtlVersion = "0.5.0"
   val doobieVersion  = "0.7.0"
-  val fs2Version = "1.0.4"
+  val fs2Version     = "1.0.4"
 
   val julToSlf4j          = "org.slf4j"           % "jul-to-slf4j"          % "1.7.25"
   val bitcoinjCore        = "org.bitcoinj"        % "bitcoinj-core"         % "0.14.6"
@@ -65,6 +65,7 @@ object Dependencies {
   val scalapbRuntime         = "com.thesamet.scalapb"       %% "scalapb-runtime"                % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib      = "com.thesamet.scalapb"       %% "scalapb-runtime"                % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntimegGrpc    = "com.thesamet.scalapb"       %% "scalapb-runtime-grpc"           % scalapb.compiler.Version.scalapbVersion
+  val scalapbCirce           = "io.github.scalapb-json"     %% "scalapb-circe"                  % "0.2.2"
   val grpcNetty              = "io.grpc"                    % "grpc-netty"                      % scalapb.compiler.Version.grpcJavaVersion
   val nettyAll               = "io.netty"                   % "netty-all"                       % "4.1.22.Final"
   val nettyTransNativeEpoll  = "io.netty"                   % "netty-transport-native-epoll"    % "4.1.22.Final" classifier "linux-x86_64"
@@ -109,7 +110,8 @@ object Dependencies {
     "org.scala-lang.modules"   %% "scala-xml"              % "1.1.0",
     "com.google.code.findbugs" % "jsr305"                  % "3.0.2",
     "com.google.errorprone"    % "error_prone_annotations" % "2.1.2",
-    "com.github.jnr"           % "jnr-ffi"                 % "2.1.7"
+    "com.github.jnr"           % "jnr-ffi"                 % "2.1.7",
+    "com.thesamet.scalapb"     %% "scalapb-runtime"        % scalapb.compiler.Version.scalapbVersion
   )
 
   private val kindProjector    = compilerPlugin("org.spire-math" %% "kind-projector"     % "0.9.8")
@@ -122,7 +124,7 @@ object Dependencies {
 
   private val logging = Seq(scalaLogging, logbackClassic, janino, julToSlf4j)
 
-  private val circeDependencies: Seq[ModuleID] =
+  val circeDependencies: Seq[ModuleID] =
     Seq(circeCore, circeGeneric, circeGenericExtras, circeParser, circeLiteral)
 
   private val http4sDependencies: Seq[ModuleID] =


### PR DESCRIPTION
### Overview
Add support for passing deploy arguments to the Scala client.

Decided to go with the Proto3 JSON support, which should be available to all languages, including the [scalapb](https://scalapb.github.io/json.html) plugin. One exception is that I added an override to the parser to expect bytes in Base16. I think @piokuc in the Python client only added this treatment during printing for 32 byte hashes, leaving everything else in Base64. The Scala client prints bytes in Base16 in things like `show-block`. 

And example JSON would be:
```
    [
      {"name": "amount", "value": {"long_value": 123456}},
      {"name": "account", "value": {"bytes_value": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"}},
      {"name": "purse_id", "value": {"optional_value": {}}}
    ]
```
That value has to be passed as a single line, like `--session-args '[{"name": ... ]'`

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-653

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
