### PR TITLE
EE-655: make WasmTestBuilder generic over global state type

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -290,6 +290,7 @@ dependencies = [
  "casperlabs-engine-wasm-prep 0.1.0",
  "grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -13,4 +13,5 @@ engine-storage = { path = "../engine-storage", package = "casperlabs-engine-stor
 engine-wasm-prep = { path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 grpc = "0.6.1"
 lazy_static = "1.3.0"
+lmdb = "0.8.0"
 protobuf = "2"

--- a/execution-engine/engine-tests/src/lib.rs
+++ b/execution-engine/engine-tests/src/lib.rs
@@ -4,6 +4,8 @@ extern crate grpc;
 #[cfg(test)]
 extern crate lazy_static;
 #[cfg(test)]
+extern crate lmdb;
+#[cfg(test)]
 extern crate protobuf;
 
 #[cfg(test)]

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -1,14 +1,17 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
+use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use grpc::RequestOptions;
+use lmdb::DatabaseFlags;
 
 use contract_ffi::value::U512;
 use engine_core::engine_state::utils::WasmiBytes;
 use engine_core::engine_state::{EngineConfig, EngineState, MAX_PAYMENT};
-use engine_core::execution::POS_NAME;
+use engine_core::execution::{self, POS_NAME};
 use engine_grpc_server::engine_server::ipc::{
     CommitRequest, Deploy, DeployCode, DeployResult, DeployResult_ExecutionResult,
     DeployResult_PreconditionFailure, ExecRequest, ExecResponse, GenesisRequest, GenesisResponse,
@@ -23,12 +26,21 @@ use engine_shared::newtypes::Blake2bHash;
 use engine_shared::test_utils;
 use engine_shared::transform::Transform;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
+use engine_storage::global_state::lmdb::LmdbGlobalState;
+use engine_storage::global_state::StateProvider;
+use engine_storage::protocol_data_store::lmdb::LmdbProtocolDataStore;
+use engine_storage::transaction_source::lmdb::LmdbEnvironment;
+use engine_storage::trie_store::lmdb::LmdbTrieStore;
 use transforms::TransformEntry;
 
 pub const DEFAULT_BLOCK_TIME: u64 = 0;
 pub const MOCKED_ACCOUNT_ADDRESS: [u8; 32] = [48u8; 32];
 pub const COMPILED_WASM_PATH: &str = "../target/wasm32-unknown-unknown/release";
 pub const GENESIS_INITIAL_BALANCE: u64 = 100_000_000_000;
+const DEFAULT_MAP_SIZE: usize = 805_306_368_000; // 750 GiB as per grpc-server default
+
+pub type InMemoryWasmTestBuilder = WasmTestBuilder<InMemoryGlobalState>;
+pub type LmdbWasmTestBuilder = WasmTestBuilder<LmdbGlobalState>;
 
 pub struct DeployBuilder {
     deploy: Deploy,
@@ -470,11 +482,10 @@ pub fn get_error_message(execution_result: DeployResult_ExecutionResult) -> Stri
 pub const STANDARD_PAYMENT_CONTRACT: &str = "standard_payment.wasm";
 
 /// Builder for simple WASM test
-#[derive(Clone)]
-pub struct WasmTestBuilder {
+pub struct WasmTestBuilder<S> {
     /// Engine state is wrapped in Rc<> to workaround missing `impl Clone for
     /// EngineState`
-    engine_state: Rc<EngineState<InMemoryGlobalState>>,
+    engine_state: Rc<EngineState<S>>,
     exec_responses: Vec<ExecResponse>,
     genesis_hash: Option<Vec<u8>>,
     post_state_hash: Option<Vec<u8>>,
@@ -493,8 +504,8 @@ pub struct WasmTestBuilder {
     pos_contract_uref: Option<contract_ffi::uref::URef>,
 }
 
-impl Default for WasmTestBuilder {
-    fn default() -> WasmTestBuilder {
+impl Default for InMemoryWasmTestBuilder {
+    fn default() -> Self {
         let engine_config = EngineConfig::new().set_use_payment_code(true);
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
         let engine_state = EngineState::new(global_state, engine_config);
@@ -513,20 +524,87 @@ impl Default for WasmTestBuilder {
     }
 }
 
+// TODO: Deriving `Clone` for `WasmTestBuilder<S>` doesn't work correctly (unsure why), so
+// implemented by hand here.  Try to derive in the future with a different compiler version.
+impl<S> Clone for WasmTestBuilder<S> {
+    fn clone(&self) -> Self {
+        WasmTestBuilder {
+            engine_state: Rc::clone(&self.engine_state),
+            exec_responses: self.exec_responses.clone(),
+            genesis_hash: self.genesis_hash.clone(),
+            post_state_hash: self.post_state_hash.clone(),
+            transforms: self.transforms.clone(),
+            bonded_validators: self.bonded_validators.clone(),
+            genesis_account: self.genesis_account.clone(),
+            mint_contract_uref: self.mint_contract_uref,
+            pos_contract_uref: self.pos_contract_uref,
+            genesis_transforms: self.genesis_transforms.clone(),
+        }
+    }
+}
+
 /// A wrapper type to disambiguate builder from an actual result
 #[derive(Clone)]
-pub struct WasmTestResult(WasmTestBuilder);
+pub struct WasmTestResult<S>(WasmTestBuilder<S>);
 
-impl WasmTestResult {
+impl<S> WasmTestResult<S> {
     /// Access the builder
-    pub fn builder(&self) -> &WasmTestBuilder {
+    pub fn builder(&self) -> &WasmTestBuilder<S> {
         &self.0
     }
 }
 
-impl WasmTestBuilder {
+impl InMemoryWasmTestBuilder {
+    pub fn new(engine_config: EngineConfig) -> Self {
+        let global_state = InMemoryGlobalState::empty().expect("should create global state");
+        let engine_state = EngineState::new(global_state, engine_config);
+        WasmTestBuilder {
+            engine_state: Rc::new(engine_state),
+            ..Default::default()
+        }
+    }
+}
+
+impl LmdbWasmTestBuilder {
+    pub fn new<T: AsRef<OsStr> + ?Sized>(data_dir: &T) -> Self {
+        let environment = Arc::new(
+            LmdbEnvironment::new(&data_dir.into(), DEFAULT_MAP_SIZE)
+                .expect("should create LmdbEnvironment"),
+        );
+        let trie_store = Arc::new(
+            LmdbTrieStore::new(&environment, None, DatabaseFlags::empty())
+                .expect("should create LmdbTrieStore"),
+        );
+        let protocol_data_store = Arc::new(
+            LmdbProtocolDataStore::new(&environment, None, DatabaseFlags::empty())
+                .expect("should create LmdbProtocolDataStore"),
+        );
+        let global_state = LmdbGlobalState::empty(environment, trie_store, protocol_data_store)
+            .expect("should create LmdbGlobalState");
+        let engine_state = EngineState::new(global_state, Default::default());
+        WasmTestBuilder {
+            engine_state: Rc::new(engine_state),
+            exec_responses: Vec::new(),
+            genesis_hash: None,
+            post_state_hash: None,
+            transforms: Vec::new(),
+            bonded_validators: Vec::new(),
+            genesis_account: None,
+            mint_contract_uref: None,
+            pos_contract_uref: None,
+            genesis_transforms: None,
+        }
+    }
+}
+
+impl<S> WasmTestBuilder<S>
+where
+    S: StateProvider,
+    S::Error: Into<execution::Error>,
+    EngineState<S>: ExecutionEngineService,
+{
     /// Carries on attributes from TestResult for further executions
-    pub fn from_result(result: WasmTestResult) -> WasmTestBuilder {
+    pub fn from_result(result: WasmTestResult<S>) -> Self {
         WasmTestBuilder {
             engine_state: result.0.engine_state,
             exec_responses: Vec::new(),
@@ -541,23 +619,6 @@ impl WasmTestBuilder {
         }
     }
 
-    pub fn new(engine_config: EngineConfig) -> WasmTestBuilder {
-        let global_state = InMemoryGlobalState::empty().expect("should create global state");
-        let engine_state = EngineState::new(global_state, engine_config);
-        WasmTestBuilder {
-            engine_state: Rc::new(engine_state),
-            exec_responses: Vec::new(),
-            genesis_hash: None,
-            post_state_hash: None,
-            transforms: Vec::new(),
-            bonded_validators: Vec::new(),
-            genesis_account: None,
-            mint_contract_uref: None,
-            pos_contract_uref: None,
-            genesis_transforms: None,
-        }
-    }
-
     pub fn run_genesis(
         &mut self,
         genesis_addr: [u8; 32],
@@ -565,7 +626,7 @@ impl WasmTestBuilder {
             contract_ffi::value::account::PublicKey,
             contract_ffi::value::U512,
         >,
-    ) -> &mut WasmTestBuilder {
+    ) -> &mut Self {
         let (genesis_request, contracts) =
             create_genesis_request(genesis_addr, genesis_validators.clone());
 
@@ -645,10 +706,7 @@ impl WasmTestBuilder {
         }
     }
 
-    pub fn exec_with_exec_request(
-        &mut self,
-        mut exec_request: ExecRequest,
-    ) -> &mut WasmTestBuilder {
+    pub fn exec_with_exec_request(&mut self, mut exec_request: ExecRequest) -> &mut Self {
         let exec_request = {
             let hash = self
                 .post_state_hash
@@ -695,7 +753,7 @@ impl WasmTestBuilder {
         block_time: u64,
         deploy_hash: [u8; 32],
         authorized_keys: Vec<contract_ffi::value::account::PublicKey>,
-    ) -> &mut WasmTestBuilder {
+    ) -> &mut Self {
         let exec_request = create_exec_request(
             address,
             payment_file,
@@ -722,7 +780,7 @@ impl WasmTestBuilder {
         session_args: impl contract_ffi::contract_api::argsparser::ArgsParser,
         block_time: u64,
         deploy_hash: [u8; 32],
-    ) -> &mut WasmTestBuilder {
+    ) -> &mut Self {
         self.exec_with_args_and_keys(
             address,
             payment_file,
@@ -743,7 +801,7 @@ impl WasmTestBuilder {
         session_file: &str,
         block_time: u64,
         deploy_hash: [u8; 32],
-    ) -> &mut WasmTestBuilder {
+    ) -> &mut Self {
         let payment_file = STANDARD_PAYMENT_CONTRACT;
         let payment_args = (U512::from(MAX_PAYMENT),);
         self.exec_with_args(
@@ -758,7 +816,7 @@ impl WasmTestBuilder {
     }
 
     /// Commit effects of previous exec call on the latest post-state hash.
-    pub fn commit(&mut self) -> &mut WasmTestBuilder {
+    pub fn commit(&mut self) -> &mut Self {
         let prestate_hash = self
             .post_state_hash
             .clone()
@@ -779,7 +837,7 @@ impl WasmTestBuilder {
         &mut self,
         prestate_hash: Vec<u8>,
         effects: HashMap<contract_ffi::key::Key, Transform>,
-    ) -> &mut WasmTestBuilder {
+    ) -> &mut Self {
         let commit_request = create_commit_request(&prestate_hash, &effects);
 
         let commit_response = self
@@ -805,7 +863,7 @@ impl WasmTestBuilder {
     }
 
     /// Expects a successful run and caches transformations
-    pub fn expect_success(&mut self) -> &mut WasmTestBuilder {
+    pub fn expect_success(&mut self) -> &mut Self {
         // Check first result, as only first result is interesting for a simple test
         let exec_response = self
             .exec_responses
@@ -893,7 +951,7 @@ impl WasmTestBuilder {
             .expect("Should have post-state hash.")
     }
 
-    pub fn get_engine_state(&self) -> &EngineState<InMemoryGlobalState> {
+    pub fn get_engine_state(&self) -> &EngineState<S> {
         &self.engine_state
     }
 
@@ -901,7 +959,7 @@ impl WasmTestBuilder {
         self.exec_responses.get(index)
     }
 
-    pub fn finish(&self) -> WasmTestResult {
+    pub fn finish(&self) -> WasmTestResult<S> {
         WasmTestResult(self.clone())
     }
 

--- a/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, Weight};
@@ -17,7 +17,7 @@ const ACCOUNT_1_INITIAL_BALANCE: u64 = MAX_PAYMENT * 2;
 fn should_manage_associated_key() {
     // for a given account, should be able to add a new associated key and update
     // that key
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     let builder = builder
         .run_genesis(GENESIS_ADDR, HashMap::new())

--- a/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::account::{PublicKey, Weight};
 use contract_ffi::value::U512;
@@ -14,7 +14,7 @@ const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 #[test]
 fn should_deploy_with_authorized_identity_key() {
     // Basic deploy with single key
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args_and_keys(
             GENESIS_ADDR,
@@ -38,7 +38,7 @@ fn should_raise_auth_failure_with_invalid_key() {
     let key_1 = [254; 32];
     assert_ne!(GENESIS_ADDR, key_1);
     // Basic deploy with single key
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args_and_keys(
             GENESIS_ADDR,
@@ -83,7 +83,7 @@ fn should_raise_auth_failure_with_invalid_keys() {
     assert_ne!(GENESIS_ADDR, key_2);
     assert_ne!(GENESIS_ADDR, key_3);
     // Basic deploy with single key
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args_and_keys(
             GENESIS_ADDR,
@@ -131,7 +131,7 @@ fn should_raise_deploy_authorization_failure() {
     assert_ne!(GENESIS_ADDR, key_2);
     assert_ne!(GENESIS_ADDR, key_3);
     // Basic deploy with single key
-    let result1 = WasmTestBuilder::default()
+    let result1 = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         // Reusing a test contract that would add new key
         .exec_with_args(
@@ -190,7 +190,7 @@ fn should_raise_deploy_authorization_failure() {
 
     // With deploy threshold == 3 using single secondary key
     // with weight == 2 should raise deploy authorization failure.
-    let result2 = WasmTestBuilder::from_result(result1)
+    let result2 = InMemoryWasmTestBuilder::from_result(result1)
         .exec_with_args_and_keys(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -224,7 +224,7 @@ fn should_raise_deploy_authorization_failure() {
     }
 
     // identity key (w: 1) and key_1 (w: 2) passes threshold of 3
-    let result3 = WasmTestBuilder::from_result(result2)
+    let result3 = InMemoryWasmTestBuilder::from_result(result2)
         .exec_with_args_and_keys(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -247,7 +247,7 @@ fn should_raise_deploy_authorization_failure() {
 
     // deployment threshold is now 4
     // failure: key_2 weight + key_1 weight < deployment threshold
-    let result4 = WasmTestBuilder::from_result(result3)
+    let result4 = InMemoryWasmTestBuilder::from_result(result3)
         .exec_with_args_and_keys(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -281,7 +281,7 @@ fn should_raise_deploy_authorization_failure() {
 
     // success: identity key weight + key_1 weight + key_2 weight >= deployment
     // threshold
-    WasmTestBuilder::from_result(result4)
+    InMemoryWasmTestBuilder::from_result(result4)
         .exec_with_args_and_keys(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -313,7 +313,7 @@ fn should_authorize_deploy_with_multiple_keys() {
     assert_ne!(GENESIS_ADDR, key_1);
     assert_ne!(GENESIS_ADDR, key_2);
     // Basic deploy with single key
-    let result1 = WasmTestBuilder::default()
+    let result1 = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         // Reusing a test contract that would add new key
         .exec_with_args(
@@ -341,7 +341,7 @@ fn should_authorize_deploy_with_multiple_keys() {
         .finish();
 
     // key_1 (w: 2) key_2 (w: 2) each passes default threshold of 1
-    WasmTestBuilder::from_result(result1)
+    InMemoryWasmTestBuilder::from_result(result1)
         .exec_with_args_and_keys(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -365,7 +365,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
     let key_1 = [254; 32];
     assert_ne!(GENESIS_ADDR, key_1);
     // Basic deploy with single key
-    let result1 = WasmTestBuilder::default()
+    let result1 = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         // Reusing a test contract that would add new key
         .exec_with_args(
@@ -396,7 +396,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
 
     // success: identity key weight + key_1 weight + key_2 weight >= deployment
     // threshold
-    let final_result = WasmTestBuilder::from_result(result1)
+    let final_result = InMemoryWasmTestBuilder::from_result(result1)
         .exec_with_args_and_keys(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,

--- a/execution-engine/engine-tests/src/test/contract_api/account/key_management_thresholds.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/key_management_thresholds.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use contract_ffi::value::account::PublicKey;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::U512;
 use engine_core::engine_state::MAX_PAYMENT;
@@ -13,7 +13,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 #[ignore]
 #[test]
 fn should_verify_key_management_permission_with_low_weight() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,
@@ -43,7 +43,7 @@ fn should_verify_key_management_permission_with_low_weight() {
 #[ignore]
 #[test]
 fn should_verify_key_management_permission_with_sufficient_weight() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/contract_api/account/known_urefs.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/known_urefs.rs
@@ -4,7 +4,7 @@ use contract_ffi::key::Key;
 use contract_ffi::value::{Value, U512};
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 const EXPECTED_UREF_VALUE: u64 = 123_456_789u64;
@@ -12,7 +12,7 @@ const EXPECTED_UREF_VALUE: u64 = 123_456_789u64;
 #[ignore]
 #[test]
 fn should_run_known_urefs_contract() {
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/contract_api/get_blocktime.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_blocktime.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{WasmTestBuilder, STANDARD_PAYMENT_CONTRACT};
+use crate::support::test_support::{InMemoryWasmTestBuilder, STANDARD_PAYMENT_CONTRACT};
 use contract_ffi::value::U512;
 use engine_core::engine_state::MAX_PAYMENT;
 
@@ -11,7 +11,7 @@ const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 fn should_run_get_blocktime_contract() {
     let block_time: u64 = 42;
 
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/contract_api/get_caller.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_caller.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
@@ -14,7 +14,7 @@ const ACCOUNT_1_INITIAL_BALANCE: u64 = MAX_PAYMENT;
 #[ignore]
 #[test]
 fn should_run_get_caller_contract() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,
@@ -28,7 +28,7 @@ fn should_run_get_caller_contract() {
         .commit()
         .expect_success();
 
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,
@@ -57,7 +57,7 @@ fn should_run_get_caller_contract() {
 #[ignore]
 #[test]
 fn should_run_get_caller_subcall_contract() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,
@@ -71,7 +71,7 @@ fn should_run_get_caller_subcall_contract() {
         .commit()
         .expect_success();
 
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/contract_api/get_phase.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_phase.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, WasmTestBuilder};
+use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder};
 use contract_ffi::execution::Phase;
 use contract_ffi::value::account::PublicKey;
 use engine_core::engine_state::EngineConfig;
@@ -26,7 +26,7 @@ fn should_run_get_phase_contract() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    WasmTestBuilder::new(engine_config)
+    InMemoryWasmTestBuilder::new(engine_config)
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_exec_request(exec_request)
         .commit()

--- a/execution-engine/engine-tests/src/test/contract_api/local_state.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/local_state.rs
@@ -5,7 +5,7 @@ use contract_ffi::key::Key;
 use contract_ffi::value::Value;
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 
@@ -14,7 +14,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 fn should_run_local_state_contract() {
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/contract_api/main_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/main_purse.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::key::Key;
 use contract_ffi::value::Account;
@@ -15,7 +15,7 @@ const ACCOUNT_1_INITIAL_BALANCE: u64 = MAX_PAYMENT;
 #[ignore]
 #[test]
 fn should_run_main_purse_contract_genesis_account() {
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     let builder = builder.run_genesis(GENESIS_ADDR, HashMap::new());
 
@@ -46,7 +46,7 @@ fn should_run_main_purse_contract_genesis_account() {
 fn should_run_main_purse_contract_account_1() {
     let account_key = Key::Account(ACCOUNT_1_ADDR);
 
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     let builder = builder
         .run_genesis(GENESIS_ADDR, HashMap::new())

--- a/execution-engine/engine-tests/src/test/contract_api/revert.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/revert.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::WasmTestBuilder;
+use crate::support::test_support::InMemoryWasmTestBuilder;
 
 const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 const REVERT_WASM: &str = "revert.wasm";
@@ -9,7 +9,7 @@ const BLOCK_TIME: u64 = 42;
 #[ignore]
 #[test]
 fn should_revert() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(GENESIS_ADDR, REVERT_WASM, BLOCK_TIME, [1u8; 32])
         .commit()

--- a/execution-engine/engine-tests/src/test/contract_api/transfer.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer.rs
@@ -649,7 +649,7 @@ fn should_fail_when_insufficient_funds() {
 #[ignore]
 #[test]
 fn should_transfer_total_amount() {
-    let mut builder = test_support::WasmTestBuilder::default();
+    let mut builder = test_support::InMemoryWasmTestBuilder::default();
 
     builder
         .run_genesis(GENESIS_ADDR, HashMap::new())

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
@@ -7,7 +7,7 @@ use engine_core::engine_state::MAX_PAYMENT;
 use engine_shared::transform::Transform;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, GENESIS_INITIAL_BALANCE, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, GENESIS_INITIAL_BALANCE, STANDARD_PAYMENT_CONTRACT,
 };
 
 const GENESIS_ADDR: [u8; 32] = [12; 32];
@@ -20,7 +20,7 @@ fn should_run_purse_to_account_transfer() {
     let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
     let genesis_public_key = PublicKey::new(GENESIS_ADDR);
 
-    let transfer_result = WasmTestBuilder::default()
+    let transfer_result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_args(
             GENESIS_ADDR,
@@ -201,7 +201,7 @@ fn should_run_purse_to_account_transfer() {
 fn should_fail_when_sending_too_much_from_purse_to_account() {
     let account_1_key = PublicKey::new(ACCOUNT_1_ADDR);
 
-    let transfer_result = WasmTestBuilder::default()
+    let transfer_result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_purse.rs
@@ -6,7 +6,7 @@ use engine_core::engine_state::MAX_PAYMENT;
 use engine_shared::transform::Transform;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, GENESIS_INITIAL_BALANCE, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, GENESIS_INITIAL_BALANCE, STANDARD_PAYMENT_CONTRACT,
 };
 
 const GENESIS_ADDR: [u8; 32] = [12; 32];
@@ -18,7 +18,7 @@ fn should_run_purse_to_purse_transfer() {
     let source = "purse:main".to_string();
     let target = "purse:secondary".to_string();
 
-    let transfer_result = WasmTestBuilder::default()
+    let transfer_result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_args(
             GENESIS_ADDR,
@@ -115,7 +115,7 @@ fn should_run_purse_to_purse_transfer_with_error() {
     let source = "purse:main".to_string();
     let target = "purse:secondary".to_string();
 
-    let transfer_result = WasmTestBuilder::default()
+    let transfer_result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/deploy/payment_code.rs
+++ b/execution-engine/engine-tests/src/test/deploy/payment_code.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use crate::support::test_support::{
-    DeployBuilder, ExecRequestBuilder, WasmTestBuilder, GENESIS_INITIAL_BALANCE,
+    DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder, GENESIS_INITIAL_BALANCE,
 };
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, PurseId};
@@ -42,7 +42,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let _response = builder
         .run_genesis(GENESIS_ADDR, HashMap::default())
@@ -117,7 +117,7 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let _response = builder
         .run_genesis(GENESIS_ADDR, HashMap::default())
@@ -206,7 +206,7 @@ fn should_raise_insufficient_payment_when_payment_code_fails() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let transfer_result = WasmTestBuilder::new(engine_config)
+    let transfer_result = InMemoryWasmTestBuilder::new(engine_config)
         .run_genesis(genesis_addr, HashMap::default())
         .exec_with_exec_request(exec_request)
         .commit()
@@ -297,7 +297,7 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let transfer_result = builder
         .run_genesis(genesis_addr, HashMap::default())
@@ -339,7 +339,7 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let transfer_result = builder
         .run_genesis(genesis_addr, HashMap::default())
@@ -409,7 +409,7 @@ fn should_correctly_charge_when_session_code_fails() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let transfer_result = builder
         .run_genesis(genesis_addr, HashMap::default())
@@ -474,7 +474,7 @@ fn should_correctly_charge_when_session_code_succeeds() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let transfer_result = builder
         .run_genesis(genesis_addr, HashMap::default())
@@ -517,7 +517,10 @@ fn should_correctly_charge_when_session_code_succeeds() {
     )
 }
 
-fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Option<PurseId> {
+fn get_pos_purse_id_by_name(
+    builder: &InMemoryWasmTestBuilder,
+    purse_name: &str,
+) -> Option<PurseId> {
     let pos_contract = builder.get_pos_contract();
 
     pos_contract
@@ -527,7 +530,7 @@ fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Opti
         .map(|u| PurseId::new(*u))
 }
 
-fn get_pos_rewards_purse_balance(builder: &WasmTestBuilder) -> U512 {
+fn get_pos_rewards_purse_balance(builder: &InMemoryWasmTestBuilder) -> U512 {
     let purse_id = get_pos_purse_id_by_name(builder, POS_REWARDS_PURSE)
         .expect("should find PoS payment purse");
     builder.get_purse_balance(purse_id)
@@ -559,7 +562,7 @@ fn should_finalize_to_rewards_purse() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     builder.run_genesis(genesis_addr, HashMap::default());
 
@@ -584,7 +587,7 @@ fn independent_standard_payments_should_not_write_the_same_keys() {
 
     let engine_config = EngineConfig::new().set_use_payment_code(true);
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     let setup_exec_request = {
         let deploy = DeployBuilder::new()
@@ -674,7 +677,7 @@ fn should_charge_non_main_purse() {
     let account_1_purse_funding_amount = U512::from(50_000_000);
 
     let engine_config = EngineConfig::new().set_use_payment_code(true);
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     // arrange
     let setup_exec_request = {

--- a/execution-engine/engine-tests/src/test/deploy/preconditions.rs
+++ b/execution-engine/engine-tests/src/test/deploy/preconditions.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, WasmTestBuilder};
+use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder};
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
 use engine_core::engine_state::EngineConfig;
@@ -35,7 +35,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let transfer_result = WasmTestBuilder::new(engine_config)
+    let transfer_result = InMemoryWasmTestBuilder::new(engine_config)
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_exec_request(exec_request)
         .finish();
@@ -72,7 +72,7 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let transfer_result = WasmTestBuilder::new(engine_config)
+    let transfer_result = InMemoryWasmTestBuilder::new(engine_config)
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_exec_request(exec_request)
         .finish();
@@ -118,7 +118,7 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let transfer_result = WasmTestBuilder::new(engine_config)
+    let transfer_result = InMemoryWasmTestBuilder::new(engine_config)
         .run_genesis(GENESIS_ADDR, HashMap::default())
         .exec_with_exec_request(exec_request)
         .finish();

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -749,7 +749,7 @@ fn should_produce_same_transforms_as_exec() {
                 .build()
         };
 
-        test_support::WasmTestBuilder::new(config)
+        test_support::InMemoryWasmTestBuilder::new(config)
             .run_genesis(genesis_addr, HashMap::default())
             .exec_with_exec_request(request)
             .expect_success()

--- a/execution-engine/engine-tests/src/test/regression/ee_221.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_221.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 
@@ -9,7 +9,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 fn should_run_ee_221_get_uref_regression_test() {
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let _result = WasmTestBuilder::default()
+    let _result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_401.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_401.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
@@ -12,7 +12,7 @@ const GENESIS_ADDR: [u8; 32] = [0u8; 32];
 #[ignore]
 #[test]
 fn should_execute_contracts_which_provide_extra_urefs() {
-    let _result = WasmTestBuilder::default()
+    let _result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_441.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_441.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
@@ -21,7 +21,7 @@ fn get_uref(key: Key) -> URef {
 fn do_pass(pass: &str) -> (URef, URef) {
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let transforms = WasmTestBuilder::default()
+    let transforms = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_460.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_460.rs
@@ -2,7 +2,7 @@ use contract_ffi::value::U512;
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use engine_core::engine_state::MAX_PAYMENT;
 use engine_shared::transform::Transform;
@@ -12,7 +12,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 #[ignore]
 #[test]
 fn should_run_ee_460_no_side_effects_on_error_regression() {
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_468.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_468.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::U512;
 use engine_core::engine_state::MAX_PAYMENT;
@@ -11,7 +11,7 @@ const GENESIS_ADDR: [u8; 32] = [7u8; 32];
 #[ignore]
 #[test]
 fn should_not_fail_deserializing() {
-    let is_error = WasmTestBuilder::default()
+    let is_error = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_470.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_470.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
 
 const GENESIS_ADDR: [u8; 32] = [12; 32];
@@ -8,7 +8,7 @@ const GENESIS_ADDR: [u8; 32] = [12; 32];
 #[ignore]
 #[test]
 fn regression_test_genesis_hash_mismatch() {
-    let mut builder_base = WasmTestBuilder::default();
+    let mut builder_base = InMemoryWasmTestBuilder::default();
 
     // Step 1.
     let builder = builder_base.run_genesis(GENESIS_ADDR, HashMap::new());

--- a/execution-engine/engine-tests/src/test/regression/ee_532.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_532.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 use engine_core::engine_state::error;
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
@@ -11,7 +11,7 @@ const UNKNOWN_ADDR: [u8; 32] = [42u8; 32];
 fn should_run_ee_532_get_uref_regression_test() {
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(
             UNKNOWN_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_536.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_536.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 
@@ -9,7 +9,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 fn should_run_ee_536_get_uref_regression_test() {
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let _result = WasmTestBuilder::default()
+    let _result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_539.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_539.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::account::Weight;
 use contract_ffi::value::U512;
@@ -14,7 +14,7 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 fn should_run_ee_539_serialize_action_thresholds_regression() {
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let _result = WasmTestBuilder::default()
+    let _result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_549.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_549.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 
 #[ignore]
 #[test]
 fn should_run_ee_549_set_refund_regression() {
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(GENESIS_ADDR, HashMap::new()).exec(
         GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/ee_572.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_572.rs
@@ -6,7 +6,7 @@ use contract_ffi::value::{Value, U512};
 use engine_core::engine_state::MAX_PAYMENT;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 
 const CREATE: &str = "create";
@@ -31,7 +31,7 @@ fn should_run_ee_572_regression() {
 
     // This test runs a contract that's after every call extends the same key with
     // more data
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     // Create Accounts
     builder

--- a/execution-engine/engine-tests/src/test/regression/ee_584.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_584.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, WasmTestBuilder};
+use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder};
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::{Value, U512};
 use engine_core::engine_state::{EngineConfig, MAX_PAYMENT};
@@ -27,7 +27,7 @@ fn should_run_ee_584_no_errored_session_transforms() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     builder
         .run_genesis(GENESIS_ADDR, HashMap::default())

--- a/execution-engine/engine-tests/src/test/regression/ee_601.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_601.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, WasmTestBuilder};
+use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder};
 use contract_ffi::key::Key;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::{Value, U512};
@@ -28,7 +28,7 @@ fn should_run_ee_601_pay_session_new_uref_collision() {
         ExecRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     builder
         .run_genesis(GENESIS_ADDR, HashMap::default())

--- a/execution-engine/engine-tests/src/test/regression/regression_test_ee_597.rs
+++ b/execution-engine/engine-tests/src/test/regression/regression_test_ee_597.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
 
-use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 #[allow(unused)]
 mod test_support;
@@ -28,7 +28,7 @@ fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
         result
     };
 
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, genesis_validators)
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/regression/regression_test_ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/regression_test_ee_598.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
 
-use test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 #[allow(unused)]
 mod test_support;
@@ -31,7 +31,7 @@ fn should_fail_unboding_more_than_it_was_staked_ee_598_regression() {
         result
     };
 
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, genesis_validators)
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use grpc::RequestOptions;
 
-use crate::support::test_support::WasmTestBuilder;
+use crate::support::test_support::InMemoryWasmTestBuilder;
 use engine_core::engine_state::{EngineConfig, EngineState};
 use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
@@ -35,7 +35,7 @@ fn should_run_genesis() {
 #[ignore]
 #[test]
 fn test_genesis_hash_match() {
-    let mut builder_base = WasmTestBuilder::default();
+    let mut builder_base = InMemoryWasmTestBuilder::default();
 
     let builder = builder_base.run_genesis(GENESIS_ADDR, HashMap::new());
 

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
@@ -13,13 +13,16 @@ use engine_shared::motes::Motes;
 use engine_shared::transform::Transform;
 
 use crate::support::test_support::{
-    self, WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    self, InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
 
-fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Option<PurseId> {
+fn get_pos_purse_id_by_name(
+    builder: &InMemoryWasmTestBuilder,
+    purse_name: &str,
+) -> Option<PurseId> {
     let pos_contract = builder.get_pos_contract();
 
     pos_contract
@@ -29,7 +32,7 @@ fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Opti
         .map(|u| PurseId::new(*u))
 }
 
-fn get_pos_bonding_purse_balance(builder: &WasmTestBuilder) -> U512 {
+fn get_pos_bonding_purse_balance(builder: &InMemoryWasmTestBuilder) -> U512 {
     let purse_id = get_pos_purse_id_by_name(builder, POS_BONDING_PURSE)
         .expect("should find PoS payment purse");
     builder.get_purse_balance(purse_id)
@@ -63,7 +66,7 @@ fn should_run_successful_bond_and_unbond() {
         result
     };
 
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, genesis_validators)
         .finish();
 
@@ -74,7 +77,7 @@ fn should_run_successful_bond_and_unbond() {
 
     let pos = result.builder().get_pos_contract_uref();
 
-    let result = WasmTestBuilder::from_result(result)
+    let result = InMemoryWasmTestBuilder::from_result(result)
         .exec_with_args(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -123,7 +126,7 @@ fn should_run_successful_bond_and_unbond() {
     );
 
     // Create new account (from genesis funds) and bond with it
-    let result = WasmTestBuilder::from_result(result)
+    let result = InMemoryWasmTestBuilder::from_result(result)
         .exec_with_args(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -205,7 +208,7 @@ fn should_run_successful_bond_and_unbond() {
     //
 
     let account_1_bal_before = result.builder().get_purse_balance(account_1.purse_id());
-    let result = WasmTestBuilder::from_result(result)
+    let result = InMemoryWasmTestBuilder::from_result(result)
         .exec_with_args(
             ACCOUNT_1_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -265,7 +268,7 @@ fn should_run_successful_bond_and_unbond() {
     //
     // Genesis account unbonds less than 50% of his stake
 
-    let result = WasmTestBuilder::from_result(result)
+    let result = InMemoryWasmTestBuilder::from_result(result)
         .exec_with_args(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -314,7 +317,7 @@ fn should_run_successful_bond_and_unbond() {
     //
     let account_1_bal_before = result.builder().get_purse_balance(account_1.purse_id());
 
-    let result = WasmTestBuilder::from_result(result)
+    let result = InMemoryWasmTestBuilder::from_result(result)
         .exec_with_args(
             ACCOUNT_1_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -366,7 +369,7 @@ fn should_run_successful_bond_and_unbond() {
     //
 
     // Genesis account unbonds less than 50% of his stake
-    let result = WasmTestBuilder::from_result(result)
+    let result = InMemoryWasmTestBuilder::from_result(result)
         .exec_with_args(
             GENESIS_ADDR,
             STANDARD_PAYMENT_CONTRACT,
@@ -466,7 +469,7 @@ fn should_fail_bonding_with_insufficient_funds() {
         result
     };
 
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, genesis_validators)
         .exec_with_args(
             GENESIS_ADDR,
@@ -524,7 +527,7 @@ fn should_fail_unbonding_validator_without_bonding_first() {
         result
     };
 
-    let result = WasmTestBuilder::default()
+    let result = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, genesis_validators)
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/commit_validators.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/commit_validators.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
 
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
+use crate::support::test_support::{InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME};
 
 const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 
@@ -17,7 +17,7 @@ fn should_return_bonded_validators() {
     .into_iter()
     .collect();
 
-    let bonded_validators = WasmTestBuilder::default()
+    let bonded_validators = InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, genesis_validators.clone())
         .exec(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
@@ -10,7 +10,7 @@ use engine_core::engine_state::MAX_PAYMENT;
 use engine_core::engine_state::{EngineConfig, CONV_RATE};
 
 use crate::support::test_support::{
-    self, DeployBuilder, ExecRequestBuilder, WasmTestBuilder, DEFAULT_BLOCK_TIME,
+    self, DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME,
     STANDARD_PAYMENT_CONTRACT,
 };
 
@@ -21,8 +21,8 @@ const GENESIS_ADDR: [u8; 32] = [6u8; 32];
 const SYSTEM_ADDR: [u8; 32] = [0u8; 32];
 const ACCOUNT_ADDR: [u8; 32] = [1u8; 32];
 
-fn initialize() -> WasmTestBuilder {
-    let mut builder = WasmTestBuilder::default();
+fn initialize() -> InMemoryWasmTestBuilder {
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
         .run_genesis(GENESIS_ADDR, HashMap::new())
@@ -94,7 +94,7 @@ fn finalize_payment_should_not_be_run_by_non_system_accounts() {
 #[test]
 fn finalize_payment_should_refund_to_specified_purse() {
     let engine_config = EngineConfig::new().set_use_payment_code(true);
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
     let payment_amount = U512::from(10_000_000);
     let refund_purse_flag: u8 = 1;
     // Don't need to run finalize_payment manually, it happens during
@@ -158,19 +158,19 @@ fn finalize_payment_should_refund_to_specified_purse() {
 
 // ------------- utility functions -------------------- //
 
-fn get_pos_payment_purse_balance(builder: &WasmTestBuilder) -> U512 {
+fn get_pos_payment_purse_balance(builder: &InMemoryWasmTestBuilder) -> U512 {
     let purse_id = get_pos_purse_id_by_name(builder, POS_PAYMENT_PURSE)
         .expect("should find PoS payment purse");
     builder.get_purse_balance(purse_id)
 }
 
-fn get_pos_rewards_purse_balance(builder: &WasmTestBuilder) -> U512 {
+fn get_pos_rewards_purse_balance(builder: &InMemoryWasmTestBuilder) -> U512 {
     let purse_id = get_pos_purse_id_by_name(builder, POS_REWARDS_PURSE)
         .expect("should find PoS rewards purse");
     builder.get_purse_balance(purse_id)
 }
 
-fn get_pos_refund_purse(builder: &WasmTestBuilder) -> Option<Key> {
+fn get_pos_refund_purse(builder: &InMemoryWasmTestBuilder) -> Option<Key> {
     let pos_contract = builder.get_pos_contract();
 
     pos_contract
@@ -179,7 +179,10 @@ fn get_pos_refund_purse(builder: &WasmTestBuilder) -> Option<Key> {
         .cloned()
 }
 
-fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Option<PurseId> {
+fn get_pos_purse_id_by_name(
+    builder: &InMemoryWasmTestBuilder,
+    purse_name: &str,
+) -> Option<PurseId> {
     let pos_contract = builder.get_pos_contract();
 
     pos_contract
@@ -190,7 +193,7 @@ fn get_pos_purse_id_by_name(builder: &WasmTestBuilder, purse_name: &str) -> Opti
 }
 
 fn get_named_account_balance(
-    builder: &WasmTestBuilder,
+    builder: &InMemoryWasmTestBuilder,
     account_address: [u8; 32],
     name: &str,
 ) -> Option<U512> {

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/get_payment_purse.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/get_payment_purse.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::U512;
 use engine_core::engine_state::MAX_PAYMENT;
@@ -13,7 +13,7 @@ const ACCOUNT_1_INITIAL_BALANCE: u64 = MAX_PAYMENT + 100;
 #[ignore]
 #[test]
 fn should_run_get_payment_purse_contract_genesis_account() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,
@@ -32,7 +32,7 @@ fn should_run_get_payment_purse_contract_genesis_account() {
 #[ignore]
 #[test]
 fn should_run_get_payment_purse_contract_account_1() {
-    WasmTestBuilder::default()
+    InMemoryWasmTestBuilder::default()
         .run_genesis(GENESIS_ADDR, HashMap::new())
         .exec_with_args(
             GENESIS_ADDR,

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/refund_purse.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/refund_purse.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, WasmTestBuilder};
+use crate::support::test_support::{DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder};
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
 use engine_core::engine_state::{EngineConfig, MAX_PAYMENT};
@@ -23,16 +23,16 @@ fn should_run_pos_refund_purse_contract_account_1() {
     refund_tests(&mut builder, ACCOUNT_1_ADDR);
 }
 
-fn initialize() -> WasmTestBuilder {
+fn initialize() -> InMemoryWasmTestBuilder {
     let engine_config = EngineConfig::new().set_use_payment_code(true);
-    let mut builder = WasmTestBuilder::new(engine_config);
+    let mut builder = InMemoryWasmTestBuilder::new(engine_config);
 
     builder.run_genesis(GENESIS_ADDR, HashMap::default());
 
     builder
 }
 
-fn transfer(builder: &mut WasmTestBuilder, address: [u8; 32], amount: U512) {
+fn transfer(builder: &mut InMemoryWasmTestBuilder, address: [u8; 32], amount: U512) {
     let exec_request = {
         let genesis_public_key = PublicKey::new(GENESIS_ADDR);
         let account_1_public_key = PublicKey::new(address);
@@ -57,7 +57,7 @@ fn transfer(builder: &mut WasmTestBuilder, address: [u8; 32], amount: U512) {
         .commit();
 }
 
-fn refund_tests(builder: &mut WasmTestBuilder, address: [u8; 32]) {
+fn refund_tests(builder: &mut InMemoryWasmTestBuilder, address: [u8; 32]) {
     let exec_request = {
         let public_key = PublicKey::new(address);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::support::test_support::{
-    WasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
+    InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME, STANDARD_PAYMENT_CONTRACT,
 };
 use contract_ffi::value::U512;
 use engine_core::engine_state::MAX_PAYMENT;
@@ -14,7 +14,7 @@ const ACCOUNT_1_INITIAL_BALANCE: u64 = MAX_PAYMENT * 2;
 #[ignore]
 #[test]
 fn should_have_read_only_access_to_system_contract_urefs() {
-    let mut builder = WasmTestBuilder::default();
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder
         .run_genesis(GENESIS_ADDR, HashMap::new())


### PR DESCRIPTION
### Overview
Makes `WasmTestBuilder` generic over global state type.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-655

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
This allows us to set up persistent test environments which will be useful for profiling only meaningful code paths.
