### PR TITLE
NO-TICKET: execution-engine: introduce AddressGenerator newtype

### DIFF
--- a/execution-engine/engine-core/src/execution/address_generator.rs
+++ b/execution-engine/engine-core/src/execution/address_generator.rs
@@ -1,0 +1,104 @@
+use blake2::digest::{Input, VariableOutput};
+use blake2::VarBlake2b;
+use rand::{RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+use contract_ffi::execution::Phase;
+
+use crate::{Address, ADDRESS_LENGTH};
+
+const SEED_LENGTH: usize = 32;
+
+/// An [`AddressGenerator`] generates [`URef`] addresses
+pub struct AddressGenerator(ChaChaRng);
+
+impl AddressGenerator {
+    /// Creates an [`AddressGenerator`] from a 32-byte hash digest and [`Phase`].
+    pub fn new(hash: [u8; 32], phase: Phase) -> AddressGenerator {
+        AddressGeneratorBuilder::new()
+            .seed_with(&hash)
+            .seed_with(&[phase as u8])
+            .build()
+    }
+
+    pub fn create_address(&mut self) -> Address {
+        let mut buff = [0u8; ADDRESS_LENGTH];
+        self.0.fill_bytes(&mut buff);
+        buff
+    }
+}
+
+/// A builder for [`AddressGenerator`].
+#[derive(Default)]
+struct AddressGeneratorBuilder {
+    data: Vec<u8>,
+}
+
+impl AddressGeneratorBuilder {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn seed_with(mut self, bytes: &[u8]) -> Self {
+        self.data.extend(bytes);
+        self
+    }
+
+    pub fn build(self) -> AddressGenerator {
+        let mut seed: [u8; SEED_LENGTH] = [0u8; SEED_LENGTH];
+        let mut hasher = VarBlake2b::new(SEED_LENGTH).unwrap();
+        hasher.input(self.data);
+        hasher.variable_result(|hash| seed.clone_from_slice(hash));
+        AddressGenerator(ChaChaRng::from_seed(seed))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use contract_ffi::execution::Phase;
+
+    use super::AddressGenerator;
+
+    const DEPLOY_HASH_1: [u8; 32] = [1u8; 32];
+    const DEPLOY_HASH_2: [u8; 32] = [2u8; 32];
+
+    #[test]
+    fn should_generate_different_numbers_for_different_seeds() {
+        let mut ag_a = AddressGenerator::new(DEPLOY_HASH_1, Phase::Session);
+        let mut ag_b = AddressGenerator::new(DEPLOY_HASH_2, Phase::Session);
+        let random_a = ag_a.create_address();
+        let random_b = ag_b.create_address();
+
+        assert_ne!(random_a, random_b)
+    }
+
+    #[test]
+    fn should_generate_same_numbers_for_same_seed() {
+        let mut ag_a = AddressGenerator::new(DEPLOY_HASH_1, Phase::Session);
+        let mut ag_b = AddressGenerator::new(DEPLOY_HASH_1, Phase::Session);
+        let random_a = ag_a.create_address();
+        let random_b = ag_b.create_address();
+
+        assert_eq!(random_a, random_b)
+    }
+
+    #[test]
+    fn should_not_generate_same_numbers_for_different_phase() {
+        let mut ag_a = AddressGenerator::new(DEPLOY_HASH_1, Phase::Payment);
+        let mut ag_b = AddressGenerator::new(DEPLOY_HASH_1, Phase::Session);
+        let mut ag_c = AddressGenerator::new(DEPLOY_HASH_1, Phase::FinalizePayment);
+        let random_a = ag_a.create_address();
+        let random_b = ag_b.create_address();
+        let random_c = ag_c.create_address();
+
+        assert_ne!(
+            random_a, random_b,
+            "different phase should have different output"
+        );
+
+        assert_ne!(
+            random_a, random_c,
+            "different phase should have different output"
+        );
+    }
+}

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -1,3 +1,4 @@
+mod address_generator;
 mod error;
 #[macro_use]
 mod executor;
@@ -5,11 +6,11 @@ mod runtime;
 #[cfg(test)]
 mod tests;
 
+pub use self::address_generator::AddressGenerator;
 pub use self::error::Error;
 pub use self::executor::{Executor, WasmiExecutor};
 pub use self::runtime::{
-    create_rng, extract_access_rights_from_keys, extract_access_rights_from_urefs,
-    instance_and_memory, Runtime,
+    extract_access_rights_from_keys, extract_access_rights_from_urefs, instance_and_memory, Runtime,
 };
 
 pub const MINT_NAME: &str = "mint";

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -5,13 +5,8 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryFrom;
 use std::iter::IntoIterator;
 
-use blake2::digest::{Input, VariableOutput};
-use blake2::VarBlake2b;
 use itertools::Itertools;
-use num_traits::ToPrimitive;
 use parity_wasm::elements::Module;
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
 use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef, Trap, TrapKind};
 
 use contract_ffi::bytesrepr::{deserialize, ToBytes, U32_SIZE};
@@ -30,7 +25,7 @@ use crate::execution::Error::{KeyNotFound, URefNotFound};
 use crate::resolvers::create_module_resolver;
 use crate::resolvers::memory_resolver::MemoryResolver;
 use crate::runtime_context::RuntimeContext;
-use crate::URefAddr;
+use crate::Address;
 
 pub struct Runtime<'a, R> {
     memory: MemoryRef,
@@ -87,7 +82,7 @@ pub fn key_to_tuple(key: Key) -> Option<([u8; 32], Option<AccessRights>)> {
 /// rights per key
 pub fn extract_access_rights_from_urefs<I: IntoIterator<Item = URef>>(
     input: I,
-) -> HashMap<URefAddr, HashSet<AccessRights>> {
+) -> HashMap<Address, HashSet<AccessRights>> {
     input
         .into_iter()
         .map(|uref: URef| (uref.addr(), uref.access_rights()))
@@ -108,7 +103,7 @@ pub fn extract_access_rights_from_urefs<I: IntoIterator<Item = URef>>(
 /// per key.
 pub fn extract_access_rights_from_keys<I: IntoIterator<Item = Key>>(
     input: I,
-) -> HashMap<URefAddr, HashSet<AccessRights>> {
+) -> HashMap<Address, HashSet<AccessRights>> {
     input
         .into_iter()
         .map(key_to_tuple)
@@ -124,17 +119,6 @@ pub fn extract_access_rights_from_keys<I: IntoIterator<Item = Key>>(
             )
         })
         .collect()
-}
-
-pub fn create_rng(deploy_hahs: [u8; 32], phase: contract_ffi::execution::Phase) -> ChaChaRng {
-    let mut seed: [u8; 32] = [0u8; 32];
-    let mut data: Vec<u8> = Vec::new();
-    let mut hasher = VarBlake2b::new(32).unwrap();
-    data.extend(&deploy_hahs);
-    data.extend_from_slice(&[phase.to_u8().expect("Phase is represented as a u8")]);
-    hasher.input(data);
-    hasher.variable_result(|hash| seed.clone_from_slice(hash));
-    ChaChaRng::from_seed(seed)
 }
 
 fn sub_call<R: StateReader<Key, Value>>(
@@ -173,7 +157,7 @@ where
             current_runtime.context.gas_limit(),
             current_runtime.context.gas_counter(),
             current_runtime.context.fn_store_id(),
-            current_runtime.context.rng(),
+            current_runtime.context.address_generator(),
             protocol_version,
             current_runtime.context.correlation_id(),
             current_runtime.context.phase(),
@@ -193,7 +177,7 @@ where
                 match downcasted_error {
                     Error::Ret(ref ret_urefs) => {
                         //insert extra urefs returned from call
-                        let ret_urefs_map: HashMap<URefAddr, HashSet<AccessRights>> =
+                        let ret_urefs_map: HashMap<Address, HashSet<AccessRights>> =
                             extract_access_rights_from_urefs(ret_urefs.clone());
                         current_runtime.context.add_urefs(ret_urefs_map);
                         return Ok(runtime.result);

--- a/execution-engine/engine-core/src/execution/tests.rs
+++ b/execution-engine/engine-core/src/execution/tests.rs
@@ -1,11 +1,7 @@
-use rand::RngCore;
-use rand_chacha::ChaChaRng;
-
 use engine_shared::gas::Gas;
 
 use super::Error;
 use crate::engine_state::execution_result::ExecutionResult;
-use crate::execution::create_rng;
 
 fn on_fail_charge_test_helper<T>(
     f: impl Fn() -> Result<T, Error>,
@@ -71,52 +67,4 @@ fn on_fail_charge_with_action() {
             assert_eq!(effect.transforms.len(), 1);
         }
     }
-}
-
-fn gen_random(rng: &mut ChaChaRng) -> [u8; 32] {
-    let mut buff = [0u8; 32];
-    rng.fill_bytes(&mut buff);
-    buff
-}
-
-#[test]
-fn should_generate_different_numbers_for_different_seeds() {
-    let mut rng_a = create_rng([1u8; 32], contract_ffi::execution::Phase::Session);
-    let mut rng_b = create_rng([2u8; 32], contract_ffi::execution::Phase::Session);
-    let random_a = gen_random(&mut rng_a);
-    let random_b = gen_random(&mut rng_b);
-
-    assert_ne!(random_a, random_b)
-}
-
-#[test]
-fn should_generate_same_numbers_for_same_seed() {
-    let mut rng_a = create_rng([1u8; 32], contract_ffi::execution::Phase::Session);
-    let mut rng_b = create_rng([1u8; 32], contract_ffi::execution::Phase::Session);
-    let random_a = gen_random(&mut rng_a);
-    let random_b = gen_random(&mut rng_b);
-
-    assert_eq!(random_a, random_b)
-}
-
-#[test]
-fn should_not_generate_same_numbers_for_different_phase() {
-    let deploy_hash = [1u8; 32];
-    let mut rng_a = create_rng(deploy_hash, contract_ffi::execution::Phase::Payment);
-    let mut rng_b = create_rng(deploy_hash, contract_ffi::execution::Phase::Session);
-    let random_a = gen_random(&mut rng_a);
-    let random_b = gen_random(&mut rng_b);
-
-    assert_ne!(
-        random_a, random_b,
-        "different phase should have different output"
-    );
-
-    let mut rng_c = create_rng(deploy_hash, contract_ffi::execution::Phase::FinalizePayment);
-    let random_c = gen_random(&mut rng_c);
-
-    assert_ne!(
-        random_a, random_c,
-        "different phase should have different output"
-    );
 }

--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -39,4 +39,6 @@ pub mod resolvers;
 pub mod runtime_context;
 pub mod tracking_copy;
 
-type URefAddr = [u8; 32];
+pub const ADDRESS_LENGTH: usize = 32;
+
+type Address = [u8; ADDRESS_LENGTH];

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -6,8 +6,6 @@ use std::rc::Rc;
 
 use blake2::digest::{Input, VariableOutput};
 use blake2::VarBlake2b;
-use rand::RngCore;
-use rand_chacha::ChaChaRng;
 
 use contract_ffi::bytesrepr::{deserialize, ToBytes};
 use contract_ffi::execution::Phase;
@@ -23,9 +21,9 @@ use engine_shared::newtypes::{CorrelationId, Validated};
 use engine_storage::global_state::StateReader;
 
 use crate::engine_state::execution_effect::ExecutionEffect;
-use crate::execution::Error;
+use crate::execution::{AddressGenerator, Error};
 use crate::tracking_copy::{AddResult, TrackingCopy};
-use crate::URefAddr;
+use crate::Address;
 
 #[cfg(test)]
 mod tests;
@@ -36,7 +34,7 @@ pub struct RuntimeContext<'a, R> {
     // Enables look up of specific uref based on human-readable name
     uref_lookup: &'a mut BTreeMap<String, Key>,
     // Used to check uref is known before use (prevents forging urefs)
-    known_urefs: HashMap<URefAddr, HashSet<AccessRights>>,
+    known_urefs: HashMap<Address, HashSet<AccessRights>>,
     // Original account for read only tasks taken before execution
     account: &'a Account,
     args: Vec<Vec<u8>>,
@@ -49,7 +47,7 @@ pub struct RuntimeContext<'a, R> {
     gas_limit: Gas,
     gas_counter: Gas,
     fn_store_id: u32,
-    rng: Rc<RefCell<ChaChaRng>>,
+    address_generator: Rc<RefCell<AddressGenerator>>,
     protocol_version: u64,
     correlation_id: CorrelationId,
     phase: Phase,
@@ -63,7 +61,7 @@ where
     pub fn new(
         state: Rc<RefCell<TrackingCopy<R>>>,
         uref_lookup: &'a mut BTreeMap<String, Key>,
-        known_urefs: HashMap<URefAddr, HashSet<AccessRights>>,
+        known_urefs: HashMap<Address, HashSet<AccessRights>>,
         args: Vec<Vec<u8>>,
         authorization_keys: BTreeSet<PublicKey>,
         account: &'a Account,
@@ -73,7 +71,7 @@ where
         gas_limit: Gas,
         gas_counter: Gas,
         fn_store_id: u32,
-        rng: Rc<RefCell<ChaChaRng>>,
+        address_generator: Rc<RefCell<AddressGenerator>>,
         protocol_version: u64,
         correlation_id: CorrelationId,
         phase: Phase,
@@ -91,7 +89,7 @@ where
             gas_limit,
             gas_counter,
             fn_store_id,
-            rng,
+            address_generator,
             protocol_version,
             correlation_id,
             phase,
@@ -206,7 +204,7 @@ where
         self.deploy_hash
     }
 
-    pub fn add_urefs(&mut self, urefs_map: HashMap<URefAddr, HashSet<AccessRights>>) {
+    pub fn add_urefs(&mut self, urefs_map: HashMap<Address, HashSet<AccessRights>>) {
         self.known_urefs.extend(urefs_map);
     }
 
@@ -218,8 +216,8 @@ where
         &self.args
     }
 
-    pub fn rng(&self) -> Rc<RefCell<ChaChaRng>> {
-        Rc::clone(&self.rng)
+    pub fn address_generator(&self) -> Rc<RefCell<AddressGenerator>> {
+        Rc::clone(&self.address_generator)
     }
 
     pub fn state(&self) -> Rc<RefCell<TrackingCopy<R>>> {
@@ -289,8 +287,7 @@ where
 
     pub fn new_uref(&mut self, value: Value) -> Result<Key, Error> {
         let uref = {
-            let mut addr = [0u8; 32];
-            self.rng.borrow_mut().fill_bytes(&mut addr);
+            let addr = self.address_generator.borrow_mut().create_address();
             URef::new(addr, AccessRights::READ_ADD_WRITE)
         };
         let key = Key::URef(uref);

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -7,6 +7,7 @@ use contract_ffi::value::account::BlockTime;
 use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
 use engine_core::engine_state::execution_effect::ExecutionEffect;
 use engine_core::execution;
+use engine_core::execution::AddressGenerator;
 use engine_core::runtime_context::RuntimeContext;
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
@@ -47,9 +48,9 @@ pub fn exec<T: FromBytes>(
     ));
 
     let phase = Phase::Session;
-    let rng = {
-        let rng = execution::create_rng(deploy_hash, phase);
-        Rc::new(RefCell::new(rng))
+    let address_generator = {
+        let address_generator = AddressGenerator::new(deploy_hash, phase);
+        Rc::new(RefCell::new(address_generator))
     };
     let gas_counter = Gas::default();
     let fn_store_id = INIT_FN_STORE_ID;
@@ -85,7 +86,7 @@ pub fn exec<T: FromBytes>(
         gas_limit,
         gas_counter,
         fn_store_id,
-        rng,
+        address_generator,
         protocol_version,
         correlation_id,
         phase,


### PR DESCRIPTION
### Overview
This PR wraps `ChaChaRng` in an `AddressGenerator` newtype to constrain its API and convey its intended usage. 

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
