### PR TITLE
NODE-793: Test Scala client's handling of contract args

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -64,7 +64,7 @@ class ABI:
     Encode (serialize) deploy args.
 
     Currently supported ABI types:
-    - unsigned integers: u32, u64, u512,
+    - unsigned integers: u32, u64, u512
     - byte_array, an array of bytes of arbitrary length,
     - account, 32 bytes long byte_array, used for encoding of public keys.
 
@@ -82,15 +82,17 @@ class ABI:
     2. By encoding arguments in a JSON format and passing them to method
       ABI.args_from_json, for example:
 
-        ABI.args_from_json('[{"u32": 100}, {"u64": 5000}]')
+        ABI.args_from_json(json_string)
 
-      The JSON encoded list contains arguments encoded as dictionaries,
-      each with just one (key, value) pair, where key is a name of one
-      of supported ABI type, and value being the argument's value.
+      See documentation of ABI.args_from_json for details of the JSON format.
 
       This method has been developed to support passing deploy arguments
       on command line.
     """
+
+    INTEGER_TYPES = ("u32", "u64", "u512", "int_value", "long_value", "big_int")
+    BYTE_ARRAY_TYPES = ("byte_array", "account", "bytes_value")
+    OPTIONAL_TYPES = ("option", "optional_value")
 
     @staticmethod
     def option(o: bytes) -> bytes:
@@ -99,15 +101,19 @@ class ABI:
         return bytes([1]) + o
 
     @staticmethod
-    def u32(n: int):
+    def optional_value(o: bytes) -> bytes:
+        return ABI.option(o)
+
+    @staticmethod
+    def u32(n: int) -> bytes:
         return struct.pack("<I", n)
 
     @staticmethod
-    def u64(n: int):
+    def u64(n: int) -> bytes:
         return struct.pack("<Q", n)
 
     @staticmethod
-    def u512(n: int):
+    def u512(n: int) -> bytes:
         bs = list(
             dropwhile(
                 lambda b: b == 0,
@@ -119,17 +125,33 @@ class ABI:
         )
 
     @staticmethod
-    def byte_array(a: bytes):
+    def byte_array(a: bytes) -> bytes:
         return ABI.u32(len(a)) + a
 
     @staticmethod
-    def account(a: bytes):
+    def bytes_value(a: bytes) -> bytes:
+        return ABI.byte_array(a)
+
+    @staticmethod
+    def account(a: bytes) -> bytes:
         if len(a) != 32:
             raise Exception("Account must be 32 bytes long")
         return ABI.byte_array(a)
 
     @staticmethod
-    def args(l: list):
+    def int_value(a: int) -> bytes:
+        # TODO: should be signed 32 bits
+        return ABI.u32(a)
+
+    def long_value(a: int) -> bytes:
+        # TODO: should be signed 64 bits
+        return ABI.u64(a)
+
+    def big_int(a: bytes) -> bytes:
+        return ABI.u512(a)
+
+    @staticmethod
+    def args(l: list) -> bytes:
         return ABI.u32(len(l)) + reduce(add, map(ABI.byte_array, l))
 
     @staticmethod
@@ -137,39 +159,37 @@ class ABI:
         """
         Convert a string with JSON representation of deploy args to binary (ABI).
 
-        The JSON should be a list of dictionaries {'type': 'value'} that represent type and value of the args,
+        The JSON should be a list of dictionaries each representing one arg,
         for example:
 
-             [{"u32":1024}, {"account":"00000000000000000000000000000000"}, {"u64":1234567890}]
+            [
+                {"name": "amount", "value": {"long_value": 123456}},
+                {"name": "account", "value": {"bytes_value": '0000000000000000000000000000000000000000000000000000000000000000'},
+                {"name": "purse_id", "value": {"optional_value": {}}},
+            ]
+
         """
         args = json.loads(s)
 
-        for arg in args:
-            if len(arg) != 1:
-                raise Exception(
-                    f"Wrong encoding of value in {arg}. Only one pair of type and value allowed."
-                )
-
         def python_value(typ, value: str):
-            if typ in ("u32", "u64", "u512"):
+            if typ in ABI.INTEGER_TYPES:
                 return int(value)
-            elif typ == "account":
+            elif typ in ABI.BYTE_ARRAY_TYPES:
                 return bytearray.fromhex(value)
+            elif typ in ABI.OPTIONAL_TYPES:
+                if not value:
+                    return None
+                return python_value(*list(value["value"].items())[0])
             raise ValueError(
-                f"Unknown type {typ}, expected ('u32', 'u64', 'u512', 'account')"
+                f"Unknown type {typ}, expected {ABI.INTEGER_TYPES + ABI.BYTE_ARRAY_TYPES}"
             )
 
-        def encode(typ: str, value: str) -> bytes:
+        def encode(arg) -> bytes:
+            typ, value = list(arg["value"].items())[0]
             v = python_value(typ, value)
             return getattr(ABI, typ)(v)
 
-        def only_one(arg):
-            items = list(arg.items())
-            if len(items) != 1:
-                raise Exception("Only one pair {'type', 'value'} allowed.")
-            return items[0]
-
-        return ABI.args([encode(*only_one(arg)) for arg in args])
+        return ABI.args([encode(arg) for arg in args])
 
 
 def read_pem_key(file_name: str):

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -94,6 +94,8 @@ class ABI:
     BYTE_ARRAY_TYPES = ("byte_array", "account", "bytes_value")
     OPTIONAL_TYPES = ("option", "optional_value")
 
+    ALL_TYPES = INTEGER_TYPES + BYTE_ARRAY_TYPES + OPTIONAL_TYPES
+
     @staticmethod
     def option(o: bytes) -> bytes:
         if o is None:
@@ -180,9 +182,7 @@ class ABI:
                 if not value:
                     return None
                 return python_value(*list(value["value"].items())[0])
-            raise ValueError(
-                f"Unknown type {typ}, expected {ABI.INTEGER_TYPES + ABI.BYTE_ARRAY_TYPES}"
-            )
+            raise ValueError(f"Unknown type {typ}, expected one of {ABI.ALL_TYPES}")
 
         def encode(arg) -> bytes:
             typ, value = list(arg["value"].items())[0]

--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -14,6 +14,7 @@ from test.cl_node.wait import (
     wait_for_approved_block_received_handler_state,
     wait_for_node_started,
     wait_for_peers_count_at_least,
+    wait_for_genesis_block,
 )
 from typing import Callable, Dict, List
 from docker import DockerClient
@@ -248,6 +249,7 @@ class OneNodeNetwork(CasperLabsNetwork):
             grpc_encryption=self.grpc_encryption,
         )
         self.add_bootstrap(config)
+        wait_for_genesis_block(self.docker_nodes[0])
 
 
 class PaymentNodeNetwork(OneNodeNetwork):

--- a/integration-testing/test/cl_node/cli.py
+++ b/integration-testing/test/cl_node/cli.py
@@ -47,10 +47,10 @@ class CLI:
 
         output = binary_output.decode("utf-8")
 
-        if command == "send-deploy":
+        if command in ("deploy", "send-deploy"):
             return output.split()[2]
 
-        if command in ("deploy", "propose"):
+        if command in ("propose",):
             return output.split()[3]
 
         if command == "show-blocks":

--- a/integration-testing/test/test_execution_cost.py
+++ b/integration-testing/test/test_execution_cost.py
@@ -1,9 +1,9 @@
-import json
 from test.cl_node.client_parser import parse_show_blocks
 from test.cl_node.docker_node import DockerNode
 from test.cl_node.casperlabs_accounts import GENESIS_ACCOUNT
 from test.cl_node.casperlabs_accounts import Account
 from test.cl_node.common import MAX_PAYMENT_COST, CONV_RATE
+from casperlabs_client import ABI
 
 
 def account_state(_block_hash: str, account: str, node0: DockerNode):
@@ -94,9 +94,12 @@ def test_error_in_payment_contract(payment_node_network):
 
     from_account = Account("genesis")
     to_account = Account(1)
-    args_json = json.dumps([{"account": to_account.public_key_hex}, {"u32": 10 ** 7}])
 
-    ABI = node0.p_client.abi
+    session_args = ABI.args(
+        [ABI.account(bytes.fromhex(to_account.public_key_hex)), ABI.u32(10 ** 7)]
+    )
+    payment_args = ABI.args([ABI.u512(10 ** 6)])
+
     response, deploy_hash_bytes = node0.p_client.deploy(
         from_address=from_account.public_key_hex,
         session_contract="transfer_to_account.wasm",
@@ -105,8 +108,8 @@ def test_error_in_payment_contract(payment_node_network):
         private_key=from_account.private_key_path,
         gas_price=1,
         gas_limit=MAX_PAYMENT_COST / CONV_RATE,
-        session_args=ABI.args_from_json(args_json),
-        payment_args=ABI.args([ABI.u512(10 ** 6)]),
+        session_args=session_args,
+        payment_args=payment_args,
     )
     genesis_balance_after_transfer = node0.client.get_balance(
         account_address=GENESIS_ACCOUNT.public_key_hex,
@@ -170,7 +173,6 @@ def test_not_enough_to_run_session(trillion_payment_node_network):
     )
     assert account1_starting_balance == 10 ** 8
 
-    ABI = node0.p_client.abi
     _, _ = node0.p_client.deploy(
         from_address=account1.public_key_hex,
         payment_contract="standard_payment.wasm",
@@ -211,8 +213,7 @@ def test_refund_after_session_code_error(payment_node_network):
         block_hash=blocks[0].summary.block_hash,
     )
 
-    args_json = json.dumps([{"u32": 10 ** 6}])
-    ABI = node0.p_client.abi
+    payment_args = ABI.args([ABI.u32(10 ** 6)])
     _, deploy_hash = node0.p_client.deploy(
         from_address=GENESIS_ACCOUNT.public_key_hex,
         session_contract="test_args_u512.wasm",
@@ -222,7 +223,7 @@ def test_refund_after_session_code_error(payment_node_network):
         gas_price=1,
         gas_limit=MAX_PAYMENT_COST / CONV_RATE,
         session_args=ABI.args([ABI.u512(100)]),
-        payment_args=ABI.args_from_json(args_json)
+        payment_args=payment_args
         # 100 is a revert code.
     )
     try:
@@ -254,23 +255,24 @@ def test_not_enough_funds_to_run_payment_code(payment_node_network):
     blocks = parse_show_blocks(node0.d_client.show_blocks(1000))
     genesis_hash = blocks[0].summary.block_hash
     assert len(blocks) == 1  # There should be only one block - the genesis block
+
+    test_account = GENESIS_ACCOUNT
     genesis_balance = node0.client.get_balance(
-        account_address=GENESIS_ACCOUNT.public_key_hex, block_hash=genesis_hash
+        account_address=test_account.public_key_hex, block_hash=genesis_hash
     )
     assert genesis_balance == 10 ** 9
-    args_json = json.dumps(
-        [{"account": GENESIS_ACCOUNT.public_key_hex}, {"u32": 10 ** 7}]
+    session_args = ABI.args(
+        [ABI.account(bytes.fromhex(test_account.public_key_hex)), ABI.u32(10 ** 7)]
     )
-    ABI = node0.p_client.abi
     _, deploy_hash = node0.p_client.deploy(
-        from_address=GENESIS_ACCOUNT.public_key_hex,
+        from_address=test_account.public_key_hex,
         session_contract="transfer_to_account.wasm",
         payment_contract="standard_payment.wasm",
-        public_key=GENESIS_ACCOUNT.public_key_path,
-        private_key=GENESIS_ACCOUNT.private_key_path,
+        public_key=test_account.public_key_path,
+        private_key=test_account.private_key_path,
         gas_price=1,
         gas_limit=MAX_PAYMENT_COST / CONV_RATE,
-        session_args=ABI.args_from_json(args_json),
+        session_args=session_args,
         payment_args=ABI.args([ABI.u512(450)]),
     )
 

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -773,7 +773,6 @@ def check_cli_abi_unsigned(cli, quote, resource_directory, unsigned_type, value,
                 '--private-key', private_key,
                 '--public-key', public_key)
         logging.info(f"EXECUTING {' '.join(cli.expand_args(args))}")
-        # import time; time.sleep(1000)
         deploy_hash = cli(*args)
 
         cli('propose')

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -729,7 +729,7 @@ def test_cli_abi_unsigned(cli, unsigned_type, test_contract):
     nonce = 0
     for number in [2, 256, 1024]:
         nonce += 1
-        args = json.dumps([{unsigned_type: number}])
+        args = json.dumps([{"name": "number", "value": {unsigned_type: number}}])
         deploy_hash = cli('deploy',
                           '--from', account.public_key_hex,
                           '--nonce', nonce,

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -516,17 +516,21 @@ def resource(fn):
 
 
 def test_args_parser():
-    account_hex = "0001000200030004000500060007000800000001000200030004000500060007"
-    account_bytes = (
+    account = (
         b"\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07\x00\x08"
         b"\x00\x00\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07"
     )
-    u32 = 1024
-    u64 = 1234567890
-    json_str = json.dumps([{"u32": u32}, {"account": account_hex}, {"u64": u64}])
+
+    amount = 123456
+
+    args = [{"name": "amount", "value": {"long_value": amount}},
+            {"name": "account", "value": {"bytes_value": account.hex()}},
+            {"name": "purse_id", "value": {"optional_value": {}}}]
+
+    json_str = json.dumps(args)
 
     assert ABI.args_from_json(json_str) == ABI.args(
-        [ABI.u32(1024), ABI.account(account_bytes), ABI.u64(1234567890)]
+        [ABI.long_value(amount), ABI.account(account), ABI.optional_value(None)]
     )
 
 

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -788,12 +788,13 @@ def test_cli_abi_multiple(cli):
     number = 1000
     total_sum = sum([1, 2, 3, 4, 5, 6, 7, 8]) * 4 + number
 
-    args = json.dumps([{'account': account_hex}, {'u32': number}])
+    session_args = json.dumps([{'name': 'account', 'value': {'account': account_hex}},
+                               {'name': 'number', 'value': {'int_value': number}}])
     deploy_hash = cli('deploy',
                       '--nonce', 1,
                       '--from', account.public_key_hex,
                       '--session', resource(test_contract),
-                      '--session-args', f"{args}",
+                      '--session-args', session_args,
                       '--payment', resource(test_contract),
                       '--private-key', account.private_key_path,
                       '--public-key', account.public_key_path,)

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -525,12 +525,13 @@ def test_args_parser():
 
     args = [{"name": "amount", "value": {"long_value": amount}},
             {"name": "account", "value": {"bytes_value": account.hex()}},
-            {"name": "purse_id", "value": {"optional_value": {}}}]
+            {"name": "purse_id", "value": {"optional_value": {}}},
+            {"name": "number", "value": {"big_int": {"value": "2", "bit_width": 512}}}]
 
     json_str = json.dumps(args)
 
     assert ABI.args_from_json(json_str) == ABI.args(
-        [ABI.long_value(amount), ABI.account(account), ABI.optional_value(None)]
+        [ABI.long_value(amount), ABI.account(account), ABI.optional_value(None), ABI.big_int(2)]
     )
 
 
@@ -719,25 +720,61 @@ def test_cli_deploy_propose_show_deploys_show_deploy_query_state_and_balance(cli
 # CLI ABI
 
 
+def int_value(x):
+    return x
+
+
+def big_int_value(x):
+    return {'value': str(x), 'bit_width': 512}
+
+
 abi_unsigned_test_data = [
-    ("u32", 'test_args_u32.wasm'),
-    ("u512", 'test_args_u512.wasm'),
+    ("int_value", 'test_args_u32.wasm', int_value),
+    ("big_int", 'test_args_u512.wasm', big_int_value),
 ]
-@pytest.mark.parametrize("unsigned_type, test_contract", abi_unsigned_test_data)
-def test_cli_abi_unsigned(cli, unsigned_type, test_contract):
+
+
+@pytest.mark.parametrize("unsigned_type, test_contract, value", abi_unsigned_test_data)
+def test_cli_abi_unsigned_scala(node, unsigned_type, test_contract, value):
+    check_cli_abi_unsigned(DockerCLI(node),
+                           lambda s: f"'{s}'",
+                           '/data',
+                           unsigned_type,
+                           value,
+                           test_contract,
+                           lambda a: (a.private_key_docker_path, a.public_key_docker_path))
+
+
+@pytest.mark.parametrize("unsigned_type, test_contract, value", abi_unsigned_test_data)
+def test_cli_abi_unsigned_python(node, unsigned_type, test_contract, value):
+    check_cli_abi_unsigned(CLI(node),
+                           lambda s: s,
+                           'resources',
+                           unsigned_type,
+                           value,
+                           test_contract,
+                           lambda a: (a.private_key_path, a.public_key_path))
+
+
+def check_cli_abi_unsigned(cli, quote, resource_directory, unsigned_type, value, test_contract, keys):
     account = GENESIS_ACCOUNT
+    private_key, public_key = keys(account)
     nonce = 0
     for number in [2, 256, 1024]:
         nonce += 1
-        args = json.dumps([{"name": "number", "value": {unsigned_type: number}}])
-        deploy_hash = cli('deploy',
-                          '--from', account.public_key_hex,
-                          '--nonce', nonce,
-                          '--session', resource(test_contract),
-                          '--session-args', f"{args}",
-                          '--payment', resource(test_contract),
-                          '--private-key', account.private_key_path,
-                          '--public-key', account.public_key_path,)
+        test_contract_path = '/'.join((resource_directory, test_contract))
+        session_args = json.dumps([{"name": "number", "value": {unsigned_type: value(number)}}])
+        args = ('deploy',
+                '--from', account.public_key_hex,
+                '--nonce', nonce,
+                '--session', test_contract_path,
+                '--session-args', quote(session_args),
+                '--payment', test_contract_path,
+                '--private-key', private_key,
+                '--public-key', public_key)
+        logging.info(f"EXECUTING {' '.join(cli.expand_args(args))}")
+        # import time; time.sleep(1000)
+        deploy_hash = cli(*args)
 
         cli('propose')
         deploy_info = cli("show-deploy", deploy_hash)


### PR DESCRIPTION
### Overview

This PR adds an integration test for new Scala CLI functionality: passing contracts args in a JSON format (JSON serialized protobuf).

Python client has been amended to handle the new JSON format as it is different than the JSON it could handle earlier, so it is now compatible with the Scala CLI.

Fixed old tests and test framework code that used the old JSON format.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-793

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
https://casperlabs.atlassian.net/browse/NODE-793
