### PR TITLE
EE-606: Integration tests bonding / unbonding POS contract AccessRights fix

### DIFF
--- a/integration-testing/contracts/bonding/call/src/lib.rs
+++ b/integration-testing/contracts/bonding/call/src/lib.rs
@@ -2,29 +2,44 @@
 
 #[macro_use]
 extern crate alloc;
-//extern crate contract_ffi;
-
 extern crate contract_ffi;
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::UPointer;
+
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{
+    call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
+    transfer_from_purse_to_purse, PurseTransferResult,
+};
 use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
 use contract_ffi::value::uint::U512;
-use contract_ffi::contract_api::{call_contract, PurseTransferResult, get_uref, transfer_from_purse_to_purse, revert};
+
+enum Error {
+    GetPosOuterURef = 1000,
+    GetPosInnerURef = 1001,
+}
+
+fn get_pos_contract() -> ContractPointer {
+    let outer: UPointer<Key> = get_uref("pos")
+        .and_then(Key::to_u_ptr)
+        .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
+    if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
+        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+    } else {
+        revert(Error::GetPosOuterURef as u32)
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = get_uref("pos").unwrap().to_u_ptr().unwrap();
-    let pos_contract: Key = contract_api::read(pos_public);
-    let pos_pointer = pos_contract.to_c_ptr().unwrap();
-
-    let source_purse = contract_api::main_purse();
-    let bonding_purse = contract_api::create_purse();
-    let bond_amount:U512 = U512::from(contract_api::get_arg::<u32>(0));
+    let pos_contract = get_pos_contract();
+    let source_purse = main_purse();
+    let bonding_purse = create_purse();
+    let bond_amount: U512 = U512::from(get_arg::<u32>(0));
 
     match transfer_from_purse_to_purse(source_purse, bonding_purse, bond_amount) {
         PurseTransferResult::TransferSuccessful => {
             let _result: () = call_contract(
-                pos_pointer,
+                pos_contract,
                 &("bond", bond_amount, bonding_purse),
                 &vec![Key::URef(bonding_purse.value())],
             );

--- a/integration-testing/contracts/unbonding/call/src/lib.rs
+++ b/integration-testing/contracts/unbonding/call/src/lib.rs
@@ -5,20 +5,36 @@ extern crate alloc;
 
 extern crate contract_ffi;
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::{call_contract, get_uref, read, revert};
 use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
 use contract_ffi::value::uint::U512;
+
+enum Error {
+    GetPosOuterURef = 1000,
+    GetPosInnerURef = 1001,
+}
+
+fn get_pos_contract() -> ContractPointer {
+    let outer: UPointer<Key> = get_uref("pos")
+        .and_then(Key::to_u_ptr)
+        .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
+    if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
+        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+    } else {
+        revert(Error::GetPosOuterURef as u32)
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
-    let pos_contract: Key = contract_api::read(pos_public);
-    let pos_pointer = pos_contract.to_c_ptr().unwrap();
+    let pos_contract: ContractPointer = get_pos_contract();
     // I dont have any safe method to check for the existence of the args.
     // I am utilizing 0(invalid) amount to indicate no args to EE.
     let unbond_amount: Option<U512> = match contract_api::get_arg::<u32>(0) {
         0 => None,
         amount => Some(amount.into()),
     };
-    let _result: () = contract_api::call_contract(pos_pointer, &("unbond", unbond_amount), &vec![]);
+    let _result: () = call_contract(pos_contract, &("unbond", unbond_amount), &vec![]);
 }


### PR DESCRIPTION
This PR adjusts the access pattern of two integration tests to comply with current AccessRight requirements. 

https://casperlabs.atlassian.net/browse/EE-606

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned for review

See: https://github.com/CasperLabs/CasperLabs/blob/eaba1498a24fd775c882159f4aee6501f798db03/execution-engine/contracts/test/pos-bonding/src/lib.rs#L33-L42 for example of access pattern
