### PR TITLE
OP-693: fix group id for keys

### DIFF
--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -28,7 +28,7 @@ if [[ -z "$DRONE_BUILD_NUMBER" ]]; then
         #echo "Falling back to casperlabs/key-generator:dev"
         docker pull casperlabs/key-generator:"$TAG" &> /dev/null
     }
-    docker run --rm -it --user $UID -v "$OUTPUT_DIR":/keys casperlabs/key-generator:"$TAG" /keys
+    docker run --rm -it --user $(id -u):$(id -g) -v "$OUTPUT_DIR":/keys casperlabs/key-generator:"$TAG" /keys
 else
     docker run --rm -v "$OUTPUT_DIR":/keys casperlabs/key-generator:DRONE-"$DRONE_BUILD_NUMBER" /keys
 fi


### PR DESCRIPTION
### Overview
Adds the correct group id for keys generated via the `docker-gen-keys` wrapper script. Also switches to using the `id` command. This is because bash doesn't set a `$GID` env variable and why not be consistent :).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-693

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
https://medium.com/redbubble/running-a-docker-container-as-a-non-root-user-7d2e00f8ee15