### PR TITLE
OP-635: attempt to make markdown checks build-fail friendly

### DIFF
--- a/ci/markdown-link-check.sh
+++ b/ci/markdown-link-check.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 
+command -v remark >/dev/null 2>&1 || { echo >&2 "Package 'remark' not installed.  Aborting."; exit 1; }
+
 LINT_OUTPUT=`remark -u validate-links -u lint-no-dead-urls . 2>&1`
 
 LINT_OUTPUT_MODIFIED=`printf '%s\n' "${LINT_OUTPUT[@]}" | grep -v 'localhost\|warnings'`
 
 if echo $LINT_OUTPUT_MODIFIED | grep -i "warning"; then
-    printf '%s\n' "${LINT_OUTPUT[@]}"
+    printf '%s\n' "${LINT_OUTPUT_MODIFIED[@]}"
     echo ""
     echo "Please Fix the above broken links! Please ignore any localhost warnings."
     exit 1


### PR DESCRIPTION
### Overview
This adds some checks to our markdown link checker, so it is more build-fail friendly
Also now, it complains if the package `remark` is not found.

### Which JIRA ticket does this PR relate to?
OP-635

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
