### PR TITLE
NODE-884: Pass gas price and receive cost as BigInt in ipc.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -496,7 +496,7 @@ object ProtoUtil {
         address = d.getHeader.accountPublicKey,
         session = session,
         payment = payment,
-        gasPrice = state.BigInt(GAS_PRICE.toString, bitWidth = 512).some,
+        gasPrice = GAS_PRICE,
         authorizationKeys = d.approvals.map(_.approverPublicKey),
         deployHash = d.deployHash
       )

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -496,7 +496,7 @@ object ProtoUtil {
         address = d.getHeader.accountPublicKey,
         session = session,
         payment = payment,
-        gasPrice = GAS_PRICE,
+        gasPrice = state.BigInt(GAS_PRICE.toString, bitWidth = 512).some,
         authorizationKeys = d.approvals.map(_.approverPublicKey),
         deployHash = d.deployHash
       )

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -41,13 +41,13 @@ message Bond {
 }
 
 message Deploy {
-    reserved 5;
-    reserved 7;
+    reserved 5; // motes in payment
+    reserved 7; // motes in payment
     // Public key of the account which is the context of the execution.
     bytes address = 1; // length 32 bytes
     DeployCode session = 3;
     DeployCode payment = 4;
-    uint64 gas_price = 6; // in units of Mote / Gas
+    io.casperlabs.casper.consensus.state.BigInt gas_price = 6; // in units of Mote / Gas
     // Public keys used to sign this deploy, to be checked against the keys
     // associated with the account.
     repeated bytes authorization_keys = 8;
@@ -55,13 +55,13 @@ message Deploy {
 }
 
 message DeployItem {
+    reserved 5; // motes in payment
     reserved 7; // nonce
     // Public key of the account which is the context of the execution.
     bytes address = 1; // length 32 bytes
     DeployPayload session = 3;
     DeployPayload payment = 4;
-    uint64 motes_transferred_in_payment = 5; // in units of Motes -- someday this will come from running payment code
-    uint64 gas_price = 6; // in units of Mote / Gas
+    io.casperlabs.casper.consensus.state.BigInt gas_price = 6; // in units of Mote / Gas
     // Public keys used to sign this deploy, to be checked against the keys
     // associated with the account.
     repeated bytes authorization_keys = 8;
@@ -204,7 +204,7 @@ message DeployResult {
     message ExecutionResult {
         ExecutionEffect effects = 1;
         DeployError error = 2;
-        uint64 cost = 3;
+        io.casperlabs.casper.consensus.state.BigInt cost = 3;
     }
 
     oneof value {

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -47,7 +47,7 @@ message Deploy {
     bytes address = 1; // length 32 bytes
     DeployCode session = 3;
     DeployCode payment = 4;
-    io.casperlabs.casper.consensus.state.BigInt gas_price = 6; // in units of Mote / Gas
+    uint64 gas_price = 6; // in units of Mote / Gas
     // Public keys used to sign this deploy, to be checked against the keys
     // associated with the account.
     repeated bytes authorization_keys = 8;
@@ -61,7 +61,7 @@ message DeployItem {
     bytes address = 1; // length 32 bytes
     DeployPayload session = 3;
     DeployPayload payment = 4;
-    io.casperlabs.casper.consensus.state.BigInt gas_price = 6; // in units of Mote / Gas
+    uint64 gas_price = 6; // in units of Mote / Gas
     // Public keys used to sign this deploy, to be checked against the keys
     // associated with the account.
     repeated bytes authorization_keys = 8;

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -100,8 +100,11 @@ class GrpcExecutionEngineService[F[_]: Defer: Sync: Log: TaskLift: Metrics] priv
       _ <- result.fold(
             _ => ().pure[F],
             deployResults => {
+              // XXX: EE returns cost as BigInt but metrics are in Long. In practice it will be unlikely exhaust the limits of Long.
               val gasSpent =
-                deployResults.foldLeft(0L)((a, d) => a + d.value.executionResult.fold(0L)(_.cost))
+                deployResults.foldLeft(0L)(
+                  (a, d) => a + d.value.executionResult.fold(0L)(_.cost.fold(0L)(_.value.toLong))
+                )
               Metrics[F].incrementCounter("gas_spent", gasSpent)
             }
           )
@@ -208,6 +211,7 @@ object ExecutionEngineService {
 
   object CommitResult {
     def apply(ipcCommitResult: io.casperlabs.ipc.CommitResult): CommitResult = {
+      // XXX: EE returns bonds as BigInt but we treat it as Long.
       val validators = ipcCommitResult.bondedValidators.map(
         b => Bond(b.validatorPublicKey, b.getStake.value.toLong)
       )


### PR DESCRIPTION
### Overview
It was asked for to make EE code with NewTypes somehow easier, get rid of some casts.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-884

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
A separate ticket exists for the type of bonds https://casperlabs.atlassian.net/browse/NODE-907

##### Why I don't think replicating this in the API is necessary
I don't think costs will ever realistically exceed `Long`, unless we artificially inflate them using the ChainSpec. A back-of-the-envelope calculation indicated that doing transfers flat-out wouldn't consume `Long.MaxValue` gas for over 700 thousand years with the current cost examples in testing (around 50K gas per deploy).

Also if the `gas_price` would really had to be `BigInt` we'd be seeing hyperinflation the world has ~never~ not seen for a long time; even the one hundred trillion dollar notes of Zimbabwe could be expressed in `Long`: 100,000,000,000,000 is less than 9,223,372,036,854,775,808. Granted, at that point paying for transfers consuming 50,000 gas, you can only afford 5 before you do need cost to be `BigInt`.

EDIT: I clearly have a small imagination and a spotty memory of history lessons: "The highest numerical value banknote ever printed was a note for 1 sextillion pengő (10^21 or 1 milliard bilpengő as printed) printed in Hungary in 1946"