### PR TITLE
Adding staticmethod to big_int and long_value in casperlabs_client ABI.

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -6,6 +6,7 @@ CasperLabs Client API library and command line tool.
 # Hack to fix the relative imports problems #
 import sys
 from pathlib import Path
+from typing import Union
 
 file = Path(__file__).resolve()
 parent, root = file.parent, file.parents[1]
@@ -149,11 +150,13 @@ class ABI:
         # TODO: should be signed 32 bits
         return ABI.u32(a)
 
+    @staticmethod
     def long_value(a: int) -> bytes:
         # TODO: should be signed 64 bits
         return ABI.u64(a)
 
-    def big_int(a) -> bytes:
+    @staticmethod
+    def big_int(a: Union[int, dict]) -> bytes:
         try:
             return ABI.u512(int(a["value"]))
         except TypeError:

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -403,18 +403,34 @@ def test_args_parser():
         b"\x00\x00\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07"
     )
 
-    amount = 123456
+    long_value = 123456
+    big_int_value = 123456789012345678901234567890
 
-    args = [{"name": "amount", "value": {"long_value": amount}},
+    long_value_abi = ABI.long_value(long_value)
+    assert long_value_abi == b"@\xe2\x01\x00\x00\x00\x00\x00"
+
+    bytes_value_abi = ABI.account(account)
+    assert bytes_value_abi == b" \x00\x00\x00\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07\x00\x08" \
+                              b"\x00\x00\x00\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00\x06\x00\x07"
+
+    optional_value_abi = ABI.optional_value(None)
+    assert optional_value_abi == b"\x00"
+
+    big_int_value_abi = ABI.big_int(big_int_value)
+    assert big_int_value_abi == b"\r\xd2\n?N\xee\xe0s\xc3\xf6\x0f\xe9\x8e\x01"
+
+    args = [{"name": "amount", "value": {"long_value": long_value}},
             {"name": "account", "value": {"bytes_value": account.hex()}},
             {"name": "purse_id", "value": {"optional_value": {}}},
-            {"name": "number", "value": {"big_int": {"value": "2", "bit_width": 512}}}]
+            {"name": "number", "value": {"big_int": {"value": f"{big_int_value}", "bit_width": 512}}}]
 
     json_str = json.dumps(args)
 
-    assert ABI.args_from_json(json_str) == ABI.args(
-        [ABI.long_value(amount), ABI.account(account), ABI.optional_value(None), ABI.big_int(2)]
+    json_abi = ABI.args_from_json(json_str)
+    raw_abi = ABI.args(
+        [long_value_abi, bytes_value_abi, optional_value_abi, big_int_value_abi]
     )
+    assert json_abi == raw_abi
 
 
 @fixture()


### PR DESCRIPTION
Correcting method definitions for long_value and big_int in casperlabs_client.

No Ticket.

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
