### PR TITLE
NODE-920: Do not generate short parameter versions for ttl and dependencies.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -109,12 +109,15 @@ object Options {
     val ttl = opt[Int](
       descr = "Time to live. Time (in milliseconds) that the deploy will remain valid for.",
       validate = _ > 0,
-      required = false
+      required = false,
+      noshort = true
     )
 
     val dependencies = opt[List[String]](
       descr = "List of deploy hashes (base16 encoded) which must be executed before this deploy.",
-      validate = _.forall(hashCheck)
+      validate = _.forall(hashCheck),
+      required = false,
+      noshort = true
     )
 
     addValidation {


### PR DESCRIPTION
### Overview
`scallop` by default generates short version of the parameter by taking the first letter of the long version. `--ttl` hijacked `t` from `target` and that caused transfer commands (that use short `-t` variant) to fail.
This PR sets `noshort=true` for `--ttl`. For a good measure, I added `noshort=true` for `dependencies` as well.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-920

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
