### PR TITLE
NO-TICK: For standalone mode, fixed cmd in docs

### DIFF
--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -96,7 +96,7 @@ You can run a single Node in standalone mode for testing purposes.
 
 ```
 mkdir -p ~/.casperlabs/genesis
-(cat keys/validator-id; echo "100") >> ~/.casperlabs/genesis/bonds.txt
+(cat keys/validator-id; echo " 100") >> ~/.casperlabs/genesis/bonds.txt
 ```
 
 ##### Step 2: Start the Execution Engine
@@ -110,7 +110,7 @@ casperlabs-engine-grpc-server ~/.casperlabs/.casper-node.sock
 
 ```
 casperlabs-node run \
-    --standalone \
+    --casper-standalone \
     --tls-key ./keys/node.key.pem \
     --tls-certificate ./keys/node.certificate.pem \
     --casper-validator-private-key-path ./keys/validator-private.pem \

--- a/node/README.md
+++ b/node/README.md
@@ -33,7 +33,7 @@ The node module comes with an executable (jar, docker image, debian or fedora pa
 To see the list of available flags you can run `./casperlabs-node --help`
 
 ### 2.1 The Node
-By default when you execute the program, it will fire up a running node instance. That instance will become either a bootstrap node (see `--standalone` flag) or will try to connect to existing bootstrap.
+By default when you execute the program, it will fire up a running node instance. That instance will become either a bootstrap node (see `--casper-standalone` flag) or will try to connect to existing bootstrap.
 
 Node will instantiate a peer-to-peer network. It will either connect to some already existing node in the network (called bootstrap node) or will create a new network (essentially acting as bootstrap node). __Note__ This release prints a great deal of diagnostic information.
 


### PR DESCRIPTION
### Overview
I want to research your source code. Some standalone docs have a trouble.
1. generate genesis has diffrent format.
2. cmd --standalone is not working, I checked source code, we need to use "-s" or "--casper-standalone" 

### Which JIRA ticket does this PR relate to?
I can't access your JIRA

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
