### PR TITLE
NODE-436: Accept multiple bootstrap options.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/comm/CommUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/comm/CommUtil.scala
@@ -84,7 +84,7 @@ object CommUtil {
       : F[Unit] = {
     val request = ApprovedBlockRequest("PleaseSendMeAnApprovedBlock").toByteString
     for {
-      maybeBootstrap <- RPConfAsk[F].reader(_.bootstrap)
+      maybeBootstrap <- RPConfAsk[F].reader(_.bootstraps.headOption)
       local          <- RPConfAsk[F].reader(_.local)
       _ <- maybeBootstrap match {
             case Some(bootstrap) =>

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -32,7 +32,7 @@ object NodeDiscoveryImpl {
       ingressScheduler: Scheduler,
       egressScheduler: Scheduler
   )(
-      init: Option[Node]
+      init: List[Node]
   ): Resource[F, NodeDiscovery[F]] = {
 
     def makeKademliaRpc: Resource[F, GrpcKademliaService[F]] =
@@ -85,7 +85,7 @@ object NodeDiscoveryImpl {
                             alivePeersCacheSize = alivePeersCacheSize
                           )
                         }
-        _ <- init.fold(().pure[F])(nodeDiscovery.addNode)
+        _ <- init.traverse(nodeDiscovery.addNode)
       } yield nodeDiscovery)
 
     def scheduleRecentlyAlivePeersCacheUpdate(implicit N: NodeDiscoveryImpl[F]): Resource[F, Unit] =

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeUtils.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeUtils.scala
@@ -48,7 +48,6 @@ object NodeUtils {
               protocol  <- url.query.param("protocol").flatMap(v => Try(v.toInt).toOption)
             } yield apply(NodeIdentifier(id), host.value, protocol, discovery)
         )
-
       maybePeer.fold[Either[CommError, Node]](Left(ParseError(s"bad address: $str")))(Right(_))
     }
   }

--- a/comm/src/main/scala/io/casperlabs/comm/rp/RPConf.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/rp/RPConf.scala
@@ -5,7 +5,7 @@ import io.casperlabs.comm.discovery.Node
 
 final case class RPConf(
     local: Node,
-    bootstrap: Option[Node],
+    bootstraps: List[Node],
     defaultTimeout: FiniteDuration,
     clearConnections: ClearConnectionsConf
 )

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -2,6 +2,7 @@ package io.casperlabs.comm.gossiping
 
 import cats._
 import cats.implicits._
+import cats.data.NonEmptyList
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus._
 import io.casperlabs.comm.discovery.{Node, NodeDiscovery, NodeIdentifier}
@@ -77,7 +78,7 @@ class GenesisApproverSpec extends WordSpecLike with Matchers with ArbitraryConse
     }
   }
 
-  "fromBootstrap" should {
+  "fromBootstraps" should {
     "return UNAVAILABLE while there is no candidate" in {
       TestFixture.fromBootstrap(
         remoteCandidate = () => Task.raiseError(Unavailable("No candidate here."))
@@ -553,7 +554,7 @@ object GenesisApproverSpec extends ArbitraryConsensus {
         implicit scheduler: Scheduler
     ): Unit =
       GenesisApproverImpl
-        .fromBootstrap[Task](
+        .fromBootstraps[Task](
           backend = environment,
           new MockNodeDiscovery(peers),
           connectToGossip = (node: Node) =>
@@ -564,7 +565,7 @@ object GenesisApproverSpec extends ArbitraryConsensus {
                 gossipService
             },
           relayFactor,
-          bootstrap,
+          NonEmptyList.one(bootstrap),
           pollInterval,
           downloadManager = environment
         )

--- a/comm/src/test/scala/io/casperlabs/comm/rp/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/rp/ClearConnectionsSpec.scala
@@ -141,7 +141,7 @@ class ClearConnectionsSpec
         clearConnections = ClearConnectionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = 1.milli,
         local = peer("src"),
-        bootstrap = None
+        bootstraps = Nil
       )
     )
 

--- a/comm/src/test/scala/io/casperlabs/comm/rp/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/rp/FindAndConnectSpec.scala
@@ -126,7 +126,7 @@ class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach w
         clearConnections = ClearConnectionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = defaultTimeout,
         local = peer("src"),
-        bootstrap = None
+        bootstraps = Nil
       )
     )
 

--- a/comm/src/test/scala/io/casperlabs/comm/rp/ResestConnectionsSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/rp/ResestConnectionsSpec.scala
@@ -68,7 +68,7 @@ class ResestConnectionsSpec
         clearConnections = ClearConnectionsConf(maxNumOfConnections, numOfConnectionsPinged),
         defaultTimeout = 1.milli,
         local = peer("src"),
-        bootstrap = None
+        bootstraps = Nil
       )
     )
 

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -53,7 +53,7 @@ object EffectsTestInstances {
       clearConnections: ClearConnectionsConf = ClearConnectionsConf(1, 1)
   ) =
     new ConstApplicativeAsk[F, RPConf](
-      RPConf(local, Some(local), defaultTimeout, clearConnections)
+      RPConf(local, List(local), defaultTimeout, clearConnections)
     )
 
   class TransportLayerStub[F[_]: Sync] extends TransportLayer[F] {

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -26,8 +26,9 @@ no-upnp = false
 # Default timeout for roundtrip connections.
 default-timeout = "5second"
 
-# Bootstrap casperlabs node address for initial seed.
+# Bootstrap casperlabs node addresses for initial seeds. Empty defaut provided for standalone mode.
 # bootstrap = "casperlabs://<keccak-hash-of-tls-public-key>@<host>?protocol=<intra-node-port>&discovery=<kademila-port>"
+bootstrap = ""
 
 # Path to data directory.
 data-dir = "$HOME/.casperlabs"

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -43,6 +43,7 @@ import scala.util.control.NoStackTrace
 
 /** Create the Casper stack using the GossipService. */
 package object gossiping {
+  import cats.data.NonEmptyList
   private implicit val metricsSource: Metrics.Source =
     Metrics.Source(Metrics.Source(Metrics.BaseSource, "node"), "gossiping")
 
@@ -501,12 +502,12 @@ package object gossiping {
                    } yield approver
                  } else {
                    for {
-                     bootstrap <- unsafeGetBootstrap[F](conf)
-                     approver <- GenesisApproverImpl.fromBootstrap(
+                     bootstraps <- unsafeGetBootstraps[F](conf)
+                     approver <- GenesisApproverImpl.fromBootstraps(
                                   backend,
                                   NodeDiscovery[F],
                                   connectToGossip,
-                                  bootstrap = bootstrap,
+                                  bootstraps = bootstraps,
                                   relayFactor = conf.server.approvalRelayFactor,
                                   pollInterval = conf.server.approvalPollInterval,
                                   downloadManager = downloadManager
@@ -737,11 +738,13 @@ package object gossiping {
     PrettyPrinter.buildString(hash)
 
   // Should only be called in non-stand alone mode.
-  private def unsafeGetBootstrap[F[_]: MonadThrowable](conf: Configuration): Resource[F, Node] =
+  private def unsafeGetBootstraps[F[_]: MonadThrowable](
+      conf: Configuration
+  ): Resource[F, NonEmptyList[Node]] =
     Resource.liftF(
       MonadThrowable[F]
         .fromOption(
-          conf.server.bootstrap,
+          NonEmptyList.fromList(conf.server.bootstrap),
           new java.lang.IllegalStateException("Bootstrap node hasn't been configured.")
         )
     )

--- a/node/src/main/scala/io/casperlabs/node/configuration/ConfParser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ConfParser.scala
@@ -36,8 +36,9 @@ private[configuration] trait ConfParserImplicits {
       pathToField: List[String],
       P: Parser[A]
   ): ValidationResult[Option[A]] = {
-    val key = snakify(("cl" :: pathToField.reverse).mkString("_"))
-    envVars.get(key).map(P.parse).toValidatedNel
+    val key      = snakify(("cl" :: pathToField.reverse).mkString("_"))
+    val maybeVal = envVars.get(key)
+    maybeVal.map(P.parse).toValidatedNel
   }
 
   def parseFromConfigFile[A](
@@ -51,10 +52,12 @@ private[configuration] trait ConfParserImplicits {
       cliByName: CamelCase => Option[String],
       pathToField: List[String],
       P: Parser[A]
-  ): ValidationResult[Option[A]] =
-    cliByName(constructCamelCase(pathToField))
+  ): ValidationResult[Option[A]] = {
+    val maybeVal = cliByName(constructCamelCase(pathToField))
+    maybeVal
       .map(P.parse)
       .toValidatedNel
+  }
 
   implicit def optionableSubConfigs[A: IsSubConfig](
       implicit

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -59,7 +59,7 @@ object Configuration extends ParserImplicits {
       dynamicHostAddress: Boolean,
       noUpnp: Boolean,
       defaultTimeout: FiniteDuration,
-      bootstrap: Option[Node],
+      bootstrap: List[Node],
       dataDir: Path,
       maxNumOfConnections: Int,
       maxMessageSize: Int,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -2,9 +2,9 @@ package io.casperlabs.node.configuration
 
 import java.nio.file.Path
 
-import cats.Show
-import cats.syntax.either._
-import cats.syntax.option._
+import cats._
+import cats.syntax._
+import cats.implicits._
 import com.github.ghik.silencer.silent
 import io.casperlabs.comm.discovery.Node
 import io.casperlabs.configuration.cli.scallop
@@ -20,17 +20,21 @@ import scala.language.implicitConversions
 private[configuration] object Converter extends ParserImplicits {
   import Options._
 
-  implicit val bootstrapAddressConverter: ValueConverter[Node] = new ValueConverter[Node] {
-    def parse(s: List[(String, List[String])]): Either[String, Option[Node]] =
-      s match {
-        case (_, uri :: Nil) :: Nil =>
-          Parser[Node].parse(uri).map(_.some)
-        case Nil => Right(None)
-        case _   => Left("provide the casperlabs node bootstrap address")
-      }
+  implicit val bootstrapAddressConverter: ValueConverter[List[Node]] =
+    new ValueConverter[List[Node]] {
+      def parse(s: List[(String, List[String])]): Either[String, Option[List[Node]]] =
+        s.unzip._2.flatten
+          .flatMap(_.split(' '))
+          .filterNot(_.isEmpty)
+          .map(uri => Parser[Node].parse(uri))
+          .sequence
+          .map {
+            case Nil   => None
+            case nodes => Some(nodes)
+          }
 
-    val argType: ArgType.V = ArgType.SINGLE
-  }
+      val argType: ArgType.V = ArgType.LIST
+    }
 
   implicit val optionsFlagConverter: ValueConverter[Flag] = new ValueConverter[Flag] {
     def parse(s: List[(String, List[String])]): Either[String, Option[Flag]] =
@@ -79,6 +83,10 @@ private[configuration] final case class Options private (
   import io.casperlabs.comm.discovery.NodeUtils
   import Options.Flag
 
+  //Used in @scallop macro when it puts things into `field`
+  private implicit def showList[T: Show]: Show[List[T]] = xs => xs.map(_.show).mkString(" ")
+  @silent("is never used")
+  private implicit val showNodeList = showList[Node]
   //Used in @scallop macro
   @silent("is never used")
   private implicit def show[T: NotNode]: Show[T] = Show.show(_.toString)
@@ -97,7 +105,9 @@ private[configuration] final case class Options private (
 
   def fieldByName(fieldName: CamelCase): Option[String] =
     subcommand
-      .flatMap(command => fields.get((command, fieldName)).flatMap(_.apply().toOption))
+      .flatMap(
+        command => fields.get((command, fieldName)).flatMap { _.apply().toOption }
+      )
 
   def parseCommand: Either[String, Configuration.Command] =
     subcommand.fold(s"Command was not provided".asLeft[Configuration.Command]) {
@@ -319,8 +329,8 @@ private[configuration] final case class Options private (
 
     @scallop
     val serverBootstrap =
-      gen[Node](
-        "Bootstrap casperlabs node address for initial seed.",
+      gen[List[Node]](
+        "Bootstrap casperlabs node address for initial seed. Accepts multiple instances for redundancy.",
         'b'
       )
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -22,16 +22,10 @@ private[configuration] object Converter extends ParserImplicits {
 
   implicit val bootstrapAddressConverter: ValueConverter[List[Node]] =
     new ValueConverter[List[Node]] {
-      def parse(s: List[(String, List[String])]): Either[String, Option[List[Node]]] =
-        s.unzip._2.flatten
-          .flatMap(_.split(' '))
-          .filterNot(_.isEmpty)
-          .map(uri => Parser[Node].parse(uri))
-          .sequence
-          .map {
-            case Nil   => None
-            case nodes => Some(nodes)
-          }
+      def parse(s: List[(String, List[String])]): Either[String, Option[List[Node]]] = {
+        val all = s.unzip._2.flatten.mkString(" ")
+        Parser[List[Node]].parse(all).map(Option(_))
+      }
 
       val argType: ArgType.V = ArgType.LIST
     }

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -24,7 +24,7 @@ private[configuration] object Converter extends ParserImplicits {
     new ValueConverter[List[Node]] {
       def parse(s: List[(String, List[String])]): Either[String, Option[List[Node]]] = {
         val all = s.unzip._2.flatten.mkString(" ")
-        Parser[List[Node]].parse(all).map(Option(_))
+        Parser[List[Node]].parse(all).map(Option(_).filterNot(_.isEmpty))
       }
 
       val argType: ArgType.V = ArgType.LIST

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -38,7 +38,7 @@ package object effects {
       gossipingRelaySaturation: Int,
       ingressScheduler: Scheduler,
       egressScheduler: Scheduler
-  )(init: Option[Node])(
+  )(init: List[Node])(
       implicit
       peerNodeAsk: NodeAsk[Task],
       log: Log[Task],

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -12,7 +12,7 @@ no-upnp = false
 default-timeout = "1second"
 standalone = false
 map-size = 1
-bootstrap = "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=1"
+bootstrap = "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=1 casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@127.0.0.1?protocol=1&discovery=1"
 data-dir = "/tmp"
 max-num-of-connections = 1
 max-message-size = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -57,6 +57,12 @@ class ConfigurationSpec
           "52.119.8.109",
           1,
           1
+        ),
+        Node(
+          NodeIdentifier("de6eed5d00cf080fc587eeb412cb31a75fd10358"),
+          "127.0.0.1",
+          1,
+          1
         )
       ),
       dataDir = Paths.get("/tmp"),

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -37,7 +37,7 @@ class ConfigurationSpec
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(
-      minSuccessful = 500,
+      minSuccessful = 100,
       workers = 1
     )
 
@@ -51,12 +51,14 @@ class ConfigurationSpec
       dynamicHostAddress = false,
       noUpnp = false,
       defaultTimeout = FiniteDuration(1, TimeUnit.SECONDS),
-      bootstrap = Node(
-        NodeIdentifier("de6eed5d00cf080fc587eeb412cb31a75fd10358"),
-        "52.119.8.109",
-        1,
-        1
-      ).some,
+      bootstrap = List(
+        Node(
+          NodeIdentifier("de6eed5d00cf080fc587eeb412cb31a75fd10358"),
+          "52.119.8.109",
+          1,
+          1
+        )
+      ),
       dataDir = Paths.get("/tmp"),
       maxNumOfConnections = 1,
       maxMessageSize = 1,
@@ -322,6 +324,10 @@ class ConfigurationSpec
             case (None, None)       => None
           }
       implicit def optionPlain[A: NotSubConfig: NotOption]: Merge[Option[A]] = _ orElse _
+      implicit def listMerge[A]: Merge[List[A]] = {
+        case (Nil, b) => b
+        case (a, _)   => a
+      }
     }
 
     Merge.gen[Configuration].merge(a, b)
@@ -339,13 +345,16 @@ class ConfigurationSpec
       case p: Node               => s""""${p.show}""""
       case p: java.nio.file.Path => s""""${p.toString}""""
       case x                     => x.toString
-    } { (acc, fullFieldName, field) =>
-      val tableName :: fieldName = fullFieldName
-      val table                  = dashify(tableName)
-      val key                    = dashify(fieldName.mkString("-"))
-      val previousTable          = acc.getOrElse(table, Map.empty[String, String])
-      val updatedKeys            = previousTable + (key -> field)
-      acc.updated(table, updatedKeys)
+    } {
+      case (acc, _, "") =>
+        acc
+      case (acc, fullFieldName, field) =>
+        val tableName :: fieldName = fullFieldName
+        val table                  = dashify(tableName)
+        val key                    = dashify(fieldName.mkString("-"))
+        val previousTable          = acc.getOrElse(table, Map.empty[String, String])
+        val updatedKeys            = previousTable + (key -> field)
+        acc.updated(table, updatedKeys)
     }
 
     val sb = new StringBuilder
@@ -369,6 +378,7 @@ class ConfigurationSpec
           v match {
             case "true"  => Some(s"$key")
             case "false" => None
+            case ""      => None
             case _       => Some(s"$key=$v")
           }
       }
@@ -383,8 +393,11 @@ class ConfigurationSpec
     reduce(conf, Map.empty[String, String])({
       case n: Node => mapper(n.show)
       case x       => mapper(x.toString)
-    }) { (envVars, fieldName, field) =>
-      envVars + (snakify(("CL" :: fieldName).mkString("_")) -> field)
+    }) {
+      case (envVars, _, "") =>
+        envVars
+      case (envVars, fieldName, field) =>
+        envVars + (snakify(("CL" :: fieldName).mkString("_")) -> field)
     }
   }
 
@@ -417,10 +430,16 @@ class ConfigurationSpec
 
       implicit val peerNode: Flattener[Node] =
         (path, a) => List((path, innerFieldsMapper(a)))
+
+      implicit val peerNodes: Flattener[List[Node]] =
+        (path, xs) => List((path, xs.map(innerFieldsMapper).mkString(" ")))
+
       implicit def default[A: NotSubConfig]: Flattener[A] =
         (path, a) => List((path, innerFieldsMapper(a)))
+
       implicit def optionSubConfig[A: IsSubConfig](implicit F: Flattener[A]): Flattener[Option[A]] =
         (path, opt) => opt.toList.flatMap(subconfig => F.flatten(path, subconfig))
+
       implicit def optionPlain[A: NotSubConfig]: Flattener[Option[A]] =
         (path, opt) => opt.toList.map(a => (path, innerFieldsMapper(a)))
     }

--- a/shared/src/main/scala/io/casperlabs/configuration/cli/scallop.scala
+++ b/shared/src/main/scala/io/casperlabs/configuration/cli/scallop.scala
@@ -71,9 +71,12 @@ object scallopImpl {
   private def tomlTypeDefinition(c: blackbox.Context)(tpe: c.Tree) = {
     import c.universe._
 
+    // To see what we're dealing with: `println(showRaw(tpe))`
     val t = tpe match {
       case Ident(TypeName("Flag")) => Ident(TypeName("Boolean"))
-      case x                       => x
+      case AppliedTypeTree(Ident(TypeName("List")), List(Ident(TypeName("Node")))) =>
+        Ident(TypeName("Node"))
+      case x => x
     }
 
     q"""
@@ -82,7 +85,7 @@ object scallopImpl {
             case "int" | "long" | "BigInt"                                   => "Integer"
             case "boolean"                                                   => "Boolean"
             case "double"                                                    => "Double"
-            case other => sys.error(s"Unexpected @scallop type: $$other")
+            case other => sys.error(s"Unexpected field type in io.casperlabs.configuration.cli.scallop annotation: $$other")
           }"""
   }
 


### PR DESCRIPTION
### Overview
Allows an operator to configure multiple bootstrap nodes. They all become initial nodes for the kademlia discovery machinery and the Genesis approver will try to download from one after the other until it succeeds.

The following are examples of passing multiple values:
```
./node/target/universal/stage/bin/casperlabs-node run \
  --server-bootstrap "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=1 casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.110?protocol=1&discovery=1"

./node/target/universal/stage/bin/casperlabs-node run \
  --server-bootstrap "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=1" 
  --server-bootstrap "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.110?protocol=1&discovery=1"
 
export CL_SERVER_BOOTSTRAP="casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=1 casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=2"
./node/target/universal/stage/bin/casperlabs-node run
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-436

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
