### PR TITLE
NO-TICKET: fix upgrade_installer in UpgradePoint ipc message

### DIFF
--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -334,8 +334,8 @@ message ChainSpec {
         ActivationPoint activation_point = 1;
         // The protocol version as of this upgrade
         io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 2;
-        // path to contract to run that applies the upgrades to system contracts
-        string upgrade_contract_path = 3;
+        // bytes for a contract to run that applies the upgrades to system contracts
+        DeployCode upgrade_installer = 3;
         // Note: this is optional; only needed when costs are changing
         CostTable new_costs = 4;
     }


### PR DESCRIPTION
This PR changes the `UpgradePoint` ipc message (in the chain spec def) to expect a `DeployCode` message instead of a path to a file. This was discussed as part of the review process for the upgrading system contracts spec. No logic uses the message type yet; its original definition was speculative.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned for review.