### PR TITLE
NODE-860: Finish off documentation of contract args' types 

### DIFF
--- a/client/src/test/scala/io/casperlabs/client/configuration/ArgsSpec.scala
+++ b/client/src/test/scala/io/casperlabs/client/configuration/ArgsSpec.scala
@@ -5,26 +5,33 @@ import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.casper.consensus.Deploy.Arg
 import io.casperlabs.casper.consensus.state.BigInt
 import io.casperlabs.casper.consensus.state.Key
+import io.casperlabs.casper.consensus.state.IntList
+import io.casperlabs.casper.consensus.state.StringList
 import com.google.protobuf.ByteString
 
 class ArgsSpec extends FlatSpec with Matchers {
   behavior of "Args"
 
   it should "parse JSON arguments" in {
-    val amount  = 123456L
-    val account = Array.range(0, 32).map(_.toByte)
-    val json    = s"""
+    val int_value   = 12345
+    val amount      = 123456L
+    val account     = Array.range(0, 32).map(_.toByte)
+    val hex_account = Base16.encode(account)
+    val json        = s"""
     [
-      {"name": "amount", "value": {"long_value": ${amount}}},
-      {"name": "account", "value": {"bytes_value": "${Base16.encode(account)}"}},
+      {"name": "my_long_value", "value": {"long_value": ${amount}}},
+      {"name": "my_account", "value": {"bytes_value": "${hex_account}"}},
       {"name": "maybe_long", "value": {"optional_value": {}}},
       {"name": "maybe_long", "value": {"optional_value": {"long_value": ${amount}}}},
       {"name": "surname", "value": {"string_value": "Nakamoto"}},
-      {"name": "number", "value": {"big_int": {"value": "2", "bit_width": 512}}},
-      {"name": "my_hash", "value": {"key": {"hash": {"hash": "${Base16.encode(account)}"}}}},
-      {"name": "my_address", "value": {"key": {"address": {"account": "${Base16.encode(account)}"}}}},
-      {"name": "my_uref", "value": {"key": {"uref": {"uref": "${Base16.encode(account)}", "access_rights": 5}}}},
-      {"name": "my_local", "value": {"key": {"local": {"hash": "${Base16.encode(account)}"}}}}
+      {"name": "big_number", "value": {"big_int": {"value": "2", "bit_width": 512}}},
+      {"name": "my_hash", "value": {"key": {"hash": {"hash": "${hex_account}"}}}},
+      {"name": "my_address", "value": {"key": {"address": {"account": "${hex_account}"}}}},
+      {"name": "my_uref", "value": {"key": {"uref": {"uref": "${hex_account}", "access_rights": 5}}}},
+      {"name": "my_local", "value": {"key": {"local": {"hash": "${hex_account}"}}}},
+      {"name": "my_int_value", "value": {"int_value": ${int_value}}},
+      {"name": "my_int_list", "value": {"int_list": {"values": [0, 1, 2]}}},
+      {"name": "my_string_list", "value": {"string_list": {"values": ["A", "B", "C"]}}}
     ]
     """
 
@@ -32,9 +39,11 @@ class ArgsSpec extends FlatSpec with Matchers {
       case Left(error) =>
         fail(error)
       case Right(args) =>
-        args should have size 10
-        args(0) shouldBe Arg("amount").withValue(Arg.Value(Arg.Value.Value.LongValue(amount)))
-        args(1) shouldBe Arg("account").withValue(
+        args should have size 13
+        args(0) shouldBe Arg("my_long_value").withValue(
+          Arg.Value(Arg.Value.Value.LongValue(amount))
+        )
+        args(1) shouldBe Arg("my_account").withValue(
           Arg.Value(Arg.Value.Value.BytesValue(ByteString.copyFrom(account)))
         )
         args(2) shouldBe Arg("maybe_long").withValue(
@@ -46,7 +55,7 @@ class ArgsSpec extends FlatSpec with Matchers {
         args(4) shouldBe Arg("surname").withValue(
           Arg.Value(Arg.Value.Value.StringValue("Nakamoto"))
         )
-        args(5) shouldBe Arg("number").withValue(
+        args(5) shouldBe Arg("big_number").withValue(
           Arg.Value(Arg.Value.Value.BigInt(BigInt("2", 512)))
         )
         args(6) shouldBe Arg("my_hash").withValue(
@@ -66,6 +75,15 @@ class ArgsSpec extends FlatSpec with Matchers {
         )
         args(9) shouldBe Arg("my_local").withValue(
           Arg.Value(Arg.Value.Value.Key(Key().withLocal(Key.Local(ByteString.copyFrom(account)))))
+        )
+        args(10) shouldBe Arg("my_int_value").withValue(
+          Arg.Value(Arg.Value.Value.IntValue(int_value))
+        )
+        args(11) shouldBe Arg("my_int_list").withValue(
+          Arg.Value(Arg.Value.Value.IntList(IntList(Array(0, 1, 2))))
+        )
+        args(12) shouldBe Arg("my_string_list").withValue(
+          Arg.Value(Arg.Value.Value.StringList(StringList(Array("A", "B", "C"))))
         )
     }
   }

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -300,6 +300,8 @@ let amount = get_arg::<u64>(0);
 | `address`        | `Key.Address` | `'{"name": "my_address", "value": {"key": {"address": {"account": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
 | `uref`           | `Key.URef`    | `'{"name": "my_uref", "value": {"key": {"uref": {"uref": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414", "access_rights": 5}}}}'`
 | `local`          | `Key.Local`   | `'{"name": "my_local", "value": {"key": {"local": {"hash": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
+| `int_list`       | `???`         | `'{"name": "my_int_list", "value": {"int_list": {"values": [0, 1, 2]}}}'`
+| `string_list`    | `???`         | `'{"name": "my_string_list", "value": {"string_list": {"values": ["A", "B", "C"]}}}'`
 
 Numeric values of `access_rights` in `uref` are defined in
 [`enum AccessRights in state.proto](https://github.com/CasperLabs/CasperLabs/blob/ca35f324179c93f0687ed4cf67d887176525b73b/protobuf/io/casperlabs/casper/consensus/state.proto#L58).

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -294,14 +294,14 @@ let amount = get_arg::<u64>(0);
 | `int_value`      | `u32`         | `'[{"name": "amount", "value": {"int_value": 123456}}]'`
 | `long_value`     | `u64`         | `'[{"name": "amount", "value": {"long_value": 123456}}]'`
 | `big_int`        | `u512`        | `'[{"name": "amount", "value": {"big_int": {"value": "123456", "bit_width": 512}}}]'`
-| `string_value`   | `string`      | `'[{"name": "surname", "value": {"string_value": "Nakamoto"}}]'`
+| `string_value`   | `String`      | `'[{"name": "surname", "value": {"string_value": "Nakamoto"}}]'`
 | `optional_value` | `Option<T>`   | `'{"name": "maybe_number", "value": {"optional_value": {}}}` or  `{"name": "maybe_number", "value": {"optional_value": {"long_value": 1000000}}}'`
-| `hash`           | `Key.Hash`    | `'{"name": "my_hash", "value": {"key": {"hash": {"hash": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
-| `address`        | `Key.Address` | `'{"name": "my_address", "value": {"key": {"address": {"account": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
-| `uref`           | `Key.URef`    | `'{"name": "my_uref", "value": {"key": {"uref": {"uref": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414", "access_rights": 5}}}}'`
-| `local`          | `Key.Local`   | `'{"name": "my_local", "value": {"key": {"local": {"hash": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
-| `int_list`       | `???`         | `'{"name": "my_int_list", "value": {"int_list": {"values": [0, 1, 2]}}}'`
-| `string_list`    | `???`         | `'{"name": "my_string_list", "value": {"string_list": {"values": ["A", "B", "C"]}}}'`
+| `hash`           | `Key::Hash`    | `'{"name": "my_hash", "value": {"key": {"hash": {"hash": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
+| `address`        | `Key::Address` | `'{"name": "my_address", "value": {"key": {"address": {"account": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
+| `uref`           | `Key::URef`    | `'{"name": "my_uref", "value": {"key": {"uref": {"uref": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414", "access_rights": 5}}}}'`
+| `local`          | `Key::Local`   | `'{"name": "my_local", "value": {"key": {"local": {"hash": "9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414"}}}}'`
+| `int_list`       | `Vec<i32>`         | `'{"name": "my_int_list", "value": {"int_list": {"values": [0, 1, 2]}}}'`
+| `string_list`    | `Vec<String>`         | `'{"name": "my_string_list", "value": {"string_list": {"values": ["A", "B", "C"]}}}'`
 
 Numeric values of `access_rights` in `uref` are defined in
 [`enum AccessRights in state.proto](https://github.com/CasperLabs/CasperLabs/blob/ca35f324179c93f0687ed4cf67d887176525b73b/protobuf/io/casperlabs/casper/consensus/state.proto#L58).


### PR DESCRIPTION
### Overview
This PR adds tests and documentation of remaining types of contract args.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-860

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Tests are in Scala only, we don't seem to have tests for all possible arg types in Rust.
