### PR TITLE
NODE-779: Single JDBC connection

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,12 +13,11 @@ Global / dependencyOverrides := Dependencies.overrides
 val protobufDirectory = file("protobuf")
 // Protos can import any other using the full path within `protobuf`. This filter reduces the list
 // for which we actually generate .scala source, so we don't get duplicates between projects.
-def protobufPathFilter(paths: String*) = {
-  (f: File) =>
-    f.getName.endsWith(".proto") && // Not directories or other artifacts.
-      paths.map(protobufDirectory.toPath.resolve).exists { path =>
-        f.toPath == path || f.toPath.startsWith(path)
-      }
+def protobufPathFilter(paths: String*) = { (f: File) =>
+  f.getName.endsWith(".proto") && // Not directories or other artifacts.
+  paths.map(protobufDirectory.toPath.resolve).exists { path =>
+    f.toPath == path || f.toPath.startsWith(path)
+  }
 }
 
 lazy val projectSettings = Seq(
@@ -368,7 +367,6 @@ lazy val storage = (project in file("storage"))
       lmdbjava,
       sqlLite,
       doobieCore,
-      doobieHikari,
       flyway,
       catsCore,
       catsEffect,

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -75,8 +75,6 @@ class NodeRuntime private[node] (
   private[this] val egressScheduler =
     Scheduler.cached("egress-io", 2, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
-  private[this] val dbConnScheduler =
-    Scheduler.cached("db-conn", 1, 64, reporter = uncaughtExceptionHandler)
   private[this] val dbIOScheduler =
     Scheduler.cached("db-io", 1, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
@@ -138,9 +136,9 @@ class NodeRuntime private[node] (
                                                                             )
         //TODO: We may want to adjust threading model for better performance
         implicit0(doobieTransactor: Transactor[Effect]) <- effects.doobieTransactor(
-                                                            connectEC = dbConnScheduler,
-                                                            transactEC = dbIOScheduler,
-                                                            conf.server.dataDir
+                                                            dbIOScheduler,
+                                                            conf.server.dataDir,
+                                                            log
                                                           )
         deployBufferChunkSize = 20 //TODO: Move to config
         implicit0(deployBuffer: DeployBuffer[Effect]) <- Resource

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -105,7 +105,12 @@ package object effects {
       log: Log[Task]
   ): Resource[Effect, Transactor[Effect]] = {
     val connectionResource = Resource.make(
-      Task(DriverManager.getConnection(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}"))
+      Task {
+        val connection =
+          DriverManager.getConnection(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
+        connection.setAutoCommit(false)
+        connection
+      }
     )(
       connection =>
         Task(connection.close())

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -1,12 +1,12 @@
 package io.casperlabs.node
 
 import java.nio.file.Path
+import java.sql.DriverManager
 
 import cats._
 import cats.effect._
 import cats.implicits._
 import cats.mtl._
-import doobie.hikari.HikariTransactor
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.casperlabs.comm.CachedConnections.ConnectionsCache
@@ -25,7 +25,6 @@ import scala.concurrent.duration._
 import scala.io.Source
 
 package object effects {
-  import com.zaxxer.hikari.HikariConfig
 
   def log: Log[Task] = Log.log
 
@@ -98,35 +97,37 @@ package object effects {
     }
 
   // https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
+  // TODO: Investigate possible performance improvements if make use of recommended compile-time options
+  // https://www.sqlite.org/compile.html#recommended_compile_time_options
   def doobieTransactor(
-      connectEC: ExecutionContext,  // for waiting on connections, should be bounded
       transactEC: ExecutionContext, // for JDBC, can be unbounded
-      serverDataDir: Path
+      serverDataDir: Path,
+      log: Log[Task]
   ): Resource[Effect, Transactor[Effect]] = {
-    val config = new HikariConfig()
-    config.setDriverClassName("org.sqlite.JDBC")
-    config.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
-    config.setMinimumIdle(1)
-    config.setMaximumPoolSize(1)
-    // `autoCommit=true` is a default for Hikari; doobie sets `autoCommit=false`.
-    // From doobie's docs:
-    // * - Auto-commit will be set to `false`;
-    // * - the transaction will `commit` on success and `rollback` on failure;
-    config.setAutoCommit(false)
-    // Using a connection pool with maximum size of 1 becuase with the default settings we got SQLITE_BUSY errors.
+    val connectionResource = Resource.make(
+      Task(DriverManager.getConnection(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}"))
+    )(
+      connection =>
+        Task(connection.close())
+          .handleErrorWith(e => log.error("Failed to close the SQLite connection", e))
+    )
+    // Using a transactor based on a single connection because with the default settings we got SQLITE_BUSY errors.
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
-    HikariTransactor
-      .fromHikariConfig[Effect](
-        config,
-        connectEC,
-        transactEC
-      )
-      .map { xa =>
+    connectionResource
+      .map { connection =>
+        val xa = Transactor.fromConnection[Effect](connection, transactEC)
         // Foreign keys support must be enabled explicitly in SQLite
-        // https://www.sqlite.org/foreignkeys.html#fk_enable
+        // https://www.sqlite.org/foreignkeys.html#fk_enable,
         Transactor.before
-          .set(xa, sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before.get(xa))
+          .set(
+            xa,
+            sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before
+              .get(xa)
+          )
       }
+      .mapK(new (Task ~> Effect) {
+        override def apply[A](fa: Task[A]): Effect[A] = fa.toEffect
+      })
   }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,7 +92,6 @@ object Dependencies {
   val apacheCommons = "commons-io"        % "commons-io"     % "2.6"
   val sqlLite       = "org.xerial"        % "sqlite-jdbc"    % "3.28.0"
   val doobieCore    = "org.tpolecat"      %% "doobie-core"   % doobieVersion
-  val doobieHikari  = "org.tpolecat"      %% "doobie-hikari" % doobieVersion
   val flyway        = "org.flywaydb"      % "flyway-core"    % "5.2.4"
   val fs2           = "co.fs2"            %% "fs2-core"      % fs2Version
 


### PR DESCRIPTION
### Overview
Replaces the Doobie Transactor based on Hikari connection pool to Transactor created from a single JDBC connection.
We still can do other performance improvements, but they require recompilation of the SQLite library with the different set of compile options: https://www.sqlite.org/compile.html#recommended_compile_time_options

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-779

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
