### PR TITLE
EE-349: Increase version of casperlabs-contract-ffi to 0.16.0

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -4,7 +4,7 @@
 name = "add-update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -41,7 +41,7 @@ dependencies = [
 name = "authorized-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ dependencies = [
 name = "bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -203,7 +203,7 @@ name = "casperlabs-engine-core"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
  "casperlabs-engine-wasm-prep 0.1.0",
@@ -227,7 +227,7 @@ dependencies = [
 name = "casperlabs-engine-grpc-server"
 version = "0.7.1"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
@@ -264,7 +264,7 @@ version = "0.2.0"
 dependencies = [
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -282,7 +282,7 @@ dependencies = [
 name = "casperlabs-engine-storage"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-wasm-prep 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -298,7 +298,7 @@ dependencies = [
 name = "casperlabs-engine-tests"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-grpc-server 0.7.1",
  "casperlabs-engine-shared 0.2.0",
@@ -317,7 +317,7 @@ dependencies = [
 name = "casperlabs-engine-wasm-prep"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "casperlabs-engine-shared 0.2.0",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -343,7 +343,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "check-system-contract-urefs-access-rights"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -396,14 +396,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "create-accounts"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "create-purse-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -432,7 +432,7 @@ name = "create-test-node-shared"
 version = "0.1.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -554,7 +554,7 @@ dependencies = [
 name = "deserialize-error"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -579,112 +579,112 @@ dependencies = [
 name = "do-nothing"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-401-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-401-regression-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-441-rng-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-460-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-532-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-536-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-539-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-549-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-572-regression-create"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-572-regression-escalate"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-584-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-597-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-598-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "ee-601-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -696,7 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "endless-loop"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -723,7 +723,7 @@ dependencies = [
 name = "faucet"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -776,42 +776,42 @@ dependencies = [
 name = "get-arg"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "get-blocktime"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "get-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "get-caller-subcall"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "get-phase"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "get-phase-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -999,14 +999,14 @@ dependencies = [
 name = "key-management-thresholds"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "known-urefs"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ dependencies = [
 name = "local-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1080,7 +1080,7 @@ dependencies = [
 name = "main-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1118,7 +1118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mint-install"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "mint-token 0.1.0",
 ]
 
@@ -1126,14 +1126,14 @@ dependencies = [
 name = "mint-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ dependencies = [
 name = "named-purse-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1335,35 +1335,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pos"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "pos-bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "pos-finalize-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "pos-get-payment-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "pos-install"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
  "pos 0.1.0",
 ]
 
@@ -1371,7 +1371,7 @@ dependencies = [
 name = "pos-refund-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1717,7 +1717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "remove-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1732,7 +1732,7 @@ dependencies = [
 name = "revert"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1852,7 +1852,7 @@ dependencies = [
 name = "simple-transfer"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1884,21 +1884,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "standard-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "standard-payment-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "state-initializer"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -1976,7 +1976,7 @@ dependencies = [
 name = "test-mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -2259,56 +2259,56 @@ dependencies = [
 name = "transfer-main-purse-to-new-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-account-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-to-account-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-to-account-02"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
 name = "transfer-to-existing-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]
@@ -2335,7 +2335,7 @@ dependencies = [
 name = "unbonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.15.0",
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]

--- a/execution-engine/contract-ffi/Cargo.toml
+++ b/execution-engine/contract-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-contract-ffi"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."


### PR DESCRIPTION
### Overview
This bumps the FFI version to allow contract-examples to be built against it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-349

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
