### PR TITLE
NODE-903: ChainSpec in integration tests

### DIFF
--- a/hack/docker/genesis-manifest.toml
+++ b/hack/docker/genesis-manifest.toml
@@ -15,7 +15,7 @@ protocol-version = 1
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
+# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos_install.wasm"
 
 # Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.

--- a/hack/docker/test-node.Dockerfile
+++ b/hack/docker/test-node.Dockerfile
@@ -6,5 +6,3 @@ FROM casperlabs/node:latest
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* && (apt-get update || apt-get update) && apt-get install -yq iproute2 iptables curl sed nmap
 
 COPY .genesis/system-contracts /opt/docker/system-contracts
-ENV CL_CASPER_MINT_CODE_PATH /opt/docker/system-contracts/mint_token.wasm
-ENV CL_CASPER_POS_CODE_PATH /opt/docker/system-contracts/pos.wasm

--- a/integration-testing/casperlabs_local_net/common.py
+++ b/integration-testing/casperlabs_local_net/common.py
@@ -64,6 +64,7 @@ CONV_RATE = 10
 TEST_ACCOUNT_INITIAL_BALANCE = 1000000000
 
 BOOTSTRAP_PATH = "/root/.casperlabs/bootstrap"
+CHAINSPEC_PATH = "/root/.casperlabs/chainspec"
 
 
 @dataclasses.dataclass(eq=True, frozen=True)

--- a/integration-testing/casperlabs_local_net/docker_base.py
+++ b/integration-testing/casperlabs_local_net/docker_base.py
@@ -101,12 +101,8 @@ class DockerBase:
         return f"/tmp/resources_{self.docker_tag}_{self.config.number}_{self.config.rand_str}"
 
     @property
-    def bonds_file(self) -> str:
-        return f"{self.host_mount_dir}/bonds.txt"
-
-    @property
-    def host_genesis_dir(self) -> str:
-        return f"{self.host_mount_dir}/genesis"
+    def host_chainspec_dir(self) -> str:
+        return f"{self.host_mount_dir}/chainspec"
 
     @property
     def host_bootstrap_dir(self) -> str:

--- a/integration-testing/casperlabs_local_net/docker_config.py
+++ b/integration-testing/casperlabs_local_net/docker_config.py
@@ -4,14 +4,13 @@ from typing import Any, Optional
 from docker import DockerClient
 
 
-from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT, Account
+from casperlabs_local_net.casperlabs_accounts import Account
 from casperlabs_local_net.common import random_string, BOOTSTRAP_PATH, testing_root_path
 
 
 DEFAULT_NODE_ENV = {
     "RUST_BACKTRACE": "full",
     "CL_LOG_LEVEL": os.environ.get("CL_LOG_LEVEL", "INFO"),
-    "CL_CASPER_IGNORE_DEPLOY_SIGNATURE": "false",
     "CL_SERVER_NO_UPNP": "true",
     "CL_VERSION": "test",
 }
@@ -76,6 +75,7 @@ class DockerConfig:
             "--tls-key": self.tls_key_path(),
             "--tls-api-certificate": self.tls_certificate_path(),
             "--tls-api-key": self.tls_key_path(),
+            "--casper-chain-spec-path": self.chain_spec_path(),
         }
         if not self.is_read_only:
             options["--casper-validator-private-key"] = self.node_private_key
@@ -83,12 +83,6 @@ class DockerConfig:
             options["--grpc-use-tls"] = ""
         if self.bootstrap_address:
             options["--server-bootstrap"] = self.bootstrap_address
-        if self.is_bootstrap:
-            gen_acct_key_file = GENESIS_ACCOUNT.public_key_filename
-            options[
-                "--casper-genesis-account-public-key-path"
-            ] = f"/root/.casperlabs/accounts/{gen_acct_key_file}"
-            options["--casper-initial-motes"] = self.initial_motes
         if self.node_public_key:
             options["--casper-validator-public-key"] = self.node_public_key
         return options

--- a/integration-testing/casperlabs_local_net/docker_config.py
+++ b/integration-testing/casperlabs_local_net/docker_config.py
@@ -5,7 +5,12 @@ from docker import DockerClient
 
 
 from casperlabs_local_net.casperlabs_accounts import Account
-from casperlabs_local_net.common import random_string, BOOTSTRAP_PATH, testing_root_path
+from casperlabs_local_net.common import (
+    random_string,
+    BOOTSTRAP_PATH,
+    CHAINSPEC_PATH,
+    testing_root_path,
+)
 
 
 DEFAULT_NODE_ENV = {
@@ -75,7 +80,7 @@ class DockerConfig:
             "--tls-key": self.tls_key_path(),
             "--tls-api-certificate": self.tls_certificate_path(),
             "--tls-api-key": self.tls_key_path(),
-            "--casper-chain-spec-path": self.chain_spec_path(),
+            "--casper-chain-spec-path": CHAINSPEC_PATH,
         }
         if not self.is_read_only:
             options["--casper-validator-private-key"] = self.node_private_key

--- a/integration-testing/casperlabs_local_net/docker_node.py
+++ b/integration-testing/casperlabs_local_net/docker_node.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Tuple, Dict, Union, Optional
 
-from casperlabs_local_net.common import MAX_PAYMENT_ABI, Contract, INITIAL_MOTES_AMOUNT
+from casperlabs_local_net.common import MAX_PAYMENT_ABI, Contract
 from casperlabs_local_net.docker_base import LoggingDockerBase
 from casperlabs_local_net.docker_client import DockerClient
 from casperlabs_local_net.errors import CasperLabsNodeAddressNotFoundError
@@ -50,9 +50,9 @@ class DockerNode(LoggingDockerBase):
     PYTHON_CLIENT = "p"
 
     def __init__(self, cl_network, config: DockerConfig):
+        self.cl_network = cl_network
         super().__init__(config)
         self.graphql = GraphQL(self)
-        self.cl_network = cl_network
         self._client = self.DOCKER_CLIENT
         self.p_client = PythonClient(self)
         self.d_client = DockerClient(self)
@@ -195,7 +195,7 @@ class DockerNode(LoggingDockerBase):
             # Give the initial motes to the genesis account, so that tests which use
             # this way of creating accounts work. But the accounts could be just
             # created this way, without having to do a transfer.
-            f.write(f"{GENESIS_ACCOUNT.public_key},{INITIAL_MOTES_AMOUNT},0\n")
+            f.write(f"{GENESIS_ACCOUNT.public_key},{self.cl_network.initial_motes},0\n")
             for i, pair in enumerate(
                 Account(i)
                 for i in range(FIRST_VALIDATOR_ACCOUNT, FIRST_VALIDATOR_ACCOUNT + N)

--- a/integration-testing/casperlabs_local_net/docker_node.py
+++ b/integration-testing/casperlabs_local_net/docker_node.py
@@ -191,7 +191,6 @@ class DockerNode(LoggingDockerBase):
     def create_genesis_accounts_file(self) -> None:
         N = self.NUMBER_OF_BONDS
         path = f"{self.host_chainspec_dir}/0-genesis/accounts.csv"
-        os.makedirs(os.path.dirname(path))
         with open(path, "a") as f:
             # Give the initial motes to the genesis account, so that tests which use
             # this way of creating accounts work. But the accounts could be just

--- a/integration-testing/resources/chainspec/0-genesis/manifest.toml
+++ b/integration-testing/resources/chainspec/0-genesis/manifest.toml
@@ -1,0 +1,46 @@
+[genesis]
+
+# Human readable name for convenience; the genesis_hash is the true identifier.
+# The name influences the genesis hash by contributing to the seeding of the pseudo-
+# random number generator used in execution engine for computing genesis post-state.
+name = "casperlabs"
+
+# Timestamp for the genesis block, also used in seeding the pseudo-random number
+# generator used in execution engine for computing genesis post-state.
+timestamp = 0
+
+# Later will be replaced by semver.
+protocol-version = 1
+
+# NOTE: The system contracts are copied by test-node.Dockerfile into the test image.
+# In the future they may be packaged as part of the JAR itself together with the chainspec.
+
+# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
+mint-code-path = "/opt/docker/system-contracts/mint_install.wasm"
+
+# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
+pos-code-path = "/opt/docker/system-contracts/pos_install.wasm"
+
+# Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
+initial-accounts-path = "accounts.csv"
+
+[wasm-costs]
+# Default opcode cost
+regular = 1
+# Div operations multiplier.
+div-multiplier = 1
+# Mul operations multiplier.
+mul-multiplier = 1
+# Memory (load/store) operations multiplier.
+mem-multiplier = 1
+# Amount of free memory (in 64kb pages) each contract can use for stack.
+mem-initial-pages = 1
+# Grow memory cost, per page (64kb)
+mem-grow-per-page = 1
+# Memory copy cost, per byte
+mem-copy-per-byte = 1
+# Max stack height (native WebAssembly stack limiter)
+max-stack-height = 1
+# Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` / `opcodes_div`
+opcodes-multiplier = 1
+opcodes-divisor = 1

--- a/integration-testing/resources/chainspec/0-genesis/manifest.toml
+++ b/integration-testing/resources/chainspec/0-genesis/manifest.toml
@@ -18,7 +18,7 @@ protocol-version = 1
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "/opt/docker/system-contracts/mint_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
+# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "/opt/docker/system-contracts/pos_install.wasm"
 
 # Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
@@ -28,19 +28,19 @@ initial-accounts-path = "accounts.csv"
 # Default opcode cost
 regular = 1
 # Div operations multiplier.
-div-multiplier = 1
+div-multiplier = 16
 # Mul operations multiplier.
-mul-multiplier = 1
+mul-multiplier = 4
 # Memory (load/store) operations multiplier.
-mem-multiplier = 1
+mem-multiplier = 2
 # Amount of free memory (in 64kb pages) each contract can use for stack.
-mem-initial-pages = 1
+mem-initial-pages = 4096
 # Grow memory cost, per page (64kb)
-mem-grow-per-page = 1
+mem-grow-per-page = 8192
 # Memory copy cost, per byte
 mem-copy-per-byte = 1
 # Max stack height (native WebAssembly stack limiter)
-max-stack-height = 1
+max-stack-height = 65536
 # Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` / `opcodes_div`
-opcodes-multiplier = 1
-opcodes-divisor = 1
+opcodes-multiplier = 3
+opcodes-divisor = 8

--- a/node/src/test/resources/chainspec/1-genesis/manifest.toml
+++ b/node/src/test/resources/chainspec/1-genesis/manifest.toml
@@ -15,7 +15,7 @@ protocol-version = 1
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
+# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos.wasm"
 
 # Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.


### PR DESCRIPTION
### Overview
Update the integration tests to use chainspec rather than bonds.txt

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-903

Builds on https://github.com/CasperLabs/CasperLabs/pull/1150
Incremental diff: https://github.com/aakoshh/CasperLabs/compare/NODE-904-hack-docker-chainspec...aakoshh:NODE-903-chainspec-integration-tests

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Kept the `GENESIS_ACCOUNT` and giving it the initial motes. It's used by tests to create other accounts. These could now be also created by the means of adding them to the accounts.csv file.
