### PR TITLE
NODE-573: Prevent error logs in AutoProposerTest

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -183,7 +183,7 @@ object AutoProposerTest {
         if (pending.nonEmpty) Created(Block()) else NoNewDeploys
       }
 
-    override def addBlock(block: Block): F[BlockStatus]                           = ???
+    override def addBlock(block: Block): F[BlockStatus]                           = (Valid: BlockStatus).pure[F]
     override def contains(block: Block): F[Boolean]                               = ???
     override def estimator(dag: DagRepresentation[F]): F[IndexedSeq[ByteString]]  = ???
     override def dag: F[DagRepresentation[F]]                                     = ???


### PR DESCRIPTION
### Overview
As in the title.

I just took a look on the stack trace from the ticket and added a dummy implementation of the `addBlock` method on `MockMultiParentCasper`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-573

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
