### PR TITLE
NODE-912: Fix DagStorage cache issues

### DIFF
--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -150,16 +150,11 @@ object SQLiteStorage {
       override def justificationToBlocks(blockHash: BlockHash): F[Set[BlockHash]] =
         dagStorage.justificationToBlocks(blockHash)
 
-      // TODO: Remove DagRepresentation#lookup because
-      // we already have BlockStorage#getBlockSummary with the same semantics
-      // and which also cached in CachingBlockStorage.
       override def lookup(blockHash: BlockHash): F[Option[Message]] =
-        blockStorage.getBlockSummary(blockHash).flatMap(Message.fromOptionalSummary[F](_))
+        dagStorage.lookup(blockHash)
 
-      // TODO: Remove DagRepresentation#contains because
-      // we already have BlockStorage#contains with the same semantics
-      // and which also cached in CachingBlockStorage.
-      override def contains(blockHash: BlockHash): F[Boolean] = blockStorage.contains(blockHash)
+      override def contains(blockHash: BlockHash): F[Boolean] =
+        dagStorage.contains(blockHash)
 
       override def topoSort(
           startBlockNumber: Long,


### PR DESCRIPTION
### Overview
Do not forward `DagStorage.lookup` and `DagStorage.contains` requests to `BlockStorage`.
Adds a separate internal cache for `BlockSummaries` in the `CachingDagStorage`

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-912

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
