### PR TITLE
NODE-918: Delegate `getBlockSummary` to DagStorage

### DIFF
--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -139,7 +139,7 @@ object SQLiteStorage {
         blockStorage.putApprovedBlock(block)
 
       override def getBlockSummary(blockHash: BlockHash): F[Option[BlockSummary]] =
-        blockStorage.getBlockSummary(blockHash)
+        dagStorage.lookup(blockHash).map(_.map(_.blockSummary))
 
       override def findBlockHashesWithDeployhash(deployHash: ByteString): F[Seq[BlockHash]] =
         blockStorage.findBlockHashesWithDeployhash(deployHash)


### PR DESCRIPTION
### Overview
When `getBlockSummary` invoked then `SQLiteStorage` delegates it to the `DagStorage` instead of `BlockStorage`. We assume that it will improve the performance due to caching by `CachingDagStorage`

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-918

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
