### PR TITLE
NODE-846: Ban unresponsive nodes temporarily

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -268,6 +268,7 @@ object GossipServiceCasperTestNodeFactory {
     def discover: F[Unit]                                  = ???
     def lookup(id: NodeIdentifier): F[Option[Node]]        = ???
     def recentlyAlivePeersAscendingDistance: F[List[Node]] = peers.pure[F]
+    def banTemp(node: Node): F[Unit]                       = ???
   }
 
   def makeNodeAsk[F[_]](node: Node)(implicit ev: Applicative[F]) =

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscovery.scala
@@ -15,6 +15,11 @@ trait NodeDiscovery[F[_]] {
 
   /** Return the recently active peers. */
   def recentlyAlivePeersAscendingDistance: F[List[Node]]
+
+  /** Explicitly mark some node as faulty so it's not considered alive even
+    * it responds to ping requests.
+    */
+  def banTemp(node: Node): F[Unit]
 }
 
 object NodeDiscovery extends NodeDiscoveryInstances {
@@ -28,6 +33,8 @@ object NodeDiscovery extends NodeDiscoveryInstances {
       def lookup(id: NodeIdentifier): T[F, Option[Node]] = C.lookup(id).liftM[T]
       def recentlyAlivePeersAscendingDistance: T[F, List[Node]] =
         C.recentlyAlivePeersAscendingDistance.liftM[T]
+      def banTemp(node: Node): T[F, Unit] =
+        C.banTemp(node).liftM[T]
     }
 }
 

--- a/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/discovery/NodeDiscoveryImpl.scala
@@ -70,6 +70,7 @@ object NodeDiscoveryImpl {
       Resource.liftF(for {
         table              <- PeerTable[F](id)
         recentlyAlivePeers <- Ref.of[F, (Set[Node], Millis)]((Set.empty, 0L))
+        temporaryBans      <- Ref.of[F, Map[Node, Millis]](Map.empty)
         nodeDiscovery <- Sync[F].delay {
                           val alivePeersCacheSize =
                             if (gossipingRelaySaturation == 100) {
@@ -81,6 +82,7 @@ object NodeDiscoveryImpl {
                             id = id,
                             table = table,
                             recentlyAlivePeersRef = recentlyAlivePeers,
+                            temporaryBansRef = temporaryBans,
                             gossipingEnabled = gossipingEnabled,
                             alivePeersCacheSize = alivePeersCacheSize
                           )
@@ -119,6 +121,8 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
     id: NodeIdentifier,
     val table: PeerTable[F],
     recentlyAlivePeersRef: Ref[F, (Set[Node], Millis)],
+    // Remember the last time a peer was banned.
+    temporaryBansRef: Ref[F, Map[Node, Millis]],
     alpha: Int = 3,
     k: Int = PeerTable.Redundancy,
     gossipingEnabled: Boolean,
@@ -155,7 +159,7 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
       _     <- addNode(peer)
     } yield peers
 
-  def discover: F[Unit] = {
+  override def discover: F[Unit] = {
 
     val initRPC = KademliaService[F].receive(pingHandler, lookupHandler)
 
@@ -183,7 +187,7 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
     } yield ()
   }
 
-  def lookup(toLookup: NodeIdentifier): F[Option[Node]] = {
+  override def lookup(toLookup: NodeIdentifier): F[Option[Node]] = {
     def loop(successQueriesN: Int, alreadyQueried: Set[NodeIdentifier], shortlist: Seq[Node])(
         maybeClosestPeerNode: Option[Node]
     ): F[Option[Node]] =
@@ -237,26 +241,37 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
   override def recentlyAlivePeersAscendingDistance: F[List[Node]] =
     recentlyAlivePeersAscendingDistance(id)
 
-  def recentlyAlivePeersAscendingDistance(anchorId: NodeIdentifier): F[List[Node]] =
-    if (gossipingEnabled)
-      recentlyAlivePeersRef.get.map {
-        case (recentlyAlivePeers, _) => PeerTable.sort(recentlyAlivePeers.toList, anchorId)(_.id)
-      } else
-      // TODO: this is misleading because returned peers won't necessarily be alive.
-      // Though, this is fine because it's only used by
-      // the old legacy communication layer code which should go away eventually
-      // io.casperlabs.comm.rp.Connect#findAndConnect
-      // The old code maintains its own list of alive connections
-      table.peersAscendingDistance
+  private def recentlyAlivePeersAscendingDistance(anchorId: NodeIdentifier): F[List[Node]] = {
+    val peersF =
+      if (gossipingEnabled)
+        recentlyAlivePeersRef.get.map {
+          case (recentlyAlivePeers, _) => PeerTable.sort(recentlyAlivePeers.toList, anchorId)(_.id)
+        } else
+        // TODO: this is misleading because returned peers won't necessarily be alive.
+        // Though, this is fine because it's only used by
+        // the old legacy communication layer code which should go away eventually
+        // io.casperlabs.comm.rp.Connect#findAndConnect
+        // The old code maintains its own list of alive connections
+        table.peersAscendingDistance
 
-  def schedulePeriodicRecentlyAlivePeersCacheUpdate: F[Unit] =
+    for {
+      bans      <- temporaryBansRef.get
+      peers     <- peersF
+      now       <- Timer[F].clock.realTime(MILLISECONDS)
+      threshold = now - alivePeersCacheExpirationPeriod.toMillis
+    } yield peers.filter { node =>
+      !bans.contains(node) || bans(node) < threshold
+    }
+  }
+
+  private[discovery] def schedulePeriodicRecentlyAlivePeersCacheUpdate: F[Unit] =
     updateRecentlyAlivePeers >>
       Timer[F].sleep(alivePeersCacheUpdatePeriod) >>
       schedulePeriodicRecentlyAlivePeersCacheUpdate
 
   // TODO: The logic might be too complex here
   // Possible simplification would be pinging all known peers in some period and cache responded ones
-  def updateRecentlyAlivePeers: F[Unit] =
+  private[discovery] def updateRecentlyAlivePeers: F[Unit] =
     for {
       (recentlyAlivePeers, lastTimeAccess) <- recentlyAlivePeersRef.get
       currentTime                          <- Timer[F].clock.realTime(MILLISECONDS)
@@ -278,12 +293,12 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
       _ <- Metrics[F].setGauge("peers_alive", newAlivePeers.size.toLong)
     } yield ()
 
-  def filterAlive(peers: List[Node]): F[List[Node]] =
+  private def filterAlive(peers: List[Node]): F[List[Node]] =
     peers.parFlatTraverse { peer =>
       KademliaService[F].ping(peer).map(success => if (success) List(peer) else Nil)
     }
 
-  def filterAlive(peers: List[Node], max: Int): F[List[Node]] = {
+  private def filterAlive(peers: List[Node], max: Int): F[List[Node]] = {
     val batches = peers.grouped(alivePeersCachePingsBatchSize).toList
     batches.foldLeftM(List.empty[Node]) {
       case (acc, _) if acc.size >= max   => acc.pure[F]
@@ -291,4 +306,10 @@ private[discovery] class NodeDiscoveryImpl[F[_]: Monad: Log: Timer: Metrics: Kad
       case (acc, batch)                  => filterAlive(batch).map(acc ++ _)
     }
   }
+
+  override def banTemp(node: Node): F[Unit] =
+    for {
+      now <- Timer[F].clock.realTime(MILLISECONDS)
+      _   <- temporaryBansRef.update(_ + (node -> now))
+    } yield ()
 }

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -572,7 +572,7 @@ object NodeDiscoverySpec {
       val effect = for {
         table                 <- PeerTable[Task](id, k)
         recentlyAlivePeersRef <- Ref.of[Task, (Set[Node], Millis)]((Set.empty[Node], 0L))
-        temporaryBans         = NodeDiscoveryImpl.NodeCache(alivePeersCacheExpirationPeriod)
+        temporaryBans         <- NodeDiscoveryImpl.NodeCache[Task](alivePeersCacheExpirationPeriod)
         implicit0(kademliaMock: KademliaMock) = new KademliaMock(
           connections,
           pings.getOrElse(_ => true)

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -481,6 +481,31 @@ class NodeDiscoverySpec extends WordSpecLike with GeneratorDrivenPropertyChecks 
         }
       }
     }
+    "banTemp" should {
+      "prevent nodes from being returned as alive until the expiry period ends" in {
+        val peers: Map[Node, List[Node]] = sample(genFullyConnectedPeers)
+        val target                       = chooseRandom(peers)
+        TextFixture.prefilledTable(
+          connections = peers,
+          k = totalN(peers),
+          alivePeersCacheSize = totalN(peers),
+          alivePeersCacheExpirationPeriod = 250.millis
+        ) { (_, nd, _) =>
+          for {
+            _         <- nd.updateRecentlyAlivePeers
+            response0 <- nd.recentlyAlivePeersAscendingDistance
+            _         <- nd.banTemp(target)
+            response1 <- nd.recentlyAlivePeersAscendingDistance
+            _         <- Task.sleep(500.millis)
+            response2 <- nd.recentlyAlivePeersAscendingDistance
+          } yield {
+            response0 should contain(target)
+            response1 should not contain (target)
+            response2 should contain(target)
+          }
+        }
+      }
+    }
   }
 }
 
@@ -547,6 +572,7 @@ object NodeDiscoverySpec {
       val effect = for {
         table                 <- PeerTable[Task](id, k)
         recentlyAlivePeersRef <- Ref.of[Task, (Set[Node], Millis)]((Set.empty[Node], 0L))
+        temporaryBansRef      <- Ref.of[Task, Map[Node, Millis]](Map.empty)
         implicit0(kademliaMock: KademliaMock) = new KademliaMock(
           connections,
           pings.getOrElse(_ => true)
@@ -556,6 +582,7 @@ object NodeDiscoverySpec {
           id,
           table,
           recentlyAlivePeersRef,
+          temporaryBansRef,
           alpha,
           k,
           true,

--- a/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/discovery/NodeDiscoverySpec.scala
@@ -572,7 +572,7 @@ object NodeDiscoverySpec {
       val effect = for {
         table                 <- PeerTable[Task](id, k)
         recentlyAlivePeersRef <- Ref.of[Task, (Set[Node], Millis)]((Set.empty[Node], 0L))
-        temporaryBansRef      <- Ref.of[Task, Map[Node, Millis]](Map.empty)
+        temporaryBans         = NodeDiscoveryImpl.NodeCache(alivePeersCacheExpirationPeriod)
         implicit0(kademliaMock: KademliaMock) = new KademliaMock(
           connections,
           pings.getOrElse(_ => true)
@@ -582,7 +582,7 @@ object NodeDiscoverySpec {
           id,
           table,
           recentlyAlivePeersRef,
-          temporaryBansRef,
+          temporaryBans,
           alpha,
           k,
           true,

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GenesisApproverSpec.scala
@@ -479,6 +479,7 @@ object GenesisApproverSpec extends ArbitraryConsensus {
     override def discover                            = ???
     override def lookup(id: NodeIdentifier)          = ???
     override def recentlyAlivePeersAscendingDistance = Task.now(peers)
+    override def banTemp(node: Node): Task[Unit]     = ???
   }
 
   class MockGossipService extends GossipService[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -208,6 +208,7 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
     def discover                            = ???
     def lookup(id: NodeIdentifier)          = ???
     def recentlyAlivePeersAscendingDistance = Task.now(nodes)
+    def banTemp(node: Node): Task[Unit]     = ???
   }
 
   object MockBackend extends GossipServiceServer.Backend[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/RelayingSpec.scala
@@ -152,6 +152,7 @@ object RelayingSpec {
         override def discover: Task[Unit]                                  = ???
         override def lookup(id: NodeIdentifier): Task[Option[Node]]        = ???
         override def recentlyAlivePeersAscendingDistance: Task[List[Node]] = Task.now(peers)
+        override def banTemp(node: Node): Task[Unit]                       = ???
       }
       val asked                 = AtomicInt(0)
       val concurrency           = AtomicInt(0)

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -45,6 +45,7 @@ object EffectsTestInstances {
     def discover: F[Unit]                                          = ???
     def lookup(id: NodeIdentifier): F[Option[Node]]                = ???
     def handleCommunications: Protocol => F[CommunicationResponse] = ???
+    def banTemp(node: Node): F[Unit]                               = ???
   }
 
   def createRPConfAsk[F[_]: Applicative](


### PR DESCRIPTION
### Overview
We had a node in long term testing that responds okay to ping requests but cannot process gossip notifications in a timely manner. Since nodes rely on the discovery module for a list of recently live nodes to gossip to, this mean that they keep trying to relay information to the slow node, which affected the total throughput. 

The PR adds a `NodeDiscovery.banTemp` method so that we can mark nodes that are unresponsive for any reason as faulty and stop gossiping to them until the Kademlia liveness caching period expires.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-846

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
