### PR TITLE
NODE-841: Use dynamic fork-join pool

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -21,27 +21,29 @@ object Main {
 
   implicit val uncaughtExceptionHandler = new UncaughtExceptionHandler(shutdownTimeout = 1.minute)
 
-  def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit =
+    Configuration
+      .parse(args.toArray, sys.env)
+      .fold(
+        errors => println(errors.mkString_("", "\n", "")), {
+          case (command, conf) =>
+            // Create a scheduler to execute the program and block waiting on it to finish.
+            implicit val scheduler: Scheduler = Scheduler.forkJoin(
+              parallelism = Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 4),
+              // We could move this to config, but NodeRuntime creates even more.
+              // Let's see if it helps with the issue we see in long term tests where
+              // block processing just stops at some point.
+              maxThreads = 64,
+              name = "node-runner",
+              reporter = uncaughtExceptionHandler
+            )
 
-    val exec: Task[Unit] =
-      for {
-        commandAndConf <- Task(Configuration.parse(args.toArray, sys.env))
-        _ <- commandAndConf
-              .fold(
-                errors => log.error(errors.mkString_("", "\n", "")),
-                { case (command, conf) => updateLoggingProps(conf) >> mainProgram(command, conf) }
-              )
-      } yield ()
+            val exec = updateLoggingProps(conf) >> mainProgram(command, conf)
 
-    // Create a scheduler to execute the program and block waiting on it to finish.
-    implicit val scheduler: Scheduler = Scheduler.computation(
-      Math.max(java.lang.Runtime.getRuntime.availableProcessors(), 2),
-      "node-runner",
-      reporter = uncaughtExceptionHandler
-    )
-
-    exec.runSyncUnsafe()
-  }
+            // This uses Scala `blocking` under the hood, so make sure the thread pool we use supports it.
+            exec.runSyncUnsafe()
+        }
+      )
 
   private def updateLoggingProps(conf: Configuration): Task[Unit] = Task {
     //https://github.com/grpc/grpc-java/issues/1577#issuecomment-228342706
@@ -50,7 +52,9 @@ object Main {
     sys.props.update("node.data.dir", conf.server.dataDir.toAbsolutePath.toString)
   }
 
-  private def mainProgram(command: Configuration.Command, conf: Configuration): Task[Unit] = {
+  private def mainProgram(command: Configuration.Command, conf: Configuration)(
+      implicit scheduler: Scheduler
+  ): Task[Unit] = {
     implicit val diagnosticsService: GrpcDiagnosticsService =
       new diagnostics.client.GrpcDiagnosticsService(
         conf.server.host.getOrElse("localhost"),
@@ -81,7 +85,7 @@ object Main {
       }
   }
 
-  private def nodeProgram(conf: Configuration): Task[Unit] = {
+  private def nodeProgram(conf: Configuration)(implicit scheduler: Scheduler): Task[Unit] = {
     val node =
       for {
         _       <- log.info(api.VersionInfo.get).toEffect

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -58,21 +58,22 @@ import scala.concurrent.duration._
 
 class NodeRuntime private[node] (
     conf: Configuration,
-    id: NodeIdentifier
+    id: NodeIdentifier,
+    mainScheduler: Scheduler
 )(
     implicit log: Log[Task],
     uncaughtExceptionHandler: UncaughtExceptionHandler
 ) {
 
   private[this] val loopScheduler =
-    Scheduler.fixedPool("loop", 4, reporter = uncaughtExceptionHandler)
+    Scheduler.fixedPool("loop", 2, reporter = uncaughtExceptionHandler)
 
   // Bounded thread pool for incoming traffic. Limited thread pool size so loads of request cannot exhaust all resources.
   private[this] val ingressScheduler =
-    Scheduler.cached("ingress-io", 4, 64, reporter = uncaughtExceptionHandler)
+    Scheduler.cached("ingress-io", 2, 64, reporter = uncaughtExceptionHandler)
   // Unbounded thread pool for outgoing, blocking IO. It is recommended to have unlimited thread pools for waiting on IO.
   private[this] val egressScheduler =
-    Scheduler.cached("egress-io", 4, Int.MaxValue, reporter = uncaughtExceptionHandler)
+    Scheduler.cached("egress-io", 2, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
   private[this] val dbConnScheduler =
     Scheduler.cached("db-conn", 1, 64, reporter = uncaughtExceptionHandler)
@@ -81,7 +82,7 @@ class NodeRuntime private[node] (
 
   private implicit val concurrentEffectForEffect: ConcurrentEffect[Effect] =
     catsConcurrentEffectForEffect(
-      egressScheduler
+      mainScheduler
     )
 
   implicit val raiseIOError: RaiseIOError[Effect] = IOError.raiseIOErrorThroughSync[Effect]
@@ -443,11 +444,12 @@ object NodeRuntime {
       conf: Configuration
   )(
       implicit
+      scheduler: Scheduler,
       log: Log[Task],
       uncaughtExceptionHandler: UncaughtExceptionHandler
   ): Effect[NodeRuntime] =
     for {
       id      <- NodeEnvironment.create(conf)
-      runtime <- Task.delay(new NodeRuntime(conf, id)).toEffect
+      runtime <- Task.delay(new NodeRuntime(conf, id, scheduler)).toEffect
     } yield runtime
 }


### PR DESCRIPTION
### Overview
Long term tests still sometimes stop processing. It turns out that `Scheduler.computation` doesn't support `blocking` which is used under the hood by `runSyncUnsafe`, so potentially it only has 1 thread to use. The PR changes it to a `Scheduler.forkJoin` pool which does support it and increases the parallelism to 4 as well.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-841

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I wanted to add the thread count to config, but NodeRuntime uses many more magic numbers. Not sure how to express it in CLI parameters.
