### PR TITLE
NO-TICKET: Optimize SQLiteDagStorage regarding validators latest messages

### DIFF
--- a/storage/src/main/resources/db/migration/V20190820_661__Create_dag_storage_tables.sql
+++ b/storage/src/main/resources/db/migration/V20190820_661__Create_dag_storage_tables.sql
@@ -24,8 +24,9 @@ CREATE INDEX idx_block_justifications
 
 CREATE TABLE validator_latest_messages
 (
-    validator  BLOB NOT NULL PRIMARY KEY,
-    block_hash BLOB NOT NULL,
+    validator  BLOB    NOT NULL PRIMARY KEY,
+    block_hash BLOB    NOT NULL,
+    rank       INTEGER NOT NULL,
     FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
 );
 

--- a/storage/src/main/resources/db/migration/V20190820_661__Create_dag_storage_tables.sql
+++ b/storage/src/main/resources/db/migration/V20190820_661__Create_dag_storage_tables.sql
@@ -24,18 +24,23 @@ CREATE INDEX idx_block_justifications
 
 CREATE TABLE validator_latest_messages
 (
-    validator  BLOB NOT NULL PRIMARY KEY,
-    block_hash BLOB NOT NULL,
+    validator  BLOB    NOT NULL,
+    block_hash BLOB    NOT NULL,
+    rank       INTEGER NOT NULL,
+    PRIMARY KEY (validator, block_hash),
     FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
 );
 
+CREATE UNIQUE INDEX idx_validator_latest_messages_validator_rank
+    ON validator_latest_messages (validator, rank);
+
 CREATE TABLE block_metadata
 (
-    block_hash     BLOB    NOT NULL PRIMARY KEY,
-    validator      BLOB    NOT NULL,
-    rank           INTEGER NOT NULL,
+    block_hash BLOB    NOT NULL PRIMARY KEY,
+    validator  BLOB    NOT NULL,
+    rank       INTEGER NOT NULL,
     --BlockSummary
-    data           BLOB    NOT NULL
+    data       BLOB    NOT NULL
 );
 
 CREATE INDEX idx_block_metadata_rank_block_hash

--- a/storage/src/main/resources/db/migration/V20190820_661__Create_dag_storage_tables.sql
+++ b/storage/src/main/resources/db/migration/V20190820_661__Create_dag_storage_tables.sql
@@ -24,15 +24,10 @@ CREATE INDEX idx_block_justifications
 
 CREATE TABLE validator_latest_messages
 (
-    validator  BLOB    NOT NULL,
-    block_hash BLOB    NOT NULL,
-    rank       INTEGER NOT NULL,
-    PRIMARY KEY (validator, block_hash),
+    validator  BLOB NOT NULL PRIMARY KEY,
+    block_hash BLOB NOT NULL,
     FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
 );
-
-CREATE UNIQUE INDEX idx_validator_latest_messages_validator_rank
-    ON validator_latest_messages (validator, rank);
 
 CREATE TABLE block_metadata
 (

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -4,7 +4,6 @@ import cats._
 import cats.data._
 import cats.effect._
 import cats.implicits._
-import com.google.protobuf.ByteString
 import doobie._
 import doobie.implicits._
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
@@ -48,32 +47,27 @@ class SQLiteDagStorage[F[_]: Bracket[?[_], Throwable]](
       )
 
     val latestMessagesQuery = {
-      if (block.isGenesisLike) {
-        val newValidators = block.state.bonds
-          .map(_.validatorPublicKey)
-          .toSet
-          .diff(block.justifications.map(_.validatorPublicKey).toSet)
-          .toList
-        // Will ignore existing entries, because genesis should only be the first block and can't be added twice
-        Update[(Validator, BlockHash)](
-          """|INSERT OR IGNORE INTO validator_latest_messages
-             |(validator, block_hash)
-             |VALUES (?, ?)""".stripMargin
-        ).updateMany(newValidators.map((_, blockSummary.blockHash)))
+      val newValidators = block.state.bonds
+        .map(_.validatorPublicKey)
+        .toSet
+        .diff(block.justifications.map(_.validatorPublicKey).toSet)
+      val validator = block.validatorPublicKey
+
+      val toUpdateValidators = if (block.isGenesisLike) {
+        // For Genesis, all validators are "new".
+        newValidators.toList
       } else {
-        // Insert by selecting blocks with the highest rank per validator
-        // The query will see effects of previous queries in transaction
-        sql"""|INSERT OR REPLACE INTO validator_latest_messages
-              |SELECT validator, block_hash
-              |FROM block_metadata a
-              |WHERE validator != ${ByteString.EMPTY}
-              |  AND NOT exists(
-              |        SELECT 1
-              |        FROM block_metadata b
-              |        WHERE a.validator = b.validator
-              |          AND a.rank < b.rank
-              |    )""".stripMargin.update.run
+        // For any other block, only validator that produced it
+        // needs to have its "latest message" updated.
+        List(validator)
       }
+
+      Update[(Validator, BlockHash, Long)](
+        """|INSERT OR IGNORE INTO validator_latest_messages
+           |(validator, block_hash, rank)
+           |VALUES (?, ?, ?)
+           |""".stripMargin
+      ).updateMany(toUpdateValidators.map((_, blockSummary.blockHash, blockSummary.rank)))
     }
 
     val topologicalSortingQuery =
@@ -185,34 +179,60 @@ class SQLiteDagStorage[F[_]: Bracket[?[_], Throwable]](
 
   override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
     sql"""|SELECT block_hash
-          |FROM validator_latest_messages
-          |WHERE validator=$validator""".stripMargin
+          |FROM validator_latest_messages a
+          |WHERE validator = $validator
+          |  AND NOT EXISTS(
+          |        SELECT 1
+          |        FROM validator_latest_messages b
+          |        WHERE a.validator = b.validator
+          |          AND a.rank < b.rank
+          |    )""".stripMargin
       .query[BlockHash]
       .option
       .transact(xa)
 
   override def latestMessage(validator: Validator): F[Option[BlockSummary]] =
-    sql"""|SELECT m.data
-          |FROM validator_latest_messages v
-          |INNER JOIN block_metadata m
-          |ON v.validator=$validator AND v.block_hash=m.block_hash""".stripMargin
+    sql"""|SELECT data
+          |FROM (SELECT validator, block_hash
+          |      FROM validator_latest_messages a
+          |      WHERE validator = $validator
+          |        AND NOT EXISTS(
+          |              SELECT 1
+          |              FROM validator_latest_messages b
+          |              WHERE a.validator = b.validator
+          |                AND a.rank < b.rank
+          |          )) c
+          |         INNER JOIN block_metadata ON c.block_hash = block_metadata.block_hash""".stripMargin
       .query[BlockSummary]
       .option
       .transact(xa)
 
   override def latestMessageHashes: F[Map[Validator, BlockHash]] =
-    sql"""|SELECT *
-          |FROM validator_latest_messages""".stripMargin
+    sql"""|SELECT validator, block_hash
+          |FROM validator_latest_messages a
+          |WHERE NOT EXISTS(
+          |    SELECT 1
+          |    FROM validator_latest_messages b
+          |    WHERE a.validator = b.validator
+          |      AND a.rank < b.rank
+          |)""".stripMargin
       .query[(Validator, BlockHash)]
       .to[List]
       .transact(xa)
       .map(_.toMap)
 
   override def latestMessages: F[Map[Validator, BlockSummary]] =
-    sql"""|SELECT v.validator, m.data
-          |FROM validator_latest_messages v
-          |INNER JOIN block_metadata m
-          |ON m.block_hash=v.block_hash""".stripMargin
+    sql"""|SELECT c.validator, data
+          |FROM (SELECT validator, block_hash
+          |      FROM validator_latest_messages a
+          |      WHERE NOT EXISTS(
+          |              SELECT 1
+          |              FROM validator_latest_messages b
+          |              WHERE a.validator = b.validator
+          |                AND a.rank < b.rank
+          |          )) c
+          |         INNER JOIN block_metadata 
+          |                    ON c.block_hash = block_metadata.block_hash""".stripMargin
       .query[(Validator, BlockSummary)]
       .to[List]
       .transact(xa)


### PR DESCRIPTION
### Overview
Derived from the discussion at #1100 
~Adds the `rank` column to the `validator_latest_messages`.~
Optimizes the insertion check.

### Which JIRA ticket does this PR relate to?
This is an unticketed PR

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._