### PR TITLE
ECO-117: Don't allow space in key name.

### DIFF
--- a/explorer/ui/src/containers/AuthContainer.ts
+++ b/explorer/ui/src/containers/AuthContainer.ts
@@ -182,10 +182,7 @@ class NewAccountFormData extends CleanableFormData {
       return 'Name cannot be empty!';
 
     if (this.name.indexOf(' ') > -1)
-      return "Please don't include spaces in the name. " +
-        "It will be the default name of the key files intended to be used with " +
-        "CLI tools which don't play that well with spaces, and it's just easier " +
-        "if the key and file names match.";
+      return "The account name should not include spaces.";
 
     if (this.accounts.some(x => x.name === this.name))
       return `An account with name '${this.name}' already exists.`;

--- a/explorer/ui/src/containers/AuthContainer.ts
+++ b/explorer/ui/src/containers/AuthContainer.ts
@@ -143,9 +143,9 @@ export class AuthContainer {
     }
   }
 
-  private addAccount(account: UserAccount) {
+  private async addAccount(account: UserAccount) {
     this.accounts!.push(account);
-    this.errors.capture(this.saveAccounts());
+    await this.errors.capture(this.saveAccounts());
   }
 
   private async saveAccounts() {
@@ -178,7 +178,14 @@ class NewAccountFormData extends CleanableFormData {
   @observable privateKeyBase64: string = '';
 
   protected check() {
-    if (this.name === '') return 'Name cannot be empty!';
+    if (this.name === '')
+      return 'Name cannot be empty!';
+
+    if (this.name.indexOf(' ') > -1)
+      return "Please don't include spaces in the name. " +
+        "It will be the default name of the key files intended to be used with " +
+        "CLI tools which don't play that well with spaces, and it's just easier " +
+        "if the key and file names match.";
 
     if (this.accounts.some(x => x.name === this.name))
       return `An account with name '${this.name}' already exists.`;


### PR DESCRIPTION
### Overview
It was pointed out that it's poor UX to create key files with spaces in it because then you have to be aware how to use them with CLI tools (the name has to be quoted), and it's also poor UX if the file name doesn't match the key name in the UI, therefore the UI should not allow spaces during account creation.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-117

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
