### PR TITLE
OP-707: Fix Drone Cronjob for Mac

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -925,6 +925,7 @@ steps:
     port:
       from_secret: mac-port
     script:
+    - export PATH=$PATH:/usr/local/bin/
     - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
     - cd execution-engine
     - make setup

--- a/.drone.yml
+++ b/.drone.yml
@@ -925,31 +925,10 @@ steps:
     port:
       from_secret: mac-port
     script:
-    - export PATH=$PATH:/usr/local/bin/
     - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
     - cd execution-engine
     - make setup
-    - ~/.cargo/bin/cargo build --release
-
-- name: build-system-contracts
-  image: appleboy/drone-ssh:latest
-  environment:
-    SSH_HOST:
-      from_secret: mac-host
-    SSH_USERNAME:
-      from_secret: mac-user
-    SSH_KEY:
-      from_secret: mac-ssh-key
-  settings:
-    command_timeout: 60m
-    port:
-      from_secret: mac-port
-    script:
-    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
-    - cd execution-engine
-    - make setup
-    - ~/.cargo/bin/cargo build -p pos --release --target wasm32-unknown-unknown
-    - ~/.cargo/bin/cargo build -p mint-token --release --target wasm32-unknown-unknown
+    - make build
 
 - name: cleanup-mac
   image: appleboy/drone-ssh:latest


### PR DESCRIPTION
### Overview
Switches the mac cronjob to use the ee makefile. Removes the `build-system-contract` step since it is taken care of by `make build`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-707

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
