### PR TITLE
NODE-883: Switch to using semver for ProtocolVersion.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/LegacyConversions.scala
@@ -52,7 +52,9 @@ object LegacyConversions {
             }
           )
           .withTimestamp(block.getHeader.timestamp)
-          .withProtocolVersion(block.getHeader.protocolVersion)
+          .withProtocolVersion(
+            consensus.state.ProtocolVersion(block.getHeader.protocolVersion.toInt)
+          )
           .withDeployCount(block.getHeader.deployCount)
           .withChainId(block.shardId)
           .withValidatorBlockSeqNum(block.seqNum)
@@ -105,7 +107,7 @@ object LegacyConversions {
           .withPostStateHash(stateHash)
           .withDeploysHash(deploysHash)
           .withTimestamp(block.getHeader.timestamp)
-          .withProtocolVersion(block.getHeader.protocolVersion)
+          .withProtocolVersion(block.getHeader.getProtocolVersion.major.toLong)
           .withDeployCount(block.getHeader.deployCount)
           .withExtraBytes(headerExtraBytes)
       )

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -559,7 +559,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
           justifications = justifications,
           state = postState,
           rank = rank,
-          protocolVersion = protocolVersion.value,
+          protocolVersion = protocolVersion,
           timestamp = now,
           chainId = chainId
         )

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -576,7 +576,7 @@ object BlockAPI {
     for {
       dag                      <- MultiParentCasper[F].dag
       header                   = block.getHeader
-      protocolVersion          = header.protocolVersion
+      protocolVersion          = header.getProtocolVersion
       deployCount              = header.deployCount
       postStateHash            = ProtoUtil.postStateHash(block)
       timestamp                = header.timestamp
@@ -586,7 +586,7 @@ object BlockAPI {
       initialFault             <- MultiParentCasper[F].normalizedInitialFault(ProtoUtil.weightMap(block))
       blockInfo <- constructor(
                     block,
-                    protocolVersion,
+                    protocolVersion.major.toLong,
                     deployCount,
                     postStateHash,
                     timestamp,

--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -12,6 +12,7 @@ import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.CasperConf
 import io.casperlabs.casper.consensus._
+import io.casperlabs.casper.consensus.state.ProtocolVersion
 import io.casperlabs.casper.genesis.contracts._
 import io.casperlabs.casper.util.ProtoUtil.{blockHeader, deployDataToEEDeploy, unsignedBlockProto}
 import io.casperlabs.casper.util.Sorting._
@@ -33,7 +34,7 @@ object Genesis {
 
   private implicit val logSource: LogSource = LogSource(this.getClass)
 
-  val protocolVersion = 1L
+  val protocolVersion = 1
 
   /** Construct deploys that will set up the system contracts. */
   @silent("is never used")
@@ -95,7 +96,7 @@ object Genesis {
         )
         .withMintCode(mintCode)
         .withProofOfStakeCode(posCode)
-        .withProtocolVersion(state.ProtocolVersion(protocolVersion))
+        .withProtocolVersion(ProtocolVersion(protocolVersion))
         .withGenesisValidators(genesisValidators)
 
       deploy = ProtoUtil.basicDeploy(
@@ -149,7 +150,7 @@ object Genesis {
         justifications = Nil,
         state = stateWithContracts,
         rank = initial.getHeader.rank,
-        protocolVersion = initial.getHeader.protocolVersion,
+        protocolVersion = initial.getHeader.getProtocolVersion,
         timestamp = initial.getHeader.timestamp,
         chainId = initial.getHeader.chainId
       )
@@ -183,7 +184,7 @@ object Genesis {
       justifications = Nil,
       state = state,
       rank = 0,
-      protocolVersion = protocolVersion,
+      protocolVersion = ProtocolVersion(protocolVersion),
       timestamp = timestamp,
       chainId = chainId
     )

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -9,6 +9,7 @@ import io.casperlabs.blockstorage.{BlockMetadata, BlockStorage, DagRepresentatio
 import io.casperlabs.casper.{PrettyPrinter, ValidatorIdentity}
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus._
+import io.casperlabs.casper.consensus.state.ProtocolVersion
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
@@ -377,7 +378,7 @@ object ProtoUtil {
       justifications: Seq[Justification],
       state: Block.GlobalState,
       rank: Long,
-      protocolVersion: Long,
+      protocolVersion: ProtocolVersion,
       timestamp: Long,
       chainId: String
   ): Block.Header =

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtocolVersions.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtocolVersions.scala
@@ -60,7 +60,7 @@ object ProtocolVersions {
       if (next.minor != 0) {
         Some("Protocol minor versions should be 0 after major version change.")
       } else if (next.patch != 0) {
-        Some("Protocol path versions should be 0 after major version change.")
+        Some("Protocol patch versions should be 0 after major version change.")
       } else {
         None
       }

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtocolVersions.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtocolVersions.scala
@@ -21,43 +21,75 @@ object ProtocolVersions {
 
   final case class BlockThreshold(blockHeightMin: Long, version: state.ProtocolVersion)
 
+  // Order thresholds from newest to oldest descending.
   private implicit val blockThresholdOrdering: Ordering[BlockThreshold] =
     Ordering.by[BlockThreshold, Long](_.blockHeightMin).reverse
 
   def apply(l: List[BlockThreshold]): ProtocolVersions = {
-    val sortedList = l.sorted(blockThresholdOrdering)
+    val descendingList = l.sorted(blockThresholdOrdering)
 
-    require(sortedList.size >= 1, "List cannot be empty.")
+    require(descendingList.size >= 1, "List cannot be empty.")
     require(
-      sortedList.last.blockHeightMin == 0,
+      descendingList.last.blockHeightMin == 0,
       "Lowest block threshold MUST have 0 as lower bound."
     )
 
-    sortedList.tail.foldLeft(
-      (Set(sortedList.head.blockHeightMin), List(sortedList.head.version))
+    descendingList.tail.foldLeft(
+      (Set(descendingList.head.blockHeightMin), descendingList.head.version)
     ) {
-      case ((rangeMinAcc, protocolVersionsSeen), currThreshold) =>
+      case ((rangeMinAcc, nextVersion), prevThreshold) =>
         assert(
-          !rangeMinAcc.contains(currThreshold.blockHeightMin),
+          !rangeMinAcc.contains(prevThreshold.blockHeightMin),
           "Block thresholds' lower boundaries can't repeat."
         )
-        assert(
-          currThreshold.version.value == protocolVersionsSeen.last.value - 1,
-          "Protocol versions should increase monotonically by 1."
-        )
-        (rangeMinAcc + currThreshold.blockHeightMin, protocolVersionsSeen :+ currThreshold.version)
+        checkFollows(prevThreshold.version, nextVersion).foreach { msg =>
+          assert(false, msg)
+        }
+        (rangeMinAcc + prevThreshold.blockHeightMin, prevThreshold.version)
     }
 
-    new ProtocolVersions(sortedList)
+    new ProtocolVersions(descendingList)
   }
 
+  def checkFollows(prev: state.ProtocolVersion, next: state.ProtocolVersion): Option[String] =
+    if (next.major < 0 || next.minor < 0 || next.patch < 0 || prev.major < 0 || prev.minor < 0 || prev.patch < 0) {
+      Some("Protocol versions cannot be negative.")
+    } else if (next.major > prev.major + 1) {
+      Some("Protocol major versions should increase monotonically by 1.")
+    } else if (next.major == prev.major + 1) {
+      if (next.minor != 0) {
+        Some("Protocol minor versions should be 0 after major version change.")
+      } else if (next.patch != 0) {
+        Some("Protocol path versions should be 0 after major version change.")
+      } else {
+        None
+      }
+    } else if (next.major == prev.major) {
+      if (next.minor > prev.minor + 1) {
+        Some(
+          "Protocol minor versions should increase monotonically by 1 within the same major version."
+        )
+      } else if (next.minor == prev.minor + 1) {
+        None
+      } else if (next.minor == prev.minor) {
+        if (next.patch <= prev.patch) {
+          Some("Protocol patch versions should increase monotonically.")
+        } else {
+          None
+        }
+      } else {
+        Some("Protocol minor versions should not go backwards within the same major version.")
+      }
+    } else {
+      Some("Protocol major versions should not go backwards.")
+    }
 }
 
 object CasperLabsProtocolVersions {
 
   // Specifies what protocol version to choose at the `blockThreshold` height.
   val thresholdsVersionMap: ProtocolVersions = ProtocolVersions(
-    List(BlockThreshold(0, state.ProtocolVersion(1)))
+    List(BlockThreshold(0, state.ProtocolVersion(1, 0, 0)))
   )
 
 }

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -290,9 +290,9 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       b: BlockSummary,
       m: BlockHeight => state.ProtocolVersion
   ): F[Boolean] = {
-    val blockVersion = b.getHeader.protocolVersion
+    val blockVersion = b.getHeader.getProtocolVersion
     val blockHeight  = b.getHeader.rank
-    val version      = m(blockHeight).value
+    val version      = m(blockHeight)
     if (blockVersion == version) {
       true.pure[F]
     } else {

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -43,7 +43,7 @@ class DeploySelectionTest
 
   val prestate        = ByteString.EMPTY
   val blocktime       = 0L
-  val protocolVersion = ProtocolVersion(1L)
+  val protocolVersion = ProtocolVersion(1)
 
   val smallBlockSizeBytes = 5 * 1024
 

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -23,6 +23,7 @@ import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.immutable.HashMap
+import io.casperlabs.casper.consensus.state.ProtocolVersion
 
 @silent("deprecated")
 class BlockQueryResponseAPITest extends FlatSpec with Matchers with DagStorageFixture {
@@ -31,9 +32,9 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with DagStorageFi
   val badTestHashQuery = "No such a hash"
 
   val genesisHashString = "0" * 64
-  val version           = 1L
+  val version           = ProtocolVersion(1)
 
-  def genesisBlock(genesisHashString: String, version: Long): Block = {
+  def genesisBlock(genesisHashString: String, version: ProtocolVersion): Block = {
     val genesisHash = ProtoUtil.stringToByteString(genesisHashString)
     val ps = Block
       .GlobalState()
@@ -108,7 +109,7 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with DagStorageFi
         _         = blockInfo.blockHash should be(secondHashString)
         _         = blockInfo.blockSize should be(secondBlock.serializedSize.toString)
         _         = blockInfo.blockNumber should be(blockNumber)
-        _         = blockInfo.protocolVersion should be(version)
+        _         = blockInfo.protocolVersion should be(version.major)
         _         = blockInfo.deployCount should be(deployCount)
         _         = blockInfo.faultTolerance should be(faultTolerance)
         _         = blockInfo.mainParentHash should be(genesisHashString)
@@ -155,7 +156,7 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with DagStorageFi
         _         = blockInfo.blockHash should be(secondHashString)
         _         = blockInfo.blockSize should be(secondBlock.serializedSize.toString)
         _         = blockInfo.blockNumber should be(blockNumber)
-        _         = blockInfo.protocolVersion should be(version)
+        _         = blockInfo.protocolVersion should be(version.major)
         _         = blockInfo.deployCount should be(deployCount)
         _         = blockInfo.faultTolerance should be(faultTolerance)
         _         = blockInfo.mainParentHash should be(genesisHashString)

--- a/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
@@ -182,7 +182,7 @@ class GenesisTest extends FlatSpec with Matchers with DagStorageFixture {
             request.initialMotes.get shouldBe state.BigInt("123", 512)
             request.mintCode.get.code.toByteArray shouldBe ("mint code".getBytes)
             request.proofOfStakeCode.get.code.toByteArray shouldBe ("proof of stake code".getBytes)
-            request.protocolVersion.get.value shouldBe 1L
+            request.protocolVersion.get.major shouldBe 1
           }
       }
     )

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -156,7 +156,7 @@ trait BlockGenerator {
           serializedJustifications,
           postState,
           rank = 0,
-          protocolVersion = 1,
+          protocolVersion = ProtocolVersion(1),
           timestamp = now,
           chainId = chainId
         )

--- a/casper/src/test/scala/io/casperlabs/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/ProtoUtilTest.scala
@@ -4,6 +4,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper._
 import io.casperlabs.casper.consensus._, Block.Justification
+import io.casperlabs.casper.consensus.state.ProtocolVersion
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen.listOfN
@@ -27,7 +28,7 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
   val blockElementGen: Gen[Block] =
     for {
       hash            <- arbitrary[BlockHash]
-      version         <- arbitrary[Long]
+      version         <- arbitrary[Int]
       timestamp       <- arbitrary[Long]
       parentsHashList <- arbitrary[Seq[BlockHash]]
       justifications  <- arbitrary[Seq[Justification]]
@@ -37,7 +38,7 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
           .Header()
           .withParentHashes(parentsHashList)
           .withJustifications(justifications)
-          .withProtocolVersion(version)
+          .withProtocolVersion(ProtocolVersion(version))
           .withTimestamp(timestamp)
       )
 

--- a/casper/src/test/scala/io/casperlabs/casper/util/ProtocolVersionsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/ProtocolVersionsTest.scala
@@ -39,7 +39,7 @@ class ProtocolVersionsTest extends WordSpec with Matchers {
             )
           )
         }
-        compareErrorMessages(thrown, "Protocol versions should increase monotonically by 1.")
+        compareErrorMessages(thrown, "Protocol major versions should increase monotonically by 1.")
       }
     }
 

--- a/casper/src/test/scala/io/casperlabs/casper/util/ProtocolVersionsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/ProtocolVersionsTest.scala
@@ -2,12 +2,17 @@ package io.casperlabs.casper.util
 
 import io.casperlabs.casper.util.ProtocolVersions.BlockThreshold
 import io.casperlabs.casper.consensus.state.ProtocolVersion
-import org.scalatest.{Assertion, Matchers, WordSpec}
+import org.scalatest.{Assertion, Inspectors, Matchers, WordSpec}
 
-class ProtocolVersionsTest extends WordSpec with Matchers {
+class ProtocolVersionsTest extends WordSpec with Matchers with Inspectors {
 
   def compareErrorMessages(error: AssertionError, expected: String): Assertion =
     error.getMessage should equal("assertion failed: " + expected)
+
+  def semver(version: String) = {
+    val Array(major, minor, patch) = version.split('.')
+    ProtocolVersion(major.toInt, minor.toInt, patch.toInt)
+  }
 
   "ProtocolVersion" when {
     "created from empty list" should {
@@ -40,6 +45,53 @@ class ProtocolVersionsTest extends WordSpec with Matchers {
           )
         }
         compareErrorMessages(thrown, "Protocol major versions should increase monotonically by 1.")
+      }
+    }
+
+    "created with invalid subsequent semver versions" should {
+      "throw an assertion error" in {
+        val invalids = Seq(
+          "1.0.0" -> "0.1.0",
+          "1.0.0" -> "1.0.0",
+          "1.0.0" -> "1.2.0",
+          "1.0.0" -> "3.0.0",
+          "1.0.0" -> "2.1.0",
+          "1.2.3" -> "2.0.1"
+        )
+        forAll(invalids) {
+          case (prev, next) =>
+            a[java.lang.AssertionError] should be thrownBy {
+              ProtocolVersions(
+                List(
+                  BlockThreshold(0, semver(prev)),
+                  BlockThreshold(11, semver(next))
+                )
+              )
+            }
+        }
+      }
+    }
+
+    "created with valid subsequent semver versions" should {
+      "not throw" in {
+        val valids = Seq(
+          "0.1.0" -> "0.1.3",
+          "0.1.0" -> "0.2.0",
+          "0.1.0" -> "0.2.3",
+          "1.0.0" -> "2.0.0",
+          "1.2.3" -> "2.0.0"
+        )
+        forAll(valids) {
+          case (prev, next) =>
+            noException should be thrownBy {
+              ProtocolVersions(
+                List(
+                  BlockThreshold(0, semver(prev)),
+                  BlockThreshold(11, semver(next))
+                )
+              )
+            }
+        }
       }
     }
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ArbitraryConsensus.scala
@@ -11,6 +11,7 @@ import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 
 import scala.collection.JavaConverters._
+import io.casperlabs.casper.consensus.state.ProtocolVersion
 
 object ArbitraryConsensus extends ArbitraryConsensus
 
@@ -93,6 +94,16 @@ trait ArbitraryConsensus {
     }
   }
 
+  implicit val arbProtocolVersion: Arbitrary[ProtocolVersion] = Arbitrary {
+    for {
+      major <- Gen.choose(0, 3)
+      minor <- Gen.choose(0, 15)
+      patch <- Gen.choose(0, 9)
+    } yield {
+      ProtocolVersion(major, minor, patch)
+    }
+  }
+
   implicit val arbSignature: Arbitrary[Signature] = Arbitrary {
     for {
       alg <- Gen.oneOf("ed25519", "secp256k1")
@@ -132,6 +143,7 @@ trait ArbitraryConsensus {
       preStateHash       <- genHash
       postStateHash      <- genHash
       validatorPublicKey <- Gen.oneOf(randomValidators)
+      protocolVersion    <- arbitrary[ProtocolVersion]
     } yield {
       Block
         .Header()
@@ -140,6 +152,7 @@ trait ArbitraryConsensus {
         .withDeployCount(deployCount)
         .withValidatorPublicKey(validatorPublicKey)
         .withBodyHash(bodyHash)
+        .withProtocolVersion(protocolVersion)
     }
   }
 

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
@@ -7,10 +7,11 @@ import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
 import io.casperlabs.casper.consensus.info._
 import io.casperlabs.crypto.codec.{Base16, Base64}
-import io.casperlabs.node.api.graphql.schema.utils.DateType
+import io.casperlabs.node.api.graphql.schema.utils.{DateType, ProtocolVersionType}
 import sangria.schema._
 
 package object types {
+
   val SignatureType = ObjectType(
     "Signature",
     "Signature used to sign Block or Deploy",
@@ -153,9 +154,9 @@ package object types {
       ),
       Field(
         "protocolVersion",
-        LongType,
+        ProtocolVersionType,
         "Protocol version of CasperLabs blockchain".some,
-        resolve = c => c.value._1.getSummary.getHeader.protocolVersion
+        resolve = c => c.value._1.getSummary.getHeader.getProtocolVersion
       ),
       Field(
         "deployCount",

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/globalstate/types/package.scala
@@ -2,6 +2,7 @@ package io.casperlabs.node.api.graphql.schema.globalstate
 
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.casper.consensus.state
+import io.casperlabs.node.api.graphql.schema.utils.ProtocolVersionType
 import sangria.schema._
 
 package object types {
@@ -137,7 +138,7 @@ package object types {
     fields[Unit, state.Contract](
       Field("body", StringType, resolve = c => Base16.encode(c.value.body.toByteArray)),
       Field("knownUrefs", ListType(NamedKey), resolve = _.value.knownUrefs),
-      Field("protocolVersion", LongType, resolve = _.value.protocolVersion.get.value)
+      Field("protocolVersion", ProtocolVersionType, resolve = _.value.getProtocolVersion)
     )
   )
 

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/utils/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/utils/package.scala
@@ -1,8 +1,12 @@
 package io.casperlabs.node.api.graphql.schema
 
+import cats._
+import cats.syntax._
+import cats.implicits._
+import io.casperlabs.casper.consensus.state.ProtocolVersion
 import java.time.{Instant, ZoneId, ZonedDateTime}
 
-import sangria.schema.ScalarType
+import sangria.schema._
 
 package object utils {
   // Not defining inputs yet because it's a read-only field
@@ -12,5 +16,30 @@ package object utils {
     coerceOutput =
       (l, _) => ZonedDateTime.ofInstant(Instant.ofEpochMilli(l), ZoneId.of("Z")).toString,
     coerceInput = _ => ???
+  )
+
+  val ProtocolVersionType = ObjectType(
+    "ProtocolVersion",
+    "ProtocolVersion at the time a Block was created; follows semver semantics",
+    fields[Unit, ProtocolVersion](
+      Field(
+        "major",
+        IntType,
+        "Major version".some,
+        resolve = c => c.value.major
+      ),
+      Field(
+        "minor",
+        IntType,
+        "Minor version".some,
+        resolve = c => c.value.minor
+      ),
+      Field(
+        "path",
+        IntType,
+        "Patch version".some,
+        resolve = c => c.value.patch
+      )
+    )
   )
 }

--- a/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
@@ -47,6 +47,20 @@ private[configuration] trait ParserImplicits {
     Node.fromAddress(s).leftMap(CommError.errorMessage)
   }
 
+  implicit val protocolVersionParser: Parser[ChainSpec.ProtocolVersion] = {
+    // Major and minor mandatory, patch optional.
+    val SemVer = """(\d+)\.(\d+)(?:\.(\d+))?""".r
+    s =>
+      s match {
+        case SemVer(major, minor, patch) =>
+          ChainSpec
+            .ProtocolVersion(major.toInt, minor.toInt, Option(patch).fold(0)(_.toInt))
+            .asRight
+        case _ =>
+          s"Unable to parse semver: $s".asLeft
+      }
+  }
+
   implicit val positiveIntParser: Parser[Refined[Int, Positive]] =
     s =>
       for {

--- a/node/src/test/resources/chainspec-invalids/genesis-with-missing-fields.toml
+++ b/node/src/test/resources/chainspec-invalids/genesis-with-missing-fields.toml
@@ -2,7 +2,7 @@
 
 name = "test-chain"
 #timestamp = 1568805354071
-protocol-version = 1
+protocol-version = "1.0.0"
 mint-code-path = "mint.wasm"
 pos-code-path = "pos.wasm"
 initial-accounts-path = "accounts.csv"

--- a/node/src/test/resources/chainspec-invalids/upgrade-with-missing-fields.toml
+++ b/node/src/test/resources/chainspec-invalids/upgrade-with-missing-fields.toml
@@ -1,6 +1,6 @@
 [upgrade]
 
-protocol-version = 3
+protocol-version = "1.3"
 # activation-point-rank = 30
 
 [wasm-costs]

--- a/node/src/test/resources/chainspec/1-genesis/manifest.toml
+++ b/node/src/test/resources/chainspec/1-genesis/manifest.toml
@@ -10,7 +10,7 @@ name = "test-chain"
 timestamp = 1568805354071
 
 # Later will be replaced by semver.
-protocol-version = 1
+protocol-version = "0.1"
 
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint.wasm"

--- a/node/src/test/resources/chainspec/2-upgrade/manifest.toml
+++ b/node/src/test/resources/chainspec/2-upgrade/manifest.toml
@@ -3,7 +3,7 @@
 activation-point-rank = 20
 
 # Later will be replaced by semver.
-protocol-version = 2
+protocol-version = "1.0.2"
 
 # Optional path to the file containing wasm bytecode installing new system contracts.
 installer-code-path = "installer.wasm"

--- a/node/src/test/resources/chainspec/3-upgrade/manifest.toml
+++ b/node/src/test/resources/chainspec/3-upgrade/manifest.toml
@@ -3,4 +3,4 @@
 activation-point-rank = 30
 
 # Later will be replaced by semver.
-protocol-version = 3
+protocol-version = "1.1.0"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ChainSpecTest.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ChainSpecTest.scala
@@ -4,6 +4,7 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.data.ValidatedNel
 import com.google.protobuf.ByteString
 import io.casperlabs.crypto.codec.Base64
+import io.casperlabs.casper.consensus.state
 import io.casperlabs.ipc
 import java.io.File
 import java.nio.file.Paths
@@ -17,7 +18,7 @@ class ChainSpecTest extends WordSpecLike with Matchers with Inspectors with Chai
       val manifest = Source.fromResource("chainspec/1-genesis/manifest.toml")
 
       check(ChainSpec.GenesisConf.parseManifest(manifest)) { conf =>
-        conf.genesis.protocolVersion shouldBe 1L
+        conf.genesis.protocolVersion shouldBe ChainSpec.ProtocolVersion(0, 1, 0)
         conf.genesis.name shouldBe "test-chain"
         conf.genesis.timestamp shouldBe 1568805354071L
         conf.genesis.mintCodePath.toString shouldBe "mint.wasm"
@@ -46,7 +47,7 @@ class ChainSpecTest extends WordSpecLike with Matchers with Inspectors with Chai
       val manifest = Source.fromResource("chainspec/2-upgrade/manifest.toml")
 
       check(ChainSpec.UpgradeConf.parseManifest(manifest)) { conf =>
-        conf.upgrade.protocolVersion shouldBe 2L
+        conf.upgrade.protocolVersion shouldBe ChainSpec.ProtocolVersion(1, 0, 2)
         conf.upgrade.activationPointRank shouldBe 20L
         conf.upgrade.installerCodePath.get.toString shouldBe "installer.wasm"
         conf.wasmCosts should not be empty
@@ -61,7 +62,7 @@ class ChainSpecTest extends WordSpecLike with Matchers with Inspectors with Chai
 
       check(ChainSpec.UpgradeConf.parseManifest(manifest)) { conf =>
         conf.upgrade.activationPointRank shouldBe 30L
-        conf.upgrade.protocolVersion shouldBe 3L
+        conf.upgrade.protocolVersion shouldBe ChainSpec.ProtocolVersion(1, 1, 0)
         conf.upgrade.installerCodePath shouldBe empty
         conf.wasmCosts shouldBe empty
       }
@@ -93,7 +94,7 @@ class ChainSpecTest extends WordSpecLike with Matchers with Inspectors with Chai
           val genesis = spec.getGenesis
           genesis.name shouldBe "test-chain"
           genesis.timestamp shouldBe 1568805354071L
-          genesis.getProtocolVersion.value shouldBe 1L
+          genesis.getProtocolVersion shouldBe state.ProtocolVersion(0, 1)
 
           new String(genesis.mintInstaller.toByteArray).trim shouldBe "mint contract bytes"
           new String(genesis.posInstaller.toByteArray).trim shouldBe "pos contract bytes"
@@ -129,7 +130,7 @@ class ChainSpecTest extends WordSpecLike with Matchers with Inspectors with Chai
 
           val upgrade = spec.upgrades(0)
           upgrade.getActivationPoint.rank shouldBe 20L
-          upgrade.getProtocolVersion.value shouldBe 2L
+          upgrade.getProtocolVersion shouldBe state.ProtocolVersion(1, 0, 2)
 
           new String(upgrade.getUpgradeInstaller.code.toByteArray).trim shouldBe "installer contract bytes"
 
@@ -153,7 +154,7 @@ class ChainSpecTest extends WordSpecLike with Matchers with Inspectors with Chai
 
           val upgrade = spec.upgrades(1)
           upgrade.getActivationPoint.rank shouldBe 30L
-          upgrade.getProtocolVersion.value shouldBe 3L
+          upgrade.getProtocolVersion shouldBe state.ProtocolVersion(1, 1, 0)
 
           upgrade.upgradeInstaller shouldBe empty
 

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -117,13 +117,14 @@ message Block {
     Signature signature = 4;
 
     message Header {
+        reserved 6; // old u64 protocol version.
         repeated bytes parent_hashes = 1;
         repeated Justification justifications = 2;
         GlobalState state = 3;
         // Hash of the body structure as a whole.
         bytes body_hash = 4;
         uint64 timestamp = 5;
-        uint64 protocol_version = 6;
+        state.ProtocolVersion protocol_version = 13;
         uint32 deploy_count = 7;
         string chain_id = 8;
         uint32 validator_block_seq_num = 9;

--- a/protobuf/io/casperlabs/casper/consensus/state.proto
+++ b/protobuf/io/casperlabs/casper/consensus/state.proto
@@ -111,5 +111,7 @@ message Account {
 message Unit {}
 
 message ProtocolVersion {
-    uint64 value = 1;
+    uint32 major = 1;
+    uint32 minor = 2;
+    uint32 patch = 3;
 }

--- a/smart-contracts/src/test/scala/io/casperlabs/smartcontracts/ExecutionEngineServiceTest.scala
+++ b/smart-contracts/src/test/scala/io/casperlabs/smartcontracts/ExecutionEngineServiceTest.scala
@@ -30,7 +30,7 @@ class ExecutionEngineServiceTest
   ) {
     case (deployItems, msgSize) =>
       val baseRequest =
-        ExecuteRequest(ByteString.EMPTY, 0L, protocolVersion = Some(ProtocolVersion(1L)))
+        ExecuteRequest(ByteString.EMPTY, 0L, protocolVersion = Some(ProtocolVersion(1)))
       val batches =
         ExecutionEngineService.batchDeploysBySize(baseRequest, msgSize)(deployItems)
       batches.flatMap(_.deploys) should contain theSameElementsInOrderAs deployItems


### PR DESCRIPTION
### Overview
To indicate what should be a non-breaking change from dApp developer perspective.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-883

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
`LegacyConversions` and `BlockAPI.showBlocks` is removed in the `new-genesis` branch, that's why I didn't bother with anything but the `major` there.
`ProtocolVersions` has a hardcoded list of versions, which must also be changed to be based on the ChainSpec.
