### PR TITLE
FIX: Better control protobuf generation to fix bloop compilation

### DIFF
--- a/hack/docker/client.sh
+++ b/hack/docker/client.sh
@@ -32,6 +32,7 @@ NODE_ID=$(cat $DIR/.casperlabs/$NODE/node-id)
 function run_default() {
     docker run --rm \
         --network casperlabs \
+        --volume $PWD/keys:/keys \
         casperlabs/client:$VERSION \
         --host $NODE --node-id $NODE_ID $CMD $@
 }

--- a/storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/StorageBenchSuite.scala
+++ b/storage/src/test/scala/io/casperlabs/blockstorage/benchmarks/StorageBenchSuite.scala
@@ -23,7 +23,7 @@ import io.casperlabs.casper.protocol.ApprovedBlock
 import io.casperlabs.casper.consensus.{Block, BlockSummary, Deploy}
 import io.casperlabs.casper.consensus.state.Key
 import io.casperlabs.ipc.Transform.TransformInstance
-import io.casperlabs.ipc.{DeployCode => _, _}
+import io.casperlabs.ipc._
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockMsgWithTransform


### PR DESCRIPTION
### Overview
Metals reported it couldn't build all projects so code navigation didn't work everywhere. `bloop compile -p storage` revealed that it couldn't find the sources generated from `transforms.proto` for some reason. The PR changes the protobuf source filter in the build so `models` only contain data from `transforms.proto` and `smartContracts` has the extra from `ipc.proto`. This fixed the problem, although I'm not exactly sure why; adding the whole `ipc` directory to `storage` also worked.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
