### PR TITLE
EE-636: simplify EngineState

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -1,17 +1,21 @@
+pub mod engine_config;
+pub mod error;
+pub mod executable_deploy_item;
+pub mod execution_effect;
+pub mod execution_result;
+pub mod genesis;
+pub mod op;
+pub mod utils;
+
 use std::cell::RefCell;
 use std::collections::{BTreeSet, HashMap};
 use std::rc::Rc;
-use std::sync::Arc;
 
-use parking_lot::Mutex;
-
-use crate::engine_state::utils::WasmiBytes;
-use crate::execution::{self, Executor, MINT_NAME, POS_NAME};
-use crate::tracking_copy::{TrackingCopy, TrackingCopyExt};
 use contract_ffi::bytesrepr::ToBytes;
 use contract_ffi::contract_api::argsparser::ArgsParser;
 use contract_ffi::execution::Phase;
 use contract_ffi::key::{Key, HASH_SIZE};
+use contract_ffi::uref::URef;
 use contract_ffi::uref::{AccessRights, UREF_ADDR_SIZE};
 use contract_ffi::value::account::{BlockTime, PublicKey, PurseId};
 use contract_ffi::value::{Account, Value, U512};
@@ -27,16 +31,9 @@ use self::execution_result::ExecutionResult;
 use self::genesis::{create_genesis_effects, GenesisResult};
 use crate::engine_state::executable_deploy_item::ExecutableDeployItem;
 use crate::engine_state::genesis::{POS_PAYMENT_PURSE, POS_REWARDS_PURSE};
-use contract_ffi::uref::URef;
-
-pub mod engine_config;
-pub mod error;
-pub mod executable_deploy_item;
-pub mod execution_effect;
-pub mod execution_result;
-pub mod genesis;
-pub mod op;
-pub mod utils;
+use crate::engine_state::utils::WasmiBytes;
+use crate::execution::{self, Executor, MINT_NAME, POS_NAME};
+use crate::tracking_copy::{TrackingCopy, TrackingCopyExt};
 
 // TODO?: MAX_PAYMENT && CONV_RATE values are currently arbitrary w/ real values
 // TBD gas * CONV_RATE = motes
@@ -47,10 +44,16 @@ pub const SYSTEM_ACCOUNT_ADDR: [u8; 32] = [0u8; 32];
 
 const DEFAULT_SESSION_MOTES: u64 = 1_000_000_000;
 
+pub enum GetBondedValidatorsError<H: History> {
+    StorageErrors(H::Error),
+    PostStateHashNotFound(Blake2bHash),
+    PoSNotFound(Key),
+}
+
 #[derive(Debug)]
 pub struct EngineState<H> {
     config: EngineConfig,
-    state: Arc<Mutex<H>>,
+    state: H,
 }
 
 impl<H> EngineState<H>
@@ -59,7 +62,6 @@ where
     H::Error: Into<execution::Error>,
 {
     pub fn new(state: H, config: EngineConfig) -> EngineState<H> {
-        let state = Arc::new(Mutex::new(state));
         EngineState { config, state }
     }
 
@@ -89,9 +91,9 @@ where
             genesis_validators,
             protocol_version,
         )?;
-        let mut state_guard = self.state.lock();
-        let prestate_hash = state_guard.empty_root();
-        let commit_result = state_guard
+        let prestate_hash = self.state.empty_root();
+        let commit_result = self
+            .state
             .commit(correlation_id, prestate_hash, effects.transforms.to_owned())
             .map_err(Into::into)?;
 
@@ -100,15 +102,11 @@ where
         Ok(genesis_result)
     }
 
-    pub fn state(&self) -> Arc<Mutex<H>> {
-        Arc::clone(&self.state)
-    }
-
     pub fn tracking_copy(
         &self,
         hash: Blake2bHash,
     ) -> Result<Option<TrackingCopy<H::Reader>>, Error> {
-        match self.state.lock().checkout(hash).map_err(Into::into)? {
+        match self.state.checkout(hash).map_err(Into::into)? {
             Some(tc) => Ok(Some(TrackingCopy::new(tc))),
             None => Ok(None),
         }
@@ -733,43 +731,34 @@ where
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
     ) -> Result<CommitResult, H::Error> {
-        self.state
-            .lock()
-            .commit(correlation_id, prestate_hash, effects)
+        self.state.commit(correlation_id, prestate_hash, effects)
     }
-}
 
-pub enum GetBondedValidatorsError<H: History> {
-    StorageErrors(H::Error),
-    PostStateHashNotFound(Blake2bHash),
-    PoSNotFound(Key),
-}
-
-/// Calculates bonded validators at `root_hash` state.
-pub fn get_bonded_validators<H: History>(
-    state: Arc<Mutex<H>>,
-    root_hash: Blake2bHash,
-    pos_key: &Key, /* Address of the PoS as currently bonded validators are stored in its known
-                    * urefs map. */
-    correlation_id: CorrelationId,
-) -> Result<HashMap<PublicKey, U512>, GetBondedValidatorsError<H>> {
-    state
-        .lock()
-        .checkout(root_hash)
-        .map_err(GetBondedValidatorsError::StorageErrors)
-        .and_then(|maybe_reader| match maybe_reader {
-            Some(reader) => match reader.read(correlation_id, &pos_key.normalize()) {
-                Ok(Some(Value::Contract(contract))) => {
-                    let bonded_validators = contract
-                        .urefs_lookup()
-                        .keys()
-                        .filter_map(|entry| utils::pos_validator_to_tuple(entry))
-                        .collect::<HashMap<PublicKey, U512>>();
-                    Ok(bonded_validators)
-                }
-                Ok(_) => Err(GetBondedValidatorsError::PoSNotFound(*pos_key)),
-                Err(error) => Err(GetBondedValidatorsError::StorageErrors(error)),
-            },
-            None => Err(GetBondedValidatorsError::PostStateHashNotFound(root_hash)),
-        })
+    /// Calculates bonded validators at `root_hash` state.
+    pub fn get_bonded_validators(
+        &self,
+        root_hash: Blake2bHash,
+        pos_key: &Key, /* Address of the PoS as currently bonded validators are stored in its
+                        * known urefs map. */
+        correlation_id: CorrelationId,
+    ) -> Result<HashMap<PublicKey, U512>, GetBondedValidatorsError<H>> {
+        self.state
+            .checkout(root_hash)
+            .map_err(GetBondedValidatorsError::StorageErrors)
+            .and_then(|maybe_reader| match maybe_reader {
+                Some(reader) => match reader.read(correlation_id, &pos_key.normalize()) {
+                    Ok(Some(Value::Contract(contract))) => {
+                        let bonded_validators = contract
+                            .urefs_lookup()
+                            .keys()
+                            .filter_map(|entry| utils::pos_validator_to_tuple(entry))
+                            .collect::<HashMap<PublicKey, U512>>();
+                        Ok(bonded_validators)
+                    }
+                    Ok(_) => Err(GetBondedValidatorsError::PoSNotFound(*pos_key)),
+                    Err(error) => Err(GetBondedValidatorsError::StorageErrors(error)),
+                },
+                None => Err(GetBondedValidatorsError::PostStateHashNotFound(root_hash)),
+            })
+    }
 }

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -11,7 +11,7 @@ use contract_ffi::key::{Key, LOCAL_SEED_SIZE};
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::{self, Account, Contract, Value};
 use engine_shared::transform::Transform;
-use engine_storage::global_state::in_memory::InMemoryGlobalState;
+use engine_storage::global_state::in_memory::{InMemoryGlobalState, InMemoryGlobalStateView};
 use engine_storage::global_state::{CommitResult, History};
 
 use super::{Error, RuntimeContext, URefAddr, Validated};
@@ -23,10 +23,10 @@ use contract_ffi::value::account::{
 };
 use engine_shared::newtypes::CorrelationId;
 
-fn mock_tc(init_key: Key, init_account: value::Account) -> TrackingCopy<InMemoryGlobalState> {
+fn mock_tc(init_key: Key, init_account: value::Account) -> TrackingCopy<InMemoryGlobalStateView> {
     let correlation_id = CorrelationId::new();
-    let mut hist = InMemoryGlobalState::empty().unwrap();
-    let root_hash = hist.root_hash;
+    let hist = InMemoryGlobalState::empty().unwrap();
+    let root_hash = hist.empty_root_hash;
     let transform = Transform::Write(value::Value::Account(init_account.clone()));
 
     let mut m = HashMap::new();
@@ -101,7 +101,7 @@ fn mock_runtime_context<'a>(
     uref_map: &'a mut BTreeMap<String, Key>,
     known_urefs: HashMap<URefAddr, HashSet<AccessRights>>,
     rng: ChaChaRng,
-) -> RuntimeContext<'a, InMemoryGlobalState> {
+) -> RuntimeContext<'a, InMemoryGlobalStateView> {
     let tc = mock_tc(base_key, account.clone());
     RuntimeContext::new(
         Rc::new(RefCell::new(tc)),
@@ -143,7 +143,7 @@ fn assert_invalid_access<T: std::fmt::Debug>(result: Result<T, Error>, expecting
 
 fn test<T, F>(known_urefs: HashMap<URefAddr, HashSet<AccessRights>>, query: F) -> Result<T, Error>
 where
-    F: Fn(RuntimeContext<InMemoryGlobalState>) -> Result<T, Error>,
+    F: Fn(RuntimeContext<InMemoryGlobalStateView>) -> Result<T, Error>,
 {
     let base_acc_addr = [0u8; 32];
     let (key, account) = mock_account(base_acc_addr);
@@ -546,7 +546,7 @@ fn uref_key_addable_invalid() {
 #[test]
 fn local_key_writeable_valid() {
     let known_urefs = HashMap::new();
-    let query = |runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
         let seed = runtime_context.seed();
         let key = random_local_key(&mut rng, seed);
@@ -559,7 +559,7 @@ fn local_key_writeable_valid() {
 #[test]
 fn local_key_writeable_invalid() {
     let known_urefs = HashMap::new();
-    let query = |runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
         let seed = [1u8; LOCAL_SEED_SIZE];
         let key = random_local_key(&mut rng, seed);
@@ -572,7 +572,7 @@ fn local_key_writeable_invalid() {
 #[test]
 fn local_key_readable_valid() {
     let known_urefs = HashMap::new();
-    let query = |runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
         let seed = runtime_context.seed();
         let key = random_local_key(&mut rng, seed);
@@ -585,7 +585,7 @@ fn local_key_readable_valid() {
 #[test]
 fn local_key_readable_invalid() {
     let known_urefs = HashMap::new();
-    let query = |runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
         let seed = [1u8; LOCAL_SEED_SIZE];
         let key = random_local_key(&mut rng, seed);
@@ -598,7 +598,7 @@ fn local_key_readable_invalid() {
 #[test]
 fn local_key_addable_valid() {
     let known_urefs = HashMap::new();
-    let query = |runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
         let seed = runtime_context.seed();
         let key = random_local_key(&mut rng, seed);
@@ -611,7 +611,7 @@ fn local_key_addable_valid() {
 #[test]
 fn local_key_addable_invalid() {
     let known_urefs = HashMap::new();
-    let query = |runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
         let seed = [1u8; LOCAL_SEED_SIZE];
         let key = random_local_key(&mut rng, seed);
@@ -626,7 +626,7 @@ fn manage_associated_keys() {
     // Testing a valid case only - successfuly added a key, and successfuly removed,
     // making sure `account_dirty` mutated
     let known_urefs = HashMap::new();
-    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let public_key = PublicKey::new([42; 32]);
         let weight = Weight::new(155);
 
@@ -693,7 +693,7 @@ fn action_thresholds_management() {
     // Testing a valid case only - successfuly added a key, and successfuly removed,
     // making sure `account_dirty` mutated
     let known_urefs = HashMap::new();
-    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         runtime_context
             .add_associated_key(PublicKey::new([42; 32]), Weight::new(254))
             .expect("Unable to add associated key with maximum weight");
@@ -734,7 +734,7 @@ fn should_verify_ownership_before_adding_key() {
     // Testing a valid case only - successfuly added a key, and successfuly removed,
     // making sure `account_dirty` mutated
     let known_urefs = HashMap::new();
-    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         // Overwrites a `base_key` to a different one before doing any operation as
         // account `[0; 32]`
         runtime_context.base_key = Key::Hash([1; 32]);
@@ -758,7 +758,7 @@ fn should_verify_ownership_before_removing_a_key() {
     // Testing a valid case only - successfuly added a key, and successfuly removed,
     // making sure `account_dirty` mutated
     let known_urefs = HashMap::new();
-    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         // Overwrites a `base_key` to a different one before doing any operation as
         // account `[0; 32]`
         runtime_context.base_key = Key::Hash([1; 32]);
@@ -782,7 +782,7 @@ fn should_verify_ownership_before_setting_action_threshold() {
     // Testing a valid case only - successfuly added a key, and successfuly removed,
     // making sure `account_dirty` mutated
     let known_urefs = HashMap::new();
-    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         // Overwrites a `base_key` to a different one before doing any operation as
         // account `[0; 32]`
         runtime_context.base_key = Key::Hash([1; 32]);
@@ -804,7 +804,7 @@ fn should_verify_ownership_before_setting_action_threshold() {
 #[test]
 fn can_roundtrip_key_value_pairs_into_local_state() {
     let known_urefs = HashMap::new();
-    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalState>| {
+    let query = |mut runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let test_key = b"test_key";
         let test_value = Value::String("test_value".to_string());
 

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -17,7 +17,7 @@ use contract_ffi::value::{Account, Contract, Value};
 use engine_shared::newtypes::CorrelationId;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
-use engine_storage::global_state::StateReader;
+use engine_storage::global_state::{History, StateReader};
 
 use super::meter::count_meter::Count;
 use super::{AddResult, QueryResult, Validated};
@@ -356,8 +356,9 @@ proptest! {
     #[test]
     fn query_empty_path(k in key_arb(), missing_key in key_arb(), v in value_arb()) {
         let correlation_id = CorrelationId::new();
-        let gs = InMemoryGlobalState::from_pairs(correlation_id, &[(k, v.to_owned())]).unwrap();
-        let mut tc = TrackingCopy::new(gs);
+        let (gs, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &[(k, v.to_owned())]).unwrap();
+        let view = gs.checkout(root_hash).unwrap().unwrap();
+        let mut tc = TrackingCopy::new(view);
         let empty_path = Vec::new();
         if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, k, &empty_path) {
             assert_eq!(v, result);
@@ -386,11 +387,12 @@ proptest! {
         let contract: Value = Contract::new(body, known_urefs, 1).into();
         let contract_key = Key::Hash(hash);
 
-        let gs = InMemoryGlobalState::from_pairs(
+        let (gs, root_hash) = InMemoryGlobalState::from_pairs(
             correlation_id,
             &[(k, v.to_owned()), (contract_key, contract)]
         ).unwrap();
-        let mut tc = TrackingCopy::new(gs);
+        let view = gs.checkout(root_hash).unwrap().unwrap();
+        let mut tc = TrackingCopy::new(view);
         let path = vec!(name.clone());
         if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, contract_key, &path) {
             assert_eq!(v, result);
@@ -430,11 +432,12 @@ proptest! {
         );
         let account_key = Key::Account(address);
 
-        let gs = InMemoryGlobalState::from_pairs(
+        let (gs, root_hash) = InMemoryGlobalState::from_pairs(
             correlation_id,
             &[(k, v.to_owned()), (account_key, Value::Account(account))],
         ).unwrap();
-        let mut tc = TrackingCopy::new(gs);
+        let view = gs.checkout(root_hash).unwrap().unwrap();
+        let mut tc = TrackingCopy::new(view);
         let path = vec!(name.clone());
         if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
             assert_eq!(v, result);
@@ -483,12 +486,13 @@ proptest! {
         );
         let account_key = Key::Account(address);
 
-        let gs = InMemoryGlobalState::from_pairs(correlation_id, &[
+        let (gs, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &[
             (k, v.to_owned()),
             (contract_key, contract),
             (account_key, Value::Account(account)),
         ]).unwrap();
-        let mut tc = TrackingCopy::new(gs);
+        let view = gs.checkout(root_hash).unwrap().unwrap();
+        let mut tc = TrackingCopy::new(view);
         let path = vec!(contract_name, state_name);
         if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
             assert_eq!(v, result);

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -13,9 +13,7 @@ use contract_ffi::value::U512;
 use engine_core::engine_state::error::Error as EngineError;
 use engine_core::engine_state::execution_result::ExecutionResult;
 use engine_core::engine_state::genesis::GenesisURefsSource;
-use engine_core::engine_state::{
-    genesis::GenesisResult, get_bonded_validators, EngineState, GetBondedValidatorsError,
-};
+use engine_core::engine_state::{genesis::GenesisResult, EngineState, GetBondedValidatorsError};
 use engine_core::execution::{Executor, WasmiExecutor};
 use engine_core::tracking_copy::QueryResult;
 use engine_shared::logging;
@@ -302,12 +300,8 @@ where
                     commit_result
                 {
                     let pos_key = Key::URef(GenesisURefsSource::default().get_pos_address());
-                    let bonded_validators_res = get_bonded_validators(
-                        self.state(),
-                        poststate_hash,
-                        &pos_key,
-                        correlation_id,
-                    );
+                    let bonded_validators_res =
+                        self.get_bonded_validators(poststate_hash, &pos_key, correlation_id);
                     bonded_validators_and_commit_result(
                         prestate_hash,
                         poststate_hash,

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -7,8 +7,7 @@ use contract_ffi::value::Value;
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 use engine_shared::transform::Transform;
 
-use crate::error;
-use crate::error::in_memory;
+use crate::error::{self, in_memory};
 use crate::global_state::StateReader;
 use crate::global_state::{commit, CommitResult, History};
 use crate::store::Store;

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -7,7 +7,8 @@ use contract_ffi::value::Value;
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 use engine_shared::transform::Transform;
 
-use crate::error::{self, in_memory};
+use crate::error;
+use crate::error::in_memory;
 use crate::global_state::StateReader;
 use crate::global_state::{commit, CommitResult, History};
 use crate::store::Store;
@@ -16,14 +17,20 @@ use crate::transaction_source::{Transaction, TransactionSource};
 use crate::trie::operations::create_hashed_empty_trie;
 use crate::trie::Trie;
 use crate::trie_store::in_memory::InMemoryTrieStore;
-use crate::trie_store::operations::{read, write, ReadResult, WriteResult};
+use crate::trie_store::operations;
+use crate::trie_store::operations::{read, ReadResult, WriteResult};
 
-/// Represents a "view" of global state at a particular root hash.
 pub struct InMemoryGlobalState {
     pub environment: Arc<InMemoryEnvironment>,
     pub store: Arc<InMemoryTrieStore>,
-    pub root_hash: Blake2bHash,
     pub empty_root_hash: Blake2bHash,
+}
+
+/// Represents a "view" of global state at a particular root hash.
+pub struct InMemoryGlobalStateView {
+    pub environment: Arc<InMemoryEnvironment>,
+    pub store: Arc<InMemoryTrieStore>,
+    pub root_hash: Blake2bHash,
 }
 
 impl InMemoryGlobalState {
@@ -38,12 +45,7 @@ impl InMemoryGlobalState {
             txn.commit()?;
             root_hash
         };
-        Ok(InMemoryGlobalState::new(
-            environment,
-            store,
-            root_hash,
-            root_hash,
-        ))
+        Ok(InMemoryGlobalState::new(environment, store, root_hash))
     }
 
     /// Creates a state from an existing environment, store, and root_hash.
@@ -51,13 +53,11 @@ impl InMemoryGlobalState {
     pub(crate) fn new(
         environment: Arc<InMemoryEnvironment>,
         store: Arc<InMemoryTrieStore>,
-        root_hash: Blake2bHash,
         empty_root_hash: Blake2bHash,
     ) -> Self {
         InMemoryGlobalState {
             environment,
             store,
-            root_hash,
             empty_root_hash,
         }
     }
@@ -67,17 +67,17 @@ impl InMemoryGlobalState {
     pub fn from_pairs(
         correlation_id: CorrelationId,
         pairs: &[(Key, Value)],
-    ) -> Result<Self, error::Error> {
-        let mut ret = InMemoryGlobalState::empty()?;
+    ) -> Result<(Self, Blake2bHash), error::Error> {
+        let state = InMemoryGlobalState::empty()?;
+        let mut current_root = state.empty_root_hash;
         {
-            let mut txn = ret.environment.create_read_write_txn()?;
-            let mut current_root = ret.root_hash;
+            let mut txn = state.environment.create_read_write_txn()?;
             for (key, value) in pairs {
                 let key = key.normalize();
-                match write::<_, _, _, InMemoryTrieStore, in_memory::Error>(
+                match operations::write::<_, _, _, InMemoryTrieStore, in_memory::Error>(
                     correlation_id,
                     &mut txn,
-                    &ret.store,
+                    &state.store,
                     &current_root,
                     &key,
                     value,
@@ -89,14 +89,13 @@ impl InMemoryGlobalState {
                     WriteResult::RootNotFound => panic!("InMemoryGlobalState has invalid root"),
                 }
             }
-            ret.root_hash = current_root;
             txn.commit()?;
         }
-        Ok(ret)
+        Ok((state, current_root))
     }
 }
 
-impl StateReader<Key, Value> for InMemoryGlobalState {
+impl StateReader<Key, Value> for InMemoryGlobalStateView {
     type Error = error::Error;
 
     fn read(&self, correlation_id: CorrelationId, key: &Key) -> Result<Option<Value>, Self::Error> {
@@ -120,23 +119,22 @@ impl StateReader<Key, Value> for InMemoryGlobalState {
 impl History for InMemoryGlobalState {
     type Error = error::Error;
 
-    type Reader = Self;
+    type Reader = InMemoryGlobalStateView;
 
     fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
         let maybe_root: Option<Trie<Key, Value>> = self.store.get(&txn, &prestate_hash)?;
-        let maybe_state = maybe_root.map(|_| InMemoryGlobalState {
+        let maybe_state = maybe_root.map(|_| InMemoryGlobalStateView {
             environment: Arc::clone(&self.environment),
             store: Arc::clone(&self.store),
             root_hash: prestate_hash,
-            empty_root_hash: self.empty_root_hash,
         });
         txn.commit()?;
         Ok(maybe_state)
     }
 
     fn commit(
-        &mut self,
+        &self,
         correlation_id: CorrelationId,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
@@ -148,14 +146,7 @@ impl History for InMemoryGlobalState {
             prestate_hash,
             effects,
         )?;
-        if let CommitResult::Success(root_hash) = commit_result {
-            self.root_hash = root_hash;
-        };
         Ok(commit_result)
-    }
-
-    fn current_root(&self) -> Blake2bHash {
-        self.root_hash
     }
 
     fn empty_root(&self) -> Blake2bHash {
@@ -203,7 +194,7 @@ mod tests {
         ]
     }
 
-    fn create_test_state() -> InMemoryGlobalState {
+    fn create_test_state() -> (InMemoryGlobalState, Blake2bHash) {
         InMemoryGlobalState::from_pairs(
             CorrelationId::new(),
             &TEST_PAIRS
@@ -218,8 +209,8 @@ mod tests {
     #[test]
     fn reads_from_a_checkout_return_expected_values() {
         let correlation_id = CorrelationId::new();
-        let state = create_test_state();
-        let checkout = state.checkout(state.root_hash).unwrap().unwrap();
+        let (state, root_hash) = create_test_state();
+        let checkout = state.checkout(root_hash).unwrap().unwrap();
         for TestPair { key, value } in TEST_PAIRS.iter().cloned() {
             assert_eq!(Some(value), checkout.read(correlation_id, &key).unwrap());
         }
@@ -227,7 +218,7 @@ mod tests {
 
     #[test]
     fn checkout_fails_if_unknown_hash_is_given() {
-        let state = create_test_state();
+        let (state, _) = create_test_state();
         let fake_hash: Blake2bHash = [1u8; 32].into();
         let result = state.checkout(fake_hash).unwrap();
         assert!(result.is_none());
@@ -239,8 +230,7 @@ mod tests {
 
         let test_pairs_updated = create_test_pairs_updated();
 
-        let mut state = create_test_state();
-        let root_hash = state.root_hash;
+        let (state, root_hash) = create_test_state();
 
         let effects: HashMap<Key, Transform> = test_pairs_updated
             .iter()
@@ -268,8 +258,7 @@ mod tests {
         let correlation_id = CorrelationId::new();
         let test_pairs_updated = create_test_pairs_updated();
 
-        let mut state = create_test_state();
-        let root_hash = state.root_hash;
+        let (state, root_hash) = create_test_state();
 
         let effects: HashMap<Key, Transform> = {
             let mut tmp = HashMap::new();
@@ -315,7 +304,7 @@ mod tests {
             11, 132, 57, 102, 129, 52, 188, 253, 43, 243, 67, 176, 41, 151,
         ];
         let init_state = test_utils::mocked_account([48u8; 32]);
-        let global_state = InMemoryGlobalState::from_pairs(correlation_id, &init_state).unwrap();
-        assert_eq!(expected_bytes, global_state.root_hash.to_vec())
+        let (_, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &init_state).unwrap();
+        assert_eq!(expected_bytes, root_hash.to_vec())
     }
 }

--- a/execution-engine/engine-storage/src/global_state/lmdb.rs
+++ b/execution-engine/engine-storage/src/global_state/lmdb.rs
@@ -20,12 +20,17 @@ use crate::trie::Trie;
 use crate::trie_store::lmdb::LmdbTrieStore;
 use crate::trie_store::operations::{read, ReadResult};
 
-/// Represents a "view" of global state at a particular root hash.
 pub struct LmdbGlobalState {
     pub(super) environment: Arc<LmdbEnvironment>,
     pub(super) store: Arc<LmdbTrieStore>,
-    pub(super) root_hash: Blake2bHash,
     pub(super) empty_root_hash: Blake2bHash,
+}
+
+/// Represents a "view" of global state at a particular root hash.
+pub struct LmdbGlobalStateView {
+    pub(super) environment: Arc<LmdbEnvironment>,
+    pub(super) store: Arc<LmdbTrieStore>,
+    pub(super) root_hash: Blake2bHash,
 }
 
 impl LmdbGlobalState {
@@ -41,12 +46,7 @@ impl LmdbGlobalState {
             txn.commit()?;
             root_hash
         };
-        Ok(LmdbGlobalState::new(
-            environment,
-            store,
-            root_hash,
-            root_hash,
-        ))
+        Ok(LmdbGlobalState::new(environment, store, root_hash))
     }
 
     /// Creates a state from an existing environment, store, and root_hash.
@@ -54,19 +54,17 @@ impl LmdbGlobalState {
     pub(crate) fn new(
         environment: Arc<LmdbEnvironment>,
         store: Arc<LmdbTrieStore>,
-        root_hash: Blake2bHash,
         empty_root_hash: Blake2bHash,
     ) -> Self {
         LmdbGlobalState {
             environment,
             store,
-            root_hash,
             empty_root_hash,
         }
     }
 }
 
-impl StateReader<Key, Value> for LmdbGlobalState {
+impl StateReader<Key, Value> for LmdbGlobalStateView {
     type Error = error::Error;
 
     fn read(&self, correlation_id: CorrelationId, key: &Key) -> Result<Option<Value>, Self::Error> {
@@ -90,23 +88,22 @@ impl StateReader<Key, Value> for LmdbGlobalState {
 impl History for LmdbGlobalState {
     type Error = error::Error;
 
-    type Reader = Self;
+    type Reader = LmdbGlobalStateView;
 
-    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error> {
+    fn checkout(&self, state_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
-        let maybe_root: Option<Trie<Key, Value>> = self.store.get(&txn, &prestate_hash)?;
-        let maybe_state = maybe_root.map(|_| LmdbGlobalState {
+        let maybe_root: Option<Trie<Key, Value>> = self.store.get(&txn, &state_hash)?;
+        let maybe_state = maybe_root.map(|_| LmdbGlobalStateView {
             environment: Arc::clone(&self.environment),
             store: Arc::clone(&self.store),
-            root_hash: prestate_hash,
-            empty_root_hash: self.empty_root_hash,
+            root_hash: state_hash,
         });
         txn.commit()?;
         Ok(maybe_state)
     }
 
     fn commit(
-        &mut self,
+        &self,
         correlation_id: CorrelationId,
         prestate_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
@@ -118,14 +115,7 @@ impl History for LmdbGlobalState {
             prestate_hash,
             effects,
         )?;
-        if let CommitResult::Success(root_hash) = commit_result {
-            self.root_hash = root_hash;
-        };
         Ok(commit_result)
-    }
-
-    fn current_root(&self) -> Blake2bHash {
-        self.root_hash
     }
 
     fn empty_root(&self) -> Blake2bHash {
@@ -177,7 +167,7 @@ mod tests {
         ]
     }
 
-    fn create_test_state() -> LmdbGlobalState {
+    fn create_test_state() -> (LmdbGlobalState, Blake2bHash) {
         let correlation_id = CorrelationId::new();
         let _temp_dir = tempdir().unwrap();
         let environment = Arc::new(
@@ -185,10 +175,10 @@ mod tests {
         );
         let store =
             Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
-        let mut ret = LmdbGlobalState::empty(environment, store).unwrap();
+        let ret = LmdbGlobalState::empty(environment, store).unwrap();
+        let mut current_root = ret.empty_root_hash;
         {
             let mut txn = ret.environment.create_read_write_txn().unwrap();
-            let mut current_root = ret.root_hash;
 
             for TestPair { key, value } in &TEST_PAIRS {
                 match write::<_, _, _, LmdbTrieStore, error::Error>(
@@ -209,17 +199,16 @@ mod tests {
                 }
             }
 
-            ret.root_hash = current_root;
             txn.commit().unwrap();
         }
-        ret
+        (ret, current_root)
     }
 
     #[test]
     fn reads_from_a_checkout_return_expected_values() {
         let correlation_id = CorrelationId::new();
-        let state = create_test_state();
-        let checkout = state.checkout(state.root_hash).unwrap().unwrap();
+        let (state, root_hash) = create_test_state();
+        let checkout = state.checkout(root_hash).unwrap().unwrap();
         for TestPair { key, value } in TEST_PAIRS.iter().cloned() {
             assert_eq!(Some(value), checkout.read(correlation_id, &key).unwrap());
         }
@@ -227,7 +216,7 @@ mod tests {
 
     #[test]
     fn checkout_fails_if_unknown_hash_is_given() {
-        let state = create_test_state();
+        let (state, _) = create_test_state();
         let fake_hash: Blake2bHash = [1u8; 32].into();
         let result = state.checkout(fake_hash).unwrap();
         assert!(result.is_none());
@@ -238,8 +227,7 @@ mod tests {
         let correlation_id = CorrelationId::new();
         let test_pairs_updated = create_test_pairs_updated();
 
-        let mut state = create_test_state();
-        let root_hash = state.root_hash;
+        let (state, root_hash) = create_test_state();
 
         let effects: HashMap<Key, Transform> = {
             let mut tmp = HashMap::new();
@@ -269,8 +257,7 @@ mod tests {
         let correlation_id = CorrelationId::new();
         let test_pairs_updated = create_test_pairs_updated();
 
-        let mut state = create_test_state();
-        let root_hash = state.root_hash;
+        let (state, root_hash) = create_test_state();
 
         let effects: HashMap<Key, Transform> = {
             let mut tmp = HashMap::new();

--- a/execution-engine/engine-storage/src/global_state/mod.rs
+++ b/execution-engine/engine-storage/src/global_state/mod.rs
@@ -62,18 +62,16 @@ pub trait History {
     type Reader: StateReader<Key, Value, Error = Self::Error>;
 
     /// Checkouts to the post state of a specific block.
-    fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error>;
+    fn checkout(&self, state_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error>;
 
     /// Applies changes and returns a new post state hash.
     /// block_hash is used for computing a deterministic and unique keys.
     fn commit(
-        &mut self,
+        &self,
         correlation_id: CorrelationId,
-        prestate_hash: Blake2bHash,
+        state_hash: Blake2bHash,
         effects: HashMap<Key, Transform>,
     ) -> Result<CommitResult, Self::Error>;
-
-    fn current_root(&self) -> Blake2bHash;
 
     fn empty_root(&self) -> Blake2bHash;
 }

--- a/execution-engine/engine-tests/src/support/test_stored_contract_support.rs
+++ b/execution-engine/engine-tests/src/support/test_stored_contract_support.rs
@@ -18,6 +18,7 @@ use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use engine_grpc_server::engine_server::mappings::{to_domain_validators, CommitTransforms};
 use engine_grpc_server::engine_server::state::{BigInt, ProtocolVersion};
 use engine_grpc_server::engine_server::{ipc, transforms};
+use engine_shared::newtypes::Blake2bHash;
 use engine_shared::test_utils;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
@@ -669,6 +670,12 @@ impl WasmTestBuilder {
             .wait_drop_metadata()
             .unwrap();
 
+        let state_root_hash: Blake2bHash = genesis_response
+            .get_success()
+            .get_poststate_hash()
+            .try_into()
+            .unwrap();
+
         // Cache genesis response transforms for easy access later
         let genesis_transforms = get_genesis_transforms(&genesis_response);
 
@@ -691,13 +698,6 @@ impl WasmTestBuilder {
                 )
             }),
         );
-
-        let state_handle = self.engine_state.state();
-
-        let state_root_hash = {
-            let state_handle_guard = state_handle.lock();
-            state_handle_guard.root_hash
-        };
 
         let genesis_hash = genesis_response.get_success().get_poststate_hash().to_vec();
         assert_eq!(state_root_hash.to_vec(), genesis_hash);

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -38,8 +38,9 @@ fn should_query_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
     let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
-    let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let root_hash = global_state.root_hash.to_vec();
+    let (global_state, root_hash) =
+        InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
+    let root_hash = root_hash.to_vec();
     let engine_state = EngineState::new(global_state, Default::default());
 
     let mut query_request = QueryRequest::new();
@@ -90,8 +91,9 @@ fn should_exec_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
     let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
-    let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let root_hash = global_state.root_hash.to_vec();
+    let (global_state, root_hash) =
+        InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
+    let root_hash = root_hash.to_vec();
     let engine_state = EngineState::new(global_state, Default::default());
 
     let mut exec_request = ExecRequest::new();
@@ -140,8 +142,9 @@ fn should_commit_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
     let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
-    let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let root_hash = global_state.root_hash.to_vec();
+    let (global_state, root_hash) =
+        InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
+    let root_hash = root_hash.to_vec();
     let engine_state = EngineState::new(global_state, Default::default());
 
     let request_options = RequestOptions::new();
@@ -187,7 +190,8 @@ fn should_validate_with_metrics() {
     setup();
     let correlation_id = CorrelationId::new();
     let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
-    let global_state = InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
+    let (global_state, _) =
+        InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
     let engine_state = EngineState::new(global_state, Default::default());
 
     let mut validate_request = ValidateRequest::new();

--- a/execution-engine/engine-tests/src/test/regression/ee_470.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_470.rs
@@ -20,7 +20,7 @@ fn regression_test_genesis_hash_mismatch() {
 
     let empty_root_hash = {
         let gs = InMemoryGlobalState::empty().expect("Empty GlobalState.");
-        gs.root_hash
+        gs.empty_root_hash
     };
 
     // This is trie's post state hash after committing genesis effects on top of

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -26,14 +26,9 @@ fn should_run_genesis() {
 
     let response = genesis_response.unwrap();
 
-    let state_handle = engine_state.state();
-
-    let state_handle_guard = state_handle.lock();
-
-    let state_root_hash = state_handle_guard.root_hash;
     let response_root_hash = response.get_success().get_poststate_hash();
 
-    assert_eq!(state_root_hash.to_vec(), response_root_hash.to_vec());
+    assert!(!response_root_hash.to_vec().is_empty());
 }
 
 #[ignore]
@@ -49,7 +44,7 @@ fn test_genesis_hash_match() {
 
     let empty_root_hash = {
         let gs = InMemoryGlobalState::empty().expect("Empty GlobalState.");
-        gs.root_hash
+        gs.empty_root_hash
     };
 
     // This is trie's post state hash after committing genesis effects on top of empty trie.


### PR DESCRIPTION
### Overview
This PR removes the `Arc<Mutex<_>>` wrapping the `H` in `EngineState`.  It prepares for a subsequent PR which will collapse `InMemoryGlobalState` and `LmdbGlobalState` into `EngineState`.  

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-636

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
