### PR TITLE
NODE-843: Fix failing deploy storage persistency integration test

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -17,7 +17,6 @@ import io.casperlabs.ipc._
 import io.casperlabs.models.BlockImplicits._
 import io.casperlabs.models.{DeployResult => _}
 import io.casperlabs.shared.Log
-import io.casperlabs.shared.Sorting.blockSummaryOrdering
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block.BlockStorage
 import io.casperlabs.storage.dag.DagRepresentation
@@ -406,6 +405,7 @@ object ExecEngineUtil {
 
     val candidateParents = candidateParentBlocks.map(BlockSummary.fromBlock).toVector
 
+    import io.casperlabs.shared.Sorting.blockSummaryOrdering
     for {
       merged <- abstractMerge[F, TransformMap, BlockSummary, state.Key](
                  candidateParents,

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -63,7 +63,7 @@ class SQLiteDagStorage[F[_]: Bracket[?[_], Throwable]](
       } else {
         // Insert by selecting blocks with the highest rank per validator
         // The query will see effects of previous queries in transaction
-        sql"""|INSERT OR REPLACE INTO validator_latest_messagesw
+        sql"""|INSERT OR REPLACE INTO validator_latest_messages
               |SELECT validator, block_hash
               |FROM block_metadata a
               |WHERE validator != ${ByteString.EMPTY}

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.data._
 import cats.effect._
 import cats.implicits._
+import com.google.protobuf.ByteString
 import doobie._
 import doobie.implicits._
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
@@ -47,27 +48,32 @@ class SQLiteDagStorage[F[_]: Bracket[?[_], Throwable]](
       )
 
     val latestMessagesQuery = {
-      val newValidators = block.state.bonds
-        .map(_.validatorPublicKey)
-        .toSet
-        .diff(block.justifications.map(_.validatorPublicKey).toSet)
-      val validator = block.validatorPublicKey
-
-      val toUpdateValidators = if (block.isGenesisLike) {
-        // For Genesis, all validators are "new".
-        newValidators.toList
+      if (block.isGenesisLike) {
+        val newValidators = block.state.bonds
+          .map(_.validatorPublicKey)
+          .toSet
+          .diff(block.justifications.map(_.validatorPublicKey).toSet)
+          .toList
+        // Will ignore existing entries, because genesis should only be the first block and can't be added twice
+        Update[(Validator, BlockHash)](
+          """|INSERT OR IGNORE INTO validator_latest_messages
+             |(validator, block_hash)
+             |VALUES (?, ?)""".stripMargin
+        ).updateMany(newValidators.map((_, blockSummary.blockHash)))
       } else {
-        // For any other block, only validator that produced it
-        // needs to have its "latest message" updated.
-        List(validator)
+        // Insert by selecting blocks with the highest rank per validator
+        // The query will see effects of previous queries in transaction
+        sql"""|INSERT OR REPLACE INTO validator_latest_messagesw
+              |SELECT validator, block_hash
+              |FROM block_metadata a
+              |WHERE validator != ${ByteString.EMPTY}
+              |  AND NOT exists(
+              |        SELECT 1
+              |        FROM block_metadata b
+              |        WHERE a.validator = b.validator
+              |          AND a.rank < b.rank
+              |    )""".stripMargin.update.run
       }
-
-      Update[(Validator, BlockHash)](
-        """|INSERT OR REPLACE INTO validator_latest_messages
-           |(validator, block_hash)
-           |VALUES (?, ?)
-           |""".stripMargin
-      ).updateMany(toUpdateValidators.map((_, blockSummary.blockHash)))
     }
 
     val topologicalSortingQuery =

--- a/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
@@ -162,6 +162,23 @@ trait BlockStorageTest
     }
   }
 
+  it should "be able to properly (de)serialize data" in {
+    forAll { b: BlockMsgWithTransform =>
+      withStorage { storage =>
+        val before = b.toByteArray
+        for {
+          _          <- storage.put(b)
+          maybeBlock <- storage.get(b.getBlockMessage.blockHash)
+          _ <- Task {
+                maybeBlock should not be None
+                val got = maybeBlock.get.toByteArray
+                assert(before.sameElements(got))
+              }
+        } yield ()
+      }
+    }
+  }
+
   //TODO: update this test to properly test rollback feature.
   //https://casperlabs.atlassian.net/browse/STOR-95
   it should "rollback the transaction on error" ignore {

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -104,6 +104,24 @@ trait DagStorageTest
       }
     }
   }
+
+  "DAG Storage" should "be able to properly (de)serialize data" in {
+    forAll { b: Block =>
+      withDagStorage { storage =>
+        val before = BlockSummary.fromBlock(b).toByteArray
+        for {
+          _                 <- storage.insert(b)
+          dag               <- storage.getRepresentation
+          maybeBlockSummary <- dag.lookup(b.blockHash)
+          _ <- Task {
+                maybeBlockSummary should not be None
+                val got = maybeBlockSummary.get.toByteArray
+                assert(before.sameElements(got))
+              }
+        } yield ()
+      }
+    }
+  }
 }
 
 class FileDagStorageTest extends DagStorageTest {

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -546,4 +546,38 @@ class SQLiteDagStorageTest extends DagStorageTest with SQLiteFixture[DagStorage[
 
   override def createTestResource: Task[DagStorage[Task]] =
     SQLiteStorage.create[Task](wrap = Task.pure)
+
+  "SQLite DAG Storage" should "override validator's latest block hash only if rank is higher" in {
+    forAll { (initial: Block, a: Block, c: Block) =>
+      withDagStorage { storage =>
+        def update(b: Block, validator: ByteString, rank: Long): Block =
+          b.withHeader(b.getHeader.withValidatorPublicKey(validator).withRank(rank))
+
+        val validator  = initial.validatorPublicKey
+        val rank       = initial.rank
+        val lowerRank  = update(a, validator, rank - 1)
+        val higherRank = update(c, validator, rank + 1)
+
+        for {
+          _      <- storage.insert(initial)
+          before <- storage.getRepresentation.flatMap(_.latestMessageHashes)
+
+          _ <- storage.insert(lowerRank)
+          // block with lower rank should be ignored
+          _ <- storage.getRepresentation.flatMap(_.latestMessageHashes).map { got =>
+                got shouldBe before
+              }
+
+          // not checking new blocks with same rank because they should be invalidated
+          // before storing because of equivocation
+
+          _ <- storage.insert(higherRank)
+          // only block with higher rank should override previous message
+          _ <- storage.getRepresentation.flatMap(_.latestMessageHashes).map { got =>
+                got shouldBe Map(validator -> higherRank.blockHash)
+              }
+        } yield ()
+      }
+    }
+  }
 }


### PR DESCRIPTION
### Overview
We can't merge #1017 because of failing integration test about deploy storage persistency.
When node contains pending deploys and restarted, then propose can fail because node will read wrong tips and feed the engine with wrong pre-state hash. Node read wrong tips because after restart it will store its genesis block (or any other block) and override the SQL table with the latest block per validators.

The fix is about filtering blocks for that table and inserting only truly new ones selecting them by the highest rank per validator, also adds a regression unit test.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-843

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._