### PR TITLE
NO-TICKET: Increasing timeouts due to CI failure of NodeDiscoverySpec

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -470,11 +470,11 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
           alivePeersCacheSize = totalN(peers),
           // To cause update on next cycle
           alivePeersCacheMinThreshold = totalN(peers) + 1,
-          alivePeersCacheUpdatePeriod = 100.milliseconds
+          alivePeersCacheUpdatePeriod = 200.milliseconds
         ) { (kademlia, nd, _) =>
           for {
             _ <- nd.schedulePeriodicRecentlyAlivePeersCacheUpdate.start
-            _ <- Task.sleep(150.millis)
+            _ <- Task.sleep(300.millis)
           } yield {
             kademlia.totalPings shouldBe (totalN(peers) * 2)
           }


### PR DESCRIPTION
### Overview
Trying to fix a non-deterministic failure in the `NodeDiscoverySpec` by bumping timeouts: https://drone-auto.casperlabs.io/CasperLabs/CasperLabs/3747/1/2

### Which JIRA ticket does this PR relate to?
This is an unticketed work

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._