### PR TITLE
NODE-847: Relay to peers in the background.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -996,7 +996,7 @@ object MultiParentCasperImpl {
           case Valid | EquivocatedBlock =>
             maybeOwnPublickKey match {
               case Some(key) if key == block.getHeader.validatorPublicKey =>
-                relaying.relay(List(block.blockHash))
+                relaying.relay(List(block.blockHash)).void
               case _ =>
                 // We were adding somebody else's block. The DownloadManager did the gossiping.
                 ().pure[F]

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/DownloadManager.scala
@@ -36,7 +36,7 @@ trait DownloadManager[F[_]] {
     *
     * The unwrapped `F[Unit]` _inside_ the `F[F[Unit]]` can be used to
     * wait until the actual download finishes, or results in an error. */
-  def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[F[Unit]]
+  def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[WaitHandle[F]]
 }
 
 object DownloadManagerImpl {
@@ -180,7 +180,11 @@ class DownloadManagerImpl[F[_]: Concurrent: Log: Timer: Metrics](
       Sync[F].unit
     )
 
-  override def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean): F[F[Unit]] =
+  override def scheduleDownload(
+      summary: BlockSummary,
+      source: Node,
+      relay: Boolean
+  ): F[WaitHandle[F]] =
     for {
       // Fail rather than block forever.
       _ <- ensureNotShutdown

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/InitialSynchronization.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/InitialSynchronization.scala
@@ -22,7 +22,7 @@ trait InitialSynchronization[F[_]] {
     *
     * @return Handle which will be resolved when node is considered to be fully synced
     */
-  def sync(): F[F[Unit]]
+  def sync(): F[WaitHandle[F]]
 }
 
 /**
@@ -46,7 +46,7 @@ class InitialSynchronizationImpl[F[_]: Concurrent: Par: Log: Timer](
     skipFailedNodesInNextRounds: Boolean,
     roundPeriod: FiniteDuration
 ) extends InitialSynchronization[F] {
-  override def sync(): F[F[Unit]] = {
+  override def sync(): F[WaitHandle[F]] = {
     def sync(node: Node): F[Unit] =
       for {
         service <- connector(node)

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/package.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/package.scala
@@ -4,4 +4,7 @@ import io.casperlabs.metrics.Metrics
 
 package object gossiping {
   val GossipingMetricsSource = Metrics.Source(CommMetricsSource, "gossiping")
+
+  /** Alias for return type of methods that return a handle that can be waited upon. */
+  type WaitHandle[F[_]] = F[Unit]
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/DownloadManagerSpec.scala
@@ -603,8 +603,9 @@ object DownloadManagerSpec {
   class MockRelaying extends Relaying[Task] {
     @volatile var relayed = Vector.empty[ByteString]
 
-    override def relay(hashes: List[ByteString]): Task[Unit] = Task.delay {
+    override def relay(hashes: List[ByteString]): Task[Task[Unit]] = Task.delay {
       synchronized { relayed = relayed ++ hashes }
+      Task.unit
     }
   }
   object MockRelaying {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -1,7 +1,7 @@
 package io.casperlabs.comm.gossiping
 
 import cats.Applicative
-import cats.effect.Sync
+import cats.effect._
 import cats.mtl.DefaultApplicativeAsk
 import cats.syntax.option._
 import cats.temp.par.Par
@@ -54,7 +54,8 @@ class RelayingSpec
           TestFixture(peers.size / 2, 0, peers, acceptOrFailure = _ => false.some) {
             (relaying, asked, _) =>
               for {
-                _ <- relaying.relay(List(hash))
+                awaitRelay <- relaying.relay(List(hash))
+                _          <- awaitRelay
               } yield asked.get() shouldBe (peers.size / 2)
           }
         }
@@ -63,7 +64,8 @@ class RelayingSpec
         forAll(genListNode, genHash) { (peers: List[Node], hash: ByteString) =>
           TestFixture(1, 50, peers, acceptOrFailure = _ => false.some) { (relaying, asked, _) =>
             for {
-              _ <- relaying.relay(List(hash))
+              awaitRelay <- relaying.relay(List(hash))
+              _          <- awaitRelay
             } yield asked.get() shouldBe 2
           }
         }
@@ -74,7 +76,8 @@ class RelayingSpec
           TestFixture(relayFactor, 100, peers, acceptOrFailure = _ => true.some) {
             (relaying, asked, _) =>
               for {
-                _ <- relaying.relay(List(hash))
+                awaitRelay <- relaying.relay(List(hash))
+                _          <- awaitRelay
               } yield asked.get() shouldBe relayFactor
           }
         }
@@ -90,7 +93,8 @@ class RelayingSpec
             acceptOrFailure = _ => synchronized(responseIter.next.some)
           ) { (relaying, asked, _) =>
             for {
-              _ <- relaying.relay(List(hash))
+              awaitRelay <- relaying.relay(List(hash))
+              _          <- awaitRelay
             } yield responses.take(asked.get()).count(identity) should be <= relayFactor
           }
         }
@@ -101,7 +105,8 @@ class RelayingSpec
           TestFixture(peers.size, 100, peers, acceptOrFailure = _ => none[Boolean], log) {
             (relaying, asked, _) =>
               for {
-                _ <- relaying.relay(List(hash))
+                awaitRelay <- relaying.relay(List(hash))
+                _          <- awaitRelay
               } yield {
                 asked.get() shouldBe peers.size
                 log.debugs.size shouldBe peers.size
@@ -115,7 +120,8 @@ class RelayingSpec
             TestFixture(peers.size, 100, peers, acceptOrFailure = _ => false.some) {
               (relaying, _, maxConcurrentRequests) =>
                 for {
-                  _ <- relaying.relay(List(hash1, hash2, hash3))
+                  awaitRelay <- relaying.relay(List(hash1, hash2, hash3))
+                  _          <- awaitRelay
                 } yield maxConcurrentRequests.get() should be > 1
             }
         }
@@ -181,7 +187,7 @@ object RelayingSpec {
         }
 
       val relayingImpl = RelayingImpl[Task](nd, gossipService, relayFactor, relaySaturation)(
-        Sync[Task],
+        Concurrent[Task],
         Par.fromParallel(CatsParallelForTask),
         log,
         metrics,

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -282,7 +282,7 @@ package object gossiping {
       } yield s.copy(connections = s.connections - peer)
     }
 
-  def makeRelaying[F[_]: Sync: Par: Log: Metrics: NodeDiscovery: NodeAsk](
+  def makeRelaying[F[_]: Concurrent: Par: Log: Metrics: NodeDiscovery: NodeAsk](
       conf: Configuration,
       connectToGossip: GossipService.Connector[F]
   ): Resource[F, Relaying[F]] =


### PR DESCRIPTION
### Overview
A node that is slow to receive gossiped data slows down the entire process. There's no reason to wait for the notifications to finish though, so run them in the background so downloads and block proposals can carry on.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-847

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
https://casperlabs.atlassian.net/browse/NODE-846 will also make arrangement so we stop trying to gossip to nodes that don't respond.