### PR TITLE
EE-639: rename History to StateProvider, update

### DIFF
--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -12,7 +12,7 @@ use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::{self, Account, Contract, Value};
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::{InMemoryGlobalState, InMemoryGlobalStateView};
-use engine_storage::global_state::{CommitResult, History};
+use engine_storage::global_state::{CommitResult, StateProvider};
 
 use super::{Error, RuntimeContext, URefAddr, Validated};
 use crate::execution::{create_rng, extract_access_rights_from_keys};

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -17,7 +17,7 @@ use contract_ffi::value::{Account, Contract, Value};
 use engine_shared::newtypes::CorrelationId;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
-use engine_storage::global_state::{History, StateReader};
+use engine_storage::global_state::{StateProvider, StateReader};
 
 use super::meter::count_meter::Count;
 use super::{AddResult, QueryResult, Validated};

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -21,7 +21,7 @@ use engine_shared::logging;
 use engine_shared::logging::log_level;
 use engine_shared::newtypes::Blake2bHash;
 use engine_shared::transform::{self, TypeMismatch};
-use engine_storage::global_state::{CommitResult, History};
+use engine_storage::global_state::{CommitResult, StateProvider};
 
 use crate::engine_server::{ipc, state, transforms};
 
@@ -839,13 +839,13 @@ impl From<ExecutionResult> for ipc::DeployResult {
     }
 }
 
-pub fn grpc_response_from_commit_result<H>(
+pub fn grpc_response_from_commit_result<S>(
     prestate_hash: Blake2bHash,
-    input: Result<CommitResult, H::Error>,
+    input: Result<CommitResult, S::Error>,
 ) -> ipc::CommitResponse
 where
-    H: History,
-    H::Error: Into<EngineError> + std::fmt::Debug,
+    S: StateProvider,
+    S::Error: Into<EngineError> + std::fmt::Debug,
 {
     match input {
         Ok(CommitResult::RootNotFound) => {

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -33,6 +33,7 @@ use engine_storage::transaction_source::lmdb::LmdbEnvironment;
 use engine_storage::trie_store::lmdb::LmdbTrieStore;
 
 use casperlabs_engine_grpc_server::engine_server;
+use engine_storage::protocol_data_store::lmdb::LmdbProtocolDataStore;
 
 // exe / proc
 const PROC_NAME: &str = "casperlabs-engine-grpc-server";
@@ -53,6 +54,7 @@ const GET_HOME_DIR_EXPECT: &str = "Could not get home directory";
 const CREATE_DATA_DIR_EXPECT: &str = "Could not create directory";
 const LMDB_ENVIRONMENT_EXPECT: &str = "Could not create LmdbEnvironment";
 const LMDB_TRIE_STORE_EXPECT: &str = "Could not create LmdbTrieStore";
+const LMDB_PROTOCOL_DATA_STORE_EXPECT: &str = "Could not create LmdbProtocolDataStore";
 const LMDB_GLOBAL_STATE_EXPECT: &str = "Could not create LmdbGlobalState";
 
 // pages / lmdb
@@ -276,7 +278,13 @@ fn get_engine_state(
         Arc::new(ret)
     };
 
-    let global_state = LmdbGlobalState::empty(Arc::clone(&environment), Arc::clone(&trie_store))
+    let protocol_data_store = {
+        let ret = LmdbProtocolDataStore::new(&environment, None, DatabaseFlags::empty())
+            .expect(LMDB_PROTOCOL_DATA_STORE_EXPECT);
+        Arc::new(ret)
+    };
+
+    let global_state = LmdbGlobalState::empty(environment, trie_store, protocol_data_store)
         .expect(LMDB_GLOBAL_STATE_EXPECT);
 
     EngineState::new(global_state, engine_config)

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -162,18 +162,18 @@ impl StateProvider for InMemoryGlobalState {
 
     fn put_protocol_data(
         &self,
-        protocol_version: &ProtocolVersion,
+        protocol_version: ProtocolVersion,
         protocol_data: &ProtocolData,
     ) -> Result<(), Self::Error> {
         let mut txn = self.environment.create_read_write_txn()?;
         self.protocol_data_store
-            .put(&mut txn, protocol_version, protocol_data)?;
+            .put(&mut txn, &protocol_version, protocol_data)?;
         txn.commit().map_err(Into::into)
     }
 
     fn get_protocol_data(
         &self,
-        protocol_version: &ProtocolVersion,
+        protocol_version: ProtocolVersion,
     ) -> Result<Option<ProtocolData>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
         let result = self.protocol_data_store.get(&txn, &protocol_version)?;

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -9,7 +9,10 @@ use engine_shared::transform::Transform;
 
 use crate::error::{self, in_memory};
 use crate::global_state::StateReader;
-use crate::global_state::{commit, CommitResult, History};
+use crate::global_state::{commit, CommitResult, StateProvider};
+use crate::protocol_data::ProtocolData;
+use crate::protocol_data_store::in_memory::InMemoryProtocolDataStore;
+use crate::protocol_data_store::ProtocolVersion;
 use crate::store::Store;
 use crate::transaction_source::in_memory::{InMemoryEnvironment, InMemoryReadTransaction};
 use crate::transaction_source::{Transaction, TransactionSource};
@@ -21,7 +24,8 @@ use crate::trie_store::operations::{read, ReadResult, WriteResult};
 
 pub struct InMemoryGlobalState {
     pub environment: Arc<InMemoryEnvironment>,
-    pub store: Arc<InMemoryTrieStore>,
+    pub trie_store: Arc<InMemoryTrieStore>,
+    pub protocol_data_store: Arc<InMemoryProtocolDataStore>,
     pub empty_root_hash: Blake2bHash,
 }
 
@@ -36,27 +40,35 @@ impl InMemoryGlobalState {
     /// Creates an empty state.
     pub fn empty() -> Result<Self, error::Error> {
         let environment = Arc::new(InMemoryEnvironment::new());
-        let store = Arc::new(InMemoryTrieStore::new(&environment, None));
+        let trie_store = Arc::new(InMemoryTrieStore::new(&environment, None));
+        let protocol_data_store = Arc::new(InMemoryProtocolDataStore::new(&environment, None));
         let root_hash: Blake2bHash = {
             let (root_hash, root) = create_hashed_empty_trie::<Key, Value>()?;
             let mut txn = environment.create_read_write_txn()?;
-            store.put(&mut txn, &root_hash, &root)?;
+            trie_store.put(&mut txn, &root_hash, &root)?;
             txn.commit()?;
             root_hash
         };
-        Ok(InMemoryGlobalState::new(environment, store, root_hash))
+        Ok(InMemoryGlobalState::new(
+            environment,
+            trie_store,
+            protocol_data_store,
+            root_hash,
+        ))
     }
 
-    /// Creates a state from an existing environment, store, and root_hash.
+    /// Creates a state from an existing environment, trie_Store, and root_hash.
     /// Intended to be used for testing.
     pub(crate) fn new(
         environment: Arc<InMemoryEnvironment>,
-        store: Arc<InMemoryTrieStore>,
+        trie_store: Arc<InMemoryTrieStore>,
+        protocol_data_store: Arc<InMemoryProtocolDataStore>,
         empty_root_hash: Blake2bHash,
     ) -> Self {
         InMemoryGlobalState {
             environment,
-            store,
+            trie_store,
+            protocol_data_store,
             empty_root_hash,
         }
     }
@@ -76,7 +88,7 @@ impl InMemoryGlobalState {
                 match operations::write::<_, _, _, InMemoryTrieStore, in_memory::Error>(
                     correlation_id,
                     &mut txn,
-                    &state.store,
+                    &state.trie_store,
                     &current_root,
                     &key,
                     value,
@@ -115,17 +127,17 @@ impl StateReader<Key, Value> for InMemoryGlobalStateView {
     }
 }
 
-impl History for InMemoryGlobalState {
+impl StateProvider for InMemoryGlobalState {
     type Error = error::Error;
 
     type Reader = InMemoryGlobalStateView;
 
     fn checkout(&self, prestate_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
-        let maybe_root: Option<Trie<Key, Value>> = self.store.get(&txn, &prestate_hash)?;
+        let maybe_root: Option<Trie<Key, Value>> = self.trie_store.get(&txn, &prestate_hash)?;
         let maybe_state = maybe_root.map(|_| InMemoryGlobalStateView {
             environment: Arc::clone(&self.environment),
-            store: Arc::clone(&self.store),
+            store: Arc::clone(&self.trie_store),
             root_hash: prestate_hash,
         });
         txn.commit()?;
@@ -140,12 +152,33 @@ impl History for InMemoryGlobalState {
     ) -> Result<CommitResult, Self::Error> {
         let commit_result = commit::<InMemoryEnvironment, InMemoryTrieStore, _, Self::Error>(
             &self.environment,
-            &self.store,
+            &self.trie_store,
             correlation_id,
             prestate_hash,
             effects,
         )?;
         Ok(commit_result)
+    }
+
+    fn put_protocol_data(
+        &self,
+        protocol_version: &ProtocolVersion,
+        protocol_data: &ProtocolData,
+    ) -> Result<(), Self::Error> {
+        let mut txn = self.environment.create_read_write_txn()?;
+        self.protocol_data_store
+            .put(&mut txn, protocol_version, protocol_data)?;
+        txn.commit().map_err(Into::into)
+    }
+
+    fn get_protocol_data(
+        &self,
+        protocol_version: &ProtocolVersion,
+    ) -> Result<Option<ProtocolData>, Self::Error> {
+        let txn = self.environment.create_read_txn()?;
+        let result = self.protocol_data_store.get(&txn, &protocol_version)?;
+        txn.commit()?;
+        Ok(result)
     }
 
     fn empty_root(&self) -> Blake2bHash {

--- a/execution-engine/engine-storage/src/global_state/lmdb.rs
+++ b/execution-engine/engine-storage/src/global_state/lmdb.rs
@@ -132,18 +132,18 @@ impl StateProvider for LmdbGlobalState {
 
     fn put_protocol_data(
         &self,
-        protocol_version: &ProtocolVersion,
+        protocol_version: ProtocolVersion,
         protocol_data: &ProtocolData,
     ) -> Result<(), Self::Error> {
         let mut txn = self.environment.create_read_write_txn()?;
         self.protocol_data_store
-            .put(&mut txn, protocol_version, protocol_data)?;
+            .put(&mut txn, &protocol_version, protocol_data)?;
         txn.commit().map_err(Into::into)
     }
 
     fn get_protocol_data(
         &self,
-        protocol_version: &ProtocolVersion,
+        protocol_version: ProtocolVersion,
     ) -> Result<Option<ProtocolData>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
         let result = self.protocol_data_store.get(&txn, &protocol_version)?;

--- a/execution-engine/engine-storage/src/global_state/lmdb.rs
+++ b/execution-engine/engine-storage/src/global_state/lmdb.rs
@@ -11,7 +11,10 @@ use engine_shared::transform::Transform;
 
 use crate::error;
 use crate::global_state::StateReader;
-use crate::global_state::{commit, CommitResult, History};
+use crate::global_state::{commit, CommitResult, StateProvider};
+use crate::protocol_data::ProtocolData;
+use crate::protocol_data_store::lmdb::LmdbProtocolDataStore;
+use crate::protocol_data_store::ProtocolVersion;
 use crate::store::Store;
 use crate::transaction_source::lmdb::LmdbEnvironment;
 use crate::transaction_source::{Transaction, TransactionSource};
@@ -21,44 +24,53 @@ use crate::trie_store::lmdb::LmdbTrieStore;
 use crate::trie_store::operations::{read, ReadResult};
 
 pub struct LmdbGlobalState {
-    pub(super) environment: Arc<LmdbEnvironment>,
-    pub(super) store: Arc<LmdbTrieStore>,
-    pub(super) empty_root_hash: Blake2bHash,
+    pub environment: Arc<LmdbEnvironment>,
+    pub trie_store: Arc<LmdbTrieStore>,
+    pub protocol_data_store: Arc<LmdbProtocolDataStore>,
+    pub empty_root_hash: Blake2bHash,
 }
 
 /// Represents a "view" of global state at a particular root hash.
 pub struct LmdbGlobalStateView {
-    pub(super) environment: Arc<LmdbEnvironment>,
-    pub(super) store: Arc<LmdbTrieStore>,
-    pub(super) root_hash: Blake2bHash,
+    pub environment: Arc<LmdbEnvironment>,
+    pub store: Arc<LmdbTrieStore>,
+    pub root_hash: Blake2bHash,
 }
 
 impl LmdbGlobalState {
-    /// Creates an empty state from an existing environment and store.
+    /// Creates an empty state from an existing environment and trie_store.
     pub fn empty(
         environment: Arc<LmdbEnvironment>,
-        store: Arc<LmdbTrieStore>,
+        trie_store: Arc<LmdbTrieStore>,
+        protocol_data_store: Arc<LmdbProtocolDataStore>,
     ) -> Result<Self, error::Error> {
         let root_hash: Blake2bHash = {
             let (root_hash, root) = create_hashed_empty_trie::<Key, Value>()?;
             let mut txn = environment.create_read_write_txn()?;
-            store.put(&mut txn, &root_hash, &root)?;
+            trie_store.put(&mut txn, &root_hash, &root)?;
             txn.commit()?;
             root_hash
         };
-        Ok(LmdbGlobalState::new(environment, store, root_hash))
+        Ok(LmdbGlobalState::new(
+            environment,
+            trie_store,
+            protocol_data_store,
+            root_hash,
+        ))
     }
 
     /// Creates a state from an existing environment, store, and root_hash.
     /// Intended to be used for testing.
     pub(crate) fn new(
         environment: Arc<LmdbEnvironment>,
-        store: Arc<LmdbTrieStore>,
+        trie_store: Arc<LmdbTrieStore>,
+        protocol_data_store: Arc<LmdbProtocolDataStore>,
         empty_root_hash: Blake2bHash,
     ) -> Self {
         LmdbGlobalState {
             environment,
-            store,
+            trie_store,
+            protocol_data_store,
             empty_root_hash,
         }
     }
@@ -85,17 +97,17 @@ impl StateReader<Key, Value> for LmdbGlobalStateView {
     }
 }
 
-impl History for LmdbGlobalState {
+impl StateProvider for LmdbGlobalState {
     type Error = error::Error;
 
     type Reader = LmdbGlobalStateView;
 
     fn checkout(&self, state_hash: Blake2bHash) -> Result<Option<Self::Reader>, Self::Error> {
         let txn = self.environment.create_read_txn()?;
-        let maybe_root: Option<Trie<Key, Value>> = self.store.get(&txn, &state_hash)?;
+        let maybe_root: Option<Trie<Key, Value>> = self.trie_store.get(&txn, &state_hash)?;
         let maybe_state = maybe_root.map(|_| LmdbGlobalStateView {
             environment: Arc::clone(&self.environment),
-            store: Arc::clone(&self.store),
+            store: Arc::clone(&self.trie_store),
             root_hash: state_hash,
         });
         txn.commit()?;
@@ -110,12 +122,33 @@ impl History for LmdbGlobalState {
     ) -> Result<CommitResult, Self::Error> {
         let commit_result = commit::<LmdbEnvironment, LmdbTrieStore, _, Self::Error>(
             &self.environment,
-            &self.store,
+            &self.trie_store,
             correlation_id,
             prestate_hash,
             effects,
         )?;
         Ok(commit_result)
+    }
+
+    fn put_protocol_data(
+        &self,
+        protocol_version: &ProtocolVersion,
+        protocol_data: &ProtocolData,
+    ) -> Result<(), Self::Error> {
+        let mut txn = self.environment.create_read_write_txn()?;
+        self.protocol_data_store
+            .put(&mut txn, protocol_version, protocol_data)?;
+        txn.commit().map_err(Into::into)
+    }
+
+    fn get_protocol_data(
+        &self,
+        protocol_version: &ProtocolVersion,
+    ) -> Result<Option<ProtocolData>, Self::Error> {
+        let txn = self.environment.create_read_txn()?;
+        let result = self.protocol_data_store.get(&txn, &protocol_version)?;
+        txn.commit()?;
+        Ok(result)
     }
 
     fn empty_root(&self) -> Blake2bHash {
@@ -173,9 +206,12 @@ mod tests {
         let environment = Arc::new(
             LmdbEnvironment::new(&_temp_dir.path().to_path_buf(), *TEST_MAP_SIZE).unwrap(),
         );
-        let store =
+        let trie_store =
             Arc::new(LmdbTrieStore::new(&environment, None, DatabaseFlags::empty()).unwrap());
-        let ret = LmdbGlobalState::empty(environment, store).unwrap();
+        let protocol_data_store = Arc::new(
+            LmdbProtocolDataStore::new(&environment, None, DatabaseFlags::empty()).unwrap(),
+        );
+        let ret = LmdbGlobalState::empty(environment, trie_store, protocol_data_store).unwrap();
         let mut current_root = ret.empty_root_hash;
         {
             let mut txn = ret.environment.create_read_write_txn().unwrap();
@@ -184,7 +220,7 @@ mod tests {
                 match write::<_, _, _, LmdbTrieStore, error::Error>(
                     correlation_id,
                     &mut txn,
-                    &ret.store,
+                    &ret.trie_store,
                     &current_root,
                     key,
                     value,

--- a/execution-engine/engine-storage/src/global_state/mod.rs
+++ b/execution-engine/engine-storage/src/global_state/mod.rs
@@ -84,13 +84,13 @@ pub trait StateProvider {
 
     fn put_protocol_data(
         &self,
-        protocol_version: &ProtocolVersion,
+        protocol_version: ProtocolVersion,
         protocol_data: &ProtocolData,
     ) -> Result<(), Self::Error>;
 
     fn get_protocol_data(
         &self,
-        protocol_version: &ProtocolVersion,
+        protocol_version: ProtocolVersion,
     ) -> Result<Option<ProtocolData>, Self::Error>;
 
     fn empty_root(&self) -> Blake2bHash;

--- a/execution-engine/engine-storage/src/global_state/mod.rs
+++ b/execution-engine/engine-storage/src/global_state/mod.rs
@@ -1,3 +1,6 @@
+pub mod in_memory;
+pub mod lmdb;
+
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::BuildHasher;
@@ -9,13 +12,19 @@ use engine_shared::logging::{log_duration, log_metric, GAUGE};
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 use engine_shared::transform::{self, Transform, TypeMismatch};
 
+use crate::protocol_data::ProtocolData;
+use crate::protocol_data_store::ProtocolVersion;
 use crate::transaction_source::{Transaction, TransactionSource};
 use crate::trie::Trie;
 use crate::trie_store::operations::{read, write, ReadResult, WriteResult};
 use crate::trie_store::TrieStore;
 
-pub mod in_memory;
-pub mod lmdb;
+const GLOBAL_STATE_COMMIT_READS: &str = "global_state_commit_reads";
+const GLOBAL_STATE_COMMIT_WRITES: &str = "global_state_commit_writes";
+const GLOBAL_STATE_COMMIT_DURATION: &str = "global_state_commit_duration";
+const GLOBAL_STATE_COMMIT_READ_DURATION: &str = "global_state_commit_read_duration";
+const GLOBAL_STATE_COMMIT_WRITE_DURATION: &str = "global_state_commit_write_duration";
+const COMMIT: &str = "commit";
 
 /// A reader of state
 pub trait StateReader<K, V> {
@@ -57,7 +66,7 @@ impl From<transform::Error> for CommitResult {
     }
 }
 
-pub trait History {
+pub trait StateProvider {
     type Error;
     type Reader: StateReader<Key, Value, Error = Self::Error>;
 
@@ -73,15 +82,19 @@ pub trait History {
         effects: HashMap<Key, Transform>,
     ) -> Result<CommitResult, Self::Error>;
 
+    fn put_protocol_data(
+        &self,
+        protocol_version: &ProtocolVersion,
+        protocol_data: &ProtocolData,
+    ) -> Result<(), Self::Error>;
+
+    fn get_protocol_data(
+        &self,
+        protocol_version: &ProtocolVersion,
+    ) -> Result<Option<ProtocolData>, Self::Error>;
+
     fn empty_root(&self) -> Blake2bHash;
 }
-
-const GLOBAL_STATE_COMMIT_READS: &str = "global_state_commit_reads";
-const GLOBAL_STATE_COMMIT_WRITES: &str = "global_state_commit_writes";
-const GLOBAL_STATE_COMMIT_DURATION: &str = "global_state_commit_duration";
-const GLOBAL_STATE_COMMIT_READ_DURATION: &str = "global_state_commit_read_duration";
-const GLOBAL_STATE_COMMIT_WRITE_DURATION: &str = "global_state_commit_write_duration";
-const COMMIT: &str = "commit";
 
 pub fn commit<'a, R, S, H, E>(
     environment: &'a R,


### PR DESCRIPTION
### Overview
This PR renames `History` to `StateProvider` and adds methods to support getting and putting protocol data.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-639

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
