### PR TITLE
EE-646: Add script to generate flamegraph from 'simple-transfer'

### DIFF
--- a/execution-engine/engine-tests/src/profiling/perf.sh
+++ b/execution-engine/engine-tests/src/profiling/perf.sh
@@ -1,51 +1,51 @@
 #!/usr/bin/env bash
 
-set -e
+set -eu -o pipefail
 
 RED='\033[0;31m'
 CYAN='\033[0;36m'
 NO_COLOR='\033[0m'
 EE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." >/dev/null 2>&1 && pwd)"
-BASE_TEMP_DIR="/tmp/simple-transfer-perf"
-THIS_RUN_TEMP_DIR="${BASE_TEMP_DIR}/$RANDOM"
+TEMP_DIR=$(mktemp -d -t simple-transfer-perf-XXXXX)
 
 check_for_perf() {
-  if ! [[ -x "$(command -v perf)" ]]; then
-    printf "${RED}perf not installed${NO_COLOR}\n\n"
-    printf "For Debian, try:\n"
-    printf "${CYAN}sudo apt install linux-tools-common linux-tools-generic linux-tools-$(uname -r)${NO_COLOR}\n\n"
-    printf "For Redhat, try:\n"
-    printf "${CYAN}sudo yum install perf${NO_COLOR}\n\n"
-    exit 127
-  fi
+    if ! [[ -x "$(command -v perf)" ]]; then
+        printf "${RED}perf not installed${NO_COLOR}\n\n"
+        printf "For Debian, try:\n"
+        printf "${CYAN}sudo apt install linux-tools-common linux-tools-generic linux-tools-$(uname -r)${NO_COLOR}\n\n"
+        printf "For Redhat, try:\n"
+        printf "${CYAN}sudo yum install perf${NO_COLOR}\n\n"
+        exit 127
+    fi
 }
 
 run_perf() {
-  cd $EE_DIR
-  make build-contracts
-  cd engine-tests/
-  cargo build --release --bin state-initializer
-  cargo build --release --bin simple-transfer
-  ../target/release/state-initializer --data-dir=../target | perf record -g --call-graph dwarf ../target/release/simple-transfer --data-dir=../target
-  mkdir -p ${THIS_RUN_TEMP_DIR}
-  mv perf.data ${THIS_RUN_TEMP_DIR}
+    cd $EE_DIR
+    make build-contracts
+    cd engine-tests/
+    cargo build --release --bin state-initializer
+    cargo build --release --bin simple-transfer
+    TARGET_DIR="${EE_DIR}/target/release"
+    DATA_DIR_ARG="--data-dir=../target"
+    ${TARGET_DIR}/state-initializer ${DATA_DIR_ARG} | perf record -g --call-graph dwarf ${TARGET_DIR}/simple-transfer ${DATA_DIR_ARG}
+    mv perf.data ${TEMP_DIR}
 }
 
 check_or_clone_flamegraph() {
-  FLAMEGRAPH_DIR="${BASE_TEMP_DIR}/Flamegraph"
-  export PATH=${FLAMEGRAPH_DIR}:${PATH}
-  if ! [[ -x "$(command -v stackcollapse-perf.pl)" ]] || ! [[ -x "$(command -v flamegraph.pl)" ]]; then
-    rm -rf ${FLAMEGRAPH_DIR}
-    git clone https://github.com/brendangregg/FlameGraph ${FLAMEGRAPH_DIR}
-  fi
+    FLAMEGRAPH_DIR="/tmp/FlameGraph"
+    export PATH=${FLAMEGRAPH_DIR}:${PATH}
+    if ! [[ -x "$(command -v stackcollapse-perf.pl)" ]] || ! [[ -x "$(command -v flamegraph.pl)" ]]; then
+        rm -rf ${FLAMEGRAPH_DIR}
+        git clone --depth=1 https://github.com/brendangregg/FlameGraph ${FLAMEGRAPH_DIR}
+    fi
 }
 
 create_flamegraph() {
-  FLAMEGRAPH="${THIS_RUN_TEMP_DIR}/flame.svg"
-  printf "Creating flamegraph at ${FLAMEGRAPH}\n"
-  cd ${THIS_RUN_TEMP_DIR}
-  perf script | stackcollapse-perf.pl | flamegraph.pl > ${FLAMEGRAPH}
-  x-www-browser ${FLAMEGRAPH}
+    FLAMEGRAPH="${TEMP_DIR}/flame.svg"
+    printf "Creating flamegraph at ${FLAMEGRAPH}\n"
+    cd ${TEMP_DIR}
+    perf script | stackcollapse-perf.pl | flamegraph.pl > ${FLAMEGRAPH}
+    x-www-browser ${FLAMEGRAPH}
 }
 
 check_for_perf

--- a/execution-engine/engine-tests/src/profiling/perf.sh
+++ b/execution-engine/engine-tests/src/profiling/perf.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NO_COLOR='\033[0m'
+EE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." >/dev/null 2>&1 && pwd)"
+BASE_TEMP_DIR="/tmp/simple-transfer-perf"
+THIS_RUN_TEMP_DIR="${BASE_TEMP_DIR}/$RANDOM"
+
+check_for_perf() {
+  if ! [[ -x "$(command -v perf)" ]]; then
+    printf "${RED}perf not installed${NO_COLOR}\n\n"
+    printf "For Debian, try:\n"
+    printf "${CYAN}sudo apt install linux-tools-common linux-tools-generic linux-tools-$(uname -r)${NO_COLOR}\n\n"
+    printf "For Redhat, try:\n"
+    printf "${CYAN}sudo yum install perf${NO_COLOR}\n\n"
+    exit 127
+  fi
+}
+
+run_perf() {
+  cd $EE_DIR
+  make build-contracts
+  cd engine-tests/
+  cargo build --release --bin state-initializer
+  cargo build --release --bin simple-transfer
+  ../target/release/state-initializer --data-dir=../target | perf record -g --call-graph dwarf ../target/release/simple-transfer --data-dir=../target
+  mkdir -p ${THIS_RUN_TEMP_DIR}
+  mv perf.data ${THIS_RUN_TEMP_DIR}
+}
+
+check_or_clone_flamegraph() {
+  FLAMEGRAPH_DIR="${BASE_TEMP_DIR}/Flamegraph"
+  export PATH=${FLAMEGRAPH_DIR}:${PATH}
+  if ! [[ -x "$(command -v stackcollapse-perf.pl)" ]] || ! [[ -x "$(command -v flamegraph.pl)" ]]; then
+    rm -rf ${FLAMEGRAPH_DIR}
+    git clone https://github.com/brendangregg/FlameGraph ${FLAMEGRAPH_DIR}
+  fi
+}
+
+create_flamegraph() {
+  FLAMEGRAPH="${THIS_RUN_TEMP_DIR}/flame.svg"
+  printf "Creating flamegraph at ${FLAMEGRAPH}\n"
+  cd ${THIS_RUN_TEMP_DIR}
+  perf script | stackcollapse-perf.pl | flamegraph.pl > ${FLAMEGRAPH}
+  x-www-browser ${FLAMEGRAPH}
+}
+
+check_for_perf
+run_perf
+check_or_clone_flamegraph
+create_flamegraph


### PR DESCRIPTION
### Overview
This PR provides a bash script to simplify creation of a flamegraph from a run of the `simple-transfer` binary target.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-646

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
