### PR TITLE
NODE-923: Fix race condition bug during block creation.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -17,16 +17,18 @@ object Estimator {
 
   implicit val decreasingOrder = Ordering[Long].reverse
 
+  /* Should not be used as long as `DagRepresentation` is not immutable. See NODE-923
   def tips[F[_]: MonadThrowable](
       dag: DagRepresentation[F],
       genesis: BlockHash,
       equivocationsTracker: EquivocationsTracker
-  ): F[IndexedSeq[BlockHash]] =
+  ): F[List[BlockHash]] =
     for {
       latestMessageHashes <- dag.latestMessageHashes
       result <- Estimator
                  .tips[F](dag, genesis, latestMessageHashes, equivocationsTracker)
-    } yield result.toIndexedSeq
+    } yield result
+   */
 
   def tips[F[_]: MonadThrowable](
       dag: DagRepresentation[F],

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -198,11 +198,12 @@ object BlockAPI {
       depth: Int
   ): F[IndexedSeq[Block]] =
     for {
-      dag       <- MultiParentCasper[F].dag
-      tipHashes <- MultiParentCasper[F].estimator(dag)
-      tipHash   = tipHashes.head
-      tip       <- ProtoUtil.unsafeGetBlock[F](tipHash)
-      mainChain <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[Block], depth)
+      dag            <- MultiParentCasper[F].dag
+      latestMessages <- dag.latestMessageHashes
+      tipHashes      <- MultiParentCasper[F].estimator(dag, latestMessages)
+      tipHash        = tipHashes.head
+      tip            <- ProtoUtil.unsafeGetBlock[F](tipHash)
+      mainChain      <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[Block], depth)
     } yield mainChain
 
   // TOOD extract common code from show blocks
@@ -253,12 +254,13 @@ object BlockAPI {
 
     def casperResponse(implicit casper: MultiParentCasper[F]) =
       for {
-        dag        <- MultiParentCasper[F].dag
-        tipHashes  <- MultiParentCasper[F].estimator(dag)
-        tipHash    = tipHashes.head
-        tip        <- ProtoUtil.unsafeGetBlock[F](tipHash)
-        mainChain  <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[Block], depth)
-        blockInfos <- mainChain.toList.traverse(getBlockInfoWithoutTuplespace[F])
+        dag            <- MultiParentCasper[F].dag
+        latestMessages <- dag.latestMessageHashes
+        tipHashes      <- MultiParentCasper[F].estimator(dag, latestMessages)
+        tipHash        = tipHashes.head
+        tip            <- ProtoUtil.unsafeGetBlock[F](tipHash)
+        mainChain      <- ProtoUtil.getMainChainUntilDepth[F](tip, IndexedSeq.empty[Block], depth)
+        blockInfos     <- mainChain.toList.traverse(getBlockInfoWithoutTuplespace[F])
       } yield blockInfos
 
     MultiParentCasperRef.withCasper[F, List[BlockInfoWithoutTuplespace]](

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -189,9 +189,12 @@ object AutoProposerTest {
         if (pending.nonEmpty) Created(Block()) else NoNewDeploys
       }
 
-    override def addBlock(block: Block): F[BlockStatus]                           = (Valid: BlockStatus).pure[F]
-    override def contains(block: Block): F[Boolean]                               = ???
-    override def estimator(dag: DagRepresentation[F]): F[IndexedSeq[ByteString]]  = ???
+    override def addBlock(block: Block): F[BlockStatus] = (Valid: BlockStatus).pure[F]
+    override def contains(block: Block): F[Boolean]     = ???
+    override def estimator(
+        dag: DagRepresentation[F],
+        lm: Map[ByteString, ByteString]
+    ): F[List[ByteString]]                                                        = ???
     override def dag: F[DagRepresentation[F]]                                     = ???
     override def fetchDependencies: F[Unit]                                       = ???
     override def normalizedInitialFault(weights: Map[ByteString, Long]): F[Float] = ???

--- a/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
@@ -253,9 +253,12 @@ class ForkchoiceTest
           c.blockHash       -> 0L
         )
 
+        latestMessageHashes <- dag.latestMessageHashes
+
         tips <- Estimator.tips(
                  dag,
                  genesis.blockHash,
+                 latestMessageHashes,
                  equivocationsTracker
                )
         _ = tips.head shouldBe c.blockHash

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -137,7 +137,8 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _                    <- MultiParentCasper[Effect].addBlock(signedBlock)
       _                    = logEff.warns.isEmpty should be(true)
       dag                  <- MultiParentCasper[Effect].dag
-      estimate             <- MultiParentCasper[Effect].estimator(dag)
+      latestMessageHashes  <- dag.latestMessageHashes
+      estimate             <- MultiParentCasper[Effect].estimator(dag, latestMessageHashes)
       _                    = estimate shouldBe IndexedSeq(signedBlock.blockHash)
       _                    = node.tearDown()
     } yield ()
@@ -176,7 +177,8 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       _                     = logEff.warns shouldBe empty
       _                     = ProtoUtil.parentHashes(signedBlock2) should be(Seq(signedBlock1.blockHash))
       dag                   <- MultiParentCasper[Effect].dag
-      estimate              <- MultiParentCasper[Effect].estimator(dag)
+      latestMessageHashes   <- dag.latestMessageHashes
+      estimate              <- MultiParentCasper[Effect].estimator(dag, latestMessageHashes)
 
       _ = estimate shouldBe IndexedSeq(signedBlock2.blockHash)
       _ <- node.tearDown()

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -35,11 +35,17 @@ class ManyValidatorsTest extends FlatSpec with Matchers with BlockGenerator with
         _ <- createAndStoreBlock[Task](Seq(genesis.blockHash), v1, bonds, bonds.map {
               case Bond(validator, _) => validator -> genesis.blockHash
             }.toMap)
-        dag  <- dagStorage.getRepresentation
-        tips <- Estimator.tips[Task](dag, genesis.blockHash, EquivocationsTracker.empty)
+        dag                 <- dagStorage.getRepresentation
+        latestMessageHashes <- dag.latestMessageHashes
+        tips <- Estimator.tips[Task](
+                 dag,
+                 genesis.blockHash,
+                 latestMessageHashes,
+                 EquivocationsTracker.empty
+               )
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMsgWithTransform],
-                         tips.toIndexedSeq
+                         tips
                        )
         implicit0(casperRef: MultiParentCasperRef[Task]) <- MultiParentCasperRef.of[Task]
         _                                                <- casperRef.set(casperEffect)

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
@@ -78,8 +78,14 @@ class BlocksResponseAPITest extends FlatSpec with Matchers with BlockGenerator w
               bonds,
               HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
             )
-        dag  <- dagStorage.getRepresentation
-        tips <- Estimator.tips[Task](dag, genesis.blockHash, EquivocationsTracker.empty)
+        dag                 <- dagStorage.getRepresentation
+        latestMessageHashes <- dag.latestMessageHashes
+        tips <- Estimator.tips[Task](
+                 dag,
+                 genesis.blockHash,
+                 latestMessageHashes,
+                 EquivocationsTracker.empty
+               )
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMsgWithTransform],
                          tips
@@ -139,8 +145,14 @@ class BlocksResponseAPITest extends FlatSpec with Matchers with BlockGenerator w
               bonds,
               HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
             )
-        dag  <- dagStorage.getRepresentation
-        tips <- Estimator.tips[Task](dag, genesis.blockHash, EquivocationsTracker.empty)
+        dag                 <- dagStorage.getRepresentation
+        latestMessageHashes <- dag.latestMessageHashes
+        tips <- Estimator.tips[Task](
+                 dag,
+                 genesis.blockHash,
+                 latestMessageHashes,
+                 EquivocationsTracker.empty
+               )
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap.empty[BlockHash, BlockMsgWithTransform],
                          tips
@@ -216,8 +228,14 @@ class BlocksResponseAPITest extends FlatSpec with Matchers with BlockGenerator w
                 bonds,
                 HashMap(v1 -> b6.blockHash, v2 -> b5.blockHash, v3 -> b4.blockHash)
               )
-          dag  <- dagStorage.getRepresentation
-          tips <- Estimator.tips[Task](dag, genesis.blockHash, EquivocationsTracker.empty)
+          dag                 <- dagStorage.getRepresentation
+          latestMessageHashes <- dag.latestMessageHashes
+          tips <- Estimator.tips[Task](
+                   dag,
+                   genesis.blockHash,
+                   latestMessageHashes,
+                   EquivocationsTracker.empty
+                 )
           casperEffect <- NoOpsCasperEffect[Task](
                            HashMap.empty[BlockHash, BlockMsgWithTransform],
                            tips

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -139,8 +139,11 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def addBlock(b: Block): F[BlockStatus]            = underlying.addBlock(b)
   def contains(b: Block): F[Boolean]                = underlying.contains(b)
   def deploy(d: Deploy): F[Either[Throwable, Unit]] = underlying.deploy(d)
-  def estimator(dag: DagRepresentation[F]): F[IndexedSeq[BlockHash]] =
-    underlying.estimator(dag)
+  def estimator(
+      dag: DagRepresentation[F],
+      latestMessagesHashes: Map[ByteString, ByteString]
+  ): F[List[BlockHash]] =
+    underlying.estimator(dag, latestMessagesHashes)
   def dag: F[DagRepresentation[F]] = underlying.dag
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =
     underlying.normalizedInitialFault(weights)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -348,8 +348,9 @@ object GossipServiceCasperTestNodeFactory {
                          backend = new SynchronizerImpl.Backend[F] {
                            override def tips: F[List[ByteString]] =
                              for {
-                               dag       <- casper.dag
-                               tipHashes <- casper.estimator(dag)
+                               dag                 <- casper.dag
+                               latestMessageHashes <- dag.latestMessageHashes
+                               tipHashes           <- casper.estimator(dag, latestMessageHashes)
                              } yield tipHashes.toList
 
                            override def justifications: F[List[ByteString]] =

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -3,6 +3,7 @@ package io.casperlabs.casper.helper
 import cats.Applicative
 import cats.effect.Sync
 import cats.implicits._
+import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus.{Block, Deploy}
 import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper}
@@ -15,7 +16,7 @@ import scala.collection.mutable.{Map => MutableMap}
 
 class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
     private val blockStorage: MutableMap[BlockHash, BlockMsgWithTransform],
-    estimatorFunc: IndexedSeq[BlockHash]
+    estimatorFunc: List[BlockHash]
 ) extends MultiParentCasper[F] {
 
   def store: Map[BlockHash, BlockMsgWithTransform] = blockStorage.toMap
@@ -31,7 +32,10 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
     } yield BlockStatus.valid
   def contains(b: Block): F[Boolean]                = false.pure[F]
   def deploy(r: Deploy): F[Either[Throwable, Unit]] = Applicative[F].pure(Right(()))
-  def estimator(dag: DagRepresentation[F]): F[IndexedSeq[BlockHash]] =
+  def estimator(
+      dag: DagRepresentation[F],
+      latestMessageHashes: Map[ByteString, ByteString]
+  ): F[List[BlockHash]] =
     estimatorFunc.pure[F]
   def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]
   def dag: F[DagRepresentation[F]]                                    = DagStorage[F].getRepresentation
@@ -44,7 +48,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
 object NoOpsCasperEffect {
   def apply[F[_]: Sync: BlockStorage: DagStorage](
       blockStorage: Map[BlockHash, BlockMsgWithTransform] = Map.empty,
-      estimatorFunc: IndexedSeq[BlockHash] = Vector(Block().blockHash)
+      estimatorFunc: List[BlockHash] = List(Block().blockHash)
   ): F[NoOpsCasperEffect[F]] =
     for {
       _ <- blockStorage.toList.traverse_ {
@@ -54,10 +58,10 @@ object NoOpsCasperEffect {
   def apply[F[_]: Sync: BlockStorage: DagStorage](): F[NoOpsCasperEffect[F]] =
     apply(
       Map(Block().blockHash -> BlockMsgWithTransform().withBlockMessage(Block())),
-      Vector(Block().blockHash)
+      List(Block().blockHash)
     )
   def apply[F[_]: Sync: BlockStorage: DagStorage](
       blockStorage: Map[BlockHash, BlockMsgWithTransform]
   ): F[NoOpsCasperEffect[F]] =
-    apply(blockStorage, Vector(Block().blockHash))
+    apply(blockStorage, List(Block().blockHash))
 }

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -520,9 +520,10 @@ package object gossiping {
                      new SynchronizerImpl.Backend[F] {
                        override def tips: F[List[ByteString]] =
                          for {
-                           casper    <- unsafeGetCasper[F]
-                           dag       <- casper.dag
-                           tipHashes <- casper.estimator(dag)
+                           casper         <- unsafeGetCasper[F]
+                           dag            <- casper.dag
+                           latestMessages <- dag.latestMessageHashes
+                           tipHashes      <- casper.estimator(dag, latestMessages)
                          } yield tipHashes.toList
 
                        override def justifications: F[List[ByteString]] =
@@ -598,10 +599,11 @@ package object gossiping {
 
                       override def listTips =
                         for {
-                          casper    <- unsafeGetCasper[F]
-                          dag       <- casper.dag
-                          tipHashes <- casper.estimator(dag)
-                          tips      <- tipHashes.toList.traverse(backend.getBlockSummary(_))
+                          casper         <- unsafeGetCasper[F]
+                          dag            <- casper.dag
+                          latestMessages <- dag.latestMessageHashes
+                          tipHashes      <- casper.estimator(dag, latestMessages)
+                          tips           <- tipHashes.toList.traverse(backend.getBlockSummary(_))
                         } yield tips.flatten
                     }
                   }


### PR DESCRIPTION
### Overview
As in the title. Please see the ticket for more context.

The solution is to pass "latest message hashes" to the estimator. This means that both parents and justifications will be calculated using the same view of the DAG.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-923

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Please note that I had to remove `Casper` trait as signature of `estimator` method did not align in the `MultiParentCasper` (namely the `A` type parameter) was being used as return type of `estimator` and in the `latestMessageHashes` argument (which did not align as `estimator` was returning `List`). I hope this will be fixed in the following PR that addresses the problem correctly.
