### PR TITLE
NO_TICK: update doc for payment-amount

### DIFF
--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -48,6 +48,7 @@ casperlabs-client \
     deploy \
     --private-key <path-to-private-key> \
     --session $COUNTER_DEFINE
+    --payment-amount 1
 ```
 
 You should see the following output:
@@ -67,6 +68,7 @@ casperlabs-client \
     deploy \
     --private-key <path-to-private-key> \
     --session $COUNTER_CALL
+    --payment-amount 1
 ```
 
 You should see the following output:

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -42,13 +42,15 @@ Create an account, which automatically creates a new keypair.  This keypair shou
 Add coins to this account using the [faucet](https://clarity.casperlabs.io/#/faucet).
 
 ##### Step 5: Deploy `counterdefine.wasm`
+
+Note: `--payment-amount` is used to define the maximum number of motes to spend on the execution of the deploy. 
 ```
 casperlabs-client \
     --host deploy.casperlabs.io \
     deploy \
     --private-key <path-to-private-key> \
     --session $COUNTER_DEFINE
-    --payment-amount 1
+    --payment-amount <int>
 ```
 
 You should see the following output:
@@ -62,13 +64,15 @@ See the instructions [here](QUERYING.md).
 
 
 ##### Step 7: Deploy `countercall.wasm`
+
+Note: `--payment-amount` is used to define the maximum number of motes to spend on the execution of the deploy.
 ```
 casperlabs-client \
     --host deploy.casperlabs.io \
     deploy \
     --private-key <path-to-private-key> \
     --session $COUNTER_CALL
-    --payment-amount 1
+    --payment-amount <int>
 ```
 
 You should see the following output:


### PR DESCRIPTION
### Overview
Adds the `--payment-amount` flag to deploy documentation. This is neccessary if `--payment` is not passed.

ie. [casperlabs] Error: No payment contract options provided; please specify --payment-amount for the standard payment.


### Which JIRA ticket does this PR relate to?
NONE

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
