### PR TITLE
NODE-681: Periodic syncing with a random node.

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -86,6 +86,9 @@ init-sync-round-period = "30second"
 # Maximum number of blocks to allow to be synced initially.
 init-sync-max-block-count = 1000000
 
+# Time to wait between periodic synchronization attempts.
+periodic-sync-round-period = "60second"
+
 # Maximum number of parallel block downloads initiated by the download manager.
 download-max-parallel-blocks = 10
 

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -36,7 +36,7 @@ import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
 import io.netty.handler.ssl.{ClientAuth, SslContext}
 import monix.eval.TaskLike
 import monix.execution.Scheduler
-
+import eu.timepit.refined.auto._
 import scala.concurrent.duration._
 import scala.util.Random
 import scala.util.control.NoStackTrace
@@ -153,7 +153,7 @@ package object gossiping {
       _ <- Resource
             .liftF(isInitialRef.get)
             .ifM(
-              makeInitialSynchronization(
+              makeInitialSynchronizer(
                 conf,
                 gossipServiceServer,
                 connectToGossip,
@@ -162,6 +162,14 @@ package object gossiping {
               ),
               Resource.liftF(().pure[F])
             )
+
+      _ <- makePeriodicSynchronizer(
+            conf,
+            gossipServiceServer,
+            connectToGossip,
+            awaitApproval.join,
+            isInitialRef
+          )
 
       // Start a loop to periodically print peer count, new and disconnected peers, based on NodeDiscovery.
       _ <- makePeerCountPrinter
@@ -623,7 +631,7 @@ package object gossiping {
     } yield server
 
   /** Initially sync with the bootstrap node and/or some others. */
-  private def makeInitialSynchronization[F[_]: Concurrent: Par: Log: Timer: NodeDiscovery](
+  private def makeInitialSynchronizer[F[_]: Concurrent: Par: Log: Timer: NodeDiscovery](
       conf: Configuration,
       gossipServiceServer: GossipServiceServer[F],
       connectToGossip: GossipService.Connector[F],
@@ -653,6 +661,45 @@ package object gossiping {
             } yield ()
           }
     } yield ()
+
+  /** Periodically sync with a random node. */
+  private def makePeriodicSynchronizer[F[_]: Concurrent: Par: Log: Timer: NodeDiscovery](
+      conf: Configuration,
+      gossipServiceServer: GossipServiceServer[F],
+      connectToGossip: GossipService.Connector[F],
+      awaitApproved: F[Unit],
+      isInitialRef: Ref[F, Boolean]
+  ): Resource[F, Unit] = {
+    def loop(synchronizer: InitialSynchronization[F]): F[Unit] = {
+      val syncOne: F[Unit] = for {
+        _         <- Time[F].sleep(conf.server.initSyncRoundPeriod)
+        hasPeers  <- NodeDiscovery[F].recentlyAlivePeersAscendingDistance.map(_.nonEmpty)
+        isInitial <- isInitialRef.get
+        // While the initial sync is running let's not pile on top.
+        _ <- synchronizer.sync().flatMap(identity).whenA(hasPeers && !isInitial)
+      } yield ()
+
+      syncOne.attempt *> loop(synchronizer)
+    }
+
+    for {
+      periodicSync <- Resource.pure[F, InitialSynchronization[F]] {
+                       new InitialSynchronizationImpl(
+                         NodeDiscovery[F],
+                         gossipServiceServer,
+                         selectNodes = ns => List(ns(Random.nextInt(ns.length))),
+                         minSuccessful = 1,
+                         memoizeNodes = false,
+                         skipFailedNodesInNextRounds = false,
+                         roundPeriod = conf.server.initSyncRoundPeriod,
+                         connector = connectToGossip
+                       )
+                     }
+      _ <- makeFiberResource {
+            awaitApproved *> loop(periodicSync)
+          }
+    } yield ()
+  }
 
   /** The TransportLayer setup prints the number of peers now and then which integration tests
     * may depend upon. We aren't using the `Connect` functionality so have to do it another way. */

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -672,7 +672,7 @@ package object gossiping {
   ): Resource[F, Unit] = {
     def loop(synchronizer: InitialSynchronization[F]): F[Unit] = {
       val syncOne: F[Unit] = for {
-        _         <- Time[F].sleep(conf.server.initSyncRoundPeriod)
+        _         <- Time[F].sleep(conf.server.periodicSyncRoundPeriod)
         hasPeers  <- NodeDiscovery[F].recentlyAlivePeersAscendingDistance.map(_.nonEmpty)
         isInitial <- isInitialRef.get
         // While the initial sync is running let's not pile on top.
@@ -691,7 +691,7 @@ package object gossiping {
                          minSuccessful = 1,
                          memoizeNodes = false,
                          skipFailedNodesInNextRounds = false,
-                         roundPeriod = conf.server.initSyncRoundPeriod,
+                         roundPeriod = conf.server.periodicSyncRoundPeriod,
                          connector = connectToGossip
                        )
                      }

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -79,6 +79,7 @@ object Configuration extends ParserImplicits {
       initSyncSkipFailedNodes: Boolean,
       initSyncRoundPeriod: FiniteDuration,
       initSyncMaxBlockCount: Int Refined Positive,
+      periodicSyncRoundPeriod: FiniteDuration,
       downloadMaxParallelBlocks: Int,
       downloadMaxRetries: Int Refined NonNegative,
       downloadRetryInitialBackoffPeriod: FiniteDuration,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -395,6 +395,10 @@ private[configuration] final case class Options private (
       gen[FiniteDuration]("Time to wait between initial synchronization attempts.")
 
     @scallop
+    val serverPeriodicSyncRoundPeriod =
+      gen[FiniteDuration]("Time to wait between periodic synchronization attempts.")
+
+    @scallop
     val serverDownloadMaxParallelBlocks =
       gen[Int]("Maximum number of parallel block downloads initiated by the download manager.")
     @scallop

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -32,6 +32,7 @@ init-sync-memoize-nodes = false
 init-sync-skip-failed-nodes = false
 init-sync-round-period = "1second"
 init-sync-max-block-count = 1
+periodic-sync-round-period = "1second"
 download-max-parallel-blocks = 1
 download-max-retries = 1
 download-retry-initial-backoff-period = "1second"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -76,6 +76,7 @@ class ConfigurationSpec
       initSyncSkipFailedNodes = false,
       initSyncRoundPeriod = FiniteDuration(1, TimeUnit.SECONDS),
       initSyncMaxBlockCount = 1,
+      periodicSyncRoundPeriod = FiniteDuration(1, TimeUnit.SECONDS),
       downloadMaxParallelBlocks = 1,
       downloadMaxRetries = 1,
       downloadRetryInitialBackoffPeriod = FiniteDuration(1, TimeUnit.SECONDS),


### PR DESCRIPTION
### Overview
In addition to push based notifications about new blocks, this PR adds a periodic synchronization with a single random node, by default once a minute.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-681

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I didn't want to repeat all the parameters of the initial sync process so the nodes don't become greedy and pull data from everywhere too often, but we can add it if we have to.
