### PR TITLE
EE-669: ipc.proto messages for upgrade endpoint

### DIFF
--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -583,6 +583,14 @@ where
 
         grpc::SingleResponse::completed(genesis_response)
     }
+
+    fn upgrade(
+        &self,
+        _request_options: ::grpc::RequestOptions,
+        _upgrade_request: ipc::UpgradeRequest,
+    ) -> ::grpc::SingleResponse<ipc::UpgradeResponse> {
+        unimplemented!("todo: impl upgrade endpoint")
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -352,7 +352,7 @@ message UpgradeRequest{
 }
 
 message UpgradeResult {
-    bytes poststate_hash = 1;
+    bytes post_state_hash = 1;
     ExecutionEffect effect = 2;
 }
 

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -346,6 +346,27 @@ message ChainSpec {
     }
 }
 
+message UpgradeRequest{
+    bytes parent_state_hash = 1;
+    ChainSpec.UpgradePoint upgrade_point =2;
+}
+
+message UpgradeResult {
+    bytes poststate_hash = 1;
+    ExecutionEffect effect = 2;
+}
+
+message UpgradeDeployError {
+    string message = 1;
+}
+
+message UpgradeResponse {
+    oneof result {
+        UpgradeResult success = 1;
+        UpgradeDeployError failed_deploy = 2;
+    }
+}
+
 // Definition of the service.
 // ExecutionEngine implements server part while Consensus implements client part.
 service ExecutionEngineService {
@@ -356,4 +377,5 @@ service ExecutionEngineService {
     rpc run_genesis (GenesisRequest) returns (GenesisResponse) {}
     rpc execute (ExecuteRequest) returns (ExecuteResponse) {}
     rpc run_genesis_with_chainspec (ChainSpec.GenesisConfig) returns (GenesisResponse) {}
+    rpc upgrade(UpgradeRequest) returns (UpgradeResponse) {}
 }


### PR DESCRIPTION
This PR introduces the necessary grpc messages for the new upgrade endpoint as defined in the upgrade system contracts spec, and a stub method in EE which will be implemented in a forthcoming PR.

https://casperlabs.atlassian.net/browse/EE-669

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned for review.