### PR TITLE
EE-372: display version number

### DIFF
--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -159,6 +159,7 @@ fn set_panic_hook() {
 /// Gets command line arguments
 fn get_args() -> ArgMatches<'static> {
     App::new(APP_NAME)
+        .version(env!("CARGO_PKG_VERSION"))
         .arg(
             Arg::with_name(ARG_LOG_LEVEL)
                 .required(false)


### PR DESCRIPTION
### Overview
This PR updates the EE to print the version number when the `--version` flag is provided.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-372

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
N/A
