### PR TITLE
OP-724: Update EE Build Doc

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -40,7 +40,7 @@ The `casperlabs-client` executable will be found here:
 
 ```
 cd execution-engine
-cargo build --release
+make build
 ```
 
 The `casperlabs-engine-grpc-server` executable will be found here:

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -40,7 +40,7 @@ The `casperlabs-client` executable will be found here:
 
 ```
 cd execution-engine
-make build
+CARGO_FLAGS=--release make build
 ```
 
 The `casperlabs-engine-grpc-server` executable will be found here:


### PR DESCRIPTION
### Overview
Updates `BUILD.md` to use Makefile for building EE.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-724

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
I left the cargo build instructions for the pos/mint contract for now. `make build` takes care of these but I noticed that using `cargo` to build these still does something. Henry was going to look into it.
