### PR TITLE
NODE-791: Test that read-only node does not accept deploy

### DIFF
--- a/integration-testing/test/cl_node/casperlabs_network.py
+++ b/integration-testing/test/cl_node/casperlabs_network.py
@@ -238,19 +238,31 @@ class OneNodeNetwork(CasperLabsNetwork):
     grpc_encryption = False
 
     def create_cl_network(self):
-        kp = self.get_key()
+        account = self.get_key()
+        self.add_bootstrap(self.docker_config(account))
+        wait_for_genesis_block(self.docker_nodes[0])
+
+    def docker_config(self, account):
         config = DockerConfig(
             self.docker_client,
-            node_private_key=kp.private_key,
-            node_public_key=kp.public_key,
+            node_private_key=account.private_key,
+            node_public_key=account.public_key,
             network=self.create_docker_network(),
             is_payment_code_enabled=self.is_payment_code_enabled,
             initial_motes=self.initial_motes,
-            node_account=kp,
+            node_account=account,
             grpc_encryption=self.grpc_encryption,
         )
-        self.add_bootstrap(config)
-        wait_for_genesis_block(self.docker_nodes[0])
+        return config
+
+
+class ReadOnlyNodeNetwork(OneNodeNetwork):
+    is_payment_code_enabled = True
+
+    def docker_config(self, account):
+        config = super().docker_config(account)
+        config.is_read_only = True
+        return config
 
 
 class PaymentNodeNetwork(OneNodeNetwork):

--- a/integration-testing/test/cl_node/docker_config.py
+++ b/integration-testing/test/cl_node/docker_config.py
@@ -42,6 +42,7 @@ class DockerConfig:
     socket_volume: Optional[str] = None
     node_account: Account = None
     grpc_encryption: bool = False
+    is_read_only: bool = False
 
     def __post_init__(self):
         if self.rand_str is None:
@@ -71,12 +72,13 @@ class DockerConfig:
         options = {
             "--server-default-timeout": "10second",
             "--server-host": server_host,
-            "--casper-validator-private-key": self.node_private_key,
             "--grpc-socket": "/root/.casperlabs/sockets/.casper-node.sock",
             "--metrics-prometheus": "",
             "--tls-certificate": self.tls_certificate_path(),
             "--tls-key": self.tls_key_path(),
         }
+        if not self.is_read_only:
+            options["--casper-validator-private-key"] = self.node_private_key
         if self.grpc_encryption:
             options["--grpc-use-tls"] = ""
         if self.bootstrap_address:

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -28,7 +28,7 @@ def docker_client_fixture() -> Generator[DockerClient, None, None]:
         docker_client.networks.prune()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def one_node_network(docker_client_fixture):
     with OneNodeNetwork(docker_client_fixture) as onn:
         onn.create_cl_network()

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -13,6 +13,7 @@ from test.cl_node.casperlabs_network import (
     TrillionPaymentNodeNetwork,
     OneNodeWithGRPCEncryption,
     EncryptedTwoNodeNetwork,
+    ReadOnlyNodeNetwork,
 )
 from docker.client import DockerClient
 
@@ -30,6 +31,13 @@ def docker_client_fixture() -> Generator[DockerClient, None, None]:
 @pytest.fixture(scope="function")
 def one_node_network(docker_client_fixture):
     with OneNodeNetwork(docker_client_fixture) as onn:
+        onn.create_cl_network()
+        yield onn
+
+
+@pytest.fixture(scope="module")
+def read_only_node_network(docker_client_fixture):
+    with ReadOnlyNodeNetwork(docker_client_fixture) as onn:
         onn.create_cl_network()
         yield onn
 

--- a/integration-testing/test/test_read_only_node.py
+++ b/integration-testing/test/test_read_only_node.py
@@ -1,0 +1,18 @@
+from pytest import raises
+
+from test.cl_node.common import PAYMENT_CONTRACT, MAX_PAYMENT_ABI
+
+
+def test_read_only_node_does_not_accept_deploy(read_only_node_network):
+    node = read_only_node_network.docker_nodes[0]
+    account = node.genesis_account
+    with raises(Exception) as exinfo:
+        node.p_client.deploy(
+            from_address=account.public_key_hex,
+            session_contract="test_helloname.wasm",
+            public_key=account.public_key_path,
+            private_key=account.private_key_path,
+            payment_contract=PAYMENT_CONTRACT,
+            payment_args=MAX_PAYMENT_ABI,
+        )
+    assert "FAILED_PRECONDITION: Node is in read-only mode" in str(exinfo.value)


### PR DESCRIPTION
### Overview
This PR adds an integration test that checks that read-only node does not accept deploys.

Added a new test fixture that starts a node in read only node (no validator's key provided on node startup).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-791

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
