### PR TITLE
NODE-856: Cache DAG Storage

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/helper/StorageFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/StorageFixture.scala
@@ -73,7 +73,7 @@ object StorageFixture {
       jdbcUrl                                = createJdbcUrl(db)
       implicit0(xa: Transactor.Aux[F, Unit]) = createTransactor(jdbcUrl)
       _                                      <- initTables(jdbcUrl)
-      storage                                <- SQLiteStorage.create[F](wrap = _.pure[F])
+      storage                                <- SQLiteStorage.create[F]()
       indexedDagStorage                      <- IndexedDagStorage.create[F](storage)
     } yield (storage, indexedDagStorage, storage)
   }

--- a/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
+++ b/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
@@ -112,10 +112,19 @@ trait ArbitraryConsensus {
     } yield block
   }
 
+  implicit val arbJustification: Arbitrary[Block.Justification] = Arbitrary {
+    for {
+      blockHash <- genHash
+      validator <- Gen.oneOf(randomValidators)
+    } yield Block.Justification(validator, blockHash)
+  }
+
   implicit val arbBlockHeader: Arbitrary[Block.Header] = Arbitrary {
     for {
       parentCount        <- Gen.choose(1, 5)
       parentHashes       <- Gen.listOfN(parentCount, genHash)
+      justificationCount <- Gen.choose(1, 5)
+      justifications     <- Gen.listOfN(justificationCount, arbJustification.arbitrary)
       deployCount        <- Gen.choose(1, 10)
       bodyHash           <- genHash
       preStateHash       <- genHash
@@ -129,6 +138,7 @@ trait ArbitraryConsensus {
         .withDeployCount(deployCount)
         .withValidatorPublicKey(validatorPublicKey)
         .withBodyHash(bodyHash)
+        .withJustifications(justifications)
     }
   }
 

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -131,7 +131,7 @@ use-tls = false
 # io.casperlabs.blockstorage.FileDagStorage.Config
 [blockstorage]
 
-# Maximum size of the in-memory block cache in bytes.
+# Maximum size of each of in-memory block/dag/justifications caches in bytes.
 cache-max-size-bytes = 262144000
 
 # io.casperlabs.node.configuration.Configuration.GrpcServer

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -156,7 +156,7 @@ class NodeRuntime private[node] (
                         maxSizeBytes = conf.blockstorage.cacheMaxSizeBytes
                       ).map(
                         cache =>
-                          // Compiler fails to inference the proper type without this
+                          // Compiler fails to infer the proper type without this
                           cache: DagStorage[Effect] with DagRepresentation[Effect]
                       )
                 )

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -499,7 +499,7 @@ private[configuration] final case class Options private (
 
     @scallop
     val blockstorageCacheMaxSizeBytes =
-      gen[Long]("Maximum size of the in-memory block cache in bytes.")
+      gen[Long]("Maximum size of each of in-memory block/dag/justifications caches in bytes.")
 
     @scallop
     val casperValidatorPublicKey =

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -155,7 +155,10 @@ object SQLiteStorage {
       override def lookup(blockHash: BlockHash): F[Option[BlockSummary]] =
         blockStorage.getBlockSummary(blockHash)
 
-      override def contains(blockHash: BlockHash): F[Boolean] = dagStorage.contains(blockHash)
+      // TODO: Remove DagRepresentation#contains because
+      // we already have BlockStorage#contains with the same semantics
+      // and which also cached in CachingBlockStorage.
+      override def contains(blockHash: BlockHash): F[Boolean] = blockStorage.contains(blockHash)
 
       override def topoSort(
           startBlockNumber: Long,

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -39,7 +39,8 @@ class CachingDagStorage[F[_]: Sync](
       underlying.justificationToBlocks(blockHash)
     )
 
-  override def getRepresentation: F[DagRepresentation[F]] = underlying.getRepresentation
+  override def getRepresentation: F[DagRepresentation[F]] =
+    (this: DagRepresentation[F]).pure[F]
 
   override private[storage] def insert(block: Block): F[DagRepresentation[F]] =
     Sync[F].delay {

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -1,0 +1,135 @@
+package io.casperlabs.storage.dag
+
+import cats._
+import cats.effect._
+import cats.implicits._
+import com.google.common.cache.{Cache, CacheBuilder}
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.models.BlockImplicits._
+import io.casperlabs.storage.DagStorageMetricsSource
+import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.dag.DagRepresentation.Validator
+import io.casperlabs.storage.dag.DagStorage.{MeteredDagRepresentation, MeteredDagStorage}
+
+import scala.collection.JavaConverters._
+
+class CachingDagStorage[F[_]: Sync](
+    underlying: DagStorage[F] with DagRepresentation[F],
+    private[dag] val childrenCache: Cache[BlockHash, Set[BlockHash]],
+    private[dag] val justificationCache: Cache[BlockHash, Set[BlockHash]]
+) extends DagStorage[F]
+    with DagRepresentation[F] {
+  private def cacheOrUnderlying[A](fromCache: => Option[A], fromUnderlying: F[A]) =
+    Sync[F].delay(fromCache) flatMap {
+      case None    => fromUnderlying
+      case Some(a) => a.pure[F]
+    }
+
+  override def children(blockHash: BlockHash): F[Set[BlockHash]] =
+    cacheOrUnderlying(
+      Option(childrenCache.getIfPresent(blockHash)),
+      underlying.children(blockHash)
+    )
+
+  /** Return blocks that having a specify justification */
+  override def justificationToBlocks(blockHash: BlockHash): F[Set[BlockHash]] =
+    cacheOrUnderlying(
+      Option(justificationCache.getIfPresent(blockHash)),
+      underlying.justificationToBlocks(blockHash)
+    )
+
+  override def getRepresentation: F[DagRepresentation[F]] = underlying.getRepresentation
+
+  override private[storage] def insert(block: Block): F[DagRepresentation[F]] =
+    Sync[F].delay {
+      val parents        = block.parentHashes
+      val justifications = block.justifications.map(_.latestBlockHash)
+      parents.foreach { parent =>
+        val newChildren = Option(childrenCache.getIfPresent(parent))
+          .getOrElse(Set.empty[BlockHash]) + block.blockHash
+        childrenCache.put(parent, newChildren)
+      }
+      justifications.foreach { justification =>
+        val newBlockHashes = Option(justificationCache.getIfPresent(justification))
+          .getOrElse(Set.empty[BlockHash]) + block.blockHash
+        justificationCache.put(justification, newBlockHashes)
+      }
+    } >> underlying.insert(block)
+
+  override def checkpoint(): F[Unit] = underlying.checkpoint()
+
+  override def clear(): F[Unit] =
+    Sync[F].delay {
+      childrenCache.invalidateAll()
+      justificationCache.invalidateAll()
+    } >> underlying.clear()
+
+  override def close(): F[Unit] = underlying.close()
+
+  override def lookup(blockHash: BlockHash): F[Option[BlockSummary]] = underlying.lookup(blockHash)
+
+  override def contains(blockHash: BlockHash): F[Boolean] =
+    Sync[F]
+      .delay {
+        val allChildren = childrenCache.asMap().values().asScala.toSet.flatten
+        allChildren(blockHash)
+      }
+      .ifM(true.pure[F], underlying.contains(blockHash))
+
+  /** Return the ranks of blocks in the DAG between start and end, inclusive. */
+  override def topoSort(
+      startBlockNumber: Long,
+      endBlockNumber: Long
+  ): fs2.Stream[F, Vector[BlockHash]] = underlying.topoSort(startBlockNumber, endBlockNumber)
+
+  /** Return ranks of blocks in the DAG from a start index to the end. */
+  override def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockHash]] =
+    underlying.topoSort(startBlockNumber)
+
+  override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]] =
+    underlying.topoSortTail(tailLength)
+
+  override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
+    underlying.latestMessageHash(validator)
+
+  override def latestMessage(validator: Validator): F[Option[BlockSummary]] =
+    underlying.latestMessage(validator)
+
+  override def latestMessageHashes: F[Map[Validator, BlockHash]] = underlying.latestMessageHashes
+
+  override def latestMessages: F[Map[Validator, BlockSummary]] = underlying.latestMessages
+}
+
+object CachingDagStorage {
+  def apply[F[_]: Sync: Metrics](
+      underlying: DagStorage[F] with DagRepresentation[F],
+      maxSizeBytes: Long,
+      name: String = "cache"
+  ): F[CachingDagStorage[F]] = {
+    val metricsF = Metrics[F]
+    val createCache = Sync[F].delay {
+      CacheBuilder
+        .newBuilder()
+        .maximumWeight(maxSizeBytes)
+        // Assuming block hashes 32 bytes long
+        .weigher((_: BlockHash, values: Set[BlockHash]) => (values.size + 1) * 32)
+        .build[BlockHash, Set[BlockHash]]()
+    }
+
+    for {
+      childrenCache      <- createCache
+      justificationCache <- createCache
+      store = new CachingDagStorage[F](
+        underlying,
+        childrenCache,
+        justificationCache
+      ) with MeteredDagStorage[F] with MeteredDagRepresentation[F] {
+        override implicit val m: Metrics[F] = metricsF
+        override implicit val ms: Metrics.Source =
+          Metrics.Source(DagStorageMetricsSource, name)
+        override implicit val a: Apply[F] = Sync[F]
+      }
+    } yield store
+  }
+}

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -84,11 +84,8 @@ class CachingDagStorage[F[_]: Sync](
   // We don't use 'contains' directly because it's overriden by BlockStorage#contains
   // at SQLiteStorage.scala
   override def contains(blockHash: BlockHash): F[Boolean] =
-    Sync[F]
-      .delay {
-        val allChildren = childrenCache.asMap().values().asScala.toSet.flatten
-        allChildren(blockHash)
-      }
+    lookup(blockHash)
+      .map(_.isDefined)
       .ifM(true.pure[F], underlying.contains(blockHash))
 
   /** Return the ranks of blocks in the DAG between start and end, inclusive. */

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -70,6 +70,11 @@ class CachingDagStorage[F[_]: Sync](
 
   override def close(): F[Unit] = underlying.close()
 
+  // TODO: Remove DagRepresentation#lookup because
+  // we already have BlockStorage#getBlockSummary with the same semantics
+  // and which also cached in CachingBlockStorage.
+  // We don't use 'lookup' directly because it's overriden by BlockStorage#getBlockSummary
+  // at SQLiteStorage.scala
   override def lookup(blockHash: BlockHash): F[Option[BlockSummary]] = underlying.lookup(blockHash)
 
   override def contains(blockHash: BlockHash): F[Boolean] =

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -77,6 +77,11 @@ class CachingDagStorage[F[_]: Sync](
   // at SQLiteStorage.scala
   override def lookup(blockHash: BlockHash): F[Option[BlockSummary]] = underlying.lookup(blockHash)
 
+  // TODO: Remove DagRepresentation#contains because
+  // we already have BlockStorage#contains with the same semantics
+  // and which also cached in CachingBlockStorage.
+  // We don't use 'contains' directly because it's overriden by BlockStorage#contains
+  // at SQLiteStorage.scala
   override def contains(blockHash: BlockHash): F[Boolean] =
     Sync[F]
       .delay {

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -32,6 +32,34 @@ object DagStorage {
       incAndMeasure("checkpoint", super.checkpoint())
   }
 
+  trait MeteredDagRepresentation[F[_]] extends DagRepresentation[F] with Metered[F] {
+    // Not measuring 'latestMessage*' because they return fs2.Stream which doesn't work with 'incAndMeasure'
+
+    abstract override def children(blockHash: BlockHash): F[Set[BlockHash]] =
+      incAndMeasure("children", super.children(blockHash))
+
+    abstract override def justificationToBlocks(blockHash: BlockHash): F[Set[BlockHash]] =
+      incAndMeasure("justificationToBlocks", super.justificationToBlocks(blockHash))
+
+    abstract override def lookup(blockHash: BlockHash): F[Option[BlockSummary]] =
+      incAndMeasure("lookup", super.lookup(blockHash))
+
+    abstract override def contains(blockHash: BlockHash): F[Boolean] =
+      incAndMeasure("contains", super.contains(blockHash))
+
+    abstract override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
+      incAndMeasure("latestMessageHash", super.latestMessageHash(validator))
+
+    abstract override def latestMessage(validator: Validator): F[Option[BlockSummary]] =
+      incAndMeasure("latestMessage", super.latestMessage(validator))
+
+    abstract override def latestMessageHashes: F[Map[Validator, BlockHash]] =
+      incAndMeasure("latestMessageHashes", super.latestMessageHashes)
+
+    abstract override def latestMessages: F[Map[Validator, BlockSummary]] =
+      incAndMeasure("latestMessages", super.latestMessages)
+  }
+
   def apply[F[_]](implicit B: DagStorage[F]): DagStorage[F] = B
 }
 

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -58,6 +58,19 @@ object DagStorage {
 
     abstract override def latestMessages: F[Map[Validator, BlockSummary]] =
       incAndMeasure("latestMessages", super.latestMessages)
+
+    abstract override def topoSort(
+        startBlockNumber: Long,
+        endBlockNumber: Long
+    ): fs2.Stream[F, Vector[BlockHash]] =
+      fs2.Stream.eval(m.incrementCounter("topoSort")) >> super
+        .topoSort(startBlockNumber, endBlockNumber)
+
+    abstract override def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockHash]] =
+      fs2.Stream.eval(m.incrementCounter("topoSort")) >> super.topoSort(startBlockNumber)
+
+    abstract override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]] =
+      fs2.Stream.eval(m.incrementCounter("topoSortTail")) >> super.topoSortTail(tailLength)
   }
 
   def apply[F[_]](implicit B: DagStorage[F]): DagStorage[F] = B

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -14,7 +14,7 @@ import io.casperlabs.models.BlockImplicits._
 import io.casperlabs.storage.DagStorageMetricsSource
 import io.casperlabs.storage.block.BlockStorage.BlockHash
 import io.casperlabs.storage.dag.DagRepresentation.Validator
-import io.casperlabs.storage.dag.DagStorage.MeteredDagStorage
+import io.casperlabs.storage.dag.DagStorage.{MeteredDagRepresentation, MeteredDagStorage}
 import io.casperlabs.storage.util.DoobieCodecs
 
 class SQLiteDagStorage[F[_]: Bracket[?[_], Throwable]](
@@ -282,13 +282,16 @@ object SQLiteDagStorage {
   private[storage] def create[F[_]: Sync](
       implicit xa: Transactor[F],
       met: Metrics[F]
-  ): F[DagStorage[F]] =
+  ): F[DagStorage[F] with DagRepresentation[F]] =
     for {
-      dagStorage <- Sync[F].delay(new SQLiteDagStorage[F](xa) with MeteredDagStorage[F] {
-                     override implicit val m: Metrics[F] = met
-                     override implicit val ms: Source =
-                       Metrics.Source(DagStorageMetricsSource, "sqlite")
-                     override implicit val a: Apply[F] = Sync[F]
-                   })
-    } yield dagStorage: DagStorage[F]
+      dagStorage <- Sync[F].delay(
+                     new SQLiteDagStorage[F](xa) with MeteredDagStorage[F]
+                     with MeteredDagRepresentation[F] {
+                       override implicit val m: Metrics[F] = met
+                       override implicit val ms: Source =
+                         Metrics.Source(DagStorageMetricsSource, "sqlite")
+                       override implicit val a: Apply[F] = Sync[F]
+                     }
+                   )
+    } yield dagStorage: DagStorage[F] with DagRepresentation[F]
 }

--- a/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
@@ -456,5 +456,5 @@ class SQLiteBlockStorageTest extends BlockStorageTest with SQLiteFixture[BlockSt
   override def db: String = "/tmp/block_storage.db"
 
   override def createTestResource: Task[BlockStorage[Task]] =
-    SQLiteStorage.create[Task](wrap = Task.pure)
+    SQLiteStorage.create[Task]()
 }

--- a/storage/src/test/scala/io/casperlabs/storage/dag/CachingDagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/CachingDagStorageTest.scala
@@ -1,0 +1,229 @@
+package io.casperlabs.storage.dag
+
+import cats.effect.concurrent.Ref
+import cats.instances.long._
+import cats.instances.map._
+import cats.instances.set._
+import cats.syntax.semigroup._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.Block
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.models.BlockImplicits._
+import io.casperlabs.storage.dag.CachingDagStorageTest.{CachingDagStorageTestData, MockMetrics}
+import io.casperlabs.storage.{ArbitraryStorageData, SQLiteFixture}
+import monix.eval.Task
+import org.scalatest._
+
+import scala.concurrent.duration._
+
+class CachingDagStorageTest
+    extends WordSpec
+    with SQLiteFixture[CachingDagStorageTestData]
+    with WordSpecLike
+    with Matchers
+    with ArbitraryStorageData {
+
+  override def db: String = "/tmp/caching_dag_storage_test.db"
+
+  private implicit val consensusConfig: ConsensusConfig = ConsensusConfig(
+    maxSessionCodeBytes = 1,
+    maxPaymentCodeBytes = 1,
+    minSessionCodeBytes = 1,
+    minPaymentCodeBytes = 1
+  )
+
+  private val sampleBlock: Block = sample(
+    arbBlock.arbitrary.suchThat(b => b.parentHashes.nonEmpty && b.justifications.nonEmpty)
+  )
+  private val parents: Seq[ByteString] = sampleBlock.parentHashes.toList
+  private val justifications: Seq[ByteString] =
+    sampleBlock.justifications.map(_.latestBlockHash).toList
+
+  private def prepareTestEnvironment(cacheSize: Long) = {
+    implicit val metrics: MockMetrics = new MockMetrics()
+    for {
+      dagStorage <- SQLiteDagStorage.create[Task]
+      cache      <- CachingDagStorage[Task](dagStorage, cacheSize)
+    } yield CachingDagStorageTestData(
+      underlying = dagStorage,
+      cache = cache,
+      metrics = metrics
+    )
+  }
+
+  override def createTestResource: Task[CachingDagStorageTestData] =
+    prepareTestEnvironment(cacheSize = 1024L * 1024L * 25L)
+
+  private def verifyCached[A](
+      name: String,
+      expected: A
+  )(
+      get: CachingDagStorage[Task] => Task[A]
+  ): Unit = {
+    // Store it through cache
+    runSQLiteTest {
+      case CachingDagStorageTestData(_, cache, metrics) =>
+        for {
+          _        <- cache.insert(sampleBlock)
+          thing    <- get(cache)
+          _        = thing shouldBe expected
+          counters <- metrics.counterRef.get
+          _        = counters(name) shouldBe 1
+        } yield ()
+    }
+    // Store it through underlying
+    runSQLiteTest {
+      case CachingDagStorageTestData(underlying, cache, metrics) =>
+        for {
+          _        <- underlying.insert(sampleBlock)
+          thing    <- get(cache)
+          _        = thing shouldBe expected
+          counters <- metrics.counterRef.get
+          _        = counters(name) shouldBe 2
+        } yield ()
+    }
+  }
+
+  "CachingDagStorage" when {
+    "children aren't in the cache" should {
+      "get them from the underlying store and not cache it" in runSQLiteTest({
+        case CachingDagStorageTestData(
+            underlying,
+            cache,
+            metrics
+            ) =>
+          for {
+            _        <- underlying.insert(sampleBlock)
+            children <- Task.traverse(parents)(cache.children).map(_.reduce(_ |+| _))
+            _        = children shouldBe Set(sampleBlock.blockHash)
+            _        <- Task.traverse(parents)(cache.children).map(_.reduce(_ |+| _))
+            counters <- metrics.counterRef.get
+            _        = counters("children") shouldBe (parents.size * 4)
+          } yield ()
+      })
+    }
+
+    "justifications aren't in the cache" should {
+      "get them from the underlying store and not cache it" in runSQLiteTest({
+        case CachingDagStorageTestData(
+            underlying,
+            cache,
+            metrics
+            ) =>
+          for {
+            _ <- underlying.insert(sampleBlock)
+            blockHashes <- Task
+                            .traverse(justifications)(cache.justificationToBlocks)
+                            .map(_.reduce(_ |+| _))
+            _        = blockHashes shouldBe Set(sampleBlock.blockHash)
+            _        <- Task.traverse(justifications)(cache.justificationToBlocks).map(_.reduce(_ |+| _))
+            counters <- metrics.counterRef.get
+            _        = counters("justificationToBlocks") shouldBe (justifications.size * 4)
+          } yield ()
+      })
+    }
+
+    "a block added into the store" should {
+      "cache children and justification to blocks" in runSQLiteTest({
+        case CachingDagStorageTestData(
+            underlying,
+            cache,
+            metrics
+            ) =>
+          for {
+            _                 <- cache.insert(sampleBlock)
+            childrenFromCache <- Task.traverse(parents)(cache.children).map(_.reduce(_ |+| _))
+            blockHashesFromCache <- Task
+                                     .traverse(justifications)(cache.justificationToBlocks)
+                                     .map(_.reduce(_ |+| _))
+            counters <- metrics.counterRef.get
+            _        = counters("insert") shouldBe 2
+            _        = counters("children") shouldBe parents.size
+            _        = counters("justificationToBlocks") shouldBe justifications.size
+            childrenFromStorage <- Task
+                                    .traverse(parents)(underlying.children)
+                                    .map(_.reduce(_ |+| _))
+            blockHashesFromStorage <- Task
+                                       .traverse(justifications)(underlying.justificationToBlocks)
+                                       .map(_.reduce(_ |+| _))
+            _ = childrenFromCache shouldBe childrenFromStorage
+            _ = childrenFromCache shouldBe Set(sampleBlock.blockHash)
+            _ = blockHashesFromCache shouldBe blockHashesFromStorage
+            _ = blockHashesFromCache shouldBe Set(sampleBlock.blockHash)
+          } yield ()
+      })
+
+      "evict items if max size threshold is reached" in {
+        runSQLiteTest(
+          resources = prepareTestEnvironment(cacheSize = 64L * 10),
+          test = {
+            case CachingDagStorageTestData(_, cache, metrics) =>
+              // 1 parent and 1 justification will result
+              // in 32 (key) + 32 (parent hash or block hash) = 64 bytes
+              // needed for reproducibility
+              def genBlock =
+                sampleBlock
+                  .withHeader(
+                    sampleBlock.getHeader.copy(
+                      parentHashes = List(sample(genHash)),
+                      justifications = List(Block.Justification(ByteString.EMPTY, sample(genHash)))
+                    )
+                  )
+                  .copy(blockHash = sample(genHash))
+
+              val blocksNum   = 20
+              val otherBlocks = List.fill(blocksNum)(genBlock)
+              val allParents  = otherBlocks.flatMap(_.parents.toList)
+              val allJustifications =
+                otherBlocks.flatMap(_.justifications.map(_.latestBlockHash).toList)
+              for {
+                _ <- Task.traverse(otherBlocks)(cache.insert)
+                _ = println("Cache size: " + cache.childrenCache.size())
+                _ <- Task
+                      .traverse(allParents)(cache.children)
+                _ <- Task
+                      .traverse(allJustifications)(cache.justificationToBlocks)
+                counters <- metrics.counterRef.get
+                // Cache eviction is non-deterministic, so can't check for precise size
+                _ = assert(counters("children") > allParents.size)
+                _ = assert(counters("justificationToBlocks") > allJustifications.size)
+              } yield ()
+          },
+          timeout = 15.seconds
+        )
+      }
+    }
+  }
+
+  "CachingDagStorage" should {
+    "cache `children`" in verifyCached("children", Set(sampleBlock.blockHash)) { store =>
+      store.children(parents.head)
+    }
+    "cache `justificationToBlocks`" in verifyCached(
+      "justificationToBlocks",
+      Set(sampleBlock.blockHash)
+    ) { store =>
+      store.justificationToBlocks(justifications.head)
+    }
+  }
+}
+
+object CachingDagStorageTest {
+  // Using the metrics added by MeteredDagStorage and MeteredDagRepresentation
+  class MockMetrics() extends Metrics.MetricsNOP[Task] {
+    val counterRef: Ref[Task, Map[String, Long]] = Ref.unsafe[Task, Map[String, Long]](Map.empty)
+
+    override def incrementCounter(name: String, delta: Long = 1)(
+        implicit ev: Metrics.Source
+    ): Task[Unit] =
+      counterRef.update {
+        _ |+| Map(name -> delta)
+      }
+  }
+
+  case class CachingDagStorageTestData(
+      underlying: DagStorage[Task] with DagRepresentation[Task],
+      cache: CachingDagStorage[Task],
+      metrics: MockMetrics
+  )
+}

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -556,7 +556,7 @@ class SQLiteDagStorageTest extends DagStorageTest with SQLiteFixture[DagStorage[
   override def db: String = "/tmp/dag_storage.db"
 
   override def createTestResource: Task[DagStorage[Task]] =
-    SQLiteStorage.create[Task](wrap = Task.pure)
+    SQLiteStorage.create[Task]()
 
   "SQLite DAG Storage" should "override validator's latest block hash only if rank is higher" in {
     forAll { (initial: Block, a: Block, c: Block) =>

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/SQLiteDeployStorageSpec.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/SQLiteDeployStorageSpec.scala
@@ -17,5 +17,7 @@ class SQLiteDeployStorageSpec
   override def db: String = "/tmp/deploy_storage.db"
 
   override def createTestResource: Task[(DeployStorageReader[Task], DeployStorageWriter[Task])] =
-    SQLiteStorage.create[Task](wrap = Task.pure).map(s => (s, s))
+    SQLiteStorage
+      .create[Task]()
+      .map(s => (s, s))
 }


### PR DESCRIPTION
### Overview
Adds in-memory cache for parent-children and justification-to-blocks relationships in the same way as in #630

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-856

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Please, pay attention that this PR won't be merged into the `dev` branch directly.