### PR TITLE
NODE-671: Deploy dependencies and time to live

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -91,13 +91,14 @@ object BlockAPI {
       }
 
     for {
-      _            <- Metrics[F].incrementCounter("deploys")
-      _            <- check("Invalid deploy hash.")(Validation[F].deployHash(d))
-      _            <- check("Invalid deploy signature.")(Validation[F].deploySignature(d))
-      headerErrors <- Validation[F].deployHeader(d)
-      _ <- MonadThrowable[F]
-            .raiseError(InvalidArgument(headerErrors.map(_.errorMessage).mkString("\n")))
-            .whenA(headerErrors.nonEmpty)
+      _ <- Metrics[F].incrementCounter("deploys")
+      _ <- check("Invalid deploy hash.")(Validation[F].deployHash(d))
+      _ <- check("Invalid deploy signature.")(Validation[F].deploySignature(d))
+      _ <- Validation[F].deployHeader(d) >>= { headerErrors =>
+            MonadThrowable[F]
+              .raiseError(InvalidArgument(headerErrors.map(_.errorMessage).mkString("\n")))
+              .whenA(headerErrors.nonEmpty)
+          }
 
       t = casper.faultToleranceThreshold
       _ <- ensureNotInDag[F](d, t)

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -94,6 +94,7 @@ object BlockAPI {
       _ <- Metrics[F].incrementCounter("deploys")
       _ <- check("Invalid deploy hash.")(Validation[F].deployHash(d))
       _ <- check("Invalid deploy signature.")(Validation[F].deploySignature(d))
+      _ <- check("Invalid deploy header.")(Validation[F].deployHeader(d))
 
       t = casper.faultToleranceThreshold
       _ <- ensureNotInDag[F](d, t)

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -440,6 +440,9 @@ object ProtoUtil {
   def stringToByteString(string: String): ByteString =
     ByteString.copyFrom(Base16.decode(string))
 
+  def getTimeToLive(h: Deploy.Header, default: Int): Int =
+    h.maybeTimeToLive.timeToLive.getOrElse(default)
+
   def basicDeploy[F[_]: Monad: Time](): F[Deploy] =
     Time[F].currentMillis.map { now =>
       basicDeploy(now, ByteString.EMPTY)

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -441,7 +441,8 @@ object ProtoUtil {
     ByteString.copyFrom(Base16.decode(string))
 
   def getTimeToLive(h: Deploy.Header, default: Int): Int =
-    h.maybeTimeToLive.timeToLive.getOrElse(default)
+    if (h.ttlMillis == 0) default
+    else h.ttlMillis
 
   def basicDeploy[F[_]: Monad: Time](): F[Deploy] =
     Time[F].currentMillis.map { now =>

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
@@ -1,10 +1,78 @@
 package io.casperlabs.casper.validation
 
+import cats.Functor
+import cats.implicits._
+import com.google.protobuf.ByteString
 import io.casperlabs.casper.InvalidBlock
+import io.casperlabs.casper.PrettyPrinter
+import io.casperlabs.shared.Log
 
 object Errors {
   // Wrapper for the tests that were originally outside the `attemptAdd` method
   // and meant the block was not getting saved.
   final case class DropErrorWrapper(status: InvalidBlock)     extends Exception
   final case class ValidateErrorWrapper(status: InvalidBlock) extends Exception(status.toString)
+
+  sealed trait DeployHeaderError { self =>
+    val deployHash: ByteString
+    def errorMessage: String
+
+    def logged[F[_]: Log: Functor]: F[DeployHeaderError] =
+      Log[F].warn(self.errorMessage).as(self)
+  }
+  object DeployHeaderError {
+    def missingHeader(deployHash: ByteString): DeployHeaderError = MissingHeader(deployHash)
+
+    def timeToLiveTooShort(deployHash: ByteString, ttl: Int, minTTL: Int): DeployHeaderError =
+      TimeToLiveTooShort(deployHash, ttl, minTTL)
+
+    def timeToLiveTooLong(deployHash: ByteString, ttl: Int, maxTTL: Int): DeployHeaderError =
+      TimeToLiveTooLong(deployHash, ttl, maxTTL)
+
+    def tooManyDependencies(
+        deployHash: ByteString,
+        numDependencies: Int,
+        maxDependencies: Int
+    ): DeployHeaderError =
+      TooManyDependencies(deployHash, numDependencies, maxDependencies)
+
+    def invalidDependency(deployHash: ByteString, dependency: ByteString): DeployHeaderError =
+      InvalidDependency(deployHash, dependency)
+
+    final case class MissingHeader(deployHash: ByteString) extends DeployHeaderError {
+      def errorMessage: String =
+        s"Deploy ${PrettyPrinter.buildString(deployHash)} does not contain a header"
+    }
+
+    final case class TimeToLiveTooShort(deployHash: ByteString, ttl: Int, minTTL: Int)
+        extends DeployHeaderError {
+      def errorMessage: String =
+        s"Time to live $ttl in deploy ${PrettyPrinter.buildString(deployHash)} shorter than minimum valid time to live $minTTL"
+    }
+
+    final case class TimeToLiveTooLong(deployHash: ByteString, ttl: Int, maxTTL: Int)
+        extends DeployHeaderError {
+      def errorMessage: String =
+        s"Time to live $ttl in deploy ${PrettyPrinter.buildString(deployHash)} longer than maximum valid time to live $maxTTL"
+    }
+
+    final case class TooManyDependencies(
+        deployHash: ByteString,
+        numDependencies: Int,
+        maxDependencies: Int
+    ) extends DeployHeaderError {
+      def errorMessage: String =
+        s"Deploy ${PrettyPrinter.buildString(deployHash)} with $numDependencies is invalid. The maximum number of dependencies is $maxDependencies"
+    }
+
+    final case class InvalidDependency(deployHash: ByteString, dependency: ByteString)
+        extends DeployHeaderError {
+      def errorMessage: String = {
+        val deploy = PrettyPrinter.buildString(deployHash)
+        val dep    = PrettyPrinter.buildString(dependency)
+
+        s"Deploy $deploy with dependency $dep is invalid. Dependencies are expected to be 32 bytes."
+      }
+    }
+  }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -37,6 +37,8 @@ trait Validation[F[_]] {
 
   def deployHash(d: consensus.Deploy): F[Boolean]
 
+  def deployHeader(d: consensus.Deploy): F[Boolean]
+
   def deploySignature(d: consensus.Deploy): F[Boolean]
 
   def signature(d: Array[Byte], sig: protocol.Signature): Boolean

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -37,7 +37,7 @@ trait Validation[F[_]] {
 
   def deployHash(d: consensus.Deploy): F[Boolean]
 
-  def deployHeader(d: consensus.Deploy): F[Boolean]
+  def deployHeader(d: consensus.Deploy): F[List[Errors.DeployHeaderError]]
 
   def deploySignature(d: consensus.Deploy): F[Boolean]
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -251,10 +251,9 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
         )
         .as(false)
     else
-      dependencies.find(_.size != 32) match {
-        case None => true.pure[F]
-        case Some(dep) =>
-          Log[F]
+      dependencies.filter(_.size != 32).foldLeft(true.pure[F]) {
+        case (f, dep) =>
+          f *> Log[F]
             .warn(
               s"Invalid dependency, ${PrettyPrinter.buildString(dep)}, in deploy ${PrettyPrinter.buildString(deployHash)}. Expected 32 byte identifier."
             )

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -264,10 +264,12 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
   def deployHeader(d: consensus.Deploy): F[Boolean] =
     d.header match {
       case Some(header) =>
-        for {
-          validTTL          <- validateTimeToLive(ProtoUtil.getTimeToLive(header, MAX_TTL), d.deployHash)
-          validDependencies <- validateDependencies(header.dependencies, d.deployHash)
-        } yield validTTL && validDependencies
+        Applicative[F].map2(
+          validateTimeToLive(ProtoUtil.getTimeToLive(header, MAX_TTL), d.deployHash),
+          validateDependencies(header.dependencies, d.deployHash)
+        ) {
+          case (validTTL, validDependencies) => validTTL && validDependencies
+        }
 
       case None =>
         Log[F]

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -228,10 +228,11 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
 
   // TODO: put in chainspec https://casperlabs.atlassian.net/browse/NODE-911
   private val MAX_TTL: Int          = 24 * 60 * 60 * 1000 // 1 day
+  private val MIN_TTL: Int          = 60 * 60 * 1000 // 1 hour
   private val MAX_DEPENDENCIES: Int = 10
 
   private def validateTimeToLive(ttl: Int, deployHash: ByteString): F[Boolean] =
-    if (ttl > 0 && ttl <= MAX_TTL) true.pure[F]
+    if (ttl > MIN_TTL && ttl <= MAX_TTL) true.pure[F]
     else
       Log[F]
         .warn(

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -238,7 +238,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
         .warn(
           s"Time to live, $ttl, of deploy ${PrettyPrinter.buildString(deployHash)} is invalid."
         )
-        .map(_ => false)
+        .as(false)
 
   private def validateDependencies(
       dependencies: Seq[ByteString],
@@ -249,7 +249,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
         .warn(
           s"Too many dependencies for deploy ${PrettyPrinter.buildString(deployHash)}."
         )
-        .map(_ => false)
+        .as(false)
     else
       dependencies.find(_.size != 32) match {
         case None => true.pure[F]
@@ -258,7 +258,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
             .warn(
               s"Invalid dependency, ${PrettyPrinter.buildString(dep)}, in deploy ${PrettyPrinter.buildString(deployHash)}. Expected 32 byte identifier."
             )
-            .map(_ => false)
+            .as(false)
       }
 
   def deployHeader(d: consensus.Deploy): F[Boolean] =
@@ -274,7 +274,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
           .warn(
             s"Header of deploy ${PrettyPrinter.buildString(d.deployHash)} is missing."
           )
-          .map(_ => false)
+          .as(false)
     }
 
   def blockSender(block: BlockSummary)(implicit bs: BlockStorage[F]): F[Boolean] =

--- a/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
@@ -24,7 +24,7 @@ class LegacyConversionsTest extends FlatSpec with ArbitraryConsensus with Matche
               val header = deploy.getHeader
               val newHeader = header
                 .withDependencies(List.empty)
-                .withMaybeTimeToLive(consensus.Deploy.Header.MaybeTimeToLive.Empty)
+                .withTtlMillis(0)
               pd.withErrorMessage("")
                 .withDeploy(
                   deploy

--- a/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/LegacyConversionsTest.scala
@@ -1,6 +1,8 @@
 package io.casperlabs.casper
 
+import com.google.protobuf.ByteString
 import io.casperlabs.comm.gossiping.ArbitraryConsensus
+import io.casperlabs.crypto.hash.Blake2b256
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks.{forAll, PropertyCheckConfiguration}
 
@@ -18,7 +20,19 @@ class LegacyConversionsTest extends FlatSpec with ArbitraryConsensus with Matche
         orig
           .withBody(
             orig.getBody.withDeploys(orig.getBody.deploys.map { pd =>
+              val deploy = pd.getDeploy
+              val header = deploy.getHeader
+              val newHeader = header
+                .withDependencies(List.empty)
+                .withMaybeTimeToLive(consensus.Deploy.Header.MaybeTimeToLive.Empty)
               pd.withErrorMessage("")
+                .withDeploy(
+                  deploy
+                    .withHeader(
+                      newHeader
+                    )
+                    .withDeployHash(ByteString.copyFrom(Blake2b256.hash(newHeader.toByteArray)))
+                )
             })
           )
       val conv = LegacyConversions.fromBlock(comp)

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -41,6 +41,7 @@ import monix.execution.Scheduler
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks.forAll
 
 import scala.collection.immutable.HashMap
 import scala.concurrent.duration._
@@ -277,9 +278,13 @@ class ValidationTest
     Validation[Task].deploySignature(deploy) shouldBeF false
   }
 
-  "Deploy header validation" should "accept valid headers" in withoutStorage {
-    val deploy = sample(arbitrary[consensus.Deploy])
-    Validation[Task].deployHeader(deploy) shouldBeF Nil
+  "Deploy header validation" should "accept valid headers" in {
+    implicit val consensusConfig =
+      ConsensusConfig(dagSize = 10, maxSessionCodeBytes = 5, maxPaymentCodeBytes = 5)
+
+    forAll { (deploy: consensus.Deploy) =>
+      withoutStorage { Validation[Task].deployHeader(deploy) } shouldBe Nil
+    }
   }
 
   it should "not accept too short time to live" in withoutStorage {

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -280,9 +280,10 @@ class ValidationTest
 
   it should "not accept invalid time to live" in withoutStorage {
     val maxTTL = 24 * 60 * 60 * 1000
+    val minTTL = 60 * 60 * 1000
     val genDeploy = for {
       d   <- arbitrary[consensus.Deploy]
-      ttl <- Gen.oneOf(Gen.const(0), Gen.choose(maxTTL + 1, Int.MaxValue))
+      ttl <- Gen.oneOf(Gen.choose(1, minTTL - 1), Gen.choose(maxTTL + 1, Int.MaxValue))
     } yield d.withHeader(
       d.getHeader.withTtlMillis(ttl)
     )

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -284,7 +284,7 @@ class ValidationTest
       d   <- arbitrary[consensus.Deploy]
       ttl <- Gen.oneOf(Gen.const(0), Gen.choose(maxTTL + 1, Int.MaxValue))
     } yield d.withHeader(
-      d.getHeader.withMaybeTimeToLive(consensus.Deploy.Header.MaybeTimeToLive.TimeToLive(ttl))
+      d.getHeader.withTtlMillis(ttl)
     )
 
     val deploy = sample(genDeploy)

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -338,12 +338,6 @@ object DeployRuntime {
     gracefulExit(program.attempt)
   }
 
-  private def maybeTimeToLive(maybeTTL: Option[Int]): consensus.Deploy.Header.MaybeTimeToLive =
-    maybeTTL match {
-      case Some(ttl) => consensus.Deploy.Header.MaybeTimeToLive.TimeToLive(ttl)
-      case None      => consensus.Deploy.Header.MaybeTimeToLive.Empty
-    }
-
   /** Constructs a [[Deploy]] from the provided arguments and writes it to a file (or STDOUT).
     */
   def makeDeploy[F[_]: Sync](
@@ -367,7 +361,7 @@ object DeployRuntime {
           .withTimestamp(System.currentTimeMillis)
           .withAccountPublicKey(from)
           .withGasPrice(deployConfig.gasPrice)
-          .withMaybeTimeToLive(maybeTimeToLive(deployConfig.timeToLive))
+          .withTtlMillis(deployConfig.timeToLive.getOrElse(0))
           .withDependencies(deployConfig.dependencies)
       )
       .withBody(

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -338,6 +338,12 @@ object DeployRuntime {
     gracefulExit(program.attempt)
   }
 
+  private def maybeTimeToLive(maybeTTL: Option[Int]): consensus.Deploy.Header.MaybeTimeToLive =
+    maybeTTL match {
+      case Some(ttl) => consensus.Deploy.Header.MaybeTimeToLive.TimeToLive(ttl)
+      case None      => consensus.Deploy.Header.MaybeTimeToLive.Empty
+    }
+
   /** Constructs a [[Deploy]] from the provided arguments and writes it to a file (or STDOUT).
     */
   def makeDeploy[F[_]: Sync](
@@ -361,6 +367,8 @@ object DeployRuntime {
           .withTimestamp(System.currentTimeMillis)
           .withAccountPublicKey(from)
           .withGasPrice(deployConfig.gasPrice)
+          .withMaybeTimeToLive(maybeTimeToLive(deployConfig.timeToLive))
+          .withDependencies(deployConfig.dependencies)
       )
       .withBody(
         consensus.Deploy

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -74,7 +74,7 @@ object DeployConfig {
       ),
       gasPrice = args.gasPrice(),
       paymentAmount = args.paymentAmount.toOption,
-      timeToLive = args.timeToLive.toOption,
+      timeToLive = args.ttl.toOption,
       dependencies = args.dependencies.toOption
         .getOrElse(List.empty)
         .map(d => ByteString.copyFrom(Base16.decode(d)))

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -42,7 +42,9 @@ final case class DeployConfig(
     sessionOptions: CodeConfig,
     paymentOptions: CodeConfig,
     gasPrice: Long,
-    paymentAmount: Option[BigInt]
+    paymentAmount: Option[BigInt],
+    timeToLive: Option[Int],
+    dependencies: List[ByteString]
 ) {
   def session(defaultArgs: Seq[Arg] = Nil) = DeployConfig.toCode(sessionOptions, defaultArgs)
   def payment(defaultArgs: Seq[Arg] = Nil) = DeployConfig.toCode(paymentOptions, defaultArgs)
@@ -71,10 +73,14 @@ object DeployConfig {
         args = args.paymentArgs.toOption.map(_.args)
       ),
       gasPrice = args.gasPrice(),
-      paymentAmount = args.paymentAmount.toOption
+      paymentAmount = args.paymentAmount.toOption,
+      timeToLive = args.timeToLive.toOption,
+      dependencies = args.dependencies.toOption
+        .getOrElse(List.empty)
+        .map(d => ByteString.copyFrom(Base16.decode(d)))
     )
 
-  val empty = DeployConfig(CodeConfig.empty, CodeConfig.empty, 0, None)
+  val empty = DeployConfig(CodeConfig.empty, CodeConfig.empty, 0, None, None, List.empty)
 
   /** Produce a Deploy.Code DTO from the options.
     * 'defaultArgs' can be used by specialized commands such as `transfer` and `unbond`

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -106,6 +106,17 @@ object Options {
       required = false
     )
 
+    val timeToLive = opt[Int](
+      descr = "Time (in milliseconds) that the deploy will remain valid for.",
+      validate = _ > 0,
+      required = false
+    )
+
+    val dependencies = opt[List[String]](
+      descr = "List of deploy hashes (base16 encoded) which must be executed before this deploy.",
+      validate = _.forall(hashCheck)
+    )
+
     addValidation {
       val sessionsProvided =
         List(session.isDefined, sessionHash.isDefined, sessionName.isDefined, sessionUref.isDefined)

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -106,8 +106,8 @@ object Options {
       required = false
     )
 
-    val timeToLive = opt[Int](
-      descr = "Time (in milliseconds) that the deploy will remain valid for.",
+    val ttl = opt[Int](
+      descr = "Time to live. Time (in milliseconds) that the deploy will remain valid for.",
       validate = _ > 0,
       required = false
     )

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -178,12 +178,7 @@ trait ArbitraryConsensus {
         .withGasPrice(gasPrice)
         .withBodyHash(bodyHash)
         .withDependencies(dependencies)
-        .withMaybeTimeToLive(
-          timeToLive
-            .fold[Deploy.Header.MaybeTimeToLive](Deploy.Header.MaybeTimeToLive.Empty)(
-              Deploy.Header.MaybeTimeToLive.TimeToLive(_)
-            )
-        )
+        .withTtlMillis(timeToLive.getOrElse(0))
       deployHash = protoHash(header)
       signature  = accountKeys.sign(deployHash)
       deploy = Deploy()

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -163,7 +163,7 @@ trait ArbitraryConsensus {
       gasPrice        <- arbitrary[Long]
       sessionCode     <- Gen.choose(0, c.maxSessionCodeBytes).flatMap(genBytes(_))
       paymentCode     <- Gen.choose(0, c.maxPaymentCodeBytes).flatMap(genBytes(_))
-      timeToLive      <- Gen.option(Gen.choose(1, 24 * 60 * 60 * 1000))
+      timeToLive      <- Gen.option(Gen.choose(1 * 60 * 60 * 1000, 24 * 60 * 60 * 1000))
       numDependencies <- Gen.chooseNum(0, 10)
       dependencies    <- Gen.listOfN(numDependencies, genHash)
       body = Deploy

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -158,11 +158,14 @@ trait ArbitraryConsensus {
 
   implicit def arbDeploy(implicit c: ConsensusConfig): Arbitrary[Deploy] = Arbitrary {
     for {
-      accountKeys <- Gen.oneOf(randomAccounts)
-      timestamp   <- Gen.choose(0L, Long.MaxValue)
-      gasPrice    <- arbitrary[Long]
-      sessionCode <- Gen.choose(0, c.maxSessionCodeBytes).flatMap(genBytes(_))
-      paymentCode <- Gen.choose(0, c.maxPaymentCodeBytes).flatMap(genBytes(_))
+      accountKeys     <- Gen.oneOf(randomAccounts)
+      timestamp       <- Gen.choose(0L, Long.MaxValue)
+      gasPrice        <- arbitrary[Long]
+      sessionCode     <- Gen.choose(0, c.maxSessionCodeBytes).flatMap(genBytes(_))
+      paymentCode     <- Gen.choose(0, c.maxPaymentCodeBytes).flatMap(genBytes(_))
+      timeToLive      <- Gen.option(Gen.choose(1, 24 * 60 * 60 * 1000))
+      numDependencies <- Gen.chooseNum(0, 10)
+      dependencies    <- Gen.listOfN(numDependencies, genHash)
       body = Deploy
         .Body()
         .withSession(Deploy.Code().withWasm(sessionCode))
@@ -174,6 +177,13 @@ trait ArbitraryConsensus {
         .withTimestamp(timestamp)
         .withGasPrice(gasPrice)
         .withBodyHash(bodyHash)
+        .withDependencies(dependencies)
+        .withMaybeTimeToLive(
+          timeToLive
+            .fold[Deploy.Header.MaybeTimeToLive](Deploy.Header.MaybeTimeToLive.Empty)(
+              Deploy.Header.MaybeTimeToLive.TimeToLive(_)
+            )
+        )
       deployHash = protoHash(header)
       signature  = accountKeys.sign(deployHash)
       deploy = Deploy()

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -43,6 +43,11 @@ message Deploy {
         uint64 gas_price = 4;
         // Hash of the body structure as a whole.
         bytes body_hash = 5;
+        // time_to_live is optional, so we wrap in `oneof` to benefit from the Empty variant
+        oneof maybe_time_to_live {
+            uint32 time_to_live = 6;
+        }
+        repeated bytes dependencies = 7;
     }
 
     message Body {

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -43,10 +43,13 @@ message Deploy {
         uint64 gas_price = 4;
         // Hash of the body structure as a whole.
         bytes body_hash = 5;
-        // time_to_live is optional, so we wrap in `oneof` to benefit from the Empty variant
-        oneof maybe_time_to_live {
-            uint32 time_to_live = 6;
-        }
+        // Time to live of the deploy, in milliseconds. A deploy can only be
+        // included in a block between Header.timestamp and
+        // Header.timestamp + Header.ttl_millis. A value of 0 is interpreted as
+        // 'not present' and a default value will be assigned instead.
+        uint32 ttl_millis = 6;
+        // List of `Deploy.deploy_hash`s  that must be executed in past blocks
+        // before this deploy can be executed.
         repeated bytes dependencies = 7;
     }
 


### PR DESCRIPTION
### Overview
Introduces `time_to_live` and `dependencies` to deploy message. Presently these are not used for anything, but this will change in the next PR.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-671

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
