### PR TITLE
EE-692: add capability to upgrade stored contracts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -929,27 +929,7 @@ steps:
     - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
     - cd execution-engine
     - make setup
-    - ~/.cargo/bin/cargo build --release
-
-- name: build-system-contracts
-  image: appleboy/drone-ssh:latest
-  environment:
-    SSH_HOST:
-      from_secret: mac-host
-    SSH_USERNAME:
-      from_secret: mac-user
-    SSH_KEY:
-      from_secret: mac-ssh-key
-  settings:
-    command_timeout: 60m
-    port:
-      from_secret: mac-port
-    script:
-    - cd DRONE_BUILD_${DRONE_BUILD_NUMBER}/CasperLabs
-    - cd execution-engine
-    - make setup
-    - ~/.cargo/bin/cargo build -p pos --release --target wasm32-unknown-unknown
-    - ~/.cargo/bin/cargo build -p mint-token --release --target wasm32-unknown-unknown
+    - make build
 
 - name: cleanup-mac
   image: appleboy/drone-ssh:latest

--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -584,6 +584,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "do-nothing-stored"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+]
+
+[[package]]
+name = "do-nothing-stored-caller"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+]
+
+[[package]]
+name = "do-nothing-stored-upgrader"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+ "create-purse-01 0.1.0",
+]
+
+[[package]]
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [
@@ -1053,6 +1075,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "local-state-stored"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+ "local-state 0.1.0",
+]
+
+[[package]]
+name = "local-state-stored-caller"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+]
+
+[[package]]
+name = "local-state-stored-upgraded"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+ "local-state 0.1.0",
+]
+
+[[package]]
+name = "local-state-stored-upgrader"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+ "local-state-stored-upgraded 0.1.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1513,27 @@ dependencies = [
  "protoc 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "purse-holder-stored"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+]
+
+[[package]]
+name = "purse-holder-stored-caller"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+]
+
+[[package]]
+name = "purse-holder-stored-upgrader"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
 ]
 
 [[package]]

--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -759,6 +759,9 @@ pub fn get_phase() -> Phase {
     deserialize(&bytes).unwrap()
 }
 
+/// Takes the name of a function to store and a contract URef, and overwrites the value under
+/// that URef with a new Contract instance containing the original contract's known_urefs, the
+/// current protocol version, and the newly created bytes of the stored function.
 pub fn upgrade_contract_at_uref(name: &str, uref: TURef<Contract>) {
     let (name_ptr, name_size, _bytes) = str_ref_to_ptr(name);
     let key: Key = uref.into();

--- a/execution-engine/contract-ffi/src/lib.rs
+++ b/execution-engine/contract-ffi/src/lib.rs
@@ -125,6 +125,12 @@ mod ext_ffi {
         ) -> i32;
         pub fn get_balance(purse_id_ptr: *const u8, purse_id_size: usize) -> i32;
         pub fn get_phase(dest_ptr: *mut u8);
+        pub fn upgrade_contract_at_uref(
+            name_ptr: *const u8,
+            name_size: usize,
+            key_ptr: *const u8,
+            key_size: usize,
+        ) -> i32;
     }
 }
 

--- a/execution-engine/contracts/test/create-purse-01/Cargo.toml
+++ b/execution-engine/contracts/test/create-purse-01/Cargo.toml
@@ -6,11 +6,12 @@ edition = "2018"
 
 [lib]
 name = "create_purse_01"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "lib"]
 
 [features]
 default = []
 std = ["contract-ffi/std"]
+lib = []
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/create-purse-01/src/lib.rs
+++ b/execution-engine/contracts/test/create-purse-01/src/lib.rs
@@ -6,13 +6,23 @@ extern crate contract_ffi;
 use alloc::string::String;
 use contract_ffi::contract_api::{self, Error};
 
-#[no_mangle]
-pub extern "C" fn call() {
-    let purse_name: String = match contract_api::get_arg(0) {
+#[repr(u32)]
+enum Args {
+    PurseName = 0,
+}
+
+pub fn delegate() {
+    let purse_name: String = match contract_api::get_arg(Args::PurseName as u32) {
         Some(Ok(data)) => data,
         Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
         None => contract_api::revert(Error::MissingArgument.into()),
     };
     let purse_id = contract_api::create_purse();
     contract_api::add_uref(&purse_name, &purse_id.value().into());
+}
+
+#[cfg(not(feature = "lib"))]
+#[no_mangle]
+pub extern "C" fn call() {
+    delegate()
 }

--- a/execution-engine/contracts/test/do-nothing-stored-caller/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name = "local-state"
+name = "do-nothing-stored-caller"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
-crate-type = ["cdylib", "lib"]
+name = "do_nothing_stored_caller"
+crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["contract-ffi/std"]
-lib = []
+std = ["contract-ffi/std" ]
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -30,7 +30,7 @@ pub extern "C" fn call() {
     };
 
     let do_nothing_uref: URef = match contract_api::get_arg(Args::DoNothingURef as u32) {
-        Some(Ok(data)) => data,
+        Some(Ok(uref)) => uref,
         Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
         None => {
             contract_api::revert(Error::User(CustomError::MissingDoNothingURefArg as u16).into())

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -1,0 +1,51 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate contract_ffi;
+
+use alloc::string::String;
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
+use contract_ffi::contract_api::{self, Error};
+use contract_ffi::uref::URef;
+
+#[repr(u32)]
+enum Args {
+    DoNothingURef = 0,
+    PurseName = 1,
+}
+
+#[repr(u16)]
+enum CustomError {
+    MissingDoNothingURefArg = 0,
+    MissingPurseNameArg = 1,
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let new_purse_name: String = match contract_api::get_arg(Args::PurseName as u32) {
+        Some(Ok(uref)) => uref,
+        Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
+        None => contract_api::revert(Error::User(CustomError::MissingPurseNameArg as u16).into()),
+    };
+
+    let do_nothing_uref: URef = match contract_api::get_arg(Args::DoNothingURef as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
+        None => {
+            contract_api::revert(Error::User(CustomError::MissingDoNothingURefArg as u16).into())
+        }
+    };
+
+    let do_nothing_contract_pointer = ContractPointer::URef(TURef::new(
+        do_nothing_uref.addr(),
+        contract_ffi::uref::AccessRights::READ,
+    ));
+
+    // call do_nothing_stored
+    contract_api::call_contract::<_, ()>(
+        do_nothing_contract_pointer.clone(),
+        &(new_purse_name.clone(),),
+        &vec![],
+    );
+}

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -9,7 +9,7 @@ use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
 use contract_ffi::contract_api::{self, Error};
 use contract_ffi::uref::URef;
 
-#[repr(u32)]
+#[repr(u16)]
 enum Args {
     DoNothingURef = 0,
     PurseName = 1,

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -24,7 +24,7 @@ enum CustomError {
 #[no_mangle]
 pub extern "C" fn call() {
     let new_purse_name: String = match contract_api::get_arg(Args::PurseName as u32) {
-        Some(Ok(uref)) => uref,
+        Some(Ok(name)) => name,
         Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
         None => contract_api::revert(Error::User(CustomError::MissingPurseNameArg as u16).into()),
     };

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "do-nothing-stored-upgrader"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "do_nothing_stored_upgrader"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std" ]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+create-purse-01 = { path = "../create-purse-01", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
@@ -1,16 +1,17 @@
 #![no_std]
 
 extern crate contract_ffi;
+extern crate create_purse_01;
 
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::Error;
+use contract_ffi::contract_api::{self, Error};
 use contract_ffi::uref::URef;
 
-#[repr(u32)]
+#[repr(u16)]
 enum Args {
     DoNothingURef = 0,
 }
 
+#[repr(u16)]
 enum CustomError {
     MissingDoNothingURefArg = 0,
     InvalidDoNothingURefArg = 1,

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
@@ -1,0 +1,45 @@
+#![no_std]
+
+extern crate contract_ffi;
+
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::Error;
+use contract_ffi::uref::URef;
+
+#[repr(u32)]
+enum Args {
+    DoNothingURef = 0,
+}
+
+enum CustomError {
+    MissingDoNothingURefArg = 0,
+    InvalidDoNothingURefArg = 1,
+    InvalidTURef = 2,
+}
+
+const ENTRY_FUNCTION_NAME: &str = "delegate";
+
+#[no_mangle]
+pub extern "C" fn delegate() {
+    create_purse_01::delegate()
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let do_nothing_uref: URef = match contract_api::get_arg(Args::DoNothingURef as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidDoNothingURefArg as u16).into())
+        }
+        None => {
+            contract_api::revert(Error::User(CustomError::MissingDoNothingURefArg as u16).into())
+        }
+    };
+
+    let turef = contract_api::pointers::TURef::from_uref(do_nothing_uref).unwrap_or_else(|_| {
+        contract_api::revert(Error::User(CustomError::InvalidTURef as u16).into())
+    });
+
+    // this should overwrite the previous contract obj with the new contract obj at the same uref
+    contract_api::upgrade_contract_at_uref(ENTRY_FUNCTION_NAME, turef);
+}

--- a/execution-engine/contracts/test/do-nothing-stored/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing-stored/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name = "local-state"
+name = "do-nothing-stored"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
-crate-type = ["cdylib", "lib"]
+name = "do_nothing_stored"
+crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["contract-ffi/std"]
-lib = []
+std = ["contract-ffi/std" ]
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
@@ -5,9 +5,8 @@ extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
-use contract_ffi::contract_api;
 use contract_ffi::contract_api::pointers::ContractPointer;
-use contract_ffi::contract_api::Error;
+use contract_ffi::contract_api::{self, Error};
 use contract_ffi::key::Key;
 
 const MINT_NAME: &str = "mint";

--- a/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
@@ -1,0 +1,41 @@
+#![no_std]
+
+extern crate alloc;
+extern crate contract_ffi;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::Error;
+use contract_ffi::key::Key;
+
+const MINT_NAME: &str = "mint";
+const ENTRY_FUNCTION_NAME: &str = "delegate";
+const CONTRACT_NAME: &str = "do_nothing_stored";
+
+#[repr(u16)]
+enum CustomError {
+    MintHash = 0,
+}
+
+#[no_mangle]
+pub extern "C" fn delegate() {}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let mint_uref = match contract_api::get_mint() {
+        ContractPointer::Hash(_) => {
+            contract_api::revert(Error::User(CustomError::MintHash as u16).into())
+        }
+        ContractPointer::URef(turef) => turef.into(),
+    };
+
+    let mint_key = Key::URef(mint_uref);
+
+    let mut known_urefs: BTreeMap<String, Key> = BTreeMap::new();
+    known_urefs.insert(String::from(MINT_NAME), mint_key);
+    let contract = contract_api::fn_by_name(ENTRY_FUNCTION_NAME, known_urefs);
+    let key = contract_api::new_turef(contract).into();
+    contract_api::add_uref(CONTRACT_NAME, &key);
+}

--- a/execution-engine/contracts/test/local-state-stored-caller/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored-caller/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name = "local-state"
+name = "local-state-stored-caller"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
-crate-type = ["cdylib", "lib"]
+name = "local_state_stored_caller"
+crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["contract-ffi/std"]
-lib = []
+std = ["contract-ffi/std" ]
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
@@ -1,0 +1,38 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate contract_ffi;
+
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
+use contract_ffi::contract_api::{self, Error};
+use contract_ffi::uref::URef;
+
+#[repr(u32)]
+enum Args {
+    LocalStateURef = 0,
+}
+
+#[repr(u16)]
+enum CustomError {
+    MissingLocalStateURefArg = 11,
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let local_state_uref: URef = match contract_api::get_arg(Args::LocalStateURef as u32) {
+        Some(Ok(uref)) => uref,
+        Some(Err(_)) => contract_api::revert(Error::InvalidArgument.into()),
+        None => {
+            contract_api::revert(Error::User(CustomError::MissingLocalStateURefArg as u16).into())
+        }
+    };
+
+    let local_state_contract_pointer = ContractPointer::URef(TURef::new(
+        local_state_uref.addr(),
+        contract_ffi::uref::AccessRights::READ,
+    ));
+
+    // call do_nothing_stored
+    contract_api::call_contract::<_, ()>(local_state_contract_pointer.clone(), &(), &vec![]);
+}

--- a/execution-engine/contracts/test/local-state-stored-upgraded/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored-upgraded/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "local-state"
+name = "local-state-stored-upgraded"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
+name = "local_state_stored_upgraded"
 crate-type = ["cdylib", "lib"]
 
 [features]
@@ -15,3 +15,4 @@ lib = []
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+local-state = { path = "../local-state", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
@@ -1,0 +1,63 @@
+#![no_std]
+#![allow(unused_imports)]
+//#![feature(cell_update)]
+
+extern crate alloc;
+extern crate contract_ffi;
+extern crate local_state;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+
+pub const ENTRY_FUNCTION_NAME: &str = "delegate";
+pub const CONTRACT_NAME: &str = "local_state_stored";
+pub const SNIPPET: &str = " I've been upgraded!";
+
+#[repr(u16)]
+enum CustomError {
+    UnableToReadMutatedLocalKey = 0,
+    LocalKeyReadMutatedBytesRepr = 1,
+}
+
+#[no_mangle]
+pub extern "C" fn delegate() {
+    local_state::delegate();
+    // read from local state
+    let mut res: String = contract_api::read_local(local_state::LOCAL_KEY)
+        .unwrap_or_default()
+        .unwrap_or_default();
+
+    res.push_str(SNIPPET);
+    // Write "Hello, "
+    contract_api::write_local(local_state::LOCAL_KEY, res);
+
+    // Read back
+    let res: String = contract_api::read_local(local_state::LOCAL_KEY)
+        .unwrap_or_else(|_| {
+            contract_api::revert(
+                contract_api::Error::User(CustomError::UnableToReadMutatedLocalKey as u16).into(),
+            )
+        })
+        .unwrap_or_else(|| {
+            contract_api::revert(
+                contract_api::Error::User(CustomError::LocalKeyReadMutatedBytesRepr as u16).into(),
+            )
+        });
+
+    // local state should be available after upgrade
+    assert!(
+        !res.is_empty(),
+        "local value should be accessible post upgrade"
+    )
+}
+
+#[cfg(not(feature = "lib"))]
+#[no_mangle]
+pub extern "C" fn call() {
+    let known_urefs: BTreeMap<String, Key> = BTreeMap::new();
+    let contract = contract_api::fn_by_name(ENTRY_FUNCTION_NAME, known_urefs);
+    let key = contract_api::new_turef(contract).into();
+    contract_api::add_uref(CONTRACT_NAME, &key);
+}

--- a/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
@@ -1,15 +1,11 @@
 #![no_std]
-#![allow(unused_imports)]
-//#![feature(cell_update)]
 
 extern crate alloc;
 extern crate contract_ffi;
 extern crate local_state;
 
-use alloc::collections::BTreeMap;
 use alloc::string::String;
 use contract_ffi::contract_api;
-use contract_ffi::key::Key;
 
 pub const ENTRY_FUNCTION_NAME: &str = "delegate";
 pub const CONTRACT_NAME: &str = "local_state_stored";
@@ -56,8 +52,8 @@ pub extern "C" fn delegate() {
 #[cfg(not(feature = "lib"))]
 #[no_mangle]
 pub extern "C" fn call() {
-    let known_urefs: BTreeMap<String, Key> = BTreeMap::new();
-    let contract = contract_api::fn_by_name(ENTRY_FUNCTION_NAME, known_urefs);
+    let contract =
+        contract_api::fn_by_name(ENTRY_FUNCTION_NAME, alloc::collections::BTreeMap::new());
     let key = contract_api::new_turef(contract).into();
     contract_api::add_uref(CONTRACT_NAME, &key);
 }

--- a/execution-engine/contracts/test/local-state-stored-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored-upgrader/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "local-state-stored-upgrader"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "local_state_stored_upgrader"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std" ]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+local-state-stored-upgraded = { path = "../local-state-stored-upgraded", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+
+extern crate contract_ffi;
+extern crate local_state_stored_upgraded;
+
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::Error;
+use contract_ffi::uref::URef;
+
+#[repr(u32)]
+enum Args {
+    LocalStateURef = 0,
+}
+
+enum CustomError {
+    MissingLocalStateURefArg = 0,
+    InvalidLocalStateURefArg = 1,
+    InvalidTURef = 2,
+}
+
+const ENTRY_FUNCTION_NAME: &str = "upgraded_delegate";
+
+#[no_mangle]
+pub extern "C" fn upgraded_delegate() {
+    local_state_stored_upgraded::delegate()
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let uref: URef = match contract_api::get_arg(Args::LocalStateURef as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidLocalStateURefArg as u16).into())
+        }
+        None => {
+            contract_api::revert(Error::User(CustomError::MissingLocalStateURefArg as u16).into())
+        }
+    };
+
+    let turef = contract_api::pointers::TURef::from_uref(uref).unwrap_or_else(|_| {
+        contract_api::revert(Error::User(CustomError::InvalidTURef as u16).into())
+    });
+
+    // this should overwrite the previous contract obj with the new contract obj at the same uref
+    contract_api::upgrade_contract_at_uref(ENTRY_FUNCTION_NAME, turef);
+}

--- a/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
@@ -3,15 +3,15 @@
 extern crate contract_ffi;
 extern crate local_state_stored_upgraded;
 
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::Error;
+use contract_ffi::contract_api::{self, Error};
 use contract_ffi::uref::URef;
 
-#[repr(u32)]
+#[repr(u16)]
 enum Args {
     LocalStateURef = 0,
 }
 
+#[repr(u16)]
 enum CustomError {
     MissingLocalStateURefArg = 0,
     InvalidLocalStateURefArg = 1,

--- a/execution-engine/contracts/test/local-state-stored/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "local-state-stored"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "local_state_stored"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std"]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+local-state = { path = "../local-state", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/test/local-state-stored/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored/src/lib.rs
@@ -1,0 +1,27 @@
+#![no_std]
+#![feature(cell_update)]
+
+extern crate alloc;
+extern crate contract_ffi;
+extern crate local_state;
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+
+const ENTRY_FUNCTION_NAME: &str = "delegate";
+const CONTRACT_NAME: &str = "local_state_stored";
+
+#[no_mangle]
+pub extern "C" fn delegate() {
+    local_state::delegate()
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let known_urefs: BTreeMap<String, Key> = BTreeMap::new();
+    let contract = contract_api::fn_by_name(ENTRY_FUNCTION_NAME, known_urefs);
+    let key = contract_api::new_turef(contract).into();
+    contract_api::add_uref(CONTRACT_NAME, &key);
+}

--- a/execution-engine/contracts/test/local-state/src/lib.rs
+++ b/execution-engine/contracts/test/local-state/src/lib.rs
@@ -4,23 +4,50 @@
 extern crate alloc;
 extern crate contract_ffi;
 use alloc::string::{String, ToString};
-use contract_ffi::contract_api::{read_local, write_local};
+use contract_ffi::contract_api;
 
-#[no_mangle]
-pub extern "C" fn call() {
+pub const LOCAL_KEY: [u8; 32] = [66u8; 32];
+pub const HELLO_PREFIX: &str = " Hello, ";
+pub const WORLD_SUFFIX: &str = "world!";
+
+#[repr(u16)]
+enum CustomError {
+    UnableToReadMutatedLocalKey = 100,
+    LocalKeyReadMutatedBytesRepr = 101,
+}
+
+pub fn delegate() {
     // Appends " Hello, world!" to a [66; 32] local key with spaces trimmed.
     // Two runs should yield value "Hello, world! Hello, world!"
+    // read from local state
+    let mut res: String = contract_api::read_local(LOCAL_KEY)
+        .unwrap_or_default()
+        .unwrap_or_default();
 
-    let mut res: String = read_local([66; 32]).unwrap_or_default().unwrap_or_default();
-    res.push_str(" Hello, ");
+    res.push_str(HELLO_PREFIX);
     // Write "Hello, "
-    write_local([66u8; 32], res);
+    contract_api::write_local(LOCAL_KEY, res);
+
     // Read (this should exercise cache)
-    let mut res: String = read_local([66u8; 32])
-        .expect("Should have local key after write")
-        .expect("Should have local key after write");
+    let mut res: String = contract_api::read_local(LOCAL_KEY)
+        .unwrap_or_else(|_| {
+            contract_api::revert(
+                contract_api::Error::User(CustomError::UnableToReadMutatedLocalKey as u16).into(),
+            )
+        })
+        .unwrap_or_else(|| {
+            contract_api::revert(
+                contract_api::Error::User(CustomError::LocalKeyReadMutatedBytesRepr as u16).into(),
+            )
+        });
     // Append
-    res.push_str("world!");
+    res.push_str(WORLD_SUFFIX);
     // Write
-    write_local([66u8; 32], res.trim().to_string());
+    contract_api::write_local(LOCAL_KEY, res.trim().to_string());
+}
+
+#[cfg(not(feature = "lib"))]
+#[no_mangle]
+pub extern "C" fn call() {
+    delegate()
 }

--- a/execution-engine/contracts/test/purse-holder-stored-caller/Cargo.toml
+++ b/execution-engine/contracts/test/purse-holder-stored-caller/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name = "local-state"
+name = "purse-holder-stored-caller"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
-crate-type = ["cdylib", "lib"]
+name = "purse_holder_stored_caller"
+crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["contract-ffi/std"]
-lib = []
+std = ["contract-ffi/std" ]
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
@@ -1,0 +1,84 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate contract_ffi;
+
+use alloc::string::String;
+use contract_ffi::contract_api::pointers::{ContractPointer, TURef};
+use contract_ffi::contract_api::{self, Error};
+use contract_ffi::uref::URef;
+
+pub const METHOD_VERSION: &str = "version";
+
+#[repr(u32)]
+enum Args {
+    PurseHolderURef = 0,
+    MethodName = 1,
+    PurseName = 2,
+}
+
+#[allow(clippy::enum_variant_names)]
+#[repr(u16)]
+enum CustomError {
+    MissingPurseHolderURefArg = 0,
+    InvalidPurseHolderURefArg = 1,
+    MissingMethodNameArg = 2,
+    InvalidMethodNameArg = 3,
+    MissingPurseNameArg = 4,
+    InvalidPurseNameArg = 5,
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let purse_holder_uref: URef = match contract_api::get_arg(Args::PurseHolderURef as u32) {
+        Some(Ok(uref)) => uref,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidPurseHolderURefArg as u16).into())
+        }
+        None => {
+            contract_api::revert(Error::User(CustomError::MissingPurseHolderURefArg as u16).into())
+        }
+    };
+    let method_name: String = match contract_api::get_arg(Args::MethodName as u32) {
+        Some(Ok(method)) => method,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidMethodNameArg as u16).into())
+        }
+        None => contract_api::revert(Error::User(CustomError::MissingMethodNameArg as u16).into()),
+    };
+
+    let purse_holder_contract_pointer = ContractPointer::URef(TURef::new(
+        purse_holder_uref.addr(),
+        contract_ffi::uref::AccessRights::READ,
+    ));
+
+    match method_name.as_str() {
+        METHOD_VERSION => {
+            let version: String = contract_api::call_contract(
+                purse_holder_contract_pointer.clone(),
+                &(method_name,),
+                &vec![],
+            );
+            let version_key = contract_api::new_turef(version).into();
+            contract_api::add_uref(METHOD_VERSION, &version_key);
+        }
+        _ => {
+            let purse_name: String = match contract_api::get_arg(Args::PurseName as u32) {
+                Some(Ok(purse)) => purse,
+                Some(Err(_)) => contract_api::revert(
+                    Error::User(CustomError::InvalidPurseNameArg as u16).into(),
+                ),
+                None => contract_api::revert(
+                    Error::User(CustomError::MissingPurseNameArg as u16).into(),
+                ),
+            };
+
+            contract_api::call_contract::<_, ()>(
+                purse_holder_contract_pointer.clone(),
+                &(method_name, purse_name),
+                &vec![],
+            );
+        }
+    };
+}

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/Cargo.toml
@@ -1,17 +1,16 @@
 [package]
-name = "local-state"
+name = "purse-holder-stored-upgrader"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
-crate-type = ["cdylib", "lib"]
+name = "purse_holder_stored_upgrader"
+crate-type = ["cdylib"]
 
 [features]
 default = []
-std = ["contract-ffi/std"]
-lib = []
+std = ["contract-ffi/std" ]
 
 [dependencies]
 contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -5,8 +5,7 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::Error;
+use contract_ffi::contract_api::{self, Error};
 use contract_ffi::uref::URef;
 
 const ENTRY_FUNCTION_NAME: &str = "apply_method";
@@ -26,6 +25,7 @@ enum CallArgs {
     PurseHolderURef = 0,
 }
 
+#[repr(u16)]
 enum CustomError {
     MissingPurseHolderURefArg = 0,
     InvalidPurseHolderURefArg = 1,
@@ -37,13 +37,17 @@ enum CustomError {
     UnknownMethodName = 7,
 }
 
+impl From<CustomError> for Error {
+    fn from(error: CustomError) -> Self {
+        Error::User(error as u16)
+    }
+}
+
 fn purse_name() -> String {
     match contract_api::get_arg(ApplyArgs::PurseName as u32) {
         Some(Ok(data)) => data,
-        Some(Err(_)) => {
-            contract_api::revert(Error::User(CustomError::InvalidPurseNameArg as u16).into())
-        }
-        None => contract_api::revert(Error::User(CustomError::MissingPurseNameArg as u16).into()),
+        Some(Err(_)) => contract_api::revert_with_error(CustomError::InvalidPurseNameArg),
+        None => contract_api::revert_with_error(CustomError::MissingPurseNameArg),
     }
 }
 
@@ -51,10 +55,8 @@ fn purse_name() -> String {
 pub extern "C" fn apply_method() {
     let method_name: String = match contract_api::get_arg(ApplyArgs::MethodName as u32) {
         Some(Ok(data)) => data,
-        Some(Err(_)) => {
-            contract_api::revert(Error::User(CustomError::InvalidMethodNameArg as u16).into())
-        }
-        None => contract_api::revert(Error::User(CustomError::MissingMethodNameArg as u16).into()),
+        Some(Err(_)) => contract_api::revert_with_error(CustomError::InvalidMethodNameArg),
+        None => contract_api::revert_with_error(CustomError::MissingMethodNameArg),
     };
     match method_name.as_str() {
         METHOD_ADD => {
@@ -67,7 +69,7 @@ pub extern "C" fn apply_method() {
             contract_api::remove_uref(&purse_name);
         }
         METHOD_VERSION => contract_api::ret(&VERSION.to_string(), &vec![]),
-        _ => contract_api::revert(Error::User(CustomError::UnknownMethodName as u16).into()),
+        _ => contract_api::revert_with_error(CustomError::UnknownMethodName),
     }
 }
 
@@ -75,17 +77,12 @@ pub extern "C" fn apply_method() {
 pub extern "C" fn call() {
     let uref: URef = match contract_api::get_arg(CallArgs::PurseHolderURef as u32) {
         Some(Ok(data)) => data,
-        Some(Err(_)) => {
-            contract_api::revert(Error::User(CustomError::InvalidPurseHolderURefArg as u16).into())
-        }
-        None => {
-            contract_api::revert(Error::User(CustomError::MissingPurseHolderURefArg as u16).into())
-        }
+        Some(Err(_)) => contract_api::revert_with_error(CustomError::InvalidPurseHolderURefArg),
+        None => contract_api::revert_with_error(CustomError::MissingPurseHolderURefArg),
     };
 
-    let turef = contract_api::pointers::TURef::from_uref(uref).unwrap_or_else(|_| {
-        contract_api::revert(Error::User(CustomError::InvalidTURef as u16).into())
-    });
+    let turef = contract_api::pointers::TURef::from_uref(uref)
+        .unwrap_or_else(|_| contract_api::revert_with_error(CustomError::InvalidTURef));
 
     // this should overwrite the previous contract obj with the new contract obj at the same uref
     contract_api::upgrade_contract_at_uref(ENTRY_FUNCTION_NAME, turef);

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -1,0 +1,96 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate contract_ffi;
+
+use alloc::string::{String, ToString};
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::Error;
+use contract_ffi::uref::URef;
+
+const ENTRY_FUNCTION_NAME: &str = "apply_method";
+pub const METHOD_ADD: &str = "add";
+pub const METHOD_REMOVE: &str = "remove";
+pub const METHOD_VERSION: &str = "version";
+pub const VERSION: &str = "1.0.1";
+
+#[repr(u32)]
+enum ApplyArgs {
+    MethodName = 0,
+    PurseName = 1,
+}
+
+#[repr(u32)]
+enum CallArgs {
+    PurseHolderURef = 0,
+}
+
+enum CustomError {
+    MissingPurseHolderURefArg = 0,
+    InvalidPurseHolderURefArg = 1,
+    MissingMethodNameArg = 2,
+    InvalidMethodNameArg = 3,
+    MissingPurseNameArg = 4,
+    InvalidPurseNameArg = 5,
+    InvalidTURef = 6,
+    UnknownMethodName = 7,
+}
+
+fn purse_name() -> String {
+    match contract_api::get_arg(ApplyArgs::PurseName as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidPurseNameArg as u16).into())
+        }
+        None => contract_api::revert(Error::User(CustomError::MissingPurseNameArg as u16).into()),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn apply_method() {
+    let method_name: String = match contract_api::get_arg(ApplyArgs::MethodName as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidMethodNameArg as u16).into())
+        }
+        None => contract_api::revert(Error::User(CustomError::MissingMethodNameArg as u16).into()),
+    };
+    match method_name.as_str() {
+        METHOD_ADD => {
+            let purse_name = purse_name();
+            let purse_id = contract_api::create_purse();
+            contract_api::add_uref(&purse_name, &purse_id.value().into());
+        }
+        METHOD_REMOVE => {
+            let purse_name = purse_name();
+            contract_api::remove_uref(&purse_name);
+        }
+        METHOD_VERSION => contract_api::ret(&VERSION.to_string(), &vec![]),
+        _ => contract_api::revert(Error::User(CustomError::UnknownMethodName as u16).into()),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let uref: URef = match contract_api::get_arg(CallArgs::PurseHolderURef as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidPurseHolderURefArg as u16).into())
+        }
+        None => {
+            contract_api::revert(Error::User(CustomError::MissingPurseHolderURefArg as u16).into())
+        }
+    };
+
+    let turef = contract_api::pointers::TURef::from_uref(uref).unwrap_or_else(|_| {
+        contract_api::revert(Error::User(CustomError::InvalidTURef as u16).into())
+    });
+
+    // this should overwrite the previous contract obj with the new contract obj at the same uref
+    contract_api::upgrade_contract_at_uref(ENTRY_FUNCTION_NAME, turef);
+
+    // set new version
+    let version_key = contract_api::new_turef(VERSION.to_string()).into();
+    contract_api::add_uref(METHOD_VERSION, &version_key);
+}

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -14,13 +14,13 @@ pub const METHOD_REMOVE: &str = "remove";
 pub const METHOD_VERSION: &str = "version";
 pub const VERSION: &str = "1.0.1";
 
-#[repr(u32)]
+#[repr(u16)]
 enum ApplyArgs {
     MethodName = 0,
     PurseName = 1,
 }
 
-#[repr(u32)]
+#[repr(u16)]
 enum CallArgs {
     PurseHolderURef = 0,
 }

--- a/execution-engine/contracts/test/purse-holder-stored/Cargo.toml
+++ b/execution-engine/contracts/test/purse-holder-stored/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "local-state"
+name = "purse-holder-stored"
 version = "0.1.0"
-authors = ["Michał Papierski <michal@casperlabs.io>"]
+authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
+name = "purse_holder_stored"
 crate-type = ["cdylib", "lib"]
 
 [features]

--- a/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
@@ -12,18 +12,19 @@ use contract_ffi::contract_api::{self, Error};
 use contract_ffi::key::Key;
 
 const MINT_NAME: &str = "mint";
-const ENTRY_FUNCTION_NAME: &str = "delegate";
+const ENTRY_FUNCTION_NAME: &str = "apply_method";
 const CONTRACT_NAME: &str = "purse_holder_stored";
 pub const METHOD_ADD: &str = "add";
 pub const METHOD_VERSION: &str = "version";
 pub const VERSION: &str = "1.0.0";
 
-#[repr(u32)]
+#[repr(u16)]
 enum Args {
     MethodName = 0,
     PurseName = 1,
 }
 
+#[repr(u16)]
 enum CustomError {
     MintHash = 0,
     MissingMethodNameArg = 1,
@@ -43,7 +44,8 @@ fn purse_name() -> String {
     }
 }
 
-pub fn apply_method() {
+#[no_mangle]
+pub extern "C" fn apply_method() {
     let method_name: String = match contract_api::get_arg(Args::MethodName as u32) {
         Some(Ok(data)) => data,
         Some(Err(_)) => {
@@ -60,11 +62,6 @@ pub fn apply_method() {
         METHOD_VERSION => contract_api::ret(&VERSION.to_string(), &vec![]),
         _ => contract_api::revert(Error::User(CustomError::UnknownMethodName as u16).into()),
     }
-}
-
-#[no_mangle]
-pub extern "C" fn delegate() {
-    apply_method()
 }
 
 #[cfg(not(feature = "lib"))]

--- a/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
@@ -1,0 +1,89 @@
+#![no_std]
+#![feature(cell_update)]
+
+#[macro_use]
+extern crate alloc;
+extern crate contract_ffi;
+
+use alloc::collections::BTreeMap;
+use alloc::string::{String, ToString};
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{self, Error};
+use contract_ffi::key::Key;
+
+const MINT_NAME: &str = "mint";
+const ENTRY_FUNCTION_NAME: &str = "delegate";
+const CONTRACT_NAME: &str = "purse_holder_stored";
+pub const METHOD_ADD: &str = "add";
+pub const METHOD_VERSION: &str = "version";
+pub const VERSION: &str = "1.0.0";
+
+#[repr(u32)]
+enum Args {
+    MethodName = 0,
+    PurseName = 1,
+}
+
+enum CustomError {
+    MintHash = 0,
+    MissingMethodNameArg = 1,
+    InvalidMethodNameArg = 2,
+    MissingPurseNameArg = 3,
+    InvalidPurseNameArg = 4,
+    UnknownMethodName = 5,
+}
+
+fn purse_name() -> String {
+    match contract_api::get_arg(Args::PurseName as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidPurseNameArg as u16).into())
+        }
+        None => contract_api::revert(Error::User(CustomError::MissingPurseNameArg as u16).into()),
+    }
+}
+
+pub fn apply_method() {
+    let method_name: String = match contract_api::get_arg(Args::MethodName as u32) {
+        Some(Ok(data)) => data,
+        Some(Err(_)) => {
+            contract_api::revert(Error::User(CustomError::InvalidMethodNameArg as u16).into())
+        }
+        None => contract_api::revert(Error::User(CustomError::MissingMethodNameArg as u16).into()),
+    };
+    match method_name.as_str() {
+        METHOD_ADD => {
+            let purse_name = purse_name();
+            let purse_id = contract_api::create_purse();
+            contract_api::add_uref(&purse_name, &purse_id.value().into());
+        }
+        METHOD_VERSION => contract_api::ret(&VERSION.to_string(), &vec![]),
+        _ => contract_api::revert(Error::User(CustomError::UnknownMethodName as u16).into()),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn delegate() {
+    apply_method()
+}
+
+#[cfg(not(feature = "lib"))]
+#[no_mangle]
+pub extern "C" fn call() {
+    let mint_uref = match contract_api::get_mint() {
+        ContractPointer::Hash(_) => {
+            contract_api::revert(Error::User(CustomError::MintHash as u16).into())
+        }
+        ContractPointer::URef(turef) => turef.into(),
+    };
+    let mint_key = Key::URef(mint_uref);
+    let mut known_urefs: BTreeMap<String, Key> = BTreeMap::new();
+    known_urefs.insert(String::from(MINT_NAME), mint_key);
+    let contract = contract_api::fn_by_name(ENTRY_FUNCTION_NAME, known_urefs);
+    let contract_name_key = contract_api::new_turef(contract).into();
+    contract_api::add_uref(CONTRACT_NAME, &contract_name_key);
+
+    // set version
+    let version_key = contract_api::new_turef(VERSION.to_string()).into();
+    contract_api::add_uref(METHOD_VERSION, &version_key);
+}

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -3,6 +3,7 @@ use std::convert::TryFrom;
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
 use contract_ffi::bytesrepr::{self, ToBytes};
+use contract_ffi::contract_api;
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, PurseId};
 use contract_ffi::value::{Value, U512};
@@ -425,7 +426,7 @@ where
                 // args(3) = size of name in Wasm memory
                 let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
                 let ret = self.upgrade_contract_at_uref(name_ptr, name_size, key_ptr, key_size)?;
-                Ok(Some(RuntimeValue::I32(ret.into())))
+                Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))
             }
         }
     }

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -417,6 +417,16 @@ where
                 self.get_phase(dest_ptr)?;
                 Ok(None)
             }
+
+            FunctionIndex::UpgradeContractAtURef => {
+                // args(0) = pointer to key in Wasm memory
+                // args(1) = size of key
+                // args(2) = pointer to name in Wasm memory
+                // args(3) = size of name in Wasm memory
+                let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
+                let ret = self.upgrade_contract_at_uref(name_ptr, name_size, key_ptr, key_size)?;
+                Ok(Some(RuntimeValue::I32(ret.into())))
+            }
         }
     }
 }

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -420,10 +420,10 @@ where
             }
 
             FunctionIndex::UpgradeContractAtURef => {
-                // args(0) = pointer to key in Wasm memory
-                // args(1) = size of key
-                // args(2) = pointer to name in Wasm memory
-                // args(3) = size of name in Wasm memory
+                // args(0) = pointer to name in Wasm memory
+                // args(1) = size of name in Wasm memory
+                // args(2) = pointer to key in Wasm memory
+                // args(3) = size of key
                 let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
                 let ret = self.upgrade_contract_at_uref(name_ptr, name_size, key_ptr, key_size)?;
                 Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -11,7 +11,7 @@ use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef, Trap, TrapKind
 
 use contract_ffi::bytesrepr::{deserialize, ToBytes, U32_SIZE};
 use contract_ffi::contract_api::argsparser::ArgsParser;
-use contract_ffi::contract_api::{PurseTransferResult, TransferResult, UpgradeResult};
+use contract_ffi::contract_api::{Error as ApiError, PurseTransferResult, TransferResult};
 use contract_ffi::key::Key;
 use contract_ffi::system_contracts::{self, mint};
 use contract_ffi::uref::{AccessRights, URef};
@@ -925,7 +925,7 @@ where
         name_size: u32,
         key_ptr: u32,
         key_size: u32,
-    ) -> Result<UpgradeResult, Trap> {
+    ) -> Result<Result<(), ApiError>, Trap> {
         let key = self.key_from_mem(key_ptr, key_size)?;
         let known_urefs = {
             match self.context.read_gs(&key)? {
@@ -947,8 +947,8 @@ where
             .context
             .upgrade_contract_at_uref(key, bytes, known_urefs)
         {
-            Ok(_) => Ok(UpgradeResult::Success),
-            Err(_) => Ok(UpgradeResult::UpgradeError),
+            Ok(_) => Ok(Ok(())),
+            Err(_) => Ok(Err(ApiError::UpgradeContractAtURef)),
         }
     }
 }

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -927,20 +927,13 @@ where
         key_size: u32,
     ) -> Result<Result<(), ApiError>, Trap> {
         let key = self.key_from_mem(key_ptr, key_size)?;
-        let known_urefs = {
-            match self.context.read_gs(&key)? {
-                None => Err(Error::KeyNotFound(key)),
-                Some(value) => {
-                    if let Value::Contract(contract) = value {
-                        Ok(contract.urefs_lookup().clone())
-                    } else {
-                        Err(Error::FunctionNotFound(format!(
-                            "Value at {:?} is not a contract",
-                            key
-                        )))
-                    }
-                }
-            }
+        let known_urefs = match self.context.read_gs(&key)? {
+            None => Err(Error::KeyNotFound(key)),
+            Some(Value::Contract(contract)) => Ok(contract.urefs_lookup().clone()),
+            Some(_) => Err(Error::FunctionNotFound(format!(
+                "Value at {:?} is not a contract",
+                key
+            ))),
         }?;
         let bytes = self.get_function_by_name(name_ptr, name_size)?;
         match self

--- a/execution-engine/engine-core/src/resolvers/mod.rs
+++ b/execution-engine/engine-core/src/resolvers/mod.rs
@@ -15,7 +15,8 @@ use crate::resolvers::memory_resolver::MemoryResolver;
 pub fn create_module_resolver(
     protocol_version: ProtocolVersion,
 ) -> Result<impl ModuleImportResolver + MemoryResolver, ResolverError> {
-    if protocol_version == ProtocolVersion::new(1) {
+    // TODO: revisit how protocol_version check here is meant to combine with upgrade
+    if protocol_version >= ProtocolVersion::new(1) {
         return Ok(v1_resolver::RuntimeModuleImportResolver::default());
     }
     Err(ResolverError::UnknownProtocolVersion(protocol_version))

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -41,6 +41,7 @@ pub enum FunctionIndex {
     TransferFromPurseToPurseIndex = 34,
     GetBalanceIndex = 35,
     GetPhaseIndex = 36,
+    UpgradeContractAtURef = 37,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -189,6 +189,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 1][..], None),
                 FunctionIndex::GetPhaseIndex.into(),
             ),
+            "upgrade_contract_at_uref" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
+                FunctionIndex::UpgradeContractAtURef.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -792,4 +792,23 @@ where
 
         Ok(())
     }
+
+    pub fn upgrade_contract_at_uref(
+        &mut self,
+        key: Key,
+        bytes: Vec<u8>,
+        known_urefs: BTreeMap<String, Key>,
+    ) -> Result<(), Error> {
+        let protocol_version = self.protocol_version();
+        let contract = Contract::new(bytes, known_urefs, protocol_version);
+        let contract = Value::Contract(contract);
+        let validated_key: Validated<Key> = Validated::new(key, |key| {
+            self.validate_writeable(&key).and(self.validate_key(&key))
+        })?;
+        let validated_value = Validated::new(contract, Validated::valid)?;
+        self.state
+            .borrow_mut()
+            .write(validated_key, validated_value);
+        Ok(())
+    }
 }

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -45,7 +45,6 @@ pub const DEFAULT_BLOCK_TIME: u64 = 0;
 pub const MOCKED_ACCOUNT_ADDRESS: [u8; 32] = [48u8; 32];
 pub const COMPILED_WASM_PATH: &str = "../target/wasm32-unknown-unknown/release";
 pub const GENESIS_INITIAL_BALANCE: u64 = 100_000_000_000;
-pub const GENESIS_TIMESTAMP: u64 = 0;
 
 /// LMDB initial map size is calculated based on DEFAULT_LMDB_PAGES and systems page size.
 ///

--- a/execution-engine/engine-tests/src/test/mod.rs
+++ b/execution-engine/engine-tests/src/test/mod.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod metrics;
+#[cfg(test)]
+mod upgrade;
 
 #[cfg(test)]
 pub mod contract_api;

--- a/execution-engine/engine-tests/src/test/system_contracts/mod.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod genesis;
+pub mod genesis;
 #[cfg(test)]
 mod mint_install;
 #[cfg(test)]

--- a/execution-engine/engine-tests/src/test/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/upgrade.rs
@@ -1,0 +1,580 @@
+use engine_core::engine_state::{EngineConfig, EngineState};
+
+use crate::support::test_support::{
+    create_genesis_config, DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder,
+    WasmTestBuilder,
+};
+
+use contract_ffi::key::Key;
+use contract_ffi::uref::URef;
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::{Account, Contract, Value, U512};
+use engine_core::engine_state::genesis::GenesisAccount;
+use engine_core::execution;
+use engine_grpc_server::engine_server::ipc::ExecResponse;
+use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
+use engine_shared::motes::Motes;
+use engine_shared::transform::Transform;
+use engine_storage::global_state::StateProvider;
+
+const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
+const ACCOUNT_1_BONDED_AMOUNT: u64 = 1_000_000;
+const ACCOUNT_1_BALANCE: u64 = 1_000_000_000;
+const PAYMENT_AMOUNT: u64 = 200_000_000;
+const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";
+const DO_NOTHING_STORED_CONTRACT_NAME: &str = "do_nothing_stored";
+const DO_NOTHING_CALLER_CONTRACT_NAME: &str = "do_nothing_stored_caller";
+const DO_NOTHING_UPGRADE_CONTRACT_NAME: &str = "do_nothing_stored_upgrader";
+const LOCAL_STATE_STORED_CONTRACT_NAME: &str = "local_state_stored";
+const LOCAL_STATE_STORED_CALLER_CONTRACT_NAME: &str = "local_state_stored_caller";
+const LOCAL_STATE_STORED_UPGRADER_CONTRACT_NAME: &str = "local_state_stored_upgrader";
+const PURSE_HOLDER_STORED_CONTRACT_NAME: &str = "purse_holder_stored";
+const PURSE_HOLDER_STORED_CALLER_CONTRACT_NAME: &str = "purse_holder_stored_caller";
+const PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME: &str = "purse_holder_stored_upgrader";
+const HELLO: &str = "Hello";
+const METHOD_ADD: &str = "add";
+const METHOD_REMOVE: &str = "remove";
+const METHOD_VERSION: &str = "version";
+const PURSE_1: &str = "purse_1";
+
+fn initialize_builder<S>(builder: &mut WasmTestBuilder<S>)
+where
+    S: StateProvider,
+    S::Error: Into<execution::Error>,
+    EngineState<S>: ExecutionEngineService,
+{
+    let account_1 = {
+        let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
+        let account_1_balance = Motes::new(ACCOUNT_1_BALANCE.into());
+        let account_1_bonded_amount = Motes::new(ACCOUNT_1_BONDED_AMOUNT.into());
+        GenesisAccount::new(
+            account_1_public_key,
+            account_1_balance,
+            account_1_bonded_amount,
+        )
+    };
+
+    builder.run_genesis(&create_genesis_config(vec![account_1]));
+}
+
+fn exec_session_code<S>(
+    builder: &mut WasmTestBuilder<S>,
+    account_public_key: &PublicKey,
+    account_deploy_counter: u8,
+    session_contract_name: &str,
+    args: impl contract_ffi::contract_api::argsparser::ArgsParser,
+) -> ExecResponse
+where
+    S: StateProvider,
+    S::Error: Into<execution::Error>,
+    EngineState<S>: ExecutionEngineService,
+{
+    let exec_request = {
+        let deploy = DeployBuilder::new()
+            .with_address(account_public_key.value())
+            .with_session_code(&format!("{}.wasm", session_contract_name), args)
+            .with_payment_code(
+                &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
+                (U512::from(PAYMENT_AMOUNT),),
+            )
+            .with_authorization_keys(&[*account_public_key])
+            .with_deploy_hash([account_deploy_counter + 1; 32])
+            .build();
+
+        ExecRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder
+        .exec_with_exec_request(exec_request)
+        .expect_success() // <- assert equivalent
+        .commit();
+
+    let exec_response = builder
+        .get_exec_response(account_deploy_counter as usize)
+        .expect("there should be a response")
+        .clone();
+
+    assert!(exec_response.has_success(), "expected success");
+
+    exec_response
+}
+
+fn query_contract<S>(builder: &mut WasmTestBuilder<S>, contract_uref: &URef) -> Option<Contract>
+where
+    S: StateProvider,
+    S::Error: Into<execution::Error>,
+    EngineState<S>: ExecutionEngineService,
+{
+    let contract_value: Value = builder
+        .query(None, Key::URef(*contract_uref), &[])
+        .expect("should have contract value");
+
+    if let Value::Contract(contract) = contract_value {
+        Some(contract)
+    } else {
+        None
+    }
+}
+
+fn query_account<S>(
+    builder: &mut WasmTestBuilder<S>,
+    account_public_key: &PublicKey,
+) -> Option<Account>
+where
+    S: StateProvider,
+    S::Error: Into<execution::Error>,
+    EngineState<S>: ExecutionEngineService,
+{
+    let account_key = Key::Account(account_public_key.value());
+
+    let account_value: Value = builder
+        .query(None, account_key, &[])
+        .expect("should have contract value");
+
+    if let Value::Account(account) = account_value {
+        Some(account)
+    } else {
+        None
+    }
+}
+
+#[ignore]
+#[test]
+fn should_upgrade_do_nothing_to_do_something() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    initialize_builder(&mut builder);
+
+    let mut account_deploy_counter: u8 = 0;
+    let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
+
+    // store do-nothing-stored
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        DO_NOTHING_STORED_CONTRACT_NAME,
+        (),
+    );
+
+    // call stored do nothing, passing a purse name as an arg
+    // which should have no affect as do nothing does nothing
+    let account_1_transformed = builder
+        .get_account(Key::Account(ACCOUNT_1_ADDR))
+        .expect("should get account 1");
+
+    assert_eq!(
+        account_1_transformed.urefs_lookup().get(PURSE_1),
+        None,
+        "purse should not exist"
+    );
+
+    account_deploy_counter += 1;
+
+    let do_nothing_stored_uref = account_1_transformed
+        .urefs_lookup()
+        .get(DO_NOTHING_STORED_CONTRACT_NAME)
+        .expect("should have do_nothing_stored uref")
+        .as_uref()
+        .expect("should have uref");
+
+    // do upgrade
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        DO_NOTHING_UPGRADE_CONTRACT_NAME,
+        (*do_nothing_stored_uref,),
+    );
+
+    account_deploy_counter += 1;
+
+    // call upgraded contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        DO_NOTHING_CALLER_CONTRACT_NAME,
+        (*do_nothing_stored_uref, PURSE_1),
+    );
+
+    let contract =
+        query_contract(&mut builder, do_nothing_stored_uref).expect("should have contract");
+
+    // currently as the system is designed the new uref for the purse is added to the
+    // caller contract instead of the account...ideally the account would get the uref
+    // but that's beyond the scope of this upgrade specific test
+    assert!(
+        contract.urefs_lookup().contains_key(PURSE_1),
+        "should have new purse uref"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_observe_version_change_across_upgrade() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    initialize_builder(&mut builder);
+
+    let mut account_deploy_counter: u8 = 0;
+    let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
+
+    // store do-nothing-stored
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_CONTRACT_NAME,
+        (),
+    );
+
+    account_deploy_counter += 1;
+
+    let account = query_account(&mut builder, &account_1_public_key).expect("should have account");
+
+    assert!(
+        account.urefs_lookup().contains_key(METHOD_VERSION),
+        "version uref should exist on install"
+    );
+
+    let stored_uref = account
+        .urefs_lookup()
+        .get("purse_holder_stored")
+        .expect("should have stored uref")
+        .as_uref()
+        .expect("should have uref");
+
+    // verify version before upgrade
+    let account = query_account(&mut builder, &account_1_public_key).expect("should have account");
+
+    let original_version = builder
+        .query(
+            None,
+            *account
+                .urefs_lookup()
+                .get(METHOD_VERSION)
+                .expect("version uref should exist"),
+            &[],
+        )
+        .expect("version should exist");
+
+    assert_eq!(
+        original_version,
+        Value::String("1.0.0".to_string()),
+        "should be original version"
+    );
+
+    // upgrade contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME,
+        (*stored_uref,),
+    );
+
+    // version should change after upgrade
+    let account = query_account(&mut builder, &account_1_public_key).expect("should have account");
+
+    let upgraded_version = builder
+        .query(
+            None,
+            *account
+                .urefs_lookup()
+                .get(METHOD_VERSION)
+                .expect("version uref should exist"),
+            &[],
+        )
+        .expect("version should exist");
+
+    assert_eq!(
+        upgraded_version,
+        Value::String("1.0.1".to_string()),
+        "should be original version"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_support_extending_functionality() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    initialize_builder(&mut builder);
+
+    let mut account_deploy_counter: u8 = 0;
+    let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
+
+    // store do-nothing-stored
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_CONTRACT_NAME,
+        (),
+    );
+
+    account_deploy_counter += 1;
+
+    let account = query_account(&mut builder, &account_1_public_key).expect("should have account");
+
+    let stored_uref = account
+        .urefs_lookup()
+        .get("purse_holder_stored")
+        .expect("should have stored uref")
+        .as_uref()
+        .expect("should have uref");
+
+    // call stored contract and persist a known uref before upgrade
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_CALLER_CONTRACT_NAME,
+        (*stored_uref, METHOD_ADD, PURSE_1),
+    );
+
+    // verify known uref actually exists prior to upgrade
+    let contract = query_contract(&mut builder, stored_uref).expect("should have contract");
+    assert!(
+        contract.urefs_lookup().contains_key(PURSE_1),
+        "purse uref should exist in contract's known_urefs before upgrade"
+    );
+
+    account_deploy_counter += 1;
+
+    // verify known uref actually exists prior to upgrade
+    let contract = query_contract(&mut builder, stored_uref).expect("should have contract");
+
+    assert!(
+        contract.urefs_lookup().contains_key(PURSE_1),
+        "PURSE_1 uref should exist in contract's known_urefs before upgrade"
+    );
+
+    // upgrade contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME,
+        (*stored_uref,),
+    );
+
+    account_deploy_counter += 1;
+
+    // verify uref still exists in known_urefs after upgrade:
+    let contract = query_contract(&mut builder, stored_uref).expect("should have contract");
+
+    assert!(
+        contract.urefs_lookup().contains_key(PURSE_1),
+        "PURSE_1 uref should still exist in contract's known_urefs after upgrade"
+    );
+
+    // call new remove function
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_CALLER_CONTRACT_NAME,
+        (*stored_uref, METHOD_REMOVE, PURSE_1),
+    );
+
+    // verify known urefs no longer include removed purse
+    let contract = query_contract(&mut builder, stored_uref).expect("should have contract");
+
+    assert!(
+        !contract.urefs_lookup().contains_key(PURSE_1),
+        "PURSE_1 uref should no longer exist in contract's known_urefs after remove"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_maintain_known_urefs_across_upgrade() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    initialize_builder(&mut builder);
+
+    let mut account_deploy_counter = 0;
+    let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
+
+    // store contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_CONTRACT_NAME,
+        (),
+    );
+
+    account_deploy_counter += 1;
+
+    let account = query_account(&mut builder, &account_1_public_key).expect("should have account");
+
+    let stored_uref = account
+        .urefs_lookup()
+        .get(PURSE_HOLDER_STORED_CONTRACT_NAME)
+        .expect("should have stored uref")
+        .as_uref()
+        .expect("should have uref");
+
+    // add several purse urefs to known_urefs
+    let total_purses: u8 = 3;
+    for index in 1..=total_purses {
+        let purse_name: &str = &format!("purse_{}", index);
+        exec_session_code(
+            &mut builder,
+            &account_1_public_key,
+            account_deploy_counter,
+            PURSE_HOLDER_STORED_CALLER_CONTRACT_NAME,
+            (*stored_uref, METHOD_ADD, purse_name),
+        );
+
+        // verify known uref actually exists prior to upgrade
+        let contract = query_contract(&mut builder, stored_uref).expect("should have contract");
+        assert!(
+            contract.urefs_lookup().contains_key(purse_name),
+            "purse uref should exist in contract's known_urefs before upgrade"
+        );
+
+        account_deploy_counter += 1;
+    }
+
+    // upgrade contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME,
+        (*stored_uref,),
+    );
+
+    // verify all urefs still exists in known_urefs after upgrade
+    let contract = query_contract(&mut builder, stored_uref).expect("should have contract");
+
+    for index in 1..=total_purses {
+        let purse_name: &str = &format!("purse_{}", index);
+        assert!(
+            contract.urefs_lookup().contains_key(purse_name),
+            format!(
+                "{} uref should still exist in contract's known_urefs after upgrade",
+                index
+            )
+        );
+    }
+}
+
+#[ignore]
+#[test]
+fn should_maintain_local_state_across_upgrade() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    initialize_builder(&mut builder);
+
+    let mut account_deploy_counter: u8 = 0;
+    let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
+
+    // store local_state_stored contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        LOCAL_STATE_STORED_CONTRACT_NAME,
+        (),
+    );
+
+    account_deploy_counter += 1;
+
+    let account = query_account(&mut builder, &account_1_public_key).expect("should have account");
+
+    let stored_uref = account
+        .urefs_lookup()
+        .get(LOCAL_STATE_STORED_CONTRACT_NAME)
+        .expect("should have stored uref")
+        .as_uref()
+        .expect("should have uref");
+
+    // call local_state_stored_contract (which will cause it to store some local state)
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        LOCAL_STATE_STORED_CALLER_CONTRACT_NAME,
+        (*stored_uref,),
+    );
+
+    account_deploy_counter += 1;
+
+    // confirm expected local state was written
+    let transform_map = &builder.get_transforms()[1];
+
+    let (local_state_key, original_local_state_value) = {
+        let mut ret: Option<(contract_ffi::key::Key, String)> = None;
+        for (k, t) in transform_map {
+            if let Transform::Write(Value::String(s)) = t {
+                if s.contains(HELLO) {
+                    ret = Some((*k, s.clone()));
+                    break;
+                }
+            }
+        }
+        ret
+    }
+    .expect("local state Write should exist");
+
+    // upgrade local_state_stored contract
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        LOCAL_STATE_STORED_UPGRADER_CONTRACT_NAME,
+        (*stored_uref,),
+    );
+
+    account_deploy_counter += 1;
+
+    // call upgraded local_state_stored_contract
+    // (local state existence is checked in upgraded contract)
+    exec_session_code(
+        &mut builder,
+        &account_1_public_key,
+        account_deploy_counter,
+        LOCAL_STATE_STORED_CALLER_CONTRACT_NAME,
+        (*stored_uref,),
+    );
+
+    // get transformed local state value post upgrade
+    let transform_map = &builder.get_transforms()[account_deploy_counter as usize];
+
+    let transform = transform_map
+        .get(&local_state_key)
+        .expect("should have second Write transform");
+
+    let write = {
+        match transform {
+            Transform::Write(Value::String(s)) => Some(s.to_owned()),
+            _ => None,
+        }
+    }
+    .expect("should have write value");
+
+    assert!(
+        write.starts_with(&original_local_state_value) && write.ends_with("upgraded!"),
+        "local state should include elements from the original version and the upgraded version"
+    );
+}


### PR DESCRIPTION
This PR adds the ability to update a stored contract under a named `URef` with new contract bytes while retaining local and global state.

https://casperlabs.atlassian.net/browse/EE-692

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR adds new tests and supporting contracts.
- [X] This PR is assigned.

NOTE: another tranche of work is queued up behind this one which adds further support for upgrading system contracts, wasm costs, and protocol version. It depends on this functionality for the bulk of the system contract upgrade process.