### PR TITLE
NO-TICKET: update docs to include new --payment-amount argument now required by the client

### DIFF
--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -47,9 +47,14 @@ Add coins to this account using the [faucet](https://clarity.casperlabs.io/#/fau
 casperlabs-client \
     --host deploy.casperlabs.io \
     bond \
+    --payment-amount 1 \
     --amount <bond-amount> \
     --private-key <path-to-private-key>
 ```
+
+Note: `--payment-amount` is used in the standard payment code to pay for the execution.
+For now, the value is not used, but payment code will be enabled on the DEVNET
+in an upcoming release.
 
 ##### Step 4: Start the Execution Engine
 
@@ -76,11 +81,13 @@ First, you must unbond:
 casperlabs-client \
     --host deploy.casperlabs.io \
     unbond \
+    --payment-amount 1 \
     --amount <unbond-amount> \
     --private-key <path-to-private-key>
 ```
 
 The `--amount` argument here is optional: you can partially unbond by providing an amount that is smaller than your bond amount, or you can omit this argument to unbond your full bond amount.
+(See note above about `--payment-amount`).
 
 After that, you can safely stop processes:
 ```


### PR DESCRIPTION
### Overview
The scala client now requires `--payment-amount` to be specified. This PR updates the documentation to include this argument.

### Which JIRA ticket does this PR relate to?
None

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
