### PR TITLE
Initial commit of mac cron pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -710,6 +710,152 @@ trigger:
   ref:
   - refs/tags/v*
 
+---
+kind: pipeline
+name: mac-nightly-cron
+
+clone:
+  disable: true
+
+steps:
+- name: mac-clone
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    command_timeout: 60m
+    port:
+      from_secret: mac-port
+    script:
+    - mkdir -p DRONE_BUILD_${DRONE_BUILD_NUMBER}
+    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}
+    - git clone -b dev https://github.com/CasperLabs/CasperLabs.git
+
+- name: build-node
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    command_timeout: 60m
+    port:
+      from_secret: mac-port
+    script:
+    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
+    - /usr/local/bin/sbt node/universal:stage
+
+- name: build-client
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    command_timeout: 60m
+    port:
+      from_secret: mac-port
+    script:
+    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
+    - /usr/local/bin/sbt client/universal:stage
+
+- name: rust-toolchain
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    command_timeout: 60m
+    port:
+      from_secret: mac-port
+    script:
+    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
+    - cd execution-engine
+    - ~/.cargo/bin/rustup toolchain install $(cat rust-toolchain)
+    - ~/.cargo/bin/rustup target add --toolchain $(cat rust-toolchain) wasm32-unknown-unknown
+
+- name: build-ee
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    command_timeout: 60m
+    port:
+      from_secret: mac-port
+    script:
+    - export PATH=$PATH:/usr/local/bin/
+    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
+    - cd execution-engine
+    - ~/.cargo/bin/cargo build --release
+
+- name: build-system-contracts
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    command_timeout: 60m
+    port:
+      from_secret: mac-port
+    script:
+    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
+    - cd execution-engine
+    - ~/.cargo/bin/cargo build -p pos --release --target wasm32-unknown-unknown
+    - ~/.cargo/bin/cargo build -p mint-token --release --target wasm32-unknown-unknown
+
+- name: cleanup-mac
+  image: appleboy/drone-ssh:latest
+  environment:
+    SSH_HOST:
+      from_secret: mac-host
+    SSH_USERNAME:
+      from_secret: mac-user
+    SSH_KEY:
+      from_secret: mac-ssh-key
+  settings:
+    port:
+      from_secret: mac-port
+    script:
+    - rm -rf DRONE_BUILD_${DRONE_BUILD_NUMBER}
+
+- name: notify-mac-cron
+  image: plugins/slack
+  settings:
+    webhook:
+      from_secret: slack_webhook
+    channel: alerts
+    template:
+    - |
+      macOS Build Status: {{#success build.status}}✔{{ else }}✘{{/success}}*{{ uppercasefirst build.status }}*
+      Drone Build: <{{ build.link }}|#{{ build.number }}>
+
+trigger:
+  cron: [ mac-hourly-cron ]
+
 # Signature for Drone
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -786,8 +786,7 @@ steps:
     script:
     - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
     - cd execution-engine
-    - ~/.cargo/bin/rustup toolchain install $(cat rust-toolchain)
-    - ~/.cargo/bin/rustup target add --toolchain $(cat rust-toolchain) wasm32-unknown-unknown
+    - make setup
 
 - name: build-ee
   image: appleboy/drone-ssh:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -854,7 +854,7 @@ steps:
     channel: alerts
     template:
     - |
-      macOS Build Status: {{#success build.status}}✔{{ else }}✘{{/success}}*{{ uppercasefirst build.status }}*
+      macOS Build Status: {{#success build.status}}✔{{ else }}✘ @sreteam {{/success}}*{{ uppercasefirst build.status }}*
       Drone Build: <{{ build.link }}|#{{ build.number }}>
   when:
     status:

--- a/.drone.yml
+++ b/.drone.yml
@@ -841,6 +841,10 @@ steps:
       from_secret: mac-port
     script:
     - rm -rf DRONE_BUILD_${DRONE_BUILD_NUMBER}
+  when:
+    status:
+    - failure
+    - success
 
 - name: notify-mac-cron
   image: plugins/slack
@@ -852,6 +856,10 @@ steps:
     - |
       macOS Build Status: {{#success build.status}}✔{{ else }}✘{{/success}}*{{ uppercasefirst build.status }}*
       Drone Build: <{{ build.link }}|#{{ build.number }}>
+  when:
+    status:
+    - failure
+    - success
 
 trigger:
   cron: [ mac-hourly-cron ]


### PR DESCRIPTION
### Overview
Brings back building on a mac into the CI pipeline. Will be configured to run hourly via drone crontabs feature. Allows us to still catch issues on the mac without slowing down our autoscaling ability.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-588

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I setup the pipeline to follow exactly how we tell users to build via https://github.com/CasperLabs/CasperLabs/blob/dev/docs/BUILD.md