### PR TITLE
ECO-107: Use the new argument API in Clarity.

### DIFF
--- a/explorer/server/src/lib/Args.ts
+++ b/explorer/server/src/lib/Args.ts
@@ -1,0 +1,26 @@
+import { Deploy } from "../grpc/io/casperlabs/casper/consensus/consensus_pb";
+
+// Functions to convert data to protobuf Deploy.Arg
+
+type ToValue<T> = (x: T) => Deploy.Arg.Value;
+
+function toValue<T>(set: (value: Deploy.Arg.Value, x: T) => void): ToValue<T> {
+  return (x: T) => {
+    const value = new Deploy.Arg.Value();
+    set(value, x);
+    return value;
+  };
+}
+
+export const BytesValue = toValue<ByteArray>((value, x) => value.setBytesValue(x));
+export const LongValue = toValue<bigint>((value, x) => value.setLongValue(Number(x)));
+
+export function Args(...args: Array<[string, Deploy.Arg.Value]>): Deploy.Arg[] {
+  return args.map((x) => {
+    const [name, value] = x;
+    const arg = new Deploy.Arg();
+    arg.setName(name);
+    arg.setValue(value);
+    return arg;
+  });
+}


### PR DESCRIPTION
### Overview
Use the `Deploy.Arg` message types defined in Protobuf rather than the ABI.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-107

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Left the ABI there as reference and because they are still used in the UI for balance queries.
