### PR TITLE
EE-576: refactor & rename UPointer

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/pointers.rs
+++ b/execution-engine/contract-ffi/src/contract_api/pointers.rs
@@ -47,11 +47,11 @@ impl<T> TURef<T> {
         }
     }
 
-    pub fn get_addr(&self) -> [u8; 32] {
+    pub fn addr(&self) -> [u8; 32] {
         self.addr
     }
 
-    pub fn get_access_rights(&self) -> AccessRights {
+    pub fn access_rights(&self) -> AccessRights {
         self.access_rights
     }
 
@@ -68,7 +68,7 @@ pub enum ContractPointer {
 
 impl<T> From<TURef<T>> for Key {
     fn from(turef: TURef<T>) -> Self {
-        let uref = URef::new(turef.get_addr(), turef.get_access_rights());
+        let uref = URef::new(turef.addr(), turef.access_rights());
         Key::URef(uref)
     }
 }

--- a/execution-engine/contract-ffi/src/contract_api/pointers.rs
+++ b/execution-engine/contract-ffi/src/contract_api/pointers.rs
@@ -18,37 +18,57 @@ impl fmt::Display for AccessRightsError {
     }
 }
 
-// TODO: UPointer might needs to be encoded into more fine grained types
+// TODO: TURef might needs to be encoded into more fine grained types
 // rather than hold AccessRights as one of the fields in order to be able
 // to statically provide guarantees about how it can operate on the keys.
 
 // URef with type information about what value is in the global state
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
-pub struct UPointer<T>(pub [u8; 32], pub AccessRights, pub PhantomData<T>);
+pub struct TURef<T> {
+    addr: [u8; 32],
+    access_rights: AccessRights,
+    _marker: PhantomData<T>,
+}
 
-impl<T> UPointer<T> {
-    pub fn new(id: [u8; 32], rights: AccessRights) -> UPointer<T> {
-        UPointer(id, rights, PhantomData)
+impl<T> TURef<T> {
+    pub fn new(addr: [u8; 32], access_rights: AccessRights) -> TURef<T> {
+        TURef {
+            addr,
+            access_rights,
+            _marker: PhantomData,
+        }
     }
 
     pub fn from_uref(uref: URef) -> Result<Self, AccessRightsError> {
         if let Some(access_rights) = uref.access_rights() {
-            Ok(UPointer(uref.addr(), access_rights, PhantomData))
+            Ok(TURef::new(uref.addr(), access_rights))
         } else {
             Err(AccessRightsError::NoAccessRights)
         }
+    }
+
+    pub fn get_addr(&self) -> [u8; 32] {
+        self.addr
+    }
+
+    pub fn get_access_rights(&self) -> AccessRights {
+        self.access_rights
+    }
+
+    pub fn set_access_rights(&mut self, access_rights: AccessRights) {
+        self.access_rights = access_rights;
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContractPointer {
     Hash([u8; 32]),
-    URef(UPointer<Contract>),
+    URef(TURef<Contract>),
 }
 
-impl<T> From<UPointer<T>> for Key {
-    fn from(u_ptr: UPointer<T>) -> Self {
-        let uref = URef::new(u_ptr.0, u_ptr.1);
+impl<T> From<TURef<T>> for Key {
+    fn from(turef: TURef<T>) -> Self {
+        let uref = URef::new(turef.get_addr(), turef.get_access_rights());
         Key::URef(uref)
     }
 }
@@ -57,7 +77,7 @@ impl From<ContractPointer> for Key {
     fn from(c_ptr: ContractPointer) -> Self {
         match c_ptr {
             ContractPointer::Hash(h) => Key::Hash(h),
-            ContractPointer::URef(u_ptr) => u_ptr.into(),
+            ContractPointer::URef(turef) => turef.into(),
         }
     }
 }

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -101,9 +101,9 @@ fn drop_hex_prefix(s: &str) -> &str {
 }
 
 impl Key {
-    pub fn to_u_ptr<T>(self) -> Option<UPointer<T>> {
+    pub fn to_turef<T>(self) -> Option<TURef<T>> {
         if let Key::URef(uref) = self {
-            UPointer::from_uref(uref).ok()
+            TURef::from_uref(uref).ok()
         } else {
             None
         }
@@ -111,7 +111,7 @@ impl Key {
 
     pub fn to_c_ptr(self) -> Option<ContractPointer> {
         match self {
-            Key::URef(uref) => UPointer::from_uref(uref).map(ContractPointer::URef).ok(),
+            Key::URef(uref) => TURef::from_uref(uref).map(ContractPointer::URef).ok(),
             Key::Hash(id) => Some(ContractPointer::Hash(id)),
             _ => None,
         }

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -220,7 +220,7 @@ impl bytesrepr::ToBytes for Vec<URef> {
 
 impl<T> From<TURef<T>> for URef {
     fn from(input: TURef<T>) -> Self {
-        URef(input.get_addr(), Some(input.get_access_rights()))
+        URef(input.addr(), Some(input.access_rights()))
     }
 }
 

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -5,7 +5,7 @@ use crate::alloc::vec::Vec;
 use crate::base16;
 use crate::bytesrepr;
 use crate::bytesrepr::{OPTION_SIZE, U32_SIZE};
-use crate::contract_api::pointers::UPointer;
+use crate::contract_api::pointers::TURef;
 
 pub const UREF_ADDR_SIZE: usize = 32;
 pub const ACCESS_RIGHTS_SIZE: usize = 1;
@@ -218,10 +218,9 @@ impl bytesrepr::ToBytes for Vec<URef> {
     }
 }
 
-impl<T> From<UPointer<T>> for URef {
-    fn from(uptr: UPointer<T>) -> Self {
-        let UPointer(id, access_rights, _) = uptr;
-        URef(id, Some(access_rights))
+impl<T> From<TURef<T>> for URef {
+    fn from(input: TURef<T>) -> Self {
+        URef(input.get_addr(), Some(input.get_access_rights()))
     }
 }
 

--- a/execution-engine/contracts/client/bonding/src/lib.rs
+++ b/execution-engine/contracts/client/bonding/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::value::uint::U512;
@@ -19,7 +19,7 @@ const POS_CONTRACT_NAME: &str = "pos";
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_uref = unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME), 55);
-    let pos_public: UPointer<Key> = unwrap_or_revert(pos_uref.to_u_ptr(), 66);
+    let pos_public: TURef<Key> = unwrap_or_revert(pos_uref.to_turef(), 66);
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 

--- a/execution-engine/contracts/client/named-purse-payment/src/lib.rs
+++ b/execution-engine/contracts/client/named-purse-payment/src/lib.rs
@@ -46,7 +46,7 @@ pub extern "C" fn call() {
             .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/client/named-purse-payment/src/lib.rs
+++ b/execution-engine/contracts/client/named-purse-payment/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use alloc::string::String;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -42,11 +42,11 @@ pub extern "C" fn call() {
     let amount: U512 = contract_api::get_arg(Arg::Amount as u32);
 
     let pos_pointer: ContractPointer = {
-        let outer: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-            .and_then(Key::to_u_ptr)
+        let outer: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+            .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
@@ -7,7 +7,7 @@ extern crate contract_ffi;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -35,11 +35,11 @@ pub extern "C" fn pay() {
     let main_purse: PurseId = contract_api::main_purse();
 
     let pos_pointer: ContractPointer = {
-        let outer: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-            .and_then(Key::to_u_ptr)
+        let outer: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+            .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
@@ -39,7 +39,7 @@ pub extern "C" fn pay() {
             .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/client/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -30,11 +30,11 @@ pub extern "C" fn call() {
     let main_purse: PurseId = contract_api::main_purse();
 
     let pos_pointer: ContractPointer = {
-        let outer: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-            .and_then(Key::to_u_ptr)
+        let outer: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+            .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/client/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment/src/lib.rs
@@ -34,7 +34,7 @@ pub extern "C" fn call() {
             .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/client/unbonding/src/lib.rs
+++ b/execution-engine/contracts/client/unbonding/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::key::Key;
 use contract_ffi::value::uint::U512;
 
@@ -20,7 +20,7 @@ const UNBOND_METHOD_NAME: &str = "unbond";
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_uref = unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME), 55);
-    let pos_public: UPointer<Key> = unwrap_or_revert(pos_uref.to_u_ptr(), 66);
+    let pos_public: TURef<Key> = unwrap_or_revert(pos_uref.to_turef(), 66);
     let pos_contract: Key = contract_api::read(pos_public);
     let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
 

--- a/execution-engine/contracts/system/mint-install/src/lib.rs
+++ b/execution-engine/contracts/system/mint-install/src/lib.rs
@@ -17,7 +17,7 @@ pub extern "C" fn mint_ext() {
 #[no_mangle]
 pub extern "C" fn call() {
     let contract = contract_api::fn_by_name("mint_ext", BTreeMap::new());
-    let uref: URef = contract_api::new_uref(contract).into();
+    let uref: URef = contract_api::new_turef(contract).into();
 
     contract_api::ret(&uref, &vec![uref]);
 }

--- a/execution-engine/contracts/system/mint-token/src/capabilities.rs
+++ b/execution-engine/contracts/system/mint-token/src/capabilities.rs
@@ -2,13 +2,13 @@ use core::convert::TryFrom;
 use core::marker::PhantomData;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::key::Key;
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::Value;
 
 /// Trait representing the ability to read a value. Use case: a key
-/// for the blockdag global state (`UPointer`) is obviously Readable,
+/// for the blockdag global state (`TURef`) is obviously Readable,
 /// however if we abstract over it then we can write unit tests for
 /// smart contracts much more easily.
 pub trait Readable<T> {
@@ -22,8 +22,8 @@ macro_rules! readable_impl {
             T: TryFrom<Value> + Clone,
         {
             fn read(&self) -> T {
-                let ptr: UPointer<T> = self.clone().into();
-                contract_api::read(ptr)
+                let turef: TURef<T> = self.clone().into();
+                contract_api::read(turef)
             }
         }
     };
@@ -43,8 +43,8 @@ macro_rules! writeable_impl {
             T: Clone,
         {
             fn write(&self, t: T) {
-                let ptr: UPointer<T> = self.clone().into();
-                contract_api::write(ptr, t);
+                let turef: TURef<T> = self.clone().into();
+                contract_api::write(turef, t);
             }
         }
     };
@@ -64,35 +64,34 @@ macro_rules! addable_impl {
             T: Clone,
         {
             fn add(&self, t: T) {
-                let ptr: UPointer<T> = self.clone().into();
-                contract_api::add(ptr, t);
+                let turef: TURef<T> = self.clone().into();
+                contract_api::add(turef, t);
             }
         }
     };
 }
 
-/// Macro for deriving conversion traits to/from UPointer
-macro_rules! into_try_from_upointer_impl {
+/// Macro for deriving conversion traits to/from TURef
+macro_rules! into_try_from_turef_impl {
     ($type:ident, $min_access:expr) => {
-        impl<T> TryFrom<UPointer<T>> for $type<T> {
+        impl<T> TryFrom<TURef<T>> for $type<T> {
             type Error = ();
 
-            fn try_from(u: UPointer<T>) -> Result<Self, Self::Error> {
-                let UPointer(id, access, phantom) = u;
-                if access & $min_access == $min_access {
-                    Ok($type(id, phantom))
+            fn try_from(u: TURef<T>) -> Result<Self, Self::Error> {
+                if u.get_access_rights() & $min_access == $min_access {
+                    Ok($type(u.get_addr(), PhantomData))
                 } else {
                     Err(())
                 }
             }
         }
 
-        // Can't implement From<$type<T>> for UPointer<T> because of the
-        // type parameter on UPointer and UPointer is not part of this crate.
-        impl<T> Into<UPointer<T>> for $type<T> {
-            fn into(self) -> UPointer<T> {
+        // Can't implement From<$type<T>> for TURef<T> because of the
+        // type parameter on TURef and TURef is not part of this crate.
+        impl<T> Into<TURef<T>> for $type<T> {
+            fn into(self) -> TURef<T> {
                 let access = $min_access;
-                UPointer::new(self.0, access)
+                TURef::new(self.0, access)
             }
         }
     };
@@ -127,7 +126,7 @@ macro_rules! from_try_from_key_impl {
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct ARef<T>(pub [u8; 32], PhantomData<T>);
 
-into_try_from_upointer_impl!(ARef, AccessRights::ADD);
+into_try_from_turef_impl!(ARef, AccessRights::ADD);
 from_try_from_key_impl!(ARef, AccessRights::ADD);
 addable_impl!(ARef<T>);
 
@@ -135,7 +134,7 @@ addable_impl!(ARef<T>);
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct RAWRef<T>(pub [u8; 32], PhantomData<T>);
 
-into_try_from_upointer_impl!(RAWRef, AccessRights::READ_ADD_WRITE);
+into_try_from_turef_impl!(RAWRef, AccessRights::READ_ADD_WRITE);
 from_try_from_key_impl!(RAWRef, AccessRights::READ_ADD_WRITE);
 readable_impl!(RAWRef<T>);
 addable_impl!(RAWRef<T>);

--- a/execution-engine/contracts/system/mint-token/src/capabilities.rs
+++ b/execution-engine/contracts/system/mint-token/src/capabilities.rs
@@ -78,8 +78,8 @@ macro_rules! into_try_from_turef_impl {
             type Error = ();
 
             fn try_from(u: TURef<T>) -> Result<Self, Self::Error> {
-                if u.get_access_rights() & $min_access == $min_access {
-                    Ok($type(u.get_addr(), PhantomData))
+                if u.access_rights() & $min_access == $min_access {
+                    Ok($type(u.addr(), PhantomData))
                 } else {
                     Err(())
                 }

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -43,9 +43,9 @@ impl Mint<ARef<U512>, RAWRef<U512>> for CLMint {
             return Err(Error::InvalidNonEmptyPurseCreation);
         }
 
-        let balance_uref: Key = contract_api::new_uref(initial_balance).into();
+        let balance_uref: Key = contract_api::new_turef(initial_balance).into();
 
-        let purse_key: URef = contract_api::new_uref(()).into();
+        let purse_key: URef = contract_api::new_turef(()).into();
         let purse_uref_name = purse_key.remove_access_rights().as_string();
 
         let purse_id: WithdrawId = WithdrawId::from_uref(purse_key).unwrap();

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -8,7 +8,7 @@ extern crate pos;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
 use contract_ffi::system_contracts::mint;
 use contract_ffi::uref::{AccessRights, URef};
@@ -41,7 +41,7 @@ pub extern "C" fn pos_ext() {
 #[no_mangle]
 pub extern "C" fn call() {
     let mint_uref: URef = contract_api::get_arg(Args::MintURef as u32);
-    let mint = ContractPointer::URef(UPointer::new(mint_uref.addr(), AccessRights::READ));
+    let mint = ContractPointer::URef(TURef::new(mint_uref.addr(), AccessRights::READ));
 
     let genesis_validators: BTreeMap<PublicKey, U512> =
         contract_api::get_arg(Args::GenesisValidators as u32);
@@ -87,7 +87,7 @@ pub extern "C" fn call() {
     });
 
     let contract = contract_api::fn_by_name("pos_ext", known_urefs);
-    let uref: URef = contract_api::new_uref(contract).into();
+    let uref: URef = contract_api::new_turef(contract).into();
 
     contract_api::ret(&uref, &vec![uref]);
 }

--- a/execution-engine/contracts/test/ee-221-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-221-regression/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::{add_uref, get_uref, new_uref};
+use contract_ffi::contract_api::{add_uref, get_uref, new_turef};
 use contract_ffi::key::Key;
 
 #[no_mangle]
@@ -13,7 +13,7 @@ pub extern "C" fn call() {
     let res1 = get_uref("nonexistinguref");
     assert!(res1.is_none());
 
-    let key = Key::URef(new_uref(()).into());
+    let key = Key::URef(new_turef(()).into());
     add_uref("nonexistinguref", &key);
 
     let res2 = get_uref("nonexistinguref");

--- a/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
@@ -7,7 +7,7 @@ extern crate contract_ffi;
 use alloc::string::String;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
 
@@ -29,7 +29,7 @@ pub extern "C" fn call() {
 
     let result: URef = contract_api::call_contract(contract_pointer, &(), &extra_urefs);
 
-    let value: String = contract_api::read(UPointer::from_uref(result).unwrap());
+    let value: String = contract_api::read(TURef::from_uref(result).unwrap());
 
     assert_eq!("Hello, world!", &value);
 }

--- a/execution-engine/contracts/test/ee-401-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression/src/lib.rs
@@ -14,7 +14,7 @@ use contract_ffi::contract_api::pointers::ContractPointer;
 #[no_mangle]
 pub extern "C" fn hello_ext() {
     let test_string = String::from("Hello, world!");
-    let test_uref = contract_api::new_uref(test_string).into();
+    let test_uref = contract_api::new_turef(test_string).into();
     let extra_urefs = [test_uref].to_vec();
     contract_api::ret(&test_uref, &extra_urefs)
 }

--- a/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
+++ b/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
@@ -10,7 +10,7 @@ use alloc::string::String;
 
 use contract_ffi::contract_api;
 use contract_ffi::contract_api::pointers::ContractPointer;
-use contract_ffi::contract_api::{add_uref, get_arg, new_uref};
+use contract_ffi::contract_api::{add_uref, get_arg, new_turef};
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
 use contract_ffi::value::U512;
@@ -26,7 +26,7 @@ pub extern "C" fn do_something() {
     // Advances RNG of the runtime
     let test_string = String::from("Hello, world!");
 
-    let test_uref = contract_api::new_uref(test_string).into();
+    let test_uref = contract_api::new_turef(test_string).into();
     contract_api::ret(&test_uref, &vec![test_uref])
 }
 
@@ -38,20 +38,20 @@ pub extern "C" fn call() {
         contract_api::store_function("do_something", BTreeMap::new());
     if flag == "pass1" {
         // Two calls should forward the internal RNG. This pass is a baseline.
-        let uref1: URef = new_uref(U512::from(0)).into();
-        let uref2: URef = new_uref(U512::from(1)).into();
+        let uref1: URef = new_turef(U512::from(0)).into();
+        let uref2: URef = new_turef(U512::from(1)).into();
         add_uref("uref1", &Key::URef(uref1));
         add_uref("uref2", &Key::URef(uref2));
     } else if flag == "pass2" {
-        let uref1: URef = new_uref(U512::from(0)).into();
+        let uref1: URef = new_turef(U512::from(0)).into();
         add_uref("uref1", &Key::URef(uref1));
         // do_nothing doesn't do anything. It SHOULD not forward the internal RNG.
         let result: String = contract_api::call_contract(do_nothing.clone(), &(), &vec![]);
         assert_eq!(result, "Hello, world!");
-        let uref2: URef = new_uref(U512::from(1)).into();
+        let uref2: URef = new_turef(U512::from(1)).into();
         add_uref("uref2", &Key::URef(uref2));
     } else if flag == "pass3" {
-        let uref1: URef = new_uref(U512::from(0)).into();
+        let uref1: URef = new_turef(U512::from(0)).into();
         add_uref("uref1", &Key::URef(uref1));
         // do_something returns a new uref, and it should forward the internal RNG.
         let uref2: URef = contract_api::call_contract(do_something.clone(), &(), &vec![]);

--- a/execution-engine/contracts/test/ee-549-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-549-regression/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
 
 const POS_CONTRACT_NAME: &str = "pos";
@@ -19,8 +19,8 @@ enum Error {
 }
 
 fn get_pos() -> ContractPointer {
-    let pos_public: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-        .and_then(Key::to_u_ptr)
+    let pos_public: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosOuterURef as u32));
 
     contract_api::read(pos_public)

--- a/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
@@ -10,7 +10,7 @@ use core::clone::Clone;
 use core::convert::Into;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::key::Key;
 use contract_ffi::uref::{AccessRights, URef};
 
@@ -19,11 +19,11 @@ const CONTRACT_NAME: &str = "create";
 
 #[no_mangle]
 pub extern "C" fn create() {
-    let reference: UPointer<String> = contract_api::new_uref(DATA.to_string());
+    let reference: TURef<String> = contract_api::new_turef(DATA.to_string());
 
     let read_only_reference: URef = {
-        let mut ret: UPointer<String> = reference.clone();
-        ret.1 = AccessRights::READ;
+        let mut ret: TURef<String> = reference.clone();
+        ret.set_access_rights(AccessRights::READ);
         ret.into()
     };
 

--- a/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
@@ -8,14 +8,14 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
 use contract_ffi::uref::{AccessRights, URef};
 
 const CONTRACT_POINTER: u32 = 0;
 
 const GET_ARG_ERROR: u32 = 100;
-const CREATE_UPOINTER_ERROR: u32 = 200;
+const CREATE_TUREF_ERROR: u32 = 200;
 
 const REPLACEMENT_DATA: &str = "bawitdaba";
 
@@ -27,9 +27,9 @@ pub extern "C" fn call() {
 
     let reference: URef = contract_api::call_contract(contract_pointer, &(), &Vec::new());
 
-    let forged_reference: UPointer<String> = {
+    let forged_reference: TURef<String> = {
         let ret = URef::new(reference.addr(), AccessRights::READ_ADD_WRITE);
-        UPointer::from_uref(ret).unwrap_or_else(|_| contract_api::revert(CREATE_UPOINTER_ERROR))
+        TURef::from_uref(ret).unwrap_or_else(|_| contract_api::revert(CREATE_TUREF_ERROR))
     };
 
     contract_api::write(forged_reference, REPLACEMENT_DATA.to_string())

--- a/execution-engine/contracts/test/ee-584-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-584-regression/src/lib.rs
@@ -8,6 +8,6 @@ use contract_ffi::contract_api;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let _ = contract_api::new_uref(String::from("Hello, World!"));
+    let _ = contract_api::new_turef(String::from("Hello, World!"));
     contract_api::revert(999)
 }

--- a/execution-engine/contracts/test/ee-597-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-597-regression/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
 use contract_ffi::value::account::PurseId;
@@ -21,11 +21,11 @@ fn purse_to_key(p: PurseId) -> Key {
 }
 
 fn get_pos_contract() -> ContractPointer {
-    let outer: UPointer<Key> = contract_api::get_uref("pos")
-        .and_then(Key::to_u_ptr)
+    let outer: TURef<Key> = contract_api::get_uref("pos")
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
     } else {
         contract_api::revert(Error::GetPosOuterURef as u32)
     }

--- a/execution-engine/contracts/test/ee-597-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-597-regression/src/lib.rs
@@ -25,7 +25,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         contract_api::revert(Error::GetPosOuterURef as u32)
     }

--- a/execution-engine/contracts/test/ee-598-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-598-regression/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
 use contract_ffi::value::account::PurseId;
@@ -21,11 +21,11 @@ fn purse_to_key(p: PurseId) -> Key {
 }
 
 fn get_pos_contract() -> ContractPointer {
-    let outer: UPointer<Key> = contract_api::get_uref("pos")
-        .and_then(Key::to_u_ptr)
+    let outer: TURef<Key> = contract_api::get_uref("pos")
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
     } else {
         contract_api::revert(Error::GetPosOuterURef as u32)
     }

--- a/execution-engine/contracts/test/ee-598-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-598-regression/src/lib.rs
@@ -25,7 +25,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         contract_api::revert(Error::GetPosOuterURef as u32)
     }

--- a/execution-engine/contracts/test/ee-601-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-601-regression/src/lib.rs
@@ -5,7 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -35,12 +35,12 @@ pub extern "C" fn call() {
         let main_purse: PurseId = contract_api::main_purse();
 
         let pos_pointer: ContractPointer = {
-            let outer: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-                .and_then(Key::to_u_ptr)
+            let outer: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+                .and_then(Key::to_turef)
                 .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
             if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr()
             {
-                ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+                ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
             } else {
                 contract_api::revert(Error::GetPosOuterURef as u32);
             }
@@ -64,7 +64,7 @@ pub extern "C" fn call() {
         }
     };
     let value = value.unwrap_or_else(|| contract_api::revert(Error::InvalidPhase as u32));
-    let result_key = contract_api::new_uref(value.to_string()).into();
+    let result_key = contract_api::new_turef(value.to_string()).into();
     let mut uref_name: String = NEW_UREF_RESULT_UREF_NAME.to_string();
     uref_name.push_str("-");
     uref_name.push_str(value);

--- a/execution-engine/contracts/test/ee-601-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-601-regression/src/lib.rs
@@ -40,7 +40,7 @@ pub extern "C" fn call() {
                 .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
             if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr()
             {
-                ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+                ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
             } else {
                 contract_api::revert(Error::GetPosOuterURef as u32);
             }

--- a/execution-engine/contracts/test/get-phase-payment/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase-payment/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::pointers::UPointer;
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::execution::Phase;
 use contract_ffi::key::Key;
@@ -24,8 +24,8 @@ enum Error {
 fn standard_payment(amount: U512) {
     let main_purse = contract_api::main_purse();
 
-    let pos_public: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-        .and_then(Key::to_u_ptr)
+    let pos_public: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosOuterURef as u32));
 
     let pos_contract = contract_api::read(pos_public)

--- a/execution-engine/contracts/test/known-urefs/src/lib.rs
+++ b/execution-engine/contracts/test/known-urefs/src/lib.rs
@@ -7,7 +7,8 @@ extern crate contract_ffi;
 use alloc::string::String;
 
 use contract_ffi::contract_api::{
-    add, add_uref, get_uref, has_uref, list_known_urefs, new_uref, read, remove_uref, revert, write,
+    add, add_uref, get_uref, has_uref, list_known_urefs, new_turef, read, remove_uref, revert,
+    write,
 };
 use contract_ffi::key::Key;
 use contract_ffi::value::U512;
@@ -23,66 +24,66 @@ pub extern "C" fn call() {
     }
 
     // Add new urefs
-    let hello_world_uref1: Key = new_uref(String::from("Hello, world!")).into();
-    add_uref("URef1", &hello_world_uref1);
+    let hello_world_key: Key = new_turef(String::from("Hello, world!")).into();
+    add_uref("hello-world", &hello_world_key);
     assert_eq!(list_known_urefs().len(), initi_uref_num + 1);
 
     // Verify if the uref is present
-    assert!(has_uref("URef1"));
+    assert!(has_uref("hello-world"));
 
-    let big_value_uref: Key = new_uref(U512::max_value()).into();
-    add_uref("URef2", &big_value_uref);
+    let big_value_key: Key = new_turef(U512::max_value()).into();
+    add_uref("big-value", &big_value_key);
 
     assert_eq!(list_known_urefs().len(), initi_uref_num + 2);
 
     // Read data hidden behind `URef1` uref
     let hello_world: String = read(
         list_known_urefs()
-            .get("URef1")
-            .expect("Unable to get URef1")
-            .to_u_ptr()
-            .expect("Unable to convert to u_ptr"),
+            .get("hello-world")
+            .expect("Unable to get hello-world")
+            .to_turef()
+            .expect("Unable to convert to turef"),
     );
     assert_eq!(hello_world, "Hello, world!");
 
     // Read data through dedicated FFI function
-    let uref1 = get_uref("URef1").unwrap_or_else(|| revert(100));
-    let uref1_ptr = uref1.to_u_ptr().unwrap_or_else(|| revert(101));
-    let hello_world: String = read(uref1_ptr);
+    let uref1 = get_uref("hello-world").unwrap_or_else(|| revert(100));
+    let turef = uref1.to_turef().unwrap_or_else(|| revert(101));
+    let hello_world: String = read(turef);
     assert_eq!(hello_world, "Hello, world!");
 
     // Remove uref
-    remove_uref("URef1");
-    assert!(!has_uref("URef1"));
+    remove_uref("hello-world");
+    assert!(!has_uref("hello-world"));
 
     // Confirm URef2 is still there
-    assert!(has_uref("URef2"));
+    assert!(has_uref("big-value"));
 
     // Get the big value back
-    let big_value_key = get_uref("URef2").unwrap_or_else(|| revert(102));
-    let big_value_uptr = big_value_key
-        .to_u_ptr()
-        .expect("Unable to get uptr for URef2");
-    let big_value: U512 = read(big_value_uptr);
+    let big_value_key = get_uref("big-value").unwrap_or_else(|| revert(102));
+    let big_value_ref = big_value_key
+        .to_turef()
+        .expect("Unable to get turef for big-value");
+    let big_value: U512 = read(big_value_ref);
     assert_eq!(big_value, U512::max_value());
 
     // Increase by 1
-    add(big_value_uptr, U512::one());
-    let new_big_value: U512 = read(big_value_uptr);
+    add(big_value_ref, U512::one());
+    let new_big_value: U512 = read(big_value_ref);
     assert_eq!(new_big_value, U512::zero());
 
     // I can overwrite some data under the pointer
-    write(big_value_uptr, U512::from(123_456_789u64));
-    let new_value: U512 = read(big_value_uptr);
+    write(big_value_ref, U512::from(123_456_789u64));
+    let new_value: U512 = read(big_value_ref);
     assert_eq!(new_value, U512::from(123_456_789u64));
 
     // Try to remove non existing uref which shouldn't fail
-    remove_uref("URef1");
+    remove_uref("hello-world");
     // Remove a valid uref
-    remove_uref("URef2");
+    remove_uref("big-value");
 
     // Cleaned up state
-    assert!(!has_uref("URef1"));
-    assert!(!has_uref("URef2"));
+    assert!(!has_uref("hello-world"));
+    assert!(!has_uref("big-value"));
     assert_eq!(list_known_urefs().len(), initi_uref_num);
 }

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -34,7 +34,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -6,7 +6,7 @@ extern crate contract_ffi;
 
 use alloc::prelude::v1::{String, Vec};
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{
     call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
     transfer_from_purse_to_account, transfer_from_purse_to_purse, PurseTransferResult,
@@ -30,11 +30,11 @@ fn purse_to_key(p: PurseId) -> Key {
 }
 
 fn get_pos_contract() -> ContractPointer {
-    let outer: UPointer<Key> = get_uref("pos")
-        .and_then(Key::to_u_ptr)
+    let outer: TURef<Key> = get_uref("pos")
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -6,7 +6,7 @@ extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -56,11 +56,11 @@ fn finalize_payment(pos: &ContractPointer, amount_spent: U512, account: PublicKe
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_pointer = {
-        let outer: UPointer<Key> = contract_api::get_uref("pos")
-            .and_then(Key::to_u_ptr)
+        let outer: TURef<Key> = contract_api::get_uref("pos")
+            .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -60,7 +60,7 @@ pub extern "C" fn call() {
             .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -5,7 +5,7 @@ extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -24,11 +24,11 @@ enum Error {
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_pointer = {
-        let outer: UPointer<Key> = contract_api::get_uref("pos")
-            .and_then(Key::to_u_ptr)
+        let outer: TURef<Key> = contract_api::get_uref("pos")
+            .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -28,7 +28,7 @@ pub extern "C" fn call() {
             .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -6,7 +6,7 @@ extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -55,11 +55,11 @@ fn submit_payment(pos: &ContractPointer, amount: U512) {
 #[no_mangle]
 pub extern "C" fn call() {
     let pos_pointer = {
-        let outer: UPointer<Key> = contract_api::get_uref("pos")
-            .and_then(Key::to_u_ptr)
+        let outer: TURef<Key> = contract_api::get_uref("pos")
+            .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -59,7 +59,7 @@ pub extern "C" fn call() {
             .and_then(Key::to_turef)
             .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
         if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+            ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
         } else {
             contract_api::revert(Error::GetPosOuterURef as u32);
         }

--- a/execution-engine/contracts/test/transfer-purse-to-account-stored/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account-stored/src/lib.rs
@@ -31,11 +31,11 @@ pub extern "C" fn transfer() {
 
     let result = format!("{:?}", transfer_result);
 
-    let result_uref: Key = contract_api::new_uref(result).into();
+    let result_uref: Key = contract_api::new_turef(result).into();
     contract_api::add_uref(TRANSFER_RESULT_UREF_NAME, &result_uref);
     contract_api::add_uref(
         MAIN_PURSE_FINAL_BALANCE_UREF_NAME,
-        &contract_api::new_uref(final_balance).into(),
+        &contract_api::new_turef(final_balance).into(),
     );
 }
 
@@ -43,6 +43,6 @@ pub extern "C" fn transfer() {
 pub extern "C" fn call() {
     let known_urefs: BTreeMap<String, Key> = BTreeMap::new();
     let contract = contract_api::fn_by_name(TRANSFER_FUNCTION_NAME, known_urefs);
-    let u_ptr = contract_api::new_uref(contract);
-    contract_api::add_uref(TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME, &u_ptr.into());
+    let key = contract_api::new_turef(contract).into();
+    contract_api::add_uref(TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME, &key);
 }

--- a/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
@@ -26,10 +26,10 @@ pub extern "C" fn call() {
 
     let result = format!("{:?}", transfer_result);
 
-    let result_uref: Key = contract_api::new_uref(result).into();
+    let result_uref: Key = contract_api::new_turef(result).into();
     contract_api::add_uref(TRANSFER_RESULT_UREF_NAME, &result_uref);
     contract_api::add_uref(
         MAIN_PURSE_FINAL_BALANCE_UREF_NAME,
-        &contract_api::new_uref(final_balance).into(),
+        &contract_api::new_turef(final_balance).into(),
     );
 }

--- a/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
@@ -7,8 +7,8 @@ extern crate contract_ffi;
 
 use alloc::string::String;
 use contract_ffi::contract_api::{
-    add_uref, create_purse, get_arg, get_balance, get_uref, has_uref, main_purse, new_uref, revert,
-    transfer_from_purse_to_purse,
+    add_uref, create_purse, get_arg, get_balance, get_uref, has_uref, main_purse, new_turef,
+    revert, transfer_from_purse_to_purse,
 };
 use contract_ffi::key::Key;
 use contract_ffi::value::account::PurseId;
@@ -52,7 +52,7 @@ pub extern "C" fn call() {
 
     let result = format!("{:?}", transfer_result);
     // Add new urefs
-    let result_uref: Key = new_uref(result).into();
-    add_uref("purse_transfer_result", &result_uref);
-    add_uref("main_purse_balance", &new_uref(final_balance).into());
+    let result_key: Key = new_turef(result).into();
+    add_uref("purse_transfer_result", &result_key);
+    add_uref("main_purse_balance", &new_turef(final_balance).into());
 }

--- a/integration-testing/contracts/bonding/call/src/lib.rs
+++ b/integration-testing/contracts/bonding/call/src/lib.rs
@@ -23,7 +23,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/integration-testing/contracts/bonding/call/src/lib.rs
+++ b/integration-testing/contracts/bonding/call/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{
     call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
     transfer_from_purse_to_purse, PurseTransferResult,
@@ -19,11 +19,11 @@ enum Error {
 }
 
 fn get_pos_contract() -> ContractPointer {
-    let outer: UPointer<Key> = get_uref("pos")
-        .and_then(Key::to_u_ptr)
+    let outer: TURef<Key> = get_uref("pos")
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/integration-testing/contracts/combined-contracts/define/src/lib.rs
+++ b/integration-testing/contracts/combined-contracts/define/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
-#[macro_use]
 
+#[macro_use]
 extern crate alloc;
 extern crate contract_ffi;
 
@@ -8,8 +8,8 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::contract_api::*;
-use contract_ffi::contract_api::pointers::UPointer;
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
 
@@ -26,9 +26,8 @@ pub extern "C" fn hello_name_ext() {
     ret(&y, &Vec::new());
 }
 
-
-fn get_list_key(name: &str) -> UPointer<Vec<String>> {
-    get_uref(name).unwrap().to_u_ptr().unwrap()
+fn get_list_key(name: &str) -> TURef<Vec<String>> {
+    get_uref(name).unwrap().to_turef().unwrap()
 }
 
 fn update_list(name: String) {
@@ -38,17 +37,16 @@ fn update_list(name: String) {
     write(list_key, list);
 }
 
-fn sub(name: String) -> Option<UPointer<Vec<String>>> {
+fn sub(name: String) -> Option<TURef<Vec<String>>> {
     if has_uref(&name) {
         let init_message = vec![String::from("Hello again!")];
-        let new_key = new_uref(init_message);
-        Some(new_key) //already subscribed
+        Some(new_turef(init_message)) //already subscribed
     } else {
         let init_message = vec![String::from("Welcome!")];
-        let new_key = new_uref(init_message);
-        add_uref(&name, &new_key.clone().into());
+        let new_turef = new_turef(init_message);
+        add_uref(&name, &new_turef.clone().into());
         update_list(name);
-        Some(new_key)
+        Some(new_turef)
     }
 }
 
@@ -62,37 +60,37 @@ fn publish(msg: String) {
     }
 }
 
- #[no_mangle]
- pub extern "C" fn mailing_list_ext() {
-     let method_name: String = get_arg(0);
-     match method_name.as_str() {
-         "sub" => match sub(get_arg(1)) {
-             Some(upointer) => {
-                 let extra_uref = URef::new(upointer.0, upointer.1);
-                 let extra_urefs = vec![extra_uref];
-                 ret(&Some(Key::from(upointer)), &extra_urefs);
-             }
-             _ => ret(&Option::<Key>::None, &Vec::new()),
-         },
-         //Note that this is totally insecure. In reality
-         //the pub method would be only available under an
-         //unforgable reference because otherwise anyone could
-         //spam the mailing list.
-         "pub" => {
-             publish(get_arg(1));
-         }
-         _ => panic!("Unknown method name!"),
-     }
- }
+#[no_mangle]
+pub extern "C" fn mailing_list_ext() {
+    let method_name: String = get_arg(0);
+    match method_name.as_str() {
+        "sub" => match sub(get_arg(1)) {
+            Some(turef) => {
+                let extra_uref = URef::new(turef.get_addr(), turef.get_access_rights());
+                let extra_urefs = vec![extra_uref];
+                ret(&Some(Key::from(turef)), &extra_urefs);
+            }
+            _ => ret(&Option::<Key>::None, &Vec::new()),
+        },
+        //Note that this is totally insecure. In reality
+        //the pub method would be only available under an
+        //unforgable reference because otherwise anyone could
+        //spam the mailing list.
+        "pub" => {
+            publish(get_arg(1));
+        }
+        _ => panic!("Unknown method name!"),
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn counter_ext() {
-    let i_key: UPointer<i32> = get_uref("count").unwrap().to_u_ptr().unwrap();
+    let turef: TURef<i32> = get_uref("count").unwrap().to_turef().unwrap();
     let method_name: String = get_arg(0);
     match method_name.as_str() {
-        "inc" => add(i_key, 1),
+        "inc" => add(turef, 1),
         "get" => {
-            let result = read(i_key);
+            let result = read(turef);
             ret(&result, &Vec::new());
         }
         _ => panic!("Unknown method name!"),
@@ -106,23 +104,23 @@ pub extern "C" fn call() {
     add_uref("hello_name", &pointer.into());
 
     // counter
-    let counter_local_key = new_uref(0); //initialize counter
+    let counter_local_turef = new_turef(0); //initialize counter
 
     //create map of references for stored contract
     let mut counter_urefs: BTreeMap<String, Key> = BTreeMap::new();
     let key_name = String::from("count");
-    counter_urefs.insert(key_name, counter_local_key.into());
+    counter_urefs.insert(key_name, counter_local_turef.into());
     let _counter_hash = store_function("counter_ext", counter_urefs);
     add_uref("counter", &_counter_hash.into());
 
     // mailing list
     let init_list: Vec<String> = Vec::new();
-    let list_key = new_uref(init_list);
+    let list_turef = new_turef(init_list);
 
     //create map of references for stored contract
     let mut mailing_list_urefs: BTreeMap<String, Key> = BTreeMap::new();
     let key_name = String::from("list");
-    mailing_list_urefs.insert(key_name, list_key.into());
+    mailing_list_urefs.insert(key_name, list_turef.into());
 
     let pointer = store_function("mailing_list_ext", mailing_list_urefs);
     add_uref("mailing", &pointer.into())

--- a/integration-testing/contracts/combined-contracts/define/src/lib.rs
+++ b/integration-testing/contracts/combined-contracts/define/src/lib.rs
@@ -66,7 +66,7 @@ pub extern "C" fn mailing_list_ext() {
     match method_name.as_str() {
         "sub" => match sub(get_arg(1)) {
             Some(turef) => {
-                let extra_uref = URef::new(turef.get_addr(), turef.get_access_rights());
+                let extra_uref = URef::new(turef.addr(), turef.access_rights());
                 let extra_urefs = vec![extra_uref];
                 ret(&Some(Key::from(turef)), &extra_urefs);
             }

--- a/integration-testing/contracts/counter/define/src/lib.rs
+++ b/integration-testing/contracts/counter/define/src/lib.rs
@@ -1,23 +1,25 @@
 #![no_std]
 
 extern crate alloc;
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate contract_ffi;
+
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::contract_api::*;
-use contract_ffi::contract_api::pointers::UPointer;
 use contract_ffi::key::Key;
 
 #[no_mangle]
 pub extern "C" fn counter_ext() {
-    let i_key: UPointer<i32> = get_uref("count").unwrap().to_u_ptr().unwrap();
+    let turef: TURef<i32> = get_uref("count").unwrap().to_turef().unwrap();
     let method_name: String = get_arg(0);
     match method_name.as_str() {
-        "inc" => add(i_key, 1),
+        "inc" => add(turef, 1),
         "get" => {
-            let result = read(i_key);
+            let result = read(turef);
             ret(&result, &Vec::new());
         }
         _ => panic!("Unknown method name!"),
@@ -26,7 +28,7 @@ pub extern "C" fn counter_ext() {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let counter_local_key = new_uref(0); //initialize counter
+    let counter_local_key = new_turef(0); //initialize counter
 
     //create map of references for stored contract
     let mut counter_urefs: BTreeMap<String, Key> = BTreeMap::new();

--- a/integration-testing/contracts/finalize-payment/src/lib.rs
+++ b/integration-testing/contracts/finalize-payment/src/lib.rs
@@ -6,7 +6,7 @@ extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::ContractPointer;
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, PurseId};
@@ -48,8 +48,8 @@ fn finalize_payment(pos: &ContractPointer, amount_spent: U512, account: PublicKe
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
-    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_contract: Key =
+        contract_api::read(contract_api::get_uref("pos").unwrap().to_turef().unwrap());
     let pos_pointer = pos_contract.to_c_ptr().unwrap();
 
     let payment_amount: U512 = contract_api::get_arg(0);

--- a/integration-testing/contracts/hello-name/call/src/lib.rs
+++ b/integration-testing/contracts/hello-name/call/src/lib.rs
@@ -6,13 +6,12 @@ extern crate contract_ffi;
 use alloc::string::String;
 use alloc::vec::Vec;
 use contract_ffi::contract_api::pointers::ContractPointer;
-use contract_ffi::contract_api::{add_uref, call_contract, get_uref, new_uref, revert};
+use contract_ffi::contract_api::{add_uref, call_contract, get_uref, new_turef, revert};
 use contract_ffi::key::Key;
 use contract_ffi::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {
-
     let hello_name_uref = get_uref("hello_name").unwrap_or_else(|| revert(100));
     let pointer = if let Key::Hash(hash) = hello_name_uref {
         ContractPointer::Hash(hash)
@@ -25,6 +24,5 @@ pub extern "C" fn call() {
     assert_eq!("Hello, World", result);
 
     //store the result at a uref so it can be seen as an effect on the global state
-    let uref = new_uref(Value::String(result));
-    add_uref("helloworld", &uref.into());
+    add_uref("helloworld", &new_turef(Value::String(result)).into());
 }

--- a/integration-testing/contracts/hello-name/define/src/lib.rs
+++ b/integration-testing/contracts/hello-name/define/src/lib.rs
@@ -1,11 +1,13 @@
 #![no_std]
 
 extern crate alloc;
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate contract_ffi;
+
 use contract_ffi::contract_api::{add_uref, get_arg, ret, store_function};
 
 fn hello_name(name: &str) -> String {

--- a/integration-testing/contracts/list-known-urefs/define/src/lib.rs
+++ b/integration-testing/contracts/list-known-urefs/define/src/lib.rs
@@ -6,7 +6,9 @@ extern crate contract_ffi;
 use alloc::borrow::ToOwned;
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
-use contract_ffi::contract_api::{add_uref, get_uref, list_known_urefs, new_uref, store_function, revert};
+use contract_ffi::contract_api::{
+    add_uref, get_uref, list_known_urefs, new_turef, revert, store_function,
+};
 use contract_ffi::key::Key;
 use contract_ffi::value::Value;
 use core::iter;
@@ -14,7 +16,7 @@ use core::iter;
 #[no_mangle]
 pub extern "C" fn list_known_urefs_ext() {
     let passed_in_uref = get_uref("Foo").unwrap_or_else(|| revert(100));
-    let uref = new_uref(Value::String("Test".to_owned()));
+    let uref = new_turef(Value::String("Test".to_owned()));
     add_uref("Bar", &uref.clone().into());
     let contracts_known_urefs = list_known_urefs();
     let expected_urefs: BTreeMap<String, Key> = {
@@ -29,11 +31,11 @@ pub extern "C" fn list_known_urefs_ext() {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let uref = new_uref(Value::Int32(1));
-    add_uref("Foo", &uref.clone().into());
+    let turef = new_turef(Value::Int32(1));
+    add_uref("Foo", &turef.clone().into());
     let _accounts_known_urefs = list_known_urefs();
     let expected_urefs: BTreeMap<String, Key> =
-        iter::once(("Foo".to_owned(), uref.into())).collect();
+        iter::once(("Foo".to_owned(), turef.into())).collect();
     // Test that `list_known_urefs` returns correct value when called in the context of an account.
     // Store `list_known_urefs_ext` to be called in the `call` part of this contract.
     // We don't have to  pass `expected_urefs` to exercise this function but

--- a/integration-testing/contracts/mailing-list/call/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/call/src/lib.rs
@@ -1,10 +1,12 @@
 #![no_std]
 
 extern crate alloc;
+
 use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate contract_ffi;
+
 use contract_ffi::contract_api::pointers::*;
 use contract_ffi::contract_api::*;
 use contract_ffi::key::Key;
@@ -36,14 +38,14 @@ pub extern "C" fn call() {
             let args = (method, message);
             let _result: () = call_contract(pointer, &args, &Vec::new());
 
-            let list_key: UPointer<Vec<String>> = sub_key.to_u_ptr().unwrap();
-            let messages = read(list_key);
+            let turef: TURef<Vec<String>> = sub_key.to_turef().unwrap();
+            let messages = read(turef);
 
-            if  messages.is_empty(){
+            if messages.is_empty() {
                 revert(2);
             }
-        },
-        None=>{
+        }
+        None => {
             revert(3);
         }
     }

--- a/integration-testing/contracts/mailing-list/define/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/define/src/lib.rs
@@ -55,7 +55,7 @@ pub extern "C" fn mailing_list_ext() {
     match method_name.as_str() {
         "sub" => match sub(get_arg(1)) {
             Some(turef) => {
-                let extra_uref = URef::new(turef.get_addr(), turef.get_access_rights());
+                let extra_uref = URef::new(turef.addr(), turef.access_rights());
                 let extra_urefs = vec![extra_uref];
                 ret(&Some(Key::from(turef)), &extra_urefs);
             }

--- a/integration-testing/contracts/mailing-list/define/src/lib.rs
+++ b/integration-testing/contracts/mailing-list/define/src/lib.rs
@@ -2,18 +2,20 @@
 
 #[macro_use]
 extern crate alloc;
+
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
 
 extern crate contract_ffi;
+
+use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::contract_api::*;
-use contract_ffi::contract_api::pointers::UPointer;
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
 
-fn get_list_key(name: &str) -> UPointer<Vec<String>> {
-    get_uref(name).unwrap().to_u_ptr().unwrap()
+fn get_list_key(name: &str) -> TURef<Vec<String>> {
+    get_uref(name).unwrap().to_turef().unwrap()
 }
 
 fn update_list(name: String) {
@@ -23,14 +25,14 @@ fn update_list(name: String) {
     write(list_key, list);
 }
 
-fn sub(name: String) -> Option<UPointer<Vec<String>>> {
+fn sub(name: String) -> Option<TURef<Vec<String>>> {
     if has_uref(&name) {
         let init_message = vec![String::from("Hello again!")];
-        let new_key = new_uref(init_message);
+        let new_key = new_turef(init_message);
         Some(new_key) //already subscribed
     } else {
         let init_message = vec![String::from("Welcome!")];
-        let new_key = new_uref(init_message);
+        let new_key = new_turef(init_message);
         add_uref(&name, &new_key.clone().into());
         update_list(name);
         Some(new_key)
@@ -47,33 +49,33 @@ fn publish(msg: String) {
     }
 }
 
- #[no_mangle]
- pub extern "C" fn mailing_list_ext() {
-     let method_name: String = get_arg(0);
-     match method_name.as_str() {
-         "sub" => match sub(get_arg(1)) {
-             Some(upointer) => {
-                 let extra_uref = URef::new(upointer.0, upointer.1);
-                 let extra_urefs = vec![extra_uref];
-                 ret(&Some(Key::from(upointer)), &extra_urefs);
-             }
-             _ => ret(&Option::<Key>::None, &Vec::new()),
-         },
-         //Note that this is totally insecure. In reality
-         //the pub method would be only available under an
-         //unforgable reference because otherwise anyone could
-         //spam the mailing list.
-         "pub" => {
-             publish(get_arg(1));
-         }
-         _ => panic!("Unknown method name!"),
-     }
- }
+#[no_mangle]
+pub extern "C" fn mailing_list_ext() {
+    let method_name: String = get_arg(0);
+    match method_name.as_str() {
+        "sub" => match sub(get_arg(1)) {
+            Some(turef) => {
+                let extra_uref = URef::new(turef.get_addr(), turef.get_access_rights());
+                let extra_urefs = vec![extra_uref];
+                ret(&Some(Key::from(turef)), &extra_urefs);
+            }
+            _ => ret(&Option::<Key>::None, &Vec::new()),
+        },
+        //Note that this is totally insecure. In reality
+        //the pub method would be only available under an
+        //unforgable reference because otherwise anyone could
+        //spam the mailing list.
+        "pub" => {
+            publish(get_arg(1));
+        }
+        _ => panic!("Unknown method name!"),
+    }
+}
 
 #[no_mangle]
 pub extern "C" fn call() {
     let init_list: Vec<String> = Vec::new();
-    let list_key = new_uref(init_list);
+    let list_key = new_turef(init_list);
 
     //create map of references for stored contract
     let mut mailing_list_urefs: BTreeMap<String, Key> = BTreeMap::new();

--- a/integration-testing/contracts/payment-purse/src/lib.rs
+++ b/integration-testing/contracts/payment-purse/src/lib.rs
@@ -4,7 +4,6 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use alloc::vec::Vec;
-use contract_ffi::contract_api::pointers::UPointer;
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::value::account::PurseId;
@@ -12,8 +11,8 @@ use contract_ffi::value::uint::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
-    let pos_contract: Key = contract_api::read(pos_public);
+    let pos_contract: Key =
+        contract_api::read(contract_api::get_uref("pos").unwrap().to_turef().unwrap());
     let pos_pointer = pos_contract.to_c_ptr().unwrap();
 
     let source_purse = contract_api::main_purse();

--- a/integration-testing/contracts/pos-bonding/src/lib.rs
+++ b/integration-testing/contracts/pos-bonding/src/lib.rs
@@ -7,7 +7,7 @@ extern crate contract_ffi;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{
     call_contract, create_purse, get_arg, get_uref, main_purse, read, revert,
     transfer_from_purse_to_account, transfer_from_purse_to_purse, PurseTransferResult,
@@ -31,11 +31,11 @@ fn purse_to_key(p: PurseId) -> Key {
 }
 
 fn get_pos_contract() -> ContractPointer {
-    let outer: UPointer<Key> = get_uref("pos")
-        .and_then(Key::to_u_ptr)
+    let outer: TURef<Key> = get_uref("pos")
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/integration-testing/contracts/pos-bonding/src/lib.rs
+++ b/integration-testing/contracts/pos-bonding/src/lib.rs
@@ -35,7 +35,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/integration-testing/contracts/refund-purse/src/lib.rs
+++ b/integration-testing/contracts/refund-purse/src/lib.rs
@@ -7,9 +7,15 @@ extern crate contract_ffi;
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::key::Key;
+use contract_ffi::uref::AccessRights;
 use contract_ffi::value::account::PurseId;
+
+enum Error {
+    GetPosOuterURef = 1000,
+    GetPosInnerURef = 1001,
+}
 
 fn purse_to_key(p: &PurseId) -> Key {
     Key::URef(p.value())
@@ -27,11 +33,20 @@ fn get_refund_purse(pos: &ContractPointer) -> Option<PurseId> {
     contract_api::call_contract(pos.clone(), &("get_refund_purse",), &Vec::new())
 }
 
+fn get_pos_contract() -> ContractPointer {
+    let outer: TURef<Key> = contract_api::get_uref("pos")
+        .and_then(Key::to_turef)
+        .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
+    if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+    } else {
+        contract_api::revert(Error::GetPosOuterURef as u32)
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_public: UPointer<Key> = contract_api::get_uref("pos").unwrap().to_u_ptr().unwrap();
-    let pos_contract: Key = contract_api::read(pos_public);
-    let pos_pointer = pos_contract.to_c_ptr().unwrap();
+    let pos_pointer = get_pos_contract();
 
     let p1 = contract_api::create_purse();
     let p2 = contract_api::create_purse();

--- a/integration-testing/contracts/refund-purse/src/lib.rs
+++ b/integration-testing/contracts/refund-purse/src/lib.rs
@@ -38,7 +38,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         contract_api::revert(Error::GetPosOuterURef as u32)
     }

--- a/integration-testing/contracts/standard-payment/src/lib.rs
+++ b/integration-testing/contracts/standard-payment/src/lib.rs
@@ -4,7 +4,7 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -18,10 +18,22 @@ enum Arg {
     Amount = 0,
 }
 
+#[allow(clippy::enum_variant_names)]
 enum Error {
     GetPosInnerURef = 1,
     GetPosOuterURef = 2,
     TransferError = 3,
+}
+
+fn get_pos_contract() -> ContractPointer {
+    let outer: TURef<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
+        .and_then(Key::to_turef)
+        .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
+    if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+    } else {
+        contract_api::revert(Error::GetPosOuterURef as u32);
+    }
 }
 
 #[no_mangle]
@@ -29,16 +41,7 @@ pub extern "C" fn call() {
     let amount: U512 = contract_api::get_arg(Arg::Amount as u32);
     let main_purse: PurseId = contract_api::main_purse();
 
-    let pos_pointer: ContractPointer = {
-        let outer: UPointer<Key> = contract_api::get_uref(POS_CONTRACT_NAME)
-            .and_then(Key::to_u_ptr)
-            .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
-        if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-            ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
-        } else {
-            contract_api::revert(Error::GetPosOuterURef as u32);
-        }
-    };
+    let pos_pointer: ContractPointer = get_pos_contract();
 
     let payment_purse: PurseId =
         contract_api::call_contract(pos_pointer, &(GET_PAYMENT_PURSE,), &vec![]);

--- a/integration-testing/contracts/standard-payment/src/lib.rs
+++ b/integration-testing/contracts/standard-payment/src/lib.rs
@@ -30,7 +30,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| contract_api::revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = contract_api::read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         contract_api::revert(Error::GetPosOuterURef as u32);
     }

--- a/integration-testing/contracts/unbonding/call/src/lib.rs
+++ b/integration-testing/contracts/unbonding/call/src/lib.rs
@@ -2,10 +2,10 @@
 
 #[macro_use]
 extern crate alloc;
-
 extern crate contract_ffi;
+
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::{ContractPointer, UPointer};
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{call_contract, get_uref, read, revert};
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
@@ -17,11 +17,11 @@ enum Error {
 }
 
 fn get_pos_contract() -> ContractPointer {
-    let outer: UPointer<Key> = get_uref("pos")
-        .and_then(Key::to_u_ptr)
+    let outer: TURef<Key> = get_uref("pos")
+        .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(UPointer::new(inner.0, AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }

--- a/integration-testing/contracts/unbonding/call/src/lib.rs
+++ b/integration-testing/contracts/unbonding/call/src/lib.rs
@@ -21,7 +21,7 @@ fn get_pos_contract() -> ContractPointer {
         .and_then(Key::to_turef)
         .unwrap_or_else(|| revert(Error::GetPosInnerURef as u32));
     if let Some(ContractPointer::URef(inner)) = read::<Key>(outer).to_c_ptr() {
-        ContractPointer::URef(TURef::new(inner.get_addr(), AccessRights::READ))
+        ContractPointer::URef(TURef::new(inner.addr(), AccessRights::READ))
     } else {
         revert(Error::GetPosOuterURef as u32)
     }


### PR DESCRIPTION
This PR refactors UPointer to have named private fields and accessors and renames it to TURef. 

https://casperlabs.atlassian.net/browse/EE-576

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.