### PR TITLE
NODE-328: Don't use effect in NodeRuntime, disable transport.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/CommErrorEffect.scala
+++ b/node/src/main/scala/io/casperlabs/node/CommErrorEffect.scala
@@ -1,0 +1,167 @@
+package io.casperlabs.node
+
+import cats.data.EitherT
+import cats.effect.{Concurrent, ConcurrentEffect, Fiber, Resource}
+import cats.mtl.{ApplicativeAsk, DefaultApplicativeAsk}
+import cats.syntax.applicative._
+import cats.syntax.either._
+import cats.temp.par.Par
+import cats.{~>, Applicative, Monad, Parallel}
+import io.casperlabs.catscontrib.Catscontrib._
+import io.casperlabs.catscontrib.eitherT._
+import io.casperlabs.comm.CommError
+import monix.eval.instances.CatsParallelForTask
+import monix.eval.{Task, TaskLike}
+import monix.execution.Scheduler
+
+object CommErrorEffect {
+  case class CommErrorException(error: CommError) extends Exception(error.toString)
+
+  /** Final Effect + helper methods */
+  type CommErrT[F[_], A] = EitherT[F, CommError, A]
+  type Effect[A]         = CommErrT[Task, A]
+
+  implicit class EitherEffectOps[A](e: Either[CommError, A]) {
+    def toEffect: Effect[A] = EitherT[Task, CommError, A](e.pure[Task])
+  }
+  implicit class TaskEffectOps[A](t: Task[A]) {
+    def toEffect: Effect[A] = t.liftM[CommErrT]
+  }
+
+  implicit def eitherTTaskable[F[_]: Monad: TaskLike, E]: TaskLike[EitherT[F, E, ?]] =
+    new TaskLike[EitherT[F, E, ?]] {
+      case class ToTaskException(e: E) extends RuntimeException
+
+      def toTask[A](fa: EitherT[F, E, A]): Task[A] =
+        TaskLike[F]
+          .toTask(fa.value)
+          .flatMap {
+            case Right(a) => Task.now(a)
+            case Left(e)  => Task.raiseError[A](ToTaskException(e))
+          }
+
+    }
+
+  implicit def eitherTApplicativeAsk[A](
+      implicit ev: ApplicativeAsk[Task, A]
+  ): ApplicativeAsk[Effect, A] =
+    new DefaultApplicativeAsk[Effect, A] {
+      val applicative: Applicative[Effect] = Applicative[Effect]
+      def ask: Effect[A]                   = ev.ask.toEffect
+    }
+
+  implicit class ResourceTaskEffectOps[A](r: Resource[Task, A]) {
+    def toEffect: Resource[Effect, A] = Resource {
+      r.allocated.map {
+        case (x, releaseTask) => (x, releaseTask.toEffect)
+      }.toEffect
+    }
+  }
+
+  // We could try figuring this out for a type as follows and then we wouldn't have to use `raiseError`:
+  // type EffectPar[A] = EitherT[Task.Par, CommError, A]
+  val catsParallelForEffect = new Parallel[Effect, Task.Par] {
+
+    override def applicative: Applicative[Task.Par] = CatsParallelForTask.applicative
+    override def monad: Monad[Effect]               = Monad[Effect]
+
+    override val sequential: Task.Par ~> Effect = new (Task.Par ~> Effect) {
+      def apply[A](fa: Task.Par[A]): Effect[A] = {
+        val task = Task.Par.unwrap(fa).map(_.asRight[CommError]).onErrorRecover {
+          case CommErrorException(ce) => ce.asLeft[A]
+        }
+        EitherT(task)
+      }
+    }
+    override val parallel: Effect ~> Task.Par = new (Effect ~> Task.Par) {
+      def apply[A](fa: Effect[A]): Task.Par[A] = {
+        val task = fa.value.flatMap {
+          case Left(ce) => Task.raiseError(new CommErrorException(ce))
+          case Right(a) => Task.pure(a)
+        }
+        Task.Par.apply(task)
+      }
+    }
+  }
+
+  val catsParForEffect: Par[Effect] = Par.fromParallel(catsParallelForEffect)
+
+  def catsConcurrentEffectForEffect(implicit scheduler: Scheduler) =
+    new ConcurrentEffect[Effect] {
+      val C = implicitly[Concurrent[Effect]]
+      val E = implicitly[cats.effect.Effect[Task]]
+      val F = implicitly[ConcurrentEffect[Task]]
+
+      // Members declared in cats.Applicative
+      def pure[A](x: A): Effect[A] =
+        C.pure[A](x)
+
+      // Members declared in cats.ApplicativeError
+      def handleErrorWith[A](fa: Effect[A])(f: Throwable => Effect[A]): Effect[A] =
+        C.handleErrorWith[A](fa)(f)
+
+      def raiseError[A](e: Throwable): Effect[A] =
+        C.raiseError[A](e)
+
+      // Members declared in cats.effect.Async
+      def async[A](k: (Either[Throwable, A] => Unit) => Unit): Effect[A] =
+        C.async[A](k)
+
+      def asyncF[A](k: (Either[Throwable, A] => Unit) => Effect[Unit]): Effect[A] =
+        C.asyncF[A](k)
+
+      // Members declared in cats.effect.Bracket
+      def bracketCase[A, B](acquire: Effect[A])(
+          use: A => Effect[B]
+      )(release: (A, cats.effect.ExitCase[Throwable]) => Effect[Unit]): Effect[B] =
+        C.bracketCase[A, B](acquire)(use)(release)
+
+      // Members declared in cats.effect.Concurrent
+      def racePair[A, B](
+          fa: Effect[A],
+          fb: Effect[B]
+      ): Effect[Either[(A, Fiber[Effect, B]), (Fiber[Effect, A], B)]] =
+        C.racePair[A, B](fa, fb)
+
+      def start[A](fa: Effect[A]): Effect[Fiber[Effect, A]] =
+        C.start[A](fa)
+
+      // Members declared in cats.effect.ConcurrentEffect
+      def runCancelable[A](fa: Effect[A])(
+          cb: Either[Throwable, A] => cats.effect.IO[Unit]
+      ): cats.effect.SyncIO[cats.effect.CancelToken[Effect]] =
+        F.runCancelable(fa.value) {
+          case Left(ex)        => cb(Left(ex))
+          case Right(Left(ce)) => cb(Left(CommErrorException(ce)))
+          case Right(Right(x)) => cb(Right(x))
+        } map { x =>
+          EitherT {
+            x.map(_.asRight[CommError]).onErrorRecover {
+              case CommErrorException(ce) => ce.asLeft[Unit]
+            }
+          }
+        }
+
+      // Members declared in cats.effect.Effect
+      def runAsync[A](fa: Effect[A])(
+          cb: Either[Throwable, A] => cats.effect.IO[Unit]
+      ): cats.effect.SyncIO[Unit] =
+        E.runAsync(fa.value) {
+          case Left(ex)        => cb(Left(ex))
+          case Right(Left(ce)) => cb(Left(CommErrorException(ce)))
+          case Right(Right(x)) => cb(Right(x))
+        }
+
+      // Members declared in cats.FlatMap
+      def flatMap[A, B](fa: Effect[A])(f: A => Effect[B]): Effect[B] =
+        C.flatMap[A, B](fa)(f)
+
+      def tailRecM[A, B](a: A)(f: A => Effect[Either[A, B]]): Effect[B] =
+        C.tailRecM[A, B](a)(f)
+
+      // Members declared in cats.effect.Sync
+      def suspend[A](thunk: => Effect[A]): Effect[A] =
+        C.suspend[A](thunk)
+
+    }
+}

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -97,13 +97,9 @@ object Main {
     def raise(msg: String) =
       Task.raiseError(new Exception(msg) with NoStackTrace)
 
-    node.value >>= {
+    node.attempt >>= {
       case Right(_) =>
         Task.unit
-      case Left(CouldNotConnectToBootstrap) =>
-        raise("Node could not connect to bootstrap node.")
-      case Left(InitializationError(msg)) =>
-        raise(msg)
       case Left(error) =>
         raise(s"Failed! Reason: '$error")
     }

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -80,12 +80,12 @@ class NodeRuntime private[node] (
   private[this] val dbIOScheduler =
     Scheduler.cached("db-io", 1, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
-  private implicit val concurrentEffectForEffect: ConcurrentEffect[Effect] =
-    catsConcurrentEffectForEffect(
-      mainScheduler
-    )
-
   implicit val raiseIOError: RaiseIOError[Effect] = IOError.raiseIOErrorThroughSync[Effect]
+
+  implicit val concurrentEffectForEffect = {
+    implicit val s = mainScheduler
+    implicitly[ConcurrentEffect[Effect]]
+  }
 
   // intra-node gossiping port.
   private val port             = conf.server.port
@@ -108,12 +108,9 @@ class NodeRuntime private[node] (
       conf      <- rpConf[Task](local, bootstrap)
     } yield conf).toEffect
 
-    implicit val logEff: Log[Effect] = Log.eitherTLog(Monad[Task], log)
-
     implicit val logId: Log[Id]         = Log.logId
     implicit val metricsId: Metrics[Id] = diagnostics.effects.metrics[Id](syncId)
-    implicit val parForEff: Par[Effect] = catsParForEffect
-    implicit val filesApiEff            = FilesAPI.create[Effect](Sync[Effect], logEff)
+    implicit val filesApiEff            = FilesAPI.create[Effect](Sync[Effect], log)
 
     // SSL context to use for the public facing API.
     val maybeApiSslContext = if (conf.grpc.useTls) {
@@ -127,8 +124,6 @@ class NodeRuntime private[node] (
       implicit val jvmMetrics  = diagnostics.effects.jvmMetrics[Task]
       implicit val nodeAsk     = eitherTApplicativeAsk(effects.peerNodeAsk(state))
 
-      implicit val metricsEff: Metrics[Effect] =
-        Metrics.eitherT[CommError, Task](Monad[Task], metrics)
       val resources = for {
         implicit0(executionEngineService: ExecutionEngineService[Effect]) <- GrpcExecutionEngineService[
                                                                               Effect
@@ -179,9 +174,9 @@ class NodeRuntime private[node] (
                                                           100L * 1024L * 1024L * 4096L
                                                         )(
                                                           Concurrent[Effect],
-                                                          logEff,
+                                                          log,
                                                           raiseIOError,
-                                                          metricsEff
+                                                          metrics
                                                         ) evalMap { underlying =>
                                                           CachingBlockStorage[Effect](
                                                             underlying,
@@ -189,7 +184,7 @@ class NodeRuntime private[node] (
                                                               conf.blockstorage.cacheMaxSizeBytes
                                                           )(
                                                             Sync[Effect],
-                                                            metricsEff
+                                                            metrics
                                                           )
                                                         }
 
@@ -199,9 +194,9 @@ class NodeRuntime private[node] (
                                                       blockStorage
                                                     )(
                                                       Concurrent[Effect],
-                                                      logEff,
+                                                      log,
                                                       raiseIOError,
-                                                      metricsEff
+                                                      metrics
                                                     )
 
         _ <- Resource.liftF {
@@ -234,7 +229,7 @@ class NodeRuntime private[node] (
           Effect
         ]()(
           Monad[Effect],
-          logEff
+          log
         )
 
         blockApiLock <- Resource.liftF(Semaphore[Effect](1))
@@ -280,12 +275,7 @@ class NodeRuntime private[node] (
                 egressScheduler
               )
             } else {
-              casper.transport.apply(
-                port,
-                conf,
-                ingressScheduler,
-                egressScheduler
-              )
+              sys.error("The transport layer can no longer be used!")
             }
       } yield (nodeDiscovery, multiParentCasperRef, deployBuffer)
 
@@ -351,14 +341,14 @@ class NodeRuntime private[node] (
     for {
       _ <- addShutdownHook(release).toEffect
       _ <- info
-      _ <- Task.defer(fetchLoop.forever.value).executeOn(loopScheduler).start.toEffect
+      _ <- Task.defer(fetchLoop.forever).executeOn(loopScheduler).start.toEffect
       _ <- Task
-            .defer(cleanupDiscardedDeploysLoop.forever.value)
+            .defer(cleanupDiscardedDeploysLoop.forever)
             .executeOn(loopScheduler)
             .start
             .toEffect
       _ <- Task
-            .defer(checkPendingDeploysExpirationLoop.forever.value)
+            .defer(checkPendingDeploysExpirationLoop.forever)
             .executeOn(loopScheduler)
             .start
             .toEffect
@@ -375,7 +365,7 @@ class NodeRuntime private[node] (
     // Everything has been moved to Resources.
     val task = for {
       _ <- log.info("Shutting down...")
-      _ <- release.value
+      _ <- release
       _ <- log.info("Goodbye.")
     } yield ()
     // Run the release synchronously so that we can see the final message.
@@ -392,14 +382,12 @@ class NodeRuntime private[node] (
     * configured environment and they mean immediate termination of the program
     */
   private def handleUnrecoverableErrors(prog: Effect[Unit]): Effect[Unit] =
-    EitherT[Task, CommError, Unit](
-      prog.value
-        .onErrorHandleWith { th =>
-          log.error("Caught unhandable error. Exiting. Stacktrace below.") *> Task.delay {
-            th.printStackTrace()
-          }
-        } *> Task.delay(System.exit(1)).as(Right(()))
-    )
+    prog
+      .onErrorHandleWith { th =>
+        log.error("Caught unhandable error. Exiting. Stacktrace below.") *> Task.delay {
+          th.printStackTrace()
+        }
+      } *> Task.delay(System.exit(1)).as(Right(()))
 
   private def rpConf[F[_]: Sync](local: Node, maybeBootstrap: Option[Node]) =
     Ref.of[F, RPConf](

--- a/node/src/main/scala/io/casperlabs/node/casper/transport.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/transport.scala
@@ -29,7 +29,8 @@ import io.casperlabs.comm.rp.Connect.{Connections, ConnectionsCell, RPConfAsk}
 import io.casperlabs.comm.rp._
 import io.casperlabs.comm.transport._
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.node._
+import io.casperlabs.node.CommErrorEffect._
+import io.casperlabs.node.effects
 import io.casperlabs.node.configuration.Configuration
 import io.casperlabs.p2p.effects._
 import io.casperlabs.shared.PathOps._

--- a/node/src/main/scala/io/casperlabs/node/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/package.scala
@@ -21,14 +21,10 @@ package node {
 package object node {
 
   /** Final Effect + helper methods */
-  type CommErrT[F[_], A] = EitherT[F, CommError, A]
-  type Effect[A]         = CommErrT[Task, A]
+  type Effect[A] = Task[A]
 
-  implicit class EitherEffectOps[A](e: Either[CommError, A]) {
-    def toEffect: Effect[A] = EitherT[Task, CommError, A](e.pure[Task])
-  }
   implicit class TaskEffectOps[A](t: Task[A]) {
-    def toEffect: Effect[A] = t.liftM[CommErrT]
+    def toEffect: Effect[A] = t
   }
 
   implicit def eitherTTaskable[F[_]: Monad: TaskLike, E]: TaskLike[EitherT[F, E, ?]] =
@@ -60,111 +56,4 @@ package object node {
       }.toEffect
     }
   }
-
-  // We could try figuring this out for a type as follows and then we wouldn't have to use `raiseError`:
-  // type EffectPar[A] = EitherT[Task.Par, CommError, A]
-  val catsParallelForEffect = new Parallel[Effect, Task.Par] {
-
-    override def applicative: Applicative[Task.Par] = CatsParallelForTask.applicative
-    override def monad: Monad[Effect]               = Monad[Effect]
-
-    override val sequential: Task.Par ~> Effect = new (Task.Par ~> Effect) {
-      def apply[A](fa: Task.Par[A]): Effect[A] = {
-        val task = Task.Par.unwrap(fa).map(_.asRight[CommError]).onErrorRecover {
-          case CommErrorException(ce) => ce.asLeft[A]
-        }
-        EitherT(task)
-      }
-    }
-    override val parallel: Effect ~> Task.Par = new (Effect ~> Task.Par) {
-      def apply[A](fa: Effect[A]): Task.Par[A] = {
-        val task = fa.value.flatMap {
-          case Left(ce) => Task.raiseError(new CommErrorException(ce))
-          case Right(a) => Task.pure(a)
-        }
-        Task.Par.apply(task)
-      }
-    }
-  }
-
-  val catsParForEffect: Par[Effect] = Par.fromParallel(catsParallelForEffect)
-
-  def catsConcurrentEffectForEffect(implicit scheduler: Scheduler) =
-    new ConcurrentEffect[Effect] {
-      val C = implicitly[Concurrent[Effect]]
-      val E = implicitly[cats.effect.Effect[Task]]
-      val F = implicitly[ConcurrentEffect[Task]]
-
-      // Members declared in cats.Applicative
-      def pure[A](x: A): Effect[A] =
-        C.pure[A](x)
-
-      // Members declared in cats.ApplicativeError
-      def handleErrorWith[A](fa: Effect[A])(f: Throwable => Effect[A]): Effect[A] =
-        C.handleErrorWith[A](fa)(f)
-
-      def raiseError[A](e: Throwable): Effect[A] =
-        C.raiseError[A](e)
-
-      // Members declared in cats.effect.Async
-      def async[A](k: (Either[Throwable, A] => Unit) => Unit): Effect[A] =
-        C.async[A](k)
-
-      def asyncF[A](k: (Either[Throwable, A] => Unit) => Effect[Unit]): Effect[A] =
-        C.asyncF[A](k)
-
-      // Members declared in cats.effect.Bracket
-      def bracketCase[A, B](acquire: Effect[A])(
-          use: A => Effect[B]
-      )(release: (A, cats.effect.ExitCase[Throwable]) => Effect[Unit]): Effect[B] =
-        C.bracketCase[A, B](acquire)(use)(release)
-
-      // Members declared in cats.effect.Concurrent
-      def racePair[A, B](
-          fa: Effect[A],
-          fb: Effect[B]
-      ): Effect[Either[(A, Fiber[Effect, B]), (Fiber[Effect, A], B)]] =
-        C.racePair[A, B](fa, fb)
-
-      def start[A](fa: Effect[A]): Effect[Fiber[Effect, A]] =
-        C.start[A](fa)
-
-      // Members declared in cats.effect.ConcurrentEffect
-      def runCancelable[A](fa: Effect[A])(
-          cb: Either[Throwable, A] => cats.effect.IO[Unit]
-      ): cats.effect.SyncIO[cats.effect.CancelToken[Effect]] =
-        F.runCancelable(fa.value) {
-          case Left(ex)        => cb(Left(ex))
-          case Right(Left(ce)) => cb(Left(CommErrorException(ce)))
-          case Right(Right(x)) => cb(Right(x))
-        } map { x =>
-          EitherT {
-            x.map(_.asRight[CommError]).onErrorRecover {
-              case CommErrorException(ce) => ce.asLeft[Unit]
-            }
-          }
-        }
-
-      // Members declared in cats.effect.Effect
-      def runAsync[A](fa: Effect[A])(
-          cb: Either[Throwable, A] => cats.effect.IO[Unit]
-      ): cats.effect.SyncIO[Unit] =
-        E.runAsync(fa.value) {
-          case Left(ex)        => cb(Left(ex))
-          case Right(Left(ce)) => cb(Left(CommErrorException(ce)))
-          case Right(Right(x)) => cb(Right(x))
-        }
-
-      // Members declared in cats.FlatMap
-      def flatMap[A, B](fa: Effect[A])(f: A => Effect[B]): Effect[B] =
-        C.flatMap[A, B](fa)(f)
-
-      def tailRecM[A, B](a: A)(f: A => Effect[Either[A, B]]): Effect[B] =
-        C.tailRecM[A, B](a)(f)
-
-      // Members declared in cats.effect.Sync
-      def suspend[A](thunk: => Effect[A]): Effect[A] =
-        C.suspend[A](thunk)
-
-    }
 }


### PR DESCRIPTION
### Overview
Checking how much work it would be to remove the `Effect`. In theory removing a layer of monad transformers could offer some speed up.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-328

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
