### PR TITLE
NO-TICK: remove mac known issue warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ The open-source CasperLabs project is building a decentralized, economic, censor
 
 ## Known Issues
 
-Currently there is a known issue with building and running the execution-engine binaries on a Mac. We recommend using docker for now until a fix is made.
-
 ## Issues
 
 If you find any issues, please [file an issue](https://github.com/CasperLabs/CasperLabs/issues/new).

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -1,10 +1,5 @@
 # Running the CasperLabs Node
 ---
-## Known Issues
-
-Currently there is a known issue with building and running the execution-engine binaries on a Mac. We recommend using docker for now until a fix is made.
----
-
 The CasperLabs node consists of two components:
 * `casperlabs-engine-grpc-server`, which executes smart contracts and persists the effects of these executions.
 * `casperlabs-node`, which handles peer-to-peer communication, consensus, and block storage.


### PR DESCRIPTION
### Overview
updates markdown files to remove warning about the mac build/package issue.

### Which JIRA ticket does this PR relate to?
NONE

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Github Releases will now have a mac tarball supplied.

https://github.com/CasperLabs/CasperLabs/releases/download/v0.7.0/casperlabs-engine-grpc-server_0.7.0_darwin_i386.tar.gz
