### PR TITLE
NODE-906: Update the README about the chainspec.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,8 +170,7 @@ cargo-native-packager/%:
 # Make an image to host the Casper Explorer UI and the faucet microservice.
 .make/docker-build/explorer: \
 		explorer/Dockerfile \
-		.make/npm/explorer \
-		build-explorer-contracts
+		build-explorer
 	docker build -f explorer/Dockerfile -t $(DOCKER_USERNAME)/explorer:$(DOCKER_LATEST_TAG) explorer
 	mkdir -p $(dir $@) && touch $@
 
@@ -179,7 +178,8 @@ cargo-native-packager/%:
 	$(TS_SRC) \
 	.make/protoc/explorer \
 	explorer/ui/package.json \
-	explorer/server/package.json
+	explorer/server/package.json \
+	build-explorer-contracts
 	# CI=false so on Drone it won't fail on warnings (currently about href).
 	./hack/build/docker-buildenv.sh "\
 			cd explorer/ui     && npm install && CI=false npm run build && cd - && \
@@ -313,15 +313,24 @@ explorer/contracts/%.wasm: .make/contracts/%
 	mkdir -p $(dir $@)
 	cp execution-engine/target/wasm32-unknown-unknown/release/$(CONTRACT).wasm $@
 
+build-client: \
+	.make/sbt-stage/client
+
 build-client-contracts: \
 	client/src/main/resources/bonding.wasm \
 	client/src/main/resources/unbonding.wasm \
 	client/src/main/resources/transfer_to_account.wasm \
 	client/src/main/resources/standard_payment.wasm
 
+build-node: \
+	.make/sbt-stage/node
+
 build-node-contracts: \
 	node/src/main/resources/chainspec/genesis/mint_install.wasm \
 	node/src/main/resources/chainspec/genesis/pos_install.wasm
+
+build-explorer: \
+	.make/npm/explorer
 
 build-explorer-contracts: \
 	explorer/contracts/client/transfer_to_account.wasm \

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -15,7 +15,7 @@ The following commands should be run from the root directory of the CasperLabs r
 #### Build the node
 
 ```
-sbt node/universal:stage
+make build-node
 ```
 
 The `casperlabs-node` executable will be found here:
@@ -27,7 +27,7 @@ The `casperlabs-node` executable will be found here:
 #### Build the client
 
 ```
-sbt client/universal:stage
+make build-client
 ```
 
 The `casperlabs-client` executable will be found here:
@@ -52,10 +52,12 @@ The `casperlabs-engine-grpc-server` executable will be found here:
 
 #### Build the Mint and Proof-of-stake Contracts
 
+This step is optional, the node will have the compiled wasm files packaged with it.
+
 ```
 cd execution-engine
-cargo build -p pos --release --target wasm32-unknown-unknown
-cargo build -p mint-token --release --target wasm32-unknown-unknown
+cargo build -p pos-install --release --target wasm32-unknown-unknown
+cargo build -p mint-install --release --target wasm32-unknown-unknown
 ```
 
 The compiled contracts will be found here:

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -60,6 +60,6 @@ cargo build -p mint-token --release --target wasm32-unknown-unknown
 
 The compiled contracts will be found here:
 ```
-./target/wasm32-unknown-unknown/release/pos.wasm
-./target/wasm32-unknown-unknown/release/mint_token.wasm
+./target/wasm32-unknown-unknown/release/pos_install.wasm
+./target/wasm32-unknown-unknown/release/mint_install.wasm
 ```

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -8,7 +8,6 @@ The CasperLabs node consists of two components:
 
 #### Using binaries (recommended):
 * [Install](INSTALL.md) the `casperlabs` package, which contains `casperlabs-node` and `casperlabs-engine-grpc-server`.
-* Download and unzip the [Mint and Proof-of-Stake Contracts](http://repo.casperlabs.io/casperlabs/repo/dev/system-contracts.tar.gz).
 * Create [keys](KEYS.md#generating-node-keys-and-validator-keys).
 
 #### Building from source:
@@ -53,9 +52,12 @@ in an upcoming release.
 
 ##### Step 4: Download the ChainSpec
 
-Download the CasperLabs ChainSpec from <TODO-CHAINSPEC-URL>. Create a directory at `~/.casperlabs/chainspec` and unzip the contents of the downloaded archive into it.
+The node comes with a ChainSpec that should allow you to connect to DevNet. To connect elsewhere,
+you need to obtain the ChainSpec, unzip it, and start the node with the `--casper-chain-spec-path`
+option pointed to the directory.
 
-The ChainSpec contains the system contracts, but if you downloaded or built them separately you need to copy them to the first directory (genesis) under `~/.casperlabs/chainspec`.
+The ChainSpec contains the system contracts, but if you downloaded or built them separately you need to copy them. You can override the defaults packaged in the node by copying the system contracts to
+`~/.casperlabs/chainspec/genesis/`, or wherever the `--server-data-dir` is pointing, which by default is `~/.casperlabs`.
 
 ##### Step 5: Start the Execution Engine
 
@@ -103,10 +105,14 @@ You can run a single Node in standalone mode for testing purposes.
 ##### Step 1: Create an `accounts.csv` file
 
 Add your validator key as the single bonded validator to the accounts in the ChainSpec.
+You can override the default accounts that come with the node by shadowing the file
+under your `--server-data-dir` directory, by default `~/.casperlabs`. For example the
+following code would cause your validator to have an initial balance of 50 million and
+a 1 million in bonds.
 
 ```
-mkdir -p ~/.casperlabs/chainspec/0-genesis
-(cat keys/validator-id; echo ",0,100") > ~/.casperlabs/chainspec/0-genesis/accounts.csv
+mkdir -p ~/.casperlabs/chainspec/genesis
+(cat keys/validator-id; echo ",50000000,1000000") > ~/.casperlabs/chainspec/genesis/accounts.csv
 ```
 
 ##### Step 2: Start the Execution Engine

--- a/docs/NODE.md
+++ b/docs/NODE.md
@@ -51,13 +51,19 @@ Note: `--payment-amount` is used in the standard payment code to pay for the exe
 For now, the value is not used, but payment code will be enabled on the DEVNET
 in an upcoming release.
 
-##### Step 4: Start the Execution Engine
+##### Step 4: Download the ChainSpec
+
+Download the CasperLabs ChainSpec from <TODO-CHAINSPEC-URL>. Create a directory at `~/.casperlabs/chainspec` and unzip the contents of the downloaded archive into it.
+
+The ChainSpec contains the system contracts, but if you downloaded or built them separately you need to copy them to the first directory (genesis) under `~/.casperlabs/chainspec`.
+
+##### Step 5: Start the Execution Engine
 
 ```
 casperlabs-engine-grpc-server ~/.casperlabs/.casper-node.sock
 ```
 
-##### Step 5: Start the Node
+##### Step 6: Start the Node
 
 In a separate terminal, run:
 ```
@@ -94,11 +100,13 @@ pkill casperlabs-engine-grpc-server
 
 You can run a single Node in standalone mode for testing purposes.
 
-##### Step 1: Create a `bonds.txt` file
+##### Step 1: Create an `accounts.csv` file
+
+Add your validator key as the single bonded validator to the accounts in the ChainSpec.
 
 ```
-mkdir -p ~/.casperlabs/genesis
-(cat keys/validator-id; echo " 100") >> ~/.casperlabs/genesis/bonds.txt
+mkdir -p ~/.casperlabs/chainspec/0-genesis
+(cat keys/validator-id; echo ",0,100") > ~/.casperlabs/chainspec/0-genesis/accounts.csv
 ```
 
 ##### Step 2: Start the Execution Engine


### PR DESCRIPTION
### Overview
Updates the `docs` to mention the ChainSpec instead of `bonds.txt`.
Adds `make` commands to build the node and client with default contracts included.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-906

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.


