### PR TITLE
NODE-824: Separate API cert

### DIFF
--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Options.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Options.scala
@@ -30,6 +30,19 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       required = false
     )
 
+  val tlsApiCertificate =
+    opt[File](
+      descr =
+        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain."
+    )
+
+  val useTls =
+    opt[String](
+      descr =
+        "Optionally, force the TLS to be on or off. When it's on without node-id or tls-api-certificate it will rely on the default system certificate chain. [true | false]",
+      validate = Set("true", "false").contains(_)
+    )
+
   val fileCheck: File => Boolean = file =>
     file.exists() && file.canRead && !file.isDirectory && file.isFile
 
@@ -79,7 +92,9 @@ object Options {
         options.host(),
         options.port(),
         options.portInternal(),
-        options.nodeId.toOption
+        options.nodeId.toOption,
+        options.tlsApiCertificate.toOption,
+        options.useTls.toOption.map(_ == "true")
       )
       val conf: Option[Configuration] = options.subcommand.map {
         case options.benchmark =>

--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Options.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Options.scala
@@ -33,7 +33,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val tlsApiCertificate =
     opt[File](
       descr =
-        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain."
+        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain. " +
+          "A certificate can be downloaded using OpenSSL: `openssl s_client -showcerts -connect localhost:40401 </dev/null 2>/dev/null | openssl x509 -outform PEM > node.crt`"
     )
 
   val useTls =

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -12,7 +12,8 @@ final case class ConnectOptions(
     portExternal: Int,
     portInternal: Int,
     nodeId: Option[String],
-    tlsApiCertificate: Option[File]
+    tlsApiCertificate: Option[File],
+    useTls: Option[Boolean]
 )
 
 /** Options to capture all the possible ways of passing one of the session or payment contracts. */
@@ -200,7 +201,8 @@ object Configuration {
       options.port(),
       options.portInternal(),
       options.nodeId.toOption,
-      options.tlsApiCertificate.toOption
+      options.tlsApiCertificate.toOption,
+      options.useTls.toOption.map(_ == "true")
     )
     val conf = options.subcommand.map {
       case options.deploy =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -11,7 +11,8 @@ final case class ConnectOptions(
     host: String,
     portExternal: Int,
     portInternal: Int,
-    nodeId: Option[String]
+    nodeId: Option[String],
+    tlsApiCertificate: Option[File]
 )
 
 /** Options to capture all the possible ways of passing one of the session or payment contracts. */
@@ -198,7 +199,8 @@ object Configuration {
       options.host(),
       options.port(),
       options.portInternal(),
-      options.nodeId.toOption
+      options.nodeId.toOption,
+      options.tlsApiCertificate.toOption
     )
     val conf = options.subcommand.map {
       case options.deploy =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -165,7 +165,14 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val nodeId =
     opt[String](
       descr =
-        "Node ID (i.e. the Keccak256 hash of the public key the node uses for TLS) in case secure communication is needed.",
+        "Node ID (i.e. the Keccak256 hash of the public key the node uses for TLS) in case secure communication is based on the intra-node certificates.",
+      required = false
+    )
+
+  val tlsApiCertificate =
+    opt[File](
+      descr =
+        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain.",
       required = false
     )
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -172,8 +172,14 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val tlsApiCertificate =
     opt[File](
       descr =
-        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain.",
-      required = false
+        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain."
+    )
+
+  val useTls =
+    opt[String](
+      descr =
+        "Optionally, force the TLS to be on or off. When it's on without node-id or tls-api-certificate it will rely on the default system certificate chain. [true | false]",
+      validate = Set("true", "false").contains(_)
     )
 
   val makeDeploy = new Subcommand("make-deploy") with DeployOptions {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -172,7 +172,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   val tlsApiCertificate =
     opt[File](
       descr =
-        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain."
+        "Certificate of the node to be used for TLS communication. If the --node-id is also provided it will override the authority in the certificate, otherwise we expect the certificate to match the domain. " +
+          "A certificate can be downloaded using OpenSSL: `openssl s_client -showcerts -connect localhost:40401 </dev/null 2>/dev/null | openssl x509 -outform PEM > node.crt`"
     )
 
   val useTls =

--- a/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
@@ -6,16 +6,16 @@ import java.nio.file.Path
 import scala.io.Source
 
 final case class Tls(
-    certificate: Path,
-    key: Path,
-    apiCertificate: Path,
-    apiKey: Path
+    intraNodeCertificate: Path,
+    intraNodeKey: Path,
+    publicApiCertificate: Path,
+    publicApiKey: Path
 ) extends SubConfig {
-  def readCertAndKey: Tls.CertAndKey =
-    read(certificate, key)
+  def readIntraNodeCertAndKey: Tls.CertAndKey =
+    read(intraNodeCertificate, intraNodeKey)
 
-  def readApiCertAndKey: Tls.CertAndKey =
-    read(apiCertificate, apiKey)
+  def readPublicApiCertAndKey: Tls.CertAndKey =
+    read(publicApiCertificate, publicApiKey)
 
   private def read(cp: Path, kp: Path): Tls.CertAndKey = {
     val c = Resources.withResource(Source.fromFile(cp.toFile))(_.mkString)

--- a/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
@@ -6,16 +6,18 @@ import java.nio.file.Path
 import scala.io.Source
 
 final case class Tls(
-    intraNodeCertificate: Path,
-    intraNodeKey: Path,
-    publicApiCertificate: Path,
-    publicApiKey: Path
+    // Intra node.
+    certificate: Path,
+    key: Path,
+    // Public API.
+    apiCertificate: Path,
+    apiKey: Path
 ) extends SubConfig {
   def readIntraNodeCertAndKey: Tls.CertAndKey =
-    read(intraNodeCertificate, intraNodeKey)
+    read(certificate, key)
 
   def readPublicApiCertAndKey: Tls.CertAndKey =
-    read(publicApiCertificate, publicApiKey)
+    read(apiCertificate, apiKey)
 
   private def read(cp: Path, kp: Path): Tls.CertAndKey = {
     val c = Resources.withResource(Source.fromFile(cp.toFile))(_.mkString)

--- a/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
@@ -8,12 +8,7 @@ import scala.io.Source
 
 final case class Tls(
     certificate: Path,
-    key: Path,
-    @ignore
-    customCertificateLocation: Boolean = false,
-    @ignore
-    customKeyLocation: Boolean = false,
-    secureRandomNonBlocking: Boolean
+    key: Path
 ) extends SubConfig {
   def readCertAndKey: Tls.CertAndKey = {
     val c = Resources.withResource(Source.fromFile(certificate.toFile))(_.mkString)

--- a/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/transport/Tls.scala
@@ -1,18 +1,25 @@
 package io.casperlabs.comm.transport
 
-import java.nio.file.Path
-
 import io.casperlabs.configuration.{ignore, SubConfig}
 import io.casperlabs.shared.Resources
+import java.nio.file.Path
 import scala.io.Source
 
 final case class Tls(
     certificate: Path,
-    key: Path
+    key: Path,
+    apiCertificate: Path,
+    apiKey: Path
 ) extends SubConfig {
-  def readCertAndKey: Tls.CertAndKey = {
-    val c = Resources.withResource(Source.fromFile(certificate.toFile))(_.mkString)
-    val k = Resources.withResource(Source.fromFile(key.toFile))(_.mkString)
+  def readCertAndKey: Tls.CertAndKey =
+    read(certificate, key)
+
+  def readApiCertAndKey: Tls.CertAndKey =
+    read(apiCertificate, apiKey)
+
+  private def read(cp: Path, kp: Path): Tls.CertAndKey = {
+    val c = Resources.withResource(Source.fromFile(cp.toFile))(_.mkString)
+    val k = Resources.withResource(Source.fromFile(kp.toFile))(_.mkString)
     (c, k)
   }
 }

--- a/hack/docker/template/docker-compose.yml
+++ b/hack/docker/template/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       CL_CASPER_VALIDATOR_PRIVATE_KEY_PATH: /root/.casperlabs/node/validator-private.pem
       CL_TLS_CERTIFICATE: /root/.casperlabs/node/node.certificate.pem
       CL_TLS_KEY: /root/.casperlabs/node/node.key.pem
+      CL_TLS_API_CERTIFICATE: /root/.casperlabs/node/node.certificate.pem
+      CL_TLS_API_KEY: /root/.casperlabs/node/node.key.pem
       CL_GRPC_USE_TLS: "true"
       CL_METRICS_PROMETHEUS: "true"
       CL_CASPER_MINT_CODE_PATH: /root/.casperlabs/genesis/system-contracts/mint_token.wasm

--- a/integration-testing/test/cl_node/docker_config.py
+++ b/integration-testing/test/cl_node/docker_config.py
@@ -76,6 +76,8 @@ class DockerConfig:
             "--metrics-prometheus": "",
             "--tls-certificate": self.tls_certificate_path(),
             "--tls-key": self.tls_key_path(),
+            "--tls-api-certificate": self.tls_certificate_path(),
+            "--tls-api-key": self.tls_key_path(),
         }
         if self.grpc_encryption:
             options["--grpc-use-tls"] = ""

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -161,6 +161,14 @@ certificate = "$HOME/.casperlabs/node.certificate.pem"
 # Path to node's unencrypted secp256r1 PKCS#8 private key file, that is being used for intra-node TLS communication.
 key = "$HOME/.casperlabs/node.key.pem"
 
+# X.509 certificate used for the public facing API, preferrably one signed by a root CA
+# so that clients which can't implement custom SSL verificaton can use standard methods.
+# The Common Name should match the host name where the node is exposed.
+api-certificate = "$HOME/.casperlabs/api.certificate.pem"
+
+# Private key to use with the public API certificate.
+api-key = "$HOME/.casperlabs/api.key.pem"
+
 
 # io.casperlabs.casper.CasperConf
 [casper]

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -154,14 +154,12 @@ use-tls = false
 # io.casperlabs.comm.transport.Tls
 [tls]
 
-# Path to node's X.509 certificate file, that is being used for identification.
+# Path to node's X.509 certificate file, that is being used for identification during intra-node gossiping.
+# The Common Name in the certificate should be the same as the Keccak256 hash of the public key in it.
 certificate = "$HOME/.casperlabs/node.certificate.pem"
 
-# Path to node's unencrypted secp256r1 PKCS#8 private key file, that is being used for TLS communication.
+# Path to node's unencrypted secp256r1 PKCS#8 private key file, that is being used for intra-node TLS communication.
 key = "$HOME/.casperlabs/node.key.pem"
-
-# Use a non blocking secure random instance.
-secure-random-non-blocking = false
 
 
 # io.casperlabs.casper.CasperConf

--- a/node/src/main/scala/io/casperlabs/node/NodeEnvironment.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeEnvironment.scala
@@ -36,7 +36,7 @@ object NodeEnvironment {
   private def name(conf: Configuration): Effect[String] = {
     val certificate: Effect[X509Certificate] =
       Task
-        .delay(CertificateHelper.fromFile(conf.tls.intraNodeCertificate.toFile))
+        .delay(CertificateHelper.fromFile(conf.tls.certificate.toFile))
         .attemptT
         .leftMap(e => InitializationError(s"Failed to read the X.509 certificate: ${e.getMessage}"))
 
@@ -69,12 +69,12 @@ object NodeEnvironment {
   )
 
   private def hasCertificate(conf: Configuration): Effect[Unit] = isValid(
-    !conf.tls.intraNodeCertificate.toFile.exists(),
-    s"Certificate file ${conf.tls.intraNodeCertificate} not found"
+    !conf.tls.certificate.toFile.exists(),
+    s"Certificate file ${conf.tls.certificate} not found"
   )
 
   private def hasKey(conf: Configuration): Effect[Unit] = isValid(
-    !conf.tls.intraNodeKey.toFile.exists(),
-    s"Secret key file ${conf.tls.intraNodeCertificate} not found"
+    !conf.tls.key.toFile.exists(),
+    s"Secret key file ${conf.tls.key} not found"
   )
 }

--- a/node/src/main/scala/io/casperlabs/node/NodeEnvironment.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeEnvironment.scala
@@ -36,7 +36,7 @@ object NodeEnvironment {
   private def name(conf: Configuration): Effect[String] = {
     val certificate: Effect[X509Certificate] =
       Task
-        .delay(CertificateHelper.fromFile(conf.tls.certificate.toFile))
+        .delay(CertificateHelper.fromFile(conf.tls.intraNodeCertificate.toFile))
         .attemptT
         .leftMap(e => InitializationError(s"Failed to read the X.509 certificate: ${e.getMessage}"))
 
@@ -69,12 +69,12 @@ object NodeEnvironment {
   )
 
   private def hasCertificate(conf: Configuration): Effect[Unit] = isValid(
-    !conf.tls.certificate.toFile.exists(),
-    s"Certificate file ${conf.tls.certificate} not found"
+    !conf.tls.intraNodeCertificate.toFile.exists(),
+    s"Certificate file ${conf.tls.intraNodeCertificate} not found"
   )
 
   private def hasKey(conf: Configuration): Effect[Unit] = isValid(
-    !conf.tls.key.toFile.exists(),
-    s"Secret key file ${conf.tls.certificate} not found"
+    !conf.tls.intraNodeKey.toFile.exists(),
+    s"Secret key file ${conf.tls.intraNodeCertificate} not found"
   )
 }

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -115,10 +115,10 @@ class NodeRuntime private[node] (
     implicit val filesApiEff            = FilesAPI.create[Effect](Sync[Effect], logEff)
 
     // SSL context to use for the public facing API.
-    val maybeApiSslContext = Option(conf.tls.readCertAndKey).filter(_ => conf.grpc.useTls).map {
-      case (cert, key) =>
-        SslContexts.forServer(cert, key, ClientAuth.NONE)
-    }
+    val maybeApiSslContext = if (conf.grpc.useTls) {
+      val (cert, key) = conf.tls.readApiCertAndKey
+      Option(SslContexts.forServer(cert, key, ClientAuth.NONE))
+    } else None
 
     rpConfState >>= (_.runState { implicit state =>
       implicit val metrics     = diagnostics.effects.metrics[Task]

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -116,7 +116,7 @@ class NodeRuntime private[node] (
 
     // SSL context to use for the public facing API.
     val maybeApiSslContext = if (conf.grpc.useTls) {
-      val (cert, key) = conf.tls.readApiCertAndKey
+      val (cert, key) = conf.tls.readPublicApiCertAndKey
       Option(SslContexts.forServer(cert, key, ClientAuth.NONE))
     } else None
 

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -53,7 +53,7 @@ package object gossiping {
       egressScheduler: Scheduler
   )(implicit logId: Log[Id], metricsId: Metrics[Id]): Resource[F, Unit] = {
 
-    val (cert, key) = conf.tls.readCertAndKey
+    val (cert, key) = conf.tls.readIntraNodeCertAndKey
 
     // SSL context to use when connecting to another node.
     val clientSslContext = SslContexts.forClient(cert, key)

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -84,8 +84,8 @@ package object transport {
       implicit0(transport: TransportLayer[Task]) = {
         effects.tcpTransportLayer(
           port,
-          conf.tls.intraNodeCertificate,
-          conf.tls.intraNodeKey,
+          conf.tls.certificate,
+          conf.tls.key,
           conf.server.maxMessageSize,
           conf.server.chunkSize,
           commTmpFolder

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -84,8 +84,8 @@ package object transport {
       implicit0(transport: TransportLayer[Task]) = {
         effects.tcpTransportLayer(
           port,
-          conf.tls.certificate,
-          conf.tls.key,
+          conf.tls.intraNodeCertificate,
+          conf.tls.intraNodeKey,
           conf.server.maxMessageSize,
           conf.server.chunkSize,
           commTmpFolder

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -139,7 +139,6 @@ object Configuration extends ParserImplicits {
       .parse(cliByName, envVars, configFile, defaultConfigFile, Nil)
       .map(updatePaths(_, defaultDataDir))
       .toEither
-      .flatMap(updateTls(_, defaultConfigFile).leftMap(NonEmptyList(_, Nil)))
       .fold(Invalid(_), Valid(_))
 
   /**
@@ -191,40 +190,6 @@ object Configuration extends ParserImplicits {
       implicit def gen[T]: Typeclass[T] = macro Magnolia.gen[T]
     }
     GenericPathUpdater.gen[Configuration].update(c)
-  }
-
-  private[configuration] def updateTls(
-      c: Configuration,
-      defaultConfigFile: Map[CamelCase, String]
-  ): Either[String, Configuration] = {
-    val dataDir = c.server.dataDir
-    for {
-      defaultDataDir <- readDefaultDataDir
-      defaultCertificate <- defaultConfigFile
-                             .get(CamelCase("tlsCertificate"))
-                             .fold("tls.certificate must have default value".asLeft[Path])(
-                               s => Parser[Path].parse(s)
-                             )
-      defaultKey <- defaultConfigFile
-                     .get(CamelCase("tlsKey"))
-                     .fold("tls.key must have default value".asLeft[Path])(
-                       s => Parser[Path].parse(s)
-                     )
-    } yield {
-      val isCertCustomLocation = stripPrefix(c.tls.certificate, dataDir) != stripPrefix(
-        defaultCertificate,
-        defaultDataDir
-      )
-      val isKeyCustomLocation =
-        stripPrefix(c.tls.key, dataDir) !=
-          stripPrefix(defaultKey, defaultDataDir)
-      c.copy(
-        tls = c.tls.copy(
-          customCertificateLocation = isCertCustomLocation,
-          customKeyLocation = isKeyCustomLocation
-        )
-      )
-    }
   }
 
   private def readDefaultDataDir: Either[String, Path] =

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -216,12 +216,6 @@ private[configuration] final case class Options private (
       )
 
     @scallop
-    val tlsSecureRandomNonBlocking =
-      gen[Flag](
-        "Use a non blocking secure random instance."
-      )
-
-    @scallop
     val serverPort =
       gen[Int]("Network port to use for intra-node gRPC communication.", 'p')
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -216,6 +216,18 @@ private[configuration] final case class Options private (
       )
 
     @scallop
+    val tlsApiCertificate =
+      gen[Path](
+        "Path to an optional X.509 certificate file signed by a trusted root CA, to be used in the with public API."
+      )
+
+    @scallop
+    val tlsApiKey =
+      gen[Path](
+        "Path to the unencrypted secp256r1 PKCS#8 private key file corresponding to the API certificate, if given."
+      )
+
+    @scallop
     val serverPort =
       gen[Int]("Network port to use for intra-node gRPC communication.", 'p')
 

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -53,8 +53,10 @@ port-internal = 1
 use-tls = false
 
 [tls]
-certificate = "/tmp/test"
-key = "/tmp/test"
+certificate = "/tmp/test.crt"
+key = "/tmp/test.key"
+api-certificate = "/tmp/test.api.crt"
+api-key = "/tmp/test.api.key"
 
 [casper]
 validator-public-key = "test"

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -55,7 +55,6 @@ use-tls = false
 [tls]
 certificate = "/tmp/test"
 key = "/tmp/test"
-secure-random-non-blocking = false
 
 [casper]
 validator-public-key = "test"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -122,8 +122,7 @@ class ConfigurationSpec
     )
     val tls = Tls(
       certificate = Paths.get("/tmp/test"),
-      key = Paths.get("/tmp/test"),
-      secureRandomNonBlocking = false
+      key = Paths.get("/tmp/test")
     )
     val lmdb = LMDBBlockStorage.Config(
       dir = Paths.get("/tmp/lmdb-block-storage"),
@@ -161,49 +160,6 @@ class ConfigurationSpec
       kamonSettings,
       influx.some
     )
-  }
-
-  test("""
-        |Configuration.updateTls should update
-        |'customCertificateLocation' and 'customKeyLocation'
-        |if certificate and key are custom""".stripMargin) {
-    forAll { (maybeDataDir: Option[Path], maybeCert: Option[Path], maybeKey: Option[Path]) =>
-      import shapeless._
-
-      /*_*/
-      val confUpdatedDataDir =
-        maybeDataDir.fold(defaultConf)(lens[Configuration].server.dataDir.set(defaultConf))
-      val confUpdatedCert =
-        maybeCert.fold(confUpdatedDataDir)(
-          lens[Configuration].tls.certificate.set(confUpdatedDataDir)
-        )
-      val confUpdatedKey =
-        maybeKey.fold(confUpdatedCert)(lens[Configuration].tls.key.set(confUpdatedCert))
-      /*_*/
-
-      val Right(defaults) = readFile(Source.fromResource("default-configuration.toml")) map Configuration.parseToml
-      val Right(res) = Configuration
-        .updateTls(Configuration.updatePaths(confUpdatedKey, defaultConf.server.dataDir), defaults)
-      val Right(defaultCert) =
-        Parser[java.nio.file.Path].parse(defaults(CamelCase("tlsCertificate")))
-      val Right(defaultKey) = Parser[java.nio.file.Path].parse(defaults(CamelCase("tlsKey")))
-
-      maybeCert match {
-        case Some(c) =>
-          val certStrippedPath        = stripPrefix(c, res.server.dataDir)
-          val defaultCertStrippedPath = stripPrefix(defaultCert, defaultConf.server.dataDir)
-          assert(res.tls.customCertificateLocation && certStrippedPath != defaultCertStrippedPath)
-        case None =>
-          assert(!res.tls.customCertificateLocation)
-      }
-      maybeKey match {
-        case Some(k) =>
-          val keyStrippedPath        = stripPrefix(k, res.server.dataDir)
-          val defaultKeyStrippedPath = stripPrefix(defaultKey, defaultConf.server.dataDir)
-          assert(res.tls.customKeyLocation && keyStrippedPath != defaultKeyStrippedPath)
-        case None => assert(!res.tls.customKeyLocation)
-      }
-    }
   }
 
   test("""

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -121,8 +121,10 @@ class ConfigurationSpec
       maxBlockSizeBytes = 1
     )
     val tls = Tls(
-      certificate = Paths.get("/tmp/test"),
-      key = Paths.get("/tmp/test")
+      certificate = Paths.get("/tmp/test.crt"),
+      key = Paths.get("/tmp/test.key"),
+      apiCertificate = Paths.get("/tmp/test.api.crt"),
+      apiKey = Paths.get("/tmp/test.api.key")
     )
     val lmdb = LMDBBlockStorage.Config(
       dir = Paths.get("/tmp/lmdb-block-storage"),


### PR DESCRIPTION
### Overview
Add separate `--tls-api-certificate` and `--tls-api-key` with which are only used if `--server-grpc-use-tls` is on. The default values are similar to the intra-node cert and key: `.casperlabs/api.certificate.pem` and `.casperlabs/api.key.pem`.

Currently the node uses the intra-node certs for the public APIs as well (if the option is enabled), but these are self-signed certificates which require the client to extract the common name from the certificate and check that it matches the hash of the public key, and also matches the node ID the client was expected to connect to. As it turned out the Python gRPC stack won't allow this, and in DevNet we also use a round-robin DNS so we can't expect which node the client will end up talking to. 

With the new settings the operator should set a certificate which is signed by a trusted root CA, so that the normal SSL validation mechanisms work.

The Scala CLI client also got new parameters:
* `--tls-api-certificate` to point at a certificate file we downloaded, which can be self-signed
* `--use-tls` to force the SSL encryption on or off, to override the default behaviour. That is, with `--use-tls true` it will either use the TLS cert or the `--node-id` (as now), but if both are empty it will try to use the system default CA roots; with `--use-tls false` we can turn it off even if the other settings are present.
Specifying `--node-id` will override the default authority (i.e. hostname) as well, so it really only works with the self-signed intra-node certs, otherwise it should be empty and we verify the host name instead.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-824

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes

