### PR TITLE
EE-573: Apply newtype pattern to Gas and Motes concepts

### DIFF
--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use crate::tracking_copy;
 
 use contract_ffi::key::Key;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::value::Value;
+use engine_shared::gas::Gas;
+use engine_shared::motes::Motes;
 use engine_shared::newtypes::CorrelationId;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::StateReader;
@@ -18,10 +20,10 @@ pub enum ExecutionResult {
     Failure {
         error: error::Error,
         effect: ExecutionEffect,
-        cost: u64,
+        cost: Gas,
     },
     /// Execution was finished successfully
-    Success { effect: ExecutionEffect, cost: u64 },
+    Success { effect: ExecutionEffect, cost: Gas },
 }
 
 impl ExecutionResult {
@@ -32,7 +34,7 @@ impl ExecutionResult {
         ExecutionResult::Failure {
             error,
             effect: Default::default(),
-            cost: 0,
+            cost: Gas::default(),
         }
     }
 
@@ -50,7 +52,7 @@ impl ExecutionResult {
         }
     }
 
-    pub fn cost(&self) -> u64 {
+    pub fn cost(&self) -> Gas {
         match self {
             ExecutionResult::Failure { cost, .. } => *cost,
             ExecutionResult::Success { cost, .. } => *cost,
@@ -64,7 +66,7 @@ impl ExecutionResult {
         }
     }
 
-    pub fn with_cost(self, cost: u64) -> Self {
+    pub fn with_cost(self, cost: Gas) -> Self {
         match self {
             ExecutionResult::Failure { error, effect, .. } => ExecutionResult::Failure {
                 error,
@@ -136,7 +138,7 @@ impl ExecutionResultBuilder {
         self
     }
 
-    pub fn total_cost(&self) -> u64 {
+    pub fn total_cost(&self) -> Gas {
         let payment_cost = self
             .payment_execution_result
             .as_ref()
@@ -152,9 +154,9 @@ impl ExecutionResultBuilder {
 
     pub fn check_forced_transfer(
         &mut self,
-        max_payment_cost: U512,
-        account_main_purse_balance: U512,
-        payment_purse_balance: U512,
+        max_payment_cost: Motes,
+        account_main_purse_balance: Motes,
+        payment_purse_balance: Motes,
         account_main_purse: Key,
         rewards_purse: Key,
     ) -> Option<ExecutionResult> {
@@ -168,7 +170,7 @@ impl ExecutionResultBuilder {
         // payment_code_spec_3_b_ii: if (balance of PoS pay purse) < (gas spent during
         // payment code execution) * conv_rate, no session
         let insufficient_balance_to_continue =
-            payment_purse_balance < (payment_result_cost * CONV_RATE).into();
+            payment_purse_balance < Motes::from_gas(payment_result_cost, CONV_RATE);
 
         // payment_code_spec_4: insufficient payment
         if !(insufficient_balance_to_continue || payment_result_is_failure) {
@@ -186,18 +188,18 @@ impl ExecutionResultBuilder {
         ops.insert(account_main_purse_normalize, Op::Write);
         transforms.insert(
             account_main_purse_normalize,
-            Transform::Write(Value::UInt512(new_balance)),
+            Transform::Write(Value::UInt512(new_balance.value())),
         );
 
         ops.insert(rewards_purse_normalize, Op::Add);
         transforms.insert(
             rewards_purse_normalize,
-            Transform::AddUInt512(max_payment_cost),
+            Transform::AddUInt512(max_payment_cost.value()),
         );
 
         let error = error::Error::InsufficientPaymentError;
         let effect = ExecutionEffect::new(ops, transforms);
-        let cost = (max_payment_cost / CONV_RATE).as_u64();
+        let cost = Gas::from_motes(max_payment_cost, CONV_RATE);
 
         Some(ExecutionResult::Failure {
             error,

--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -170,7 +170,7 @@ impl ExecutionResultBuilder {
         // payment_code_spec_3_b_ii: if (balance of PoS pay purse) < (gas spent during
         // payment code execution) * conv_rate, no session
         let insufficient_balance_to_continue =
-            payment_purse_balance < Motes::from_gas(payment_result_cost, CONV_RATE);
+            payment_purse_balance < Motes::from_gas(payment_result_cost, CONV_RATE)?;
 
         // payment_code_spec_4: insufficient payment
         if !(insufficient_balance_to_continue || payment_result_is_failure) {
@@ -199,7 +199,7 @@ impl ExecutionResultBuilder {
 
         let error = error::Error::InsufficientPaymentError;
         let effect = ExecutionEffect::new(ops, transforms);
-        let cost = Gas::from_motes(max_payment_cost, CONV_RATE);
+        let cost = Gas::from_motes(max_payment_cost, CONV_RATE).unwrap_or_default();
 
         Some(ExecutionResult::Failure {
             error,

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -383,7 +383,7 @@ where
 
             let session_motes = Motes::from_u64(DEFAULT_SESSION_MOTES);
 
-            let gas_limit = Gas::from_motes(session_motes, CONV_RATE);
+            let gas_limit = Gas::from_motes(session_motes, CONV_RATE).unwrap_or_default();
 
             // Session code execution
             let session_result = executor.exec(
@@ -543,7 +543,7 @@ where
         let payment_result = {
             // payment_code_spec_1: init pay environment w/ gas limit == (max_payment_cost /
             // conv_rate)
-            let pay_gas_limit = Gas::from_motes(max_payment_cost, CONV_RATE);
+            let pay_gas_limit = Gas::from_motes(max_payment_cost, CONV_RATE).unwrap_or_default();
 
             // Create payment code module from bytes
             // validation_spec_1: valid wasm bytes
@@ -636,8 +636,9 @@ where
             // payment code execution) * conv_rate, yes session
             // session_code_spec_1: gas limit = ((balance of PoS payment purse) / conv_rate)
             // - (gas spent during payment execution)
-            let session_gas_limit: Gas =
-                Gas::from_motes(payment_purse_balance, CONV_RATE) - payment_result_cost;
+            let session_gas_limit: Gas = Gas::from_motes(payment_purse_balance, CONV_RATE)
+                .unwrap_or_default()
+                - payment_result_cost;
 
             executor.exec(
                 session_module,
@@ -682,7 +683,7 @@ where
 
             let proof_of_stake_args = {
                 //((gas spent during payment code execution) + (gas spent during session code execution)) * conv_rate
-                let finalize_cost_motes: Motes = Motes::from_gas(execution_result_builder.total_cost(), CONV_RATE);
+                let finalize_cost_motes: Motes = Motes::from_gas(execution_result_builder.total_cost(), CONV_RATE).expect("motes overflow");
                 let args = ("finalize_payment", finalize_cost_motes.value(), account_addr);
                 ArgsParser::parse(&args)
                     .and_then(|args| args.to_bytes())

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -4,15 +4,17 @@ use std::rc::Rc;
 
 use parity_wasm::elements::Module;
 
-use crate::engine_state::execution_result::ExecutionResult;
 use contract_ffi::bytesrepr::deserialize;
 use contract_ffi::execution::Phase;
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
 use contract_ffi::value::account::{BlockTime, PublicKey};
 use contract_ffi::value::{Account, Value};
+use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
 use engine_storage::global_state::StateReader;
+
+use crate::engine_state::execution_result::ExecutionResult;
 
 use super::Error;
 use super::{create_rng, extract_access_rights_from_keys, instance_and_memory, Runtime};
@@ -30,7 +32,7 @@ pub trait Executor<A> {
         account: &Account,
         authorized_keys: BTreeSet<PublicKey>,
         blocktime: BlockTime,
-        gas_limit: u64,
+        gas_limit: Gas,
         protocol_version: u64,
         correlation_id: CorrelationId,
         tc: Rc<RefCell<TrackingCopy<R>>>,
@@ -49,7 +51,7 @@ pub trait Executor<A> {
         account: &Account,
         authorization_keys: BTreeSet<PublicKey>,
         blocktime: BlockTime,
-        gas_limit: u64,
+        gas_limit: Gas,
         protocol_version: u64,
         correlation_id: CorrelationId,
         state: Rc<RefCell<TrackingCopy<R>>>,
@@ -108,7 +110,7 @@ impl Executor<Module> for WasmiExecutor {
         account: &Account,
         authorized_keys: BTreeSet<PublicKey>,
         blocktime: BlockTime,
-        gas_limit: u64,
+        gas_limit: Gas,
         protocol_version: u64,
         correlation_id: CorrelationId,
         tc: Rc<RefCell<TrackingCopy<R>>>,
@@ -125,7 +127,7 @@ impl Executor<Module> for WasmiExecutor {
             extract_access_rights_from_keys(uref_lookup_local.values().cloned());
         let account_bytes = base_key.as_account().unwrap();
         let rng = create_rng(account_bytes, account.nonce(), phase);
-        let gas_counter = 0u64;
+        let gas_counter: Gas = Gas::default();
         let fn_store_id = 0u32;
 
         // Snapshot of effects before execution, so in case of error
@@ -137,7 +139,11 @@ impl Executor<Module> for WasmiExecutor {
         } else {
             // TODO: figure out how this works with the cost model
             // https://casperlabs.atlassian.net/browse/EE-239
-            on_fail_charge!(deserialize(args), args.len() as u64, effects_snapshot)
+            on_fail_charge!(
+                deserialize(args),
+                Gas::from_u64(args.len() as u64),
+                effects_snapshot
+            )
         };
 
         let context = RuntimeContext::new(
@@ -180,7 +186,7 @@ impl Executor<Module> for WasmiExecutor {
         account: &Account,
         authorization_keys: BTreeSet<PublicKey>,
         blocktime: BlockTime,
-        gas_limit: u64,
+        gas_limit: Gas,
         protocol_version: u64,
         correlation_id: CorrelationId,
         state: Rc<RefCell<TrackingCopy<R>>>,
@@ -198,7 +204,7 @@ impl Executor<Module> for WasmiExecutor {
             let rng = create_rng(account.pub_key(), account.nonce(), phase);
             Rc::new(RefCell::new(rng))
         };
-        let gas_counter = 0u64; // maybe const?
+        let gas_counter = Gas::default(); // maybe const?
         let fn_store_id = 0u32; // maybe const?
 
         // Snapshot of effects before execution, so in case of error only nonce update
@@ -208,7 +214,11 @@ impl Executor<Module> for WasmiExecutor {
         let args: Vec<Vec<u8>> = if args.is_empty() {
             Vec::new()
         } else {
-            on_fail_charge!(deserialize(args), args.len() as u64, effects_snapshot)
+            on_fail_charge!(
+                deserialize(args),
+                Gas::from_u64(args.len() as u64),
+                effects_snapshot
+            )
         };
 
         let context = RuntimeContext::new(

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -2,15 +2,17 @@ use std::convert::TryFrom;
 
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
+use contract_ffi::bytesrepr::{self, ToBytes};
 use contract_ffi::key::Key;
+use contract_ffi::value::account::{PublicKey, PurseId};
 use contract_ffi::value::{Value, U512};
+
+use engine_shared::gas::Gas;
 use engine_storage::global_state::StateReader;
 
 use super::args::Args;
 use super::{Error, Runtime};
 use crate::resolvers::v1_function_index::FunctionIndex;
-use contract_ffi::bytesrepr::{self, ToBytes};
-use contract_ffi::value::account::{PublicKey, PurseId};
 
 impl<'a, R: StateReader<Key, Value>> Externals for Runtime<'a, R>
 where
@@ -223,7 +225,7 @@ where
 
             FunctionIndex::GasFuncIndex => {
                 let gas: u32 = Args::parse(args)?;
-                self.gas(u64::from(gas))?;
+                self.gas(Gas::from_u64(gas.into()))?;
                 Ok(None)
             }
 

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -17,12 +17,12 @@ use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef, Trap, TrapKind
 use contract_ffi::bytesrepr::{deserialize, ToBytes, U32_SIZE};
 use contract_ffi::contract_api::argsparser::ArgsParser;
 use contract_ffi::contract_api::{PurseTransferResult, TransferResult};
-
 use contract_ffi::key::Key;
 use contract_ffi::system_contracts::{self, mint};
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::account::{ActionType, PublicKey, PurseId, Weight, PUBLIC_KEY_SIZE};
 use contract_ffi::value::{Account, Value, U512};
+use engine_shared::gas::Gas;
 use engine_storage::global_state::StateReader;
 
 use super::{Error, MINT_NAME, POS_NAME};
@@ -239,7 +239,7 @@ where
     /// Returns false if gas limit exceeded and true if not.
     /// Intuition about the return value sense is to aswer the question 'are we
     /// allowed to continue?'
-    fn charge_gas(&mut self, amount: u64) -> bool {
+    fn charge_gas(&mut self, amount: Gas) -> bool {
         let prev = self.context.gas_counter();
         match prev.checked_add(amount) {
             // gas charge overflow protection
@@ -252,7 +252,7 @@ where
         }
     }
 
-    fn gas(&mut self, amount: u64) -> Result<(), Trap> {
+    fn gas(&mut self, amount: Gas) -> Result<(), Trap> {
         if self.charge_gas(amount) {
             Ok(())
         } else {

--- a/execution-engine/engine-core/src/execution/tests.rs
+++ b/execution-engine/engine-core/src/execution/tests.rs
@@ -1,14 +1,16 @@
 use rand::RngCore;
 use rand_chacha::ChaChaRng;
 
+use engine_shared::gas::Gas;
+
 use super::Error;
 use crate::engine_state::execution_result::ExecutionResult;
 use crate::execution::create_rng;
 
 fn on_fail_charge_test_helper<T>(
     f: impl Fn() -> Result<T, Error>,
-    success_cost: u64,
-    error_cost: u64,
+    success_cost: Gas,
+    error_cost: Gas,
 ) -> ExecutionResult {
     let _result = on_fail_charge!(f(), error_cost);
     ExecutionResult::Success {
@@ -19,16 +21,22 @@ fn on_fail_charge_test_helper<T>(
 
 #[test]
 fn on_fail_charge_ok_test() {
-    match on_fail_charge_test_helper(|| Ok(()), 123, 456) {
-        ExecutionResult::Success { cost, .. } => assert_eq!(cost, 123),
+    let val = Gas::from_u64(123);
+    match on_fail_charge_test_helper(|| Ok(()), val, Gas::from_u64(456)) {
+        ExecutionResult::Success { cost, .. } => assert_eq!(cost, val),
         ExecutionResult::Failure { .. } => panic!("Should be success"),
     }
 }
 #[test]
 fn on_fail_charge_err_laziness_test() {
-    match on_fail_charge_test_helper(|| Err(Error::GasLimit) as Result<(), _>, 123, 456) {
+    let error_cost = Gas::from_u64(456);
+    match on_fail_charge_test_helper(
+        || Err(Error::GasLimit) as Result<(), _>,
+        Gas::from_u64(123),
+        error_cost,
+    ) {
         ExecutionResult::Success { .. } => panic!("Should fail"),
-        ExecutionResult::Failure { cost, .. } => assert_eq!(cost, 456),
+        ExecutionResult::Failure { cost, .. } => assert_eq!(cost, error_cost),
     }
 }
 #[test]
@@ -39,7 +47,7 @@ fn on_fail_charge_with_action() {
     use engine_shared::transform::Transform;
     let f = || {
         let input: Result<(), Error> = Err(Error::GasLimit);
-        on_fail_charge!(input, 456, {
+        on_fail_charge!(input, Gas::from_u64(456), {
             let mut effect = ExecutionEffect::default();
 
             effect.ops.insert(Key::Hash([42u8; 32]), Op::Read);
@@ -51,13 +59,13 @@ fn on_fail_charge_with_action() {
         });
         ExecutionResult::Success {
             effect: Default::default(),
-            cost: 0,
+            cost: Gas::default(),
         }
     };
     match f() {
         ExecutionResult::Success { .. } => panic!("Should fail"),
         ExecutionResult::Failure { cost, effect, .. } => {
-            assert_eq!(cost, 456);
+            assert_eq!(cost, Gas::from_u64(456));
             // Check if the containers are non-empty
             assert_eq!(effect.ops.len(), 1);
             assert_eq!(effect.transforms.len(), 1);

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -21,6 +21,7 @@ use contract_ffi::value::account::{
     SetThresholdFailure, UpdateKeyFailure, Weight,
 };
 use contract_ffi::value::{Contract, Value};
+use engine_shared::gas::Gas;
 use engine_shared::newtypes::{CorrelationId, Validated};
 use engine_storage::global_state::StateReader;
 
@@ -44,8 +45,8 @@ pub struct RuntimeContext<'a, R> {
     //(could point at an account or contract in the global state)
     base_key: Key,
     blocktime: BlockTime,
-    gas_limit: u64,
-    gas_counter: u64,
+    gas_limit: Gas,
+    gas_counter: Gas,
     fn_store_id: u32,
     rng: Rc<RefCell<ChaChaRng>>,
     protocol_version: u64,
@@ -67,8 +68,8 @@ where
         account: &'a Account,
         base_key: Key,
         blocktime: BlockTime,
-        gas_limit: u64,
-        gas_counter: u64,
+        gas_limit: Gas,
+        gas_counter: Gas,
         fn_store_id: u32,
         rng: Rc<RefCell<ChaChaRng>>,
         protocol_version: u64,
@@ -218,15 +219,15 @@ where
         Rc::clone(&self.state)
     }
 
-    pub fn gas_limit(&self) -> u64 {
+    pub fn gas_limit(&self) -> Gas {
         self.gas_limit
     }
 
-    pub fn gas_counter(&self) -> u64 {
+    pub fn gas_counter(&self) -> Gas {
         self.gas_counter
     }
 
-    pub fn set_gas_counter(&mut self, new_gas_counter: u64) {
+    pub fn set_gas_counter(&mut self, new_gas_counter: Gas) {
         self.gas_counter = new_gas_counter;
     }
 

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -9,7 +9,13 @@ use rand_chacha::ChaChaRng;
 use contract_ffi::execution::Phase;
 use contract_ffi::key::{Key, LOCAL_SEED_SIZE};
 use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::value::account::{
+    AccountActivity, ActionType, AddKeyFailure, AssociatedKeys, BlockTime, PublicKey, PurseId,
+    RemoveKeyFailure, SetThresholdFailure, Weight,
+};
 use contract_ffi::value::{self, Account, Contract, Value};
+use engine_shared::gas::Gas;
+use engine_shared::newtypes::CorrelationId;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::{InMemoryGlobalState, InMemoryGlobalStateView};
 use engine_storage::global_state::{CommitResult, History};
@@ -17,11 +23,6 @@ use engine_storage::global_state::{CommitResult, History};
 use super::{Error, RuntimeContext, URefAddr, Validated};
 use crate::execution::{create_rng, extract_access_rights_from_keys};
 use crate::tracking_copy::TrackingCopy;
-use contract_ffi::value::account::{
-    AccountActivity, ActionType, AddKeyFailure, AssociatedKeys, BlockTime, PublicKey, PurseId,
-    RemoveKeyFailure, SetThresholdFailure, Weight,
-};
-use engine_shared::newtypes::CorrelationId;
 
 fn mock_tc(init_key: Key, init_account: value::Account) -> TrackingCopy<InMemoryGlobalStateView> {
     let correlation_id = CorrelationId::new();
@@ -112,8 +113,8 @@ fn mock_runtime_context<'a>(
         &account,
         base_key,
         BlockTime(0),
-        0,
-        0,
+        Gas::default(),
+        Gas::default(),
         0,
         Rc::new(RefCell::new(rng)),
         1,
@@ -413,8 +414,8 @@ fn contract_key_addable_valid() {
         &account,
         contract_key,
         BlockTime(0),
-        0,
-        0,
+        Gas::default(),
+        Gas::default(),
         0,
         Rc::new(RefCell::new(chacha_rng)),
         1,
@@ -468,8 +469,8 @@ fn contract_key_addable_invalid() {
         &account,
         other_contract_key,
         BlockTime(0),
-        0,
-        0,
+        Gas::default(),
+        Gas::default(),
         0,
         Rc::new(RefCell::new(chacha_rng)),
         1,

--- a/execution-engine/engine-core/src/tracking_copy/ext.rs
+++ b/execution-engine/engine-core/src/tracking_copy/ext.rs
@@ -1,13 +1,14 @@
 use contract_ffi::bytesrepr::ToBytes;
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
-use contract_ffi::value::{Account, Contract, Value, U512};
-
-use crate::execution;
-use crate::tracking_copy::{QueryResult, TrackingCopy};
+use contract_ffi::value::{Account, Contract, Value};
+use engine_shared::motes::Motes;
 use engine_shared::newtypes::{CorrelationId, Validated};
 use engine_shared::transform::TypeMismatch;
 use engine_storage::global_state::StateReader;
+
+use crate::execution;
+use crate::tracking_copy::{QueryResult, TrackingCopy};
 
 pub struct SystemContractInfo {
     outer_key: Key,
@@ -66,7 +67,7 @@ pub trait TrackingCopyExt<R> {
         &mut self,
         correlation_id: CorrelationId,
         balance_key: Key,
-    ) -> Result<U512, Self::Error>;
+    ) -> Result<Motes, Self::Error>;
 
     /// Gets the system contract, packaged with its outer uref key and inner
     /// uref key
@@ -137,13 +138,13 @@ where
         &mut self,
         correlation_id: CorrelationId,
         key: Key,
-    ) -> Result<U512, Self::Error> {
+    ) -> Result<Motes, Self::Error> {
         let query_result = match self.query(correlation_id, key, &[]) {
             Ok(query_result) => query_result,
             Err(_) => return Err(execution::Error::KeyNotFound(key)),
         };
         match query_result {
-            QueryResult::Success(Value::UInt512(balance)) => Ok(balance),
+            QueryResult::Success(Value::UInt512(balance)) => Ok(Motes::new(balance)),
             QueryResult::Success(other) => Err(execution::Error::TypeMismatch(TypeMismatch::new(
                 "Value::UInt512".to_string(),
                 other.type_string(),

--- a/execution-engine/engine-core/src/tracking_copy/mod.rs
+++ b/execution-engine/engine-core/src/tracking_copy/mod.rs
@@ -16,11 +16,12 @@ use engine_shared::newtypes::{CorrelationId, Validated};
 use engine_shared::transform::{self, Transform, TypeMismatch};
 use engine_storage::global_state::StateReader;
 
+use crate::engine_state::execution_effect::ExecutionEffect;
+use crate::engine_state::op::Op;
+
 pub use self::ext::TrackingCopyExt;
 use self::meter::heap_meter::HeapSize;
 use self::meter::Meter;
-use crate::engine_state::execution_effect::ExecutionEffect;
-use crate::engine_state::op::Op;
 
 #[derive(Debug)]
 pub enum QueryResult {

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -6,7 +6,6 @@ use std::rc::Rc;
 use proptest::collection::vec;
 use proptest::prelude::*;
 
-use crate::engine_state::op::Op;
 use contract_ffi::gens::*;
 use contract_ffi::key::Key;
 use contract_ffi::uref::{AccessRights, URef};
@@ -18,6 +17,8 @@ use engine_shared::newtypes::CorrelationId;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
 use engine_storage::global_state::{History, StateReader};
+
+use crate::engine_state::op::Op;
 
 use super::meter::count_meter::Count;
 use super::{AddResult, QueryResult, Validated};

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -696,7 +696,8 @@ impl From<ExecutionResult> for ipc::DeployResult {
                 let mut deploy_result = ipc::DeployResult::new();
                 let mut execution_result = ipc::DeployResult_ExecutionResult::new();
                 execution_result.set_effects(ipc_ee);
-                execution_result.set_cost(cost);
+                // TODO: executionresult cost should be BIGINT; see https://casperlabs.atlassian.net/browse/EE-649
+                execution_result.set_cost(cost.as_u64());
                 deploy_result.set_execution_result(execution_result);
                 deploy_result
             }
@@ -725,25 +726,25 @@ impl From<ExecutionResult> for ipc::DeployResult {
                         ExecutionError::DeploymentAuthorizationFailure,
                     ) => precondition_failure(error.to_string()),
                     EngineError::StorageError(storage_err) => {
-                        execution_error(storage_err.to_string(), cost, effect)
+                        execution_error(storage_err.to_string(), cost.as_u64(), effect)
                     }
                     error @ EngineError::AuthorizationError => {
                         precondition_failure(error.to_string())
                     }
                     EngineError::MissingSystemContractError(msg) => {
-                        execution_error(msg, cost, effect)
+                        execution_error(msg, cost.as_u64(), effect)
                     }
                     error @ EngineError::InsufficientPaymentError => {
                         let msg = error.to_string();
-                        execution_error(msg, cost, effect)
+                        execution_error(msg, cost.as_u64(), effect)
                     }
                     error @ EngineError::DeployError => {
                         let msg = error.to_string();
-                        execution_error(msg, cost, effect)
+                        execution_error(msg, cost.as_u64(), effect)
                     }
                     error @ EngineError::FinalizationError => {
                         let msg = error.to_string();
-                        execution_error(msg, cost, effect)
+                        execution_error(msg, cost.as_u64(), effect)
                     }
                     EngineError::ExecError(exec_error) => match exec_error {
                         ExecutionError::GasLimit => {
@@ -756,7 +757,7 @@ impl From<ExecutionResult> for ipc::DeployResult {
                             let exec_result = {
                                 let mut tmp = ipc::DeployResult_ExecutionResult::new();
                                 tmp.set_error(deploy_error);
-                                tmp.set_cost(cost);
+                                tmp.set_cost(cost.as_u64());
                                 tmp.set_effects(effect.into());
                                 tmp
                             };
@@ -766,7 +767,7 @@ impl From<ExecutionResult> for ipc::DeployResult {
                         }
                         ExecutionError::KeyNotFound(key) => {
                             let msg = format!("Key {:?} not found.", key);
-                            execution_error(msg, cost, effect)
+                            execution_error(msg, cost.as_u64(), effect)
                         }
                         ExecutionError::InvalidNonce {
                             deploy_nonce,
@@ -791,7 +792,7 @@ impl From<ExecutionResult> for ipc::DeployResult {
                         }
                         ExecutionError::Revert(status) => {
                             let error_msg = format!("Exit code: {}", status);
-                            execution_error(error_msg, cost, effect)
+                            execution_error(error_msg, cost.as_u64(), effect)
                         }
                         ExecutionError::Interpreter(error) => {
                             // If the error happens during contract execution it's mapped to
@@ -809,28 +810,30 @@ impl From<ExecutionResult> for ipc::DeployResult {
                                     match downcasted_error {
                                         ExecutionError::Revert(status) => {
                                             let errors_msg = format!("Exit code: {}", status);
-                                            execution_error(errors_msg, cost, effect)
+                                            execution_error(errors_msg, cost.as_u64(), effect)
                                         }
                                         ExecutionError::KeyNotFound(key) => {
                                             let errors_msg = format!("Key {:?} not found.", key);
-                                            execution_error(errors_msg, cost, effect)
+                                            execution_error(errors_msg, cost.as_u64(), effect)
                                         }
-                                        other => {
-                                            execution_error(format!("{:?}", other), cost, effect)
-                                        }
+                                        other => execution_error(
+                                            format!("{:?}", other),
+                                            cost.as_u64(),
+                                            effect,
+                                        ),
                                     }
                                 }
 
                                 None => {
                                     let msg = format!("{:?}", error);
-                                    execution_error(msg, cost, effect)
+                                    execution_error(msg, cost.as_u64(), effect)
                                 }
                             }
                         }
                         // TODO(mateusz.gorski): Be more specific about execution errors
                         other => {
                             let msg = format!("{:?}", other);
-                            execution_error(msg, cost, effect)
+                            execution_error(msg, cost.as_u64(), effect)
                         }
                     },
                 }
@@ -993,6 +996,7 @@ mod tests {
     use engine_core::engine_state::execution_effect::ExecutionEffect;
     use engine_core::engine_state::execution_result::ExecutionResult;
     use engine_core::execution::Error;
+    use engine_shared::gas::Gas;
     use engine_shared::newtypes::Blake2bHash;
     use engine_shared::transform::gens::transform_arb;
     use engine_shared::transform::Transform;
@@ -1040,7 +1044,7 @@ mod tests {
         };
         let execution_effect: ExecutionEffect =
             ExecutionEffect::new(HashMap::new(), input_transforms.clone());
-        let cost: u64 = 123;
+        let cost: Gas = Gas::from_u64(123);
         let execution_result: ExecutionResult = ExecutionResult::Success {
             effect: execution_effect,
             cost,
@@ -1048,7 +1052,7 @@ mod tests {
         let mut ipc_deploy_result: ipc::DeployResult = execution_result.into();
         assert!(ipc_deploy_result.has_execution_result());
         let mut success = ipc_deploy_result.take_execution_result();
-        assert_eq!(success.get_cost(), cost);
+        assert_eq!(success.get_cost(), cost.as_u64());
 
         // Extract transform map from the IPC message and parse it back to the domain
         let ipc_transforms: HashMap<Key, Transform> = {
@@ -1063,7 +1067,7 @@ mod tests {
         assert_eq!(&input_transforms, &ipc_transforms);
     }
 
-    fn into_execution_failure<E: Into<EngineError>>(error: E, cost: u64) -> ExecutionResult {
+    fn into_execution_failure<E: Into<EngineError>>(error: E, cost: Gas) -> ExecutionResult {
         ExecutionResult::Failure {
             error: error.into(),
             effect: Default::default(),
@@ -1071,18 +1075,18 @@ mod tests {
         }
     }
 
-    fn test_cost<E: Into<EngineError>>(expected_cost: u64, err: E) -> u64 {
+    fn test_cost<E: Into<EngineError>>(expected_cost: Gas, err: E) -> Gas {
         let execution_failure = into_execution_failure(err, expected_cost);
         let ipc_deploy_result: ipc::DeployResult = execution_failure.into();
         assert!(ipc_deploy_result.has_execution_result());
         let success = ipc_deploy_result.get_execution_result();
-        success.get_cost()
+        Gas::from_u64(success.get_cost())
     }
 
     #[test]
     fn storage_error_has_cost() {
         use engine_storage::error::Error::*;
-        let cost: u64 = 100;
+        let cost: Gas = Gas::from_u64(100);
         // TODO: actually create an Rkv error
         // assert_eq!(test_cost(cost, RkvError("Error".to_owned())), cost);
         let bytesrepr_err = contract_ffi::bytesrepr::Error::EarlyEndOfStream;
@@ -1091,7 +1095,7 @@ mod tests {
 
     #[test]
     fn exec_err_has_cost() {
-        let cost: u64 = 100;
+        let cost: Gas = Gas::from_u64(100);
         // GasLimit error is treated differently at the moment so test separately
         assert_eq!(
             test_cost(cost, engine_core::execution::Error::GasLimit),
@@ -1140,7 +1144,7 @@ mod tests {
         let exec_result = ExecutionResult::Failure {
             error: ExecError(revert_error),
             effect: Default::default(),
-            cost: 10,
+            cost: Gas::from_u64(10),
         };
         let ipc_result: ipc::DeployResult = exec_result.into();
         assert!(ipc_result.has_execution_result());

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -6,7 +6,6 @@ use std::io::ErrorKind;
 use std::marker::{Send, Sync};
 use std::time::Instant;
 
-use crate::engine_server::ipc::CommitResponse;
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{BlockTime, PublicKey};
 use contract_ffi::value::U512;
@@ -25,6 +24,7 @@ use engine_wasm_prep::{Preprocessor, WasmiPreprocessor};
 
 use self::ipc_grpc::ExecutionEngineService;
 use self::mappings::*;
+use crate::engine_server::ipc::CommitResponse;
 
 pub mod ipc;
 pub mod ipc_grpc;

--- a/execution-engine/engine-shared/src/gas.rs
+++ b/execution-engine/engine-shared/src/gas.rs
@@ -1,0 +1,181 @@
+use std::fmt;
+
+use contract_ffi::value::U512;
+
+use crate::motes::Motes;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
+pub struct Gas(U512);
+
+impl Gas {
+    pub fn new(value: U512) -> Self {
+        Gas(value)
+    }
+
+    pub fn value(&self) -> U512 {
+        self.0
+    }
+
+    pub fn from_motes(motes: Motes, conv_rate: u64) -> Self {
+        Self::new(motes.value() / conv_rate)
+    }
+
+    pub fn checked_add(&self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.value()).map(Self::new)
+    }
+
+    // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
+    pub fn as_u64(&self) -> u64 {
+        self.0.as_u64()
+    }
+
+    // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
+    pub fn from_u64(value: u64) -> Self {
+        Gas(U512::from(value))
+    }
+}
+
+impl Default for Gas {
+    fn default() -> Self {
+        Gas(U512::zero())
+    }
+}
+
+impl fmt::Display for Gas {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl std::ops::Add for Gas {
+    type Output = Gas;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let val = self.value() + rhs.value();
+        Gas::new(val)
+    }
+}
+
+impl std::ops::Sub for Gas {
+    type Output = Gas;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let val = self.value() - rhs.value();
+        Gas::new(val)
+    }
+}
+
+impl std::ops::Div for Gas {
+    type Output = Gas;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let val = self.value() / rhs.value();
+        Gas::new(val)
+    }
+}
+
+impl std::ops::Mul for Gas {
+    type Output = Gas;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let val = self.value() * rhs.value();
+        Gas::new(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gas::Gas;
+    use crate::motes::Motes;
+    use contract_ffi::value::U512;
+
+    #[test]
+    fn should_be_able_to_get_instance_of_gas() {
+        let initial_value = 1;
+        let gas = Gas::new(U512::from(initial_value));
+        assert_eq!(
+            initial_value,
+            gas.value().as_u64(),
+            "should have equal value"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_get_instance_from_u64() {
+        let initial_value = 1;
+        let gas = Gas::from_u64(initial_value);
+        assert_eq!(
+            initial_value,
+            gas.value().as_u64(),
+            "should have equal value"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_compare_two_instances_of_gas() {
+        let left_gas = Gas::new(U512::from(1));
+        let right_gas = Gas::new(U512::from(1));
+        assert_eq!(left_gas, right_gas, "should be equal");
+        let right_gas = Gas::new(U512::from(2));
+        assert_ne!(left_gas, right_gas, "should not be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_add_two_instances_of_gas() {
+        let left_gas = Gas::new(U512::from(1));
+        let right_gas = Gas::new(U512::from(1));
+        let expected_gas = Gas::new(U512::from(2));
+        assert_eq!((left_gas + right_gas), expected_gas, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_subtract_two_instances_of_gas() {
+        let left_gas = Gas::new(U512::from(1));
+        let right_gas = Gas::new(U512::from(1));
+        let expected_gas = Gas::new(U512::from(0));
+        assert_eq!((left_gas - right_gas), expected_gas, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_multiply_two_instances_of_gas() {
+        let left_gas = Gas::new(U512::from(100));
+        let right_gas = Gas::new(U512::from(10));
+        let expected_gas = Gas::new(U512::from(1000));
+        assert_eq!((left_gas * right_gas), expected_gas, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_divide_two_instances_of_gas() {
+        let left_gas = Gas::new(U512::from(1000));
+        let right_gas = Gas::new(U512::from(100));
+        let expected_gas = Gas::new(U512::from(10));
+        assert_eq!((left_gas / right_gas), expected_gas, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_convert_from_mote() {
+        let mote = Motes::new(U512::from(100));
+        let gas = Gas::from_motes(mote, 10);
+        let expected_gas = Gas::new(U512::from(10));
+        assert_eq!(gas, expected_gas, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_default() {
+        let gas = Gas::default();
+        let expected_gas = Gas::new(U512::from(0));
+        assert_eq!(gas, expected_gas, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_compare_relative_value() {
+        let left_gas = Gas::new(U512::from(100));
+        let right_gas = Gas::new(U512::from(10));
+        assert!(left_gas > right_gas, "should be gt");
+        let right_gas = Gas::new(U512::from(100));
+        assert!(left_gas >= right_gas, "should be gte");
+        assert!(left_gas <= right_gas, "should be lte");
+        let left_gas = Gas::new(U512::from(10));
+        assert!(left_gas < right_gas, "should be lt");
+    }
+}

--- a/execution-engine/engine-shared/src/gas.rs
+++ b/execution-engine/engine-shared/src/gas.rs
@@ -190,6 +190,6 @@ mod tests {
         let motes = Motes::new(U512::zero());
         let conv_rate = 0;
         let maybe = Gas::from_motes(motes, conv_rate);
-        assert!(maybe.is_none(), "should be none due to overflow");
+        assert!(maybe.is_none(), "should be none due to divide by zero");
     }
 }

--- a/execution-engine/engine-shared/src/lib.rs
+++ b/execution-engine/engine-shared/src/lib.rs
@@ -12,7 +12,9 @@ extern crate num;
 extern crate parity_wasm;
 
 #[macro_use]
+pub mod gas;
 pub mod logging;
+pub mod motes;
 pub mod newtypes;
 pub mod os;
 pub mod semver;

--- a/execution-engine/engine-shared/src/motes.rs
+++ b/execution-engine/engine-shared/src/motes.rs
@@ -1,0 +1,192 @@
+use std::fmt;
+
+use contract_ffi::value::U512;
+
+use crate::gas::Gas;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
+pub struct Motes(U512);
+
+impl Motes {
+    pub fn new(value: U512) -> Motes {
+        Motes(value)
+    }
+
+    pub fn checked_add(&self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.value()).map(Self::new)
+    }
+
+    pub fn value(&self) -> U512 {
+        self.0
+    }
+
+    pub fn from_gas(gas: Gas, conv_rate: u64) -> Motes {
+        Self::new(gas.value() * conv_rate)
+    }
+
+    // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
+    pub fn from_u64(value: u64) -> Motes {
+        Motes(U512::from(value))
+    }
+}
+
+impl Default for Motes {
+    fn default() -> Self {
+        Motes(U512::zero())
+    }
+}
+
+impl fmt::Display for Motes {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl std::ops::Add for Motes {
+    type Output = Motes;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        let val = self.value() + rhs.value();
+        Motes::new(val)
+    }
+}
+
+impl std::ops::Sub for Motes {
+    type Output = Motes;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        let val = self.value() - rhs.value();
+        Motes::new(val)
+    }
+}
+
+impl std::ops::Div for Motes {
+    type Output = Motes;
+
+    fn div(self, rhs: Self) -> Self::Output {
+        let val = self.value() / rhs.value();
+        Motes::new(val)
+    }
+}
+
+impl std::ops::Mul for Motes {
+    type Output = Motes;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        let val = self.value() * rhs.value();
+        Motes::new(val)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::gas::Gas;
+    use crate::motes::Motes;
+    use contract_ffi::value::U512;
+
+    #[test]
+    fn should_be_able_to_get_instance_of_motes() {
+        let initial_value = 1;
+        let motes = Motes::new(U512::from(initial_value));
+        assert_eq!(
+            initial_value,
+            motes.value().as_u64(),
+            "should have equal value"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_get_instance_from_u64() {
+        let initial_value = 1;
+        let motes = Motes::from_u64(initial_value);
+        assert_eq!(
+            initial_value,
+            motes.value().as_u64(),
+            "should have equal value"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_compare_two_instances_of_motes() {
+        let left_motes = Motes::new(U512::from(1));
+        let right_motes = Motes::new(U512::from(1));
+        assert_eq!(left_motes, right_motes, "should be equal");
+        let right_motes = Motes::new(U512::from(2));
+        assert_ne!(left_motes, right_motes, "should not be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_add_two_instances_of_motes() {
+        let left_motes = Motes::new(U512::from(1));
+        let right_motes = Motes::new(U512::from(1));
+        let expected_motes = Motes::new(U512::from(2));
+        assert_eq!(
+            (left_motes + right_motes),
+            expected_motes,
+            "should be equal"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_subtract_two_instances_of_motes() {
+        let left_motes = Motes::new(U512::from(1));
+        let right_motes = Motes::new(U512::from(1));
+        let expected_motes = Motes::new(U512::from(0));
+        assert_eq!(
+            (left_motes - right_motes),
+            expected_motes,
+            "should be equal"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_multiply_two_instances_of_motes() {
+        let left_motes = Motes::new(U512::from(100));
+        let right_motes = Motes::new(U512::from(10));
+        let expected_motes = Motes::new(U512::from(1000));
+        assert_eq!(
+            (left_motes * right_motes),
+            expected_motes,
+            "should be equal"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_divide_two_instances_of_motes() {
+        let left_motes = Motes::new(U512::from(1000));
+        let right_motes = Motes::new(U512::from(100));
+        let expected_motes = Motes::new(U512::from(10));
+        assert_eq!(
+            (left_motes / right_motes),
+            expected_motes,
+            "should be equal"
+        )
+    }
+
+    #[test]
+    fn should_be_able_to_convert_from_motes() {
+        let gas = Gas::new(U512::from(100));
+        let motes = Motes::from_gas(gas, 10);
+        let expected_motes = Motes::new(U512::from(1000));
+        assert_eq!(motes, expected_motes, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_default() {
+        let motes = Motes::default();
+        let expected_motes = Motes::new(U512::from(0));
+        assert_eq!(motes, expected_motes, "should be equal")
+    }
+
+    #[test]
+    fn should_be_able_to_compare_relative_value() {
+        let left_motes = Motes::new(U512::from(100));
+        let right_motes = Motes::new(U512::from(10));
+        assert!(left_motes > right_motes, "should be gt");
+        let right_motes = Motes::new(U512::from(100));
+        assert!(left_motes >= right_motes, "should be gte");
+        assert!(left_motes <= right_motes, "should be lte");
+        let left_motes = Motes::new(U512::from(10));
+        assert!(left_motes < right_motes, "should be lt");
+    }
+}

--- a/execution-engine/engine-shared/src/motes.rs
+++ b/execution-engine/engine-shared/src/motes.rs
@@ -4,7 +4,7 @@ use contract_ffi::value::U512;
 
 use crate::gas::Gas;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub struct Motes(U512);
 
 impl Motes {
@@ -20,19 +20,15 @@ impl Motes {
         self.0
     }
 
-    pub fn from_gas(gas: Gas, conv_rate: u64) -> Motes {
-        Self::new(gas.value() * conv_rate)
+    pub fn from_gas(gas: Gas, conv_rate: u64) -> Option<Self> {
+        gas.value()
+            .checked_mul(U512::from(conv_rate))
+            .map(Self::new)
     }
 
     // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
     pub fn from_u64(value: u64) -> Motes {
         Motes(U512::from(value))
-    }
-}
-
-impl Default for Motes {
-    fn default() -> Self {
-        Motes(U512::zero())
     }
 }
 
@@ -166,7 +162,7 @@ mod tests {
     #[test]
     fn should_be_able_to_convert_from_motes() {
         let gas = Gas::new(U512::from(100));
-        let motes = Motes::from_gas(gas, 10);
+        let motes = Motes::from_gas(gas, 10).expect("should have value");
         let expected_motes = Motes::new(U512::from(1000));
         assert_eq!(motes, expected_motes, "should be equal")
     }
@@ -188,5 +184,22 @@ mod tests {
         assert!(left_motes <= right_motes, "should be lte");
         let left_motes = Motes::new(U512::from(10));
         assert!(left_motes < right_motes, "should be lt");
+    }
+
+    #[test]
+    fn should_default() {
+        let left_motes = Motes::new(U512::from(0));
+        let right_motes = Motes::default();
+        assert_eq!(left_motes, right_motes, "should be equal");
+        let u512 = U512::zero();
+        assert_eq!(left_motes.value(), u512, "should be equal");
+    }
+
+    #[test]
+    fn should_support_checked_mul_from_gas() {
+        let gas = Gas::new(U512::MAX);
+        let conv_rate = 10;
+        let maybe = Motes::from_gas(gas, conv_rate);
+        assert!(maybe.is_none(), "should be none due to overflow");
     }
 }


### PR DESCRIPTION
This PR adds newtypes for `Gas` and `Motes`, and applies them to existing logic that was variously using `U512` or `u64` variables. 

https://casperlabs.atlassian.net/browse/EE-573

- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR includes several new unit tests for each newtype

NOTE: there is some future work to be done in the ipc messages to replace a few fields related to gas or cost using  `u64` with `BigInt`...see https://casperlabs.atlassian.net/browse/EE-649