### PR TITLE
NODE-832: comment out eventLoopGroup until we understand why it causes problems on some systems

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -39,7 +39,10 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
     var builder = NettyChannelBuilder
       .forAddress(conn.host, port)
       .maxInboundMessageSize(DefaultMaxMessageSize)
-      .eventLoopGroup(new NioEventLoopGroup(0, scheduler))
+      //.eventLoopGroup(new NioEventLoopGroup(0, scheduler))
+      // The above line is commented out on purpose; it causes
+      // a problem on some systems. The reason for this is still
+      // under investigation (see NODE-832).
       .executor(scheduler)
 
     builder = conn.nodeId match {


### PR DESCRIPTION
### Overview
Without the `eventLoopGroup` line of code, the scala client no longer hangs on some of our AWS instances. It remains an open issue to figure why this is a problem and how it could be fixed without simply removing this line.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-832

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
