### PR TITLE
NO-TICKET: fix mint Error from u32

### DIFF
--- a/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
@@ -55,6 +55,9 @@ impl TryFrom<u32> for Error {
             d if d == Error::DestNotFound as u32 => Ok(Error::DestNotFound),
             d if d == Error::InvalidURef as u32 => Ok(Error::InvalidURef),
             d if d == Error::InvalidAccessRights as u32 => Ok(Error::InvalidAccessRights),
+            d if d == Error::InvalidNonEmptyPurseCreation as u32 => {
+                Ok(Error::InvalidNonEmptyPurseCreation)
+            }
             _ => Err(TryFromDeserializedU32Error(())),
         }
     }


### PR DESCRIPTION
### Overview
This fixes a bug in `impl TryFrom<u32> for mint::error::Error`.

### Which JIRA ticket does this PR relate to?
None

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
