### PR TITLE
EE-675: Update bonding and unbonding contracts to only use READ permissions on PoS contract

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -21,6 +21,7 @@ use argsparser::ArgsParser;
 use core::convert::{TryFrom, TryInto};
 
 const MINT_NAME: &str = "mint";
+const POS_NAME: &str = "pos";
 
 /// Read value under the key in the global state
 pub fn read<T>(turef: TURef<T>) -> T
@@ -557,15 +558,23 @@ pub fn transfer_from_purse_to_purse(
     .expect("Should parse result")
 }
 
-pub fn get_mint() -> Option<ContractPointer> {
-    let mint_public_uref = get_uref(MINT_NAME)?;
+fn get_system_contract(name: &str) -> Option<ContractPointer> {
+    let public_uref = get_uref(name)?;
 
-    if let Some(Value::Key(Key::URef(mint_private_uref))) = read_untyped(&mint_public_uref) {
-        let pointer = pointers::TURef::new(mint_private_uref.addr(), AccessRights::READ);
+    if let Some(Value::Key(Key::URef(private_uref))) = read_untyped(&public_uref) {
+        let pointer = pointers::TURef::new(private_uref.addr(), AccessRights::READ);
         Some(ContractPointer::URef(pointer))
     } else {
         None
     }
+}
+
+pub fn get_mint() -> Option<ContractPointer> {
+    get_system_contract(MINT_NAME)
+}
+
+pub fn get_pos() -> Option<ContractPointer> {
+    get_system_contract(POS_NAME)
 }
 
 pub fn get_phase() -> Phase {

--- a/execution-engine/contracts/client/bonding/src/lib.rs
+++ b/execution-engine/contracts/client/bonding/src/lib.rs
@@ -4,13 +4,11 @@
 extern crate alloc;
 extern crate contract_ffi;
 
-use contract_ffi::contract_api::pointers::TURef;
 use contract_ffi::contract_api::{self, PurseTransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::value::uint::U512;
 
 const BOND_METHOD_NAME: &str = "bond";
-const POS_CONTRACT_NAME: &str = "pos";
 
 // Bonding contract.
 //
@@ -18,10 +16,7 @@ const POS_CONTRACT_NAME: &str = "pos";
 // Issues bonding request to the PoS contract.
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_uref = unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME), 55);
-    let pos_public: TURef<Key> = unwrap_or_revert(pos_uref.to_turef(), 66);
-    let pos_contract: Key = contract_api::read(pos_public);
-    let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
+    let pos_pointer = unwrap_or_revert(contract_api::get_pos(), 77);
 
     let source_purse = contract_api::main_purse();
     let bonding_purse = contract_api::create_purse();

--- a/execution-engine/contracts/client/unbonding/src/lib.rs
+++ b/execution-engine/contracts/client/unbonding/src/lib.rs
@@ -5,11 +5,8 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use contract_ffi::contract_api;
-use contract_ffi::contract_api::pointers::TURef;
-use contract_ffi::key::Key;
 use contract_ffi::value::uint::U512;
 
-const POS_CONTRACT_NAME: &str = "pos";
 const UNBOND_METHOD_NAME: &str = "unbond";
 
 // Unbonding contract.
@@ -19,10 +16,7 @@ const UNBOND_METHOD_NAME: &str = "unbond";
 // Otherwise (`Some<u64>`) unbonds with part of the bonded stakes.
 #[no_mangle]
 pub extern "C" fn call() {
-    let pos_uref = unwrap_or_revert(contract_api::get_uref(POS_CONTRACT_NAME), 55);
-    let pos_public: TURef<Key> = unwrap_or_revert(pos_uref.to_turef(), 66);
-    let pos_contract: Key = contract_api::read(pos_public);
-    let pos_pointer = unwrap_or_revert(pos_contract.to_c_ptr(), 77);
+    let pos_pointer = unwrap_or_revert(contract_api::get_pos(), 77);
 
     let unbond_amount: Option<U512> = contract_api::get_arg::<Option<u64>>(0).map(U512::from);
 


### PR DESCRIPTION
### Overview
The standard client bonding and unbonding contracts tried to use more permissions than are allowed for regular user accounts, causing an error in the deploy (see e.g. https://github.com/CasperLabs/CasperLabs/issues/1122). This PR fixes that issue.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-675

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
