### PR TITLE
NODE-851: Change long_value to be signed.

### DIFF
--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -90,7 +90,7 @@ message Deploy {
                 state.IntList int_list = 4;
                 string string_value = 5;
                 state.StringList string_list = 6;
-                uint64 long_value = 7;
+                int64 long_value = 7;
                 state.BigInt big_int = 8;
                 state.Key key = 9;
             }


### PR DESCRIPTION
### Overview
The ABI only seems to want U64 and U512, and in `State.Value` we see `long_value` as `uint64` as well, but it doesn't sit well with the fact that `int_value` is `int32`. It seems natural to be symmetric there and allow negative values. 

Piotr thinks as long as people only pass positive values to their contracts _now_, we can use signed values in the API.

`BigInt` is also unsigned in the ABI. Perhaps we can deal with that later, since at the moment it's just a string in the API.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-851

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Not sure if we should change `State.Value.long_value` as well or not.
