### PR TITLE
NODE-675: remove query limiting deploy selection to 1 per account

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/deploybuffer/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/deploybuffer/DeployBuffer.scala
@@ -72,13 +72,6 @@ import scala.concurrent.duration.FiniteDuration
 
   def readPending: F[List[Deploy]]
 
-  /** Reads deploys in PENDING state, unique per account, returning oldest one.
-    *
-    * NOTE: Since deploy buffer tables don't have deploy's nonce we pick entry
-    * with the lowest `creation_time_seconds` value.
-    */
-  def readAccountPendingOldest(): fs2.Stream[F, DeployHash]
-
   def readPendingHashes: F[List[ByteString]]
 
   def getPendingOrProcessed(hash: ByteString): F[Option[Deploy]]
@@ -214,22 +207,6 @@ class DeployBufferImpl[F[_]: Metrics: Time: Sync](chunkSize: Int)(
 
   override def readPendingHashes: F[List[ByteString]] =
     readHashesByStatus(PendingStatusCode)
-
-  override def readAccountPendingOldest(): fs2.Stream[F, DeployHash] =
-    sql"""| SELECT hash FROM (
-          |   SELECT bd.hash, bd.account, d.create_time_seconds
-          |   FROM deploys d
-          |   INNER JOIN buffered_deploys bd
-          |   ON d.hash = bd.hash
-          |   WHERE bd.status = $PendingStatusCode
-          | ) pda
-          | GROUP BY pda.account
-          | HAVING MIN(pda.create_time_seconds)
-          | ORDER BY pda.create_time_seconds
-          |""".stripMargin
-      .query[DeployHash]
-      .stream
-      .transact(xa)
 
   private def readByStatus(status: Int): F[List[Deploy]] =
     sql"""|SELECT data FROM deploys

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -251,8 +251,8 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       signedBlock <- (node0.casperEff.deploy(data1) *> node0.casperEff.createBlock)
                       .map { case Created(block) => block }
 
-      // NOTE: It won't actually include `data1` in the block because it still has `data0`.
-      _ = signedBlock.getBody.deploys.map(_.getDeploy) should contain only (data0)
+      // NOTE: It can include both data0 and data1 because they don't conflict.
+      _ = signedBlock.getBody.deploys.map(_.getDeploy) should contain only (data0, data1)
 
       _ <- node0.casperEff.addBlock(signedBlock)
       _ <- node1.receive() //receives block1; should not ask for block0
@@ -1141,43 +1141,6 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       Created(block) <- node.casperEff.deploy(deploy) *> MultiParentCasper[Effect].createBlock
       _              <- MultiParentCasper[Effect].addBlock(block)
       _              <- MultiParentCasper[Effect].createBlock shouldBeF io.casperlabs.casper.NoNewDeploys
-    } yield ()
-  }
-
-  it should "only execute the next deploy per account in one proposal" in effectTest {
-    val node             = standaloneEff(genesis, transforms, validatorKeys.head)
-    implicit val timeEff = new LogicalTime[Effect]
-
-    def propose() =
-      for {
-        create         <- node.casperEff.createBlock
-        Created(block) = create
-        _              <- node.casperEff.addBlock(block)
-      } yield block
-
-    for {
-      deploy1 <- ProtoUtil.basicDeploy[Effect]()
-      deploy2 <- ProtoUtil.basicDeploy[Effect]()
-      _       <- node.casperEff.deploy(deploy1)
-      _       <- node.casperEff.deploy(deploy2)
-
-      block1           <- propose()
-      _                = block1.getBody.deploys.map(_.getDeploy) should contain only (deploy1)
-      processedDeploys <- node.deployBufferEff.readProcessed
-      pendingDeploys   <- node.deployBufferEff.readPending
-      _                = processedDeploys should contain only (deploy1)
-      _                = pendingDeploys should contain only (deploy2)
-
-      block2           <- propose()
-      _                = block2.getBody.deploys.map(_.getDeploy) should contain only (deploy2)
-      processedDeploys <- node.deployBufferEff.readProcessed
-      pendingDeploys   <- node.deployBufferEff.readPending
-      _ = processedDeploys should contain theSameElementsAs List(
-        deploy1,
-        deploy2
-      )
-      _ = pendingDeploys shouldBe empty
-
     } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/DeployBufferSpec.scala
@@ -303,26 +303,6 @@ trait DeployBufferSpec
         timeout = 15.seconds
       )
     }
-
-    "readAccountPendingOldest" should {
-      val existMultipleDeploysPerAccount: List[Deploy] => Boolean =
-        deploys => deploys.groupBy(_.getHeader.accountPublicKey).exists(_._2.size > 1)
-      "return PENDING deploys, one per account, with the lowest creation_time_second" in forAll(
-        deploysGen().suchThat(existMultipleDeploysPerAccount)
-      ) { deploys =>
-        testFixture { db =>
-          for {
-            _ <- db.addAsPending(deploys)
-            expected = deploys
-              .groupBy(_.getHeader.accountPublicKey)
-              .mapValues(_.minBy(_.getHeader.timestamp))
-              .values
-              .map(_.deployHash)
-            got <- db.readAccountPendingOldest().compile.toList
-          } yield got should contain theSameElementsAs expected
-        }
-      }
-    }
   }
 
   private def chooseHash(deploys: List[Deploy]): ByteString =

--- a/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBuffer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/deploybuffer/MockDeployBuffer.scala
@@ -114,19 +114,6 @@ class MockDeployBuffer[F[_]: Sync: Log](
 
   override def readPendingHashes: F[List[ByteString]] = readPending.map(_.map(_.deployHash))
 
-  override def readAccountPendingOldest(): fs2.Stream[F, DeployHash] =
-    fs2.Stream
-      .eval(
-        readPending.map(
-          _.groupBy(_.getHeader.accountPublicKey)
-            .mapValues(_.minBy(_.getHeader.timestamp))
-            .values
-            .map(_.deployHash)
-            .toList
-        )
-      )
-      .flatMap(deploys => fs2.Stream.fromIterator(deploys.toIterator))
-
   override def getByHashes(l: Set[ByteString]): fs2.Stream[F, Deploy] = {
     val deploys =
       (readPending, readProcessed).mapN(_ ++ _).map(_.filter(d => l.contains(d.deployHash)))


### PR DESCRIPTION
### Overview
Without nonces we no longer to need to forcefully limit to picking only one deploy per account in each block.

@goral09 pointed out that it will likely still be the common case that deploys from the same account will not make it into the same block due to conflicts in payment code (the standard payment code pays from the main purse, which would be the same for two deploys from the same account). Obviously a savvy user could work around this by having a payment code that uses different purses for different deploys to eliminate those conflicts, but we do not want to assume everyone will do that. The next step to allowing multiple deploys from the same account be in the same block is to allow sequentially executed deploys in a block (we can start working on this feature next sprint).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-675

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
