### PR TITLE
EE-671: system upgrade endpoint

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -1223,6 +1223,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "modified-mint"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+ "mint-token 0.1.0",
+]
+
+[[package]]
+name = "modified-mint-caller"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+]
+
+[[package]]
+name = "modified-mint-upgrader"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.16.0",
+ "modified-mint 0.1.0",
+]
+
+[[package]]
 name = "named-keys"
 version = "0.1.0"
 dependencies = [

--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-engine-wasm-prep 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -8,7 +8,7 @@ use crate::bytesrepr::{self, deserialize, FromBytes, ToBytes};
 use crate::execution::{Phase, PHASE_SIZE};
 use crate::ext_ffi;
 use crate::key::{Key, UREF_SIZE};
-use crate::uref::{AccessRights, URef};
+use crate::uref::URef;
 use crate::value::account::{
     Account, ActionType, AddKeyFailure, BlockTime, PublicKey, PurseId, RemoveKeyFailure,
     SetThresholdFailure, UpdateKeyFailure, Weight, BLOCKTIME_SER_SIZE, PURSE_ID_SIZE_SERIALIZED,
@@ -733,7 +733,8 @@ fn get_system_contract(name: &str) -> ContractPointer {
     let key = get_key(name).unwrap_or_else(|| revert(Error::GetURef.into()));
 
     if let Key::URef(uref) = key {
-        let reference = TURef::new(uref.addr(), AccessRights::READ);
+        let reference =
+            TURef::from_uref(uref).unwrap_or_else(|_| revert(Error::UnexpectedKeyVariant.into()));
         ContractPointer::URef(reference)
     } else {
         revert(Error::UnexpectedKeyVariant.into())

--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -86,7 +86,7 @@ pub enum Error {
     UpgradeContractAtURef,
     /// Failed to transfer motes.
     Transfer,
-    ///
+    /// No access rights.
     NoAccessRights,
     /// User-specified value.  The internal `u16` value is added to `u16::MAX as u32 + 1` when an
     /// `Error::User` is converted to a `u32`.

--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -86,6 +86,8 @@ pub enum Error {
     UpgradeContractAtURef,
     /// Failed to transfer motes.
     Transfer,
+    ///
+    NoAccessRights,
     /// User-specified value.  The internal `u16` value is added to `u16::MAX as u32 + 1` when an
     /// `Error::User` is converted to a `u32`.
     User(u16),
@@ -108,6 +110,7 @@ impl From<Error> for u32 {
             Error::InvalidArgument => 12,
             Error::UpgradeContractAtURef => 13,
             Error::Transfer => 14,
+            Error::NoAccessRights => 15,
             Error::User(value) => RESERVED_ERROR_MAX + 1 + u32::from(value),
         }
     }
@@ -130,6 +133,7 @@ impl Debug for Error {
             Error::InvalidArgument => write!(f, "Error::InvalidArgument")?,
             Error::UpgradeContractAtURef => write!(f, "Error::UpgradeContractAtURef")?,
             Error::Transfer => write!(f, "Error::Transfer")?,
+            Error::NoAccessRights => write!(f, "Error::NoAccessRights")?,
             Error::User(value) => write!(f, "Error::User({})", value)?,
         }
         write!(f, " [{}]", u32::from(*self))
@@ -160,6 +164,7 @@ pub fn result_from(value: i32) -> Result<(), Error> {
         12 => Err(Error::InvalidArgument),
         13 => Err(Error::UpgradeContractAtURef),
         14 => Err(Error::Transfer),
+        15 => Err(Error::NoAccessRights),
         _ => {
             if value > RESERVED_ERROR_MAX as i32 && value <= (2 * RESERVED_ERROR_MAX + 1) as i32 {
                 Err(Error::User(value as u16))
@@ -734,7 +739,7 @@ fn get_system_contract(name: &str) -> ContractPointer {
 
     if let Key::URef(uref) = key {
         let reference =
-            TURef::from_uref(uref).unwrap_or_else(|_| revert(Error::UnexpectedKeyVariant.into()));
+            TURef::from_uref(uref).unwrap_or_else(|_| revert(Error::NoAccessRights.into()));
         ContractPointer::URef(reference)
     } else {
         revert(Error::UnexpectedKeyVariant.into())

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -163,10 +163,6 @@ pub fn delegate() {
             let transfer_result = mint.transfer(source, target, amount);
             contract_api::ret(&transfer_result, &vec![]);
         }
-        "version" => {
-            contract_api::ret(&"1.0.0", &vec![]);
-        }
-
         _ => panic!("Unknown method name!"),
     }
 }

--- a/execution-engine/contracts/test/modified-mint-caller/Cargo.toml
+++ b/execution-engine/contracts/test/modified-mint-caller/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "modified-mint-caller"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "modified_mint_caller"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std"]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
@@ -1,0 +1,21 @@
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate contract_ffi;
+
+use alloc::string::String;
+use contract_ffi::contract_api;
+use contract_ffi::key::Key;
+
+const NEW_ENDPOINT_NAME: &str = "version";
+const RESULT_TUREF_NAME: &str = "output_version";
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let mint_pointer = contract_api::get_mint();
+    let value: String = contract_api::call_contract(mint_pointer, &(NEW_ENDPOINT_NAME,), &vec![]);
+    let value_turef = contract_api::new_turef(value);
+    let key = Key::URef(value_turef.into());
+    contract_api::put_key(RESULT_TUREF_NAME, &key);
+}

--- a/execution-engine/contracts/test/modified-mint-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/modified-mint-upgrader/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "modified-mint-upgrader"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "modified_mint_upgrader"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std"]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+modified-mint = { path = "../modified-mint", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/test/modified-mint-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-upgrader/src/lib.rs
@@ -1,0 +1,36 @@
+#![no_std]
+
+extern crate alloc;
+extern crate contract_ffi;
+extern crate modified_mint;
+
+use contract_ffi::contract_api;
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::Error;
+
+#[repr(u16)]
+enum CustomError {
+    ContractPointerHash = 1,
+}
+
+pub const MINT_NAME: &str = "mint";
+pub const EXT_FUNCTION_NAME: &str = "modified_mint_ext";
+
+#[no_mangle]
+pub extern "C" fn modified_mint_ext() {
+    modified_mint::delegate();
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let mint_pointer = contract_api::get_mint();
+
+    let mint_turef = match mint_pointer {
+        ContractPointer::Hash(_) => {
+            contract_api::revert(Error::User(CustomError::ContractPointerHash as u16).into())
+        }
+        ContractPointer::URef(turef) => turef,
+    };
+
+    contract_api::upgrade_contract_at_uref(EXT_FUNCTION_NAME, mint_turef);
+}

--- a/execution-engine/contracts/test/modified-mint/Cargo.toml
+++ b/execution-engine/contracts/test/modified-mint/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "modified-mint"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+name = "modified_mint"
+crate-type = ["lib", "cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std"]
+lib = []
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }
+mint-token = { path = "../../system/mint-token", default-features = false, features = ["lib"] }

--- a/execution-engine/contracts/test/modified-mint/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint/src/lib.rs
@@ -4,80 +4,17 @@
 #[macro_use]
 extern crate alloc;
 extern crate contract_ffi;
-
-mod capabilities;
-
-// These types are purposely defined in a separate module
-// so that their constructors are hidden and therefore
-// we must use the conversion methods from Key elsewhere
-// in the code.
-pub mod internal_purse_id;
-pub mod mint;
+extern crate mint_token;
 
 use alloc::string::String;
-use core::convert::TryInto;
 
 use contract_ffi::contract_api::{self, Error as ApiError};
-use contract_ffi::key::Key;
 use contract_ffi::system_contracts::mint::error::Error;
 use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::KEY_SIZE;
 use contract_ffi::value::U512;
-
-use capabilities::{ARef, RAWRef};
-use internal_purse_id::{DepositId, WithdrawId};
-use mint::Mint;
-
-const SYSTEM_ACCOUNT: [u8; KEY_SIZE] = [0u8; KEY_SIZE];
-
-pub struct CLMint;
-
-impl Mint<ARef<U512>, RAWRef<U512>> for CLMint {
-    type PurseId = WithdrawId;
-    type DepOnlyId = DepositId;
-
-    fn mint(&self, initial_balance: U512) -> Result<Self::PurseId, Error> {
-        let caller = contract_api::get_caller();
-        if !initial_balance.is_zero() && caller.value() != SYSTEM_ACCOUNT {
-            return Err(Error::InvalidNonEmptyPurseCreation);
-        }
-
-        let balance_uref: Key = contract_api::new_turef(initial_balance).into();
-
-        let purse_key: URef = contract_api::new_turef(()).into();
-        let purse_uref_name = purse_key.remove_access_rights().as_string();
-
-        let purse_id: WithdrawId = WithdrawId::from_uref(purse_key).unwrap();
-
-        // store balance uref so that the runtime knows the mint has full access
-        contract_api::put_key(&purse_uref_name, &balance_uref);
-
-        // store association between purse id and balance uref
-        //
-        // Gorski writes:
-        //   I'm worried that this can lead to overwriting of values in the local state.
-        //   Since it accepts a raw byte array it's possible to construct one by hand.
-        // Of course,   a key can be overwritten only when that write is
-        // performed in the "owner" context   so it aligns with other semantics
-        // of write but I would prefer if were able to enforce   uniqueness
-        // somehow.
-        contract_api::write_local(purse_id.raw_id(), balance_uref);
-
-        Ok(purse_id)
-    }
-
-    fn lookup(&self, p: Self::PurseId) -> Option<RAWRef<U512>> {
-        contract_api::read_local(p.raw_id())
-            .ok()?
-            .and_then(|key: Key| key.try_into().ok())
-    }
-
-    fn dep_lookup(&self, p: Self::DepOnlyId) -> Option<ARef<U512>> {
-        contract_api::read_local(p.raw_id())
-            .ok()?
-            .and_then(|key: Key| key.try_into().ok())
-    }
-}
+use mint_token::internal_purse_id::{DepositId, WithdrawId};
+use mint_token::mint::Mint;
+use mint_token::CLMint;
 
 pub fn delegate() {
     let mint = CLMint;
@@ -164,7 +101,7 @@ pub fn delegate() {
             contract_api::ret(&transfer_result, &vec![]);
         }
         "version" => {
-            contract_api::ret(&"1.0.0", &vec![]);
+            contract_api::ret(&"1.1.0", &vec![]);
         }
 
         _ => panic!("Unknown method name!"),

--- a/execution-engine/contracts/test/modified-mint/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint/src/lib.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 extern crate contract_ffi;
 extern crate mint_token;
 
-use alloc::string::String;
+use alloc::string::{String, ToString};
 
 use contract_ffi::contract_api::{self, Error as ApiError};
 use contract_ffi::system_contracts::mint::error::Error;
@@ -15,6 +15,8 @@ use contract_ffi::value::U512;
 use mint_token::internal_purse_id::{DepositId, WithdrawId};
 use mint_token::mint::Mint;
 use mint_token::CLMint;
+
+const VERSION: &str = "1.1.0";
 
 pub fn delegate() {
     let mint = CLMint;
@@ -101,7 +103,7 @@ pub fn delegate() {
             contract_api::ret(&transfer_result, &vec![]);
         }
         "version" => {
-            contract_api::ret(&"1.1.0", &vec![]);
+            contract_api::ret(&VERSION.to_string(), &vec![]);
         }
 
         _ => panic!("Unknown method name!"),

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     #[fail(display = "Invalid public key length: expected {}, actual {}", _0, _1)]
     InvalidPublicKeyLength { expected: usize, actual: usize },
     #[fail(display = "Invalid protocol version: {}", _0)]
-    InvalidProtocolVersion { protocol_version: ProtocolVersion },
+    InvalidProtocolVersion(ProtocolVersion),
     #[fail(display = "Wasm preprocessing error: {:?}", _0)]
     WasmPreprocessingError(engine_wasm_prep::PreprocessingError),
     #[fail(display = "Wasm serialization error: {:?}", _0)]

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -6,15 +6,16 @@ use contract_ffi::bytesrepr;
 use contract_ffi::system_contracts::mint;
 
 use crate::execution;
+use contract_ffi::value::ProtocolVersion;
 
 #[derive(Fail, Debug)]
 pub enum Error {
-    #[fail(display = "Invalid protocol version")]
-    InvalidProtocolVersion,
     #[fail(display = "Invalid hash length: expected {}, actual {}", _0, _1)]
     InvalidHashLength { expected: usize, actual: usize },
     #[fail(display = "Invalid public key length: expected {}, actual {}", _0, _1)]
     InvalidPublicKeyLength { expected: usize, actual: usize },
+    #[fail(display = "Invalid protocol version: {}", _0)]
+    InvalidProtocolVersion { protocol_version: ProtocolVersion },
     #[fail(display = "Wasm preprocessing error: {:?}", _0)]
     WasmPreprocessingError(engine_wasm_prep::PreprocessingError),
     #[fail(display = "Wasm serialization error: {:?}", _0)]

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -551,16 +551,17 @@ where
             };
 
             let blocktime = BlockTime::default();
+
             let deploy_hash = {
-                let bytes: Vec<u8> = {
-                    let mut ret = Vec::new();
-                    ret.extend_from_slice(
-                        &upgrade_config.new_protocol_version().value().to_le_bytes(),
-                    );
-                    ret
-                };
+                // seeds address generator w/ protocol version
+                let bytes: Vec<u8> = upgrade_config
+                    .new_protocol_version()
+                    .value()
+                    .to_le_bytes()
+                    .to_vec();
                 Blake2bHash::new(&bytes).into()
             };
+
             // upgrade has no gas limit; approximating with MAX
             let gas_limit = Gas::new(std::u64::MAX.into());
             let phase = Phase::System;

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -550,7 +550,6 @@ where
                 ret
             };
 
-            // TODO: do we need blocktime on the request?
             let blocktime = BlockTime::default();
             let deploy_hash = {
                 let bytes: Vec<u8> = {

--- a/execution-engine/engine-core/src/engine_state/upgrade.rs
+++ b/execution-engine/engine-core/src/engine_state/upgrade.rs
@@ -1,0 +1,112 @@
+use std::fmt;
+
+use crate::engine_state::execution_effect::ExecutionEffect;
+use contract_ffi::key::Key;
+use contract_ffi::value::ProtocolVersion;
+use engine_shared::newtypes::Blake2bHash;
+use engine_shared::transform::TypeMismatch;
+use engine_storage::global_state::CommitResult;
+use engine_wasm_prep::wasm_costs::WasmCosts;
+
+pub enum UpgradeResult {
+    RootNotFound,
+    KeyNotFound(Key),
+    TypeMismatch(TypeMismatch),
+    Success {
+        post_state_hash: Blake2bHash,
+        effect: ExecutionEffect,
+    },
+}
+
+impl fmt::Display for UpgradeResult {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            UpgradeResult::RootNotFound => write!(f, "Root not found"),
+            UpgradeResult::KeyNotFound(key) => write!(f, "Key not found: {}", key),
+            UpgradeResult::TypeMismatch(type_mismatch) => {
+                write!(f, "Type mismatch: {:?}", type_mismatch)
+            }
+            UpgradeResult::Success {
+                post_state_hash,
+                effect,
+            } => write!(f, "Success: {} {:?}", post_state_hash, effect),
+        }
+    }
+}
+
+impl UpgradeResult {
+    pub fn from_commit_result(commit_result: CommitResult, effect: ExecutionEffect) -> Self {
+        match commit_result {
+            CommitResult::RootNotFound => UpgradeResult::RootNotFound,
+            CommitResult::KeyNotFound(key) => UpgradeResult::KeyNotFound(key),
+            CommitResult::TypeMismatch(type_mismatch) => UpgradeResult::TypeMismatch(type_mismatch),
+            CommitResult::Success { state_root, .. } => UpgradeResult::Success {
+                post_state_hash: state_root,
+                effect,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpgradeConfig {
+    pre_state_hash: Blake2bHash,
+    current_protocol_version: ProtocolVersion,
+    new_protocol_version: ProtocolVersion,
+    upgrade_installer_args: Option<Vec<u8>>,
+    upgrade_installer_bytes: Option<Vec<u8>>,
+    wasm_costs: Option<WasmCosts>,
+    activation_point: Option<u64>,
+}
+
+impl UpgradeConfig {
+    pub fn new(
+        pre_state_hash: Blake2bHash,
+        current_protocol_version: ProtocolVersion,
+        new_protocol_version: ProtocolVersion,
+        upgrade_installer_args: Option<Vec<u8>>,
+        upgrade_installer_bytes: Option<Vec<u8>>,
+        wasm_costs: Option<WasmCosts>,
+        activation_point: Option<u64>,
+    ) -> Self {
+        UpgradeConfig {
+            pre_state_hash,
+            current_protocol_version,
+            new_protocol_version,
+            upgrade_installer_args,
+            upgrade_installer_bytes,
+            wasm_costs,
+            activation_point,
+        }
+    }
+
+    pub fn pre_state_hash(&self) -> Blake2bHash {
+        self.pre_state_hash
+    }
+
+    pub fn current_protocol_version(&self) -> ProtocolVersion {
+        self.current_protocol_version
+    }
+
+    pub fn new_protocol_version(&self) -> ProtocolVersion {
+        self.new_protocol_version
+    }
+
+    pub fn upgrade_installer_args(&self) -> Option<&[u8]> {
+        let args = self.upgrade_installer_args.as_ref()?;
+        Some(args.as_slice())
+    }
+
+    pub fn upgrade_installer_bytes(&self) -> Option<&[u8]> {
+        let bytes = self.upgrade_installer_bytes.as_ref()?;
+        Some(bytes.as_slice())
+    }
+
+    pub fn wasm_costs(&self) -> Option<WasmCosts> {
+        self.wasm_costs
+    }
+
+    pub fn activation_point(&self) -> Option<u64> {
+        self.activation_point
+    }
+}

--- a/execution-engine/engine-core/src/engine_state/upgrade.rs
+++ b/execution-engine/engine-core/src/engine_state/upgrade.rs
@@ -1,12 +1,15 @@
 use std::fmt;
 
-use crate::engine_state::execution_effect::ExecutionEffect;
 use contract_ffi::key::Key;
 use contract_ffi::value::ProtocolVersion;
 use engine_shared::newtypes::Blake2bHash;
 use engine_shared::transform::TypeMismatch;
 use engine_storage::global_state::CommitResult;
 use engine_wasm_prep::wasm_costs::WasmCosts;
+
+use crate::engine_state::execution_effect::ExecutionEffect;
+
+pub type ActivationPoint = u64;
 
 pub enum UpgradeResult {
     RootNotFound,
@@ -56,7 +59,7 @@ pub struct UpgradeConfig {
     upgrade_installer_args: Option<Vec<u8>>,
     upgrade_installer_bytes: Option<Vec<u8>>,
     wasm_costs: Option<WasmCosts>,
-    activation_point: Option<u64>,
+    activation_point: Option<ActivationPoint>,
 }
 
 impl UpgradeConfig {
@@ -67,7 +70,7 @@ impl UpgradeConfig {
         upgrade_installer_args: Option<Vec<u8>>,
         upgrade_installer_bytes: Option<Vec<u8>>,
         wasm_costs: Option<WasmCosts>,
-        activation_point: Option<u64>,
+        activation_point: Option<ActivationPoint>,
     ) -> Self {
         UpgradeConfig {
             pre_state_hash,

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -169,7 +169,7 @@ where
         let blocktime = BlockTime(exec_request.get_block_time());
 
         // TODO: don't unwrap
-        let wasm_costs = self.wasm_costs(protocol_version).unwrap();
+        let wasm_costs = self.wasm_costs(protocol_version).unwrap().unwrap();
 
         let deploys = exec_request.get_deploys();
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -21,11 +21,11 @@ use engine_shared::logging;
 use engine_shared::logging::{log_duration, log_info};
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 use engine_storage::global_state::{CommitResult, StateProvider};
-use engine_wasm_prep::wasm_costs::WasmCosts;
 use engine_wasm_prep::{Preprocessor, WasmiPreprocessor};
 
 use self::ipc_grpc::ExecutionEngineService;
 use self::mappings::*;
+use engine_core::engine_state::upgrade::{UpgradeConfig, UpgradeResult};
 use engine_shared::logging::log_level::LogLevel;
 
 pub mod ipc;
@@ -41,14 +41,16 @@ const METRIC_DURATION_EXEC: &str = "exec_duration";
 const METRIC_DURATION_QUERY: &str = "query_duration";
 const METRIC_DURATION_VALIDATE: &str = "validate_duration";
 const METRIC_DURATION_GENESIS: &str = "genesis_duration";
+const METRIC_DURATION_UPGRADE: &str = "upgrade_duration";
 
 const TAG_RESPONSE_COMMIT: &str = "commit_response";
 const TAG_RESPONSE_EXEC: &str = "exec_response";
 const TAG_RESPONSE_QUERY: &str = "query_response";
 const TAG_RESPONSE_VALIDATE: &str = "validate_response";
 const TAG_RESPONSE_GENESIS: &str = "genesis_response";
+const TAG_RESPONSE_UPGRADE: &str = "upgrade_response";
 
-const PROTOCOL_VERSION: u64 = 1;
+const DEFAULT_PROTOCOL_VERSION: u64 = 1;
 
 // Idea is that Engine will represent the core of the execution engine project.
 // It will act as an entry point for execution of Wasm binaries.
@@ -167,7 +169,7 @@ where
         let blocktime = BlockTime(exec_request.get_block_time());
 
         // TODO: don't unwrap
-        let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
+        let wasm_costs = self.wasm_costs(protocol_version).unwrap();
 
         let deploys = exec_request.get_deploys();
 
@@ -228,7 +230,7 @@ where
         let blocktime = BlockTime(exec_request.get_block_time());
 
         // TODO: don't unwrap
-        let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
+        let wasm_costs = self.wasm_costs(protocol_version).unwrap();
 
         let deploys = exec_request.get_deploys();
 
@@ -282,7 +284,13 @@ where
         let correlation_id = CorrelationId::new();
 
         // TODO
-        let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
+        let protocol_version = {
+            if commit_request.get_protocol_version().value < DEFAULT_PROTOCOL_VERSION {
+                ProtocolVersion::new(DEFAULT_PROTOCOL_VERSION)
+            } else {
+                ProtocolVersion::new(commit_request.get_protocol_version().value)
+            }
+        };
 
         // Acquire pre-state hash
         let pre_state_hash: Blake2bHash = match commit_request.get_prestate_hash().try_into() {
@@ -663,9 +671,81 @@ where
     fn upgrade(
         &self,
         _request_options: ::grpc::RequestOptions,
-        _upgrade_request: ipc::UpgradeRequest,
+        upgrade_request: ipc::UpgradeRequest,
     ) -> ::grpc::SingleResponse<ipc::UpgradeResponse> {
-        unimplemented!("todo: impl upgrade endpoint")
+        let start = Instant::now();
+        let correlation_id = CorrelationId::new();
+
+        let upgrade_config: UpgradeConfig = match upgrade_request.try_into() {
+            Ok(upgrade_config) => upgrade_config,
+            Err(error) => {
+                let err_msg = error.to_string();
+                logging::log_error(&err_msg);
+
+                let mut upgrade_deploy_error = ipc::UpgradeDeployError::new();
+                upgrade_deploy_error.set_message(err_msg);
+                let mut upgrade_response = ipc::UpgradeResponse::new();
+                upgrade_response.set_failed_deploy(upgrade_deploy_error);
+
+                log_duration(
+                    correlation_id,
+                    METRIC_DURATION_UPGRADE,
+                    TAG_RESPONSE_UPGRADE,
+                    start.elapsed(),
+                );
+
+                return grpc::SingleResponse::completed(upgrade_response);
+            }
+        };
+
+        let upgrade_response = match self.commit_upgrade(correlation_id, upgrade_config) {
+            Ok(UpgradeResult::Success {
+                post_state_hash,
+                effect,
+            }) => {
+                let success_message = format!("upgrade successful: {}", post_state_hash);
+                log_info(&success_message);
+
+                let mut upgrade_result = ipc::UpgradeResult::new();
+                upgrade_result.set_post_state_hash(post_state_hash.to_vec());
+                upgrade_result.set_effect(effect.into());
+
+                let mut ret = ipc::UpgradeResponse::new();
+                ret.set_success(upgrade_result);
+                ret
+            }
+            Ok(upgrade_result) => {
+                let err_msg = upgrade_result.to_string();
+                logging::log_error(&err_msg);
+
+                let mut upgrade_deploy_error = ipc::UpgradeDeployError::new();
+                upgrade_deploy_error.set_message(err_msg);
+
+                let mut ret = ipc::UpgradeResponse::new();
+                ret.set_failed_deploy(upgrade_deploy_error);
+                ret
+            }
+            Err(err) => {
+                let err_msg = err.to_string();
+                logging::log_error(&err_msg);
+
+                let mut upgrade_deploy_error = ipc::UpgradeDeployError::new();
+                upgrade_deploy_error.set_message(err_msg);
+
+                let mut ret = ipc::UpgradeResponse::new();
+                ret.set_failed_deploy(upgrade_deploy_error);
+                ret
+            }
+        };
+
+        log_duration(
+            correlation_id,
+            METRIC_DURATION_UPGRADE,
+            TAG_RESPONSE_UPGRADE,
+            start.elapsed(),
+        );
+
+        grpc::SingleResponse::completed(upgrade_response)
     }
 }
 

--- a/execution-engine/engine-shared/Cargo.toml
+++ b/execution-engine/engine-shared/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 blake2 = "0.8"
 chrono = "0.4.6"
 contract-ffi = { path = "../contract-ffi", features = ["std", "gens"], package = "casperlabs-contract-ffi" }
+engine-wasm-prep = { path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 hostname = "0.1.5"
 lazy_static = "1.3.0"
 libc = "0.2.54"

--- a/execution-engine/engine-shared/src/test_utils.rs
+++ b/execution-engine/engine-shared/src/test_utils.rs
@@ -9,6 +9,7 @@ use contract_ffi::key::Key;
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::account::PurseId;
 use contract_ffi::value::{Account, Value};
+use engine_wasm_prep::wasm_costs::WasmCosts;
 
 /// Returns `true` if a we can serialize and then deserialize a value
 pub fn test_serialization_roundtrip<T>(t: &T) -> bool
@@ -40,4 +41,34 @@ pub fn mocked_account(account_addr: [u8; 32]) -> Vec<(Key, Value)> {
     let purse_id = PurseId::new(URef::new([0u8; 32], AccessRights::READ_ADD_WRITE));
     let account = Account::create(account_addr, BTreeMap::new(), purse_id);
     vec![(Key::Account(account_addr), Value::Account(account))]
+}
+
+pub fn wasm_costs_mock() -> WasmCosts {
+    WasmCosts {
+        regular: 1,
+        div: 16,
+        mul: 4,
+        mem: 2,
+        initial_mem: 4096,
+        grow_mem: 8192,
+        memcpy: 1,
+        max_stack_height: 64 * 1024,
+        opcodes_mul: 3,
+        opcodes_div: 8,
+    }
+}
+
+pub fn wasm_costs_free() -> WasmCosts {
+    WasmCosts {
+        regular: 0,
+        div: 0,
+        mul: 0,
+        mem: 0,
+        initial_mem: 4096,
+        grow_mem: 8192,
+        memcpy: 0,
+        max_stack_height: 64 * 1024,
+        opcodes_mul: 1,
+        opcodes_div: 1,
+    }
 }

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -94,42 +94,19 @@ mod tests {
 
     use contract_ffi::uref::{AccessRights, URef};
     use engine_shared::test_utils;
-    use engine_wasm_prep::wasm_costs::WasmCosts;
 
     use super::{gens, ProtocolData};
 
     #[test]
     fn should_serialize_and_deserialize() {
         let v1 = {
-            let costs = WasmCosts {
-                regular: 1,
-                div: 16,
-                mul: 4,
-                mem: 2,
-                initial_mem: 4096,
-                grow_mem: 8192,
-                memcpy: 1,
-                max_stack_height: 64 * 1024,
-                opcodes_mul: 3,
-                opcodes_div: 8,
-            };
+            let costs = test_utils::wasm_costs_mock();
             let mint_reference = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
             let proof_of_stake_reference = URef::new([1u8; 32], AccessRights::READ_ADD_WRITE);
             ProtocolData::new(costs, mint_reference, proof_of_stake_reference)
         };
         let free = {
-            let costs = WasmCosts {
-                regular: 0,
-                div: 0,
-                mul: 0,
-                mem: 0,
-                initial_mem: 4096,
-                grow_mem: 8192,
-                memcpy: 0,
-                max_stack_height: 64 * 1024,
-                opcodes_mul: 1,
-                opcodes_div: 1,
-            };
+            let costs = test_utils::wasm_costs_free();
             let mint_reference = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
             let proof_of_stake_reference = URef::new([1u8; 32], AccessRights::READ_ADD_WRITE);
             ProtocolData::new(costs, mint_reference, proof_of_stake_reference)

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -93,7 +93,6 @@ mod tests {
     use proptest::proptest;
 
     use contract_ffi::uref::{AccessRights, URef};
-    use contract_ffi::value::ProtocolVersion;
     use engine_shared::test_utils;
     use engine_wasm_prep::wasm_costs::WasmCosts;
 
@@ -102,13 +101,35 @@ mod tests {
     #[test]
     fn should_serialize_and_deserialize() {
         let v1 = {
-            let costs = WasmCosts::from_version(ProtocolVersion::new(1)).unwrap();
+            let costs = WasmCosts {
+                regular: 1,
+                div: 16,
+                mul: 4,
+                mem: 2,
+                initial_mem: 4096,
+                grow_mem: 8192,
+                memcpy: 1,
+                max_stack_height: 64 * 1024,
+                opcodes_mul: 3,
+                opcodes_div: 8,
+            };
             let mint_reference = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
             let proof_of_stake_reference = URef::new([1u8; 32], AccessRights::READ_ADD_WRITE);
             ProtocolData::new(costs, mint_reference, proof_of_stake_reference)
         };
         let free = {
-            let costs = WasmCosts::free();
+            let costs = WasmCosts {
+                regular: 0,
+                div: 0,
+                mul: 0,
+                mem: 0,
+                initial_mem: 4096,
+                grow_mem: 8192,
+                memcpy: 0,
+                max_stack_height: 64 * 1024,
+                opcodes_mul: 1,
+                opcodes_div: 1,
+            };
             let mint_reference = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
             let proof_of_stake_reference = URef::new([1u8; 32], AccessRights::READ_ADD_WRITE);
             ProtocolData::new(costs, mint_reference, proof_of_stake_reference)

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -15,12 +15,13 @@ use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
 use engine_storage::global_state::StateProvider;
-use engine_wasm_prep::wasm_costs::WasmCosts;
 use engine_wasm_prep::WasmiPreprocessor;
 use std::cell::RefCell;
 use std::collections::BTreeSet;
 use std::convert::TryInto;
 use std::rc::Rc;
+
+use crate::test::DEFAULT_WASM_COSTS;
 
 const INIT_FN_STORE_ID: u32 = 0;
 const INIT_PROTOCOL_VERSION: u64 = 1;
@@ -105,7 +106,9 @@ where
         module_bytes: wasm_bytes,
         args: Vec::new(),
     };
-    let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
+
+    let wasm_costs = *DEFAULT_WASM_COSTS;
+
     let preprocessor = WasmiPreprocessor::new(wasm_costs);
     let parity_module = builder
         .get_engine_state()

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -261,11 +261,7 @@ impl ExecuteRequestBuilder {
         self.execute_request
     }
 
-    pub fn standard(
-        addr: [u8; 32],
-        session_file: &str,
-        session_args: impl ArgsParser,
-    ) -> ExecuteRequest {
+    pub fn standard(addr: [u8; 32], session_file: &str, session_args: impl ArgsParser) -> Self {
         let mut rng = rand::thread_rng();
         let deploy_hash: [u8; 32] = rng.gen();
 
@@ -277,7 +273,7 @@ impl ExecuteRequestBuilder {
             .with_deploy_hash(deploy_hash)
             .build();
 
-        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+        ExecuteRequestBuilder::new().push_deploy(deploy)
     }
 }
 

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -307,14 +307,7 @@ pub struct UpgradeRequestBuilder {
 
 impl UpgradeRequestBuilder {
     pub fn new() -> Self {
-        UpgradeRequestBuilder {
-            pre_state_hash: Default::default(),
-            current_protocol_version: Default::default(),
-            new_protocol_version: Default::default(),
-            upgrade_installer: Default::default(),
-            new_costs: None,
-            activation_point: Default::default(),
-        }
+        Default::default()
     }
 
     pub fn with_pre_state_hash(mut self, pre_state_hash: &[u8]) -> Self {
@@ -384,7 +377,14 @@ impl UpgradeRequestBuilder {
 
 impl Default for UpgradeRequestBuilder {
     fn default() -> Self {
-        unimplemented!()
+        UpgradeRequestBuilder {
+            pre_state_hash: Default::default(),
+            current_protocol_version: Default::default(),
+            new_protocol_version: Default::default(),
+            upgrade_installer: Default::default(),
+            new_costs: None,
+            activation_point: Default::default(),
+        }
     }
 }
 

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -2,18 +2,15 @@ use grpc::RequestOptions;
 use lazy_static;
 
 use engine_core::engine_state::{EngineConfig, EngineState};
+use engine_grpc_server::engine_server::ipc::{CommitRequest, QueryRequest, ValidateRequest};
+use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
+use engine_grpc_server::engine_server::state::{Key, Key_Address};
 use engine_shared::logging::log_level::LogLevel;
 use engine_shared::logging::log_settings::{self, LogLevelFilter, LogSettings};
 use engine_shared::logging::logger::{self, LogBufferProvider, BUFFERED_LOGGER};
 use engine_shared::newtypes::CorrelationId;
 use engine_shared::test_utils;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
-
-use engine_grpc_server::engine_server::ipc::{
-    CommitRequest, Deploy, ExecRequest, QueryRequest, ValidateRequest,
-};
-use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
-use engine_grpc_server::engine_server::state::{Key, Key_Address};
 
 use crate::support::test_support;
 
@@ -58,58 +55,6 @@ fn should_query_with_metrics() {
 
     let _query_response_result = engine_state
         .query(RequestOptions::new(), query_request)
-        .wait_drop_metadata();
-
-    let log_items = BUFFERED_LOGGER
-        .extract_correlated(&correlation_id.to_string())
-        .expect("log items expected");
-
-    for log_item in log_items {
-        assert!(
-            log_item
-                .properties
-                .contains_key(&"correlation_id".to_string()),
-            "should have correlation_id"
-        );
-
-        let matched_correlation_id = log_item
-            .properties
-            .get(&"correlation_id".to_string())
-            .expect("should have correlation id value");
-
-        assert_eq!(
-            matched_correlation_id,
-            &correlation_id.to_string(),
-            "correlation_id should match"
-        );
-
-        assert_eq!(log_item.log_level, "Metric", "expected Metric");
-    }
-}
-
-#[test]
-fn should_exec_with_metrics() {
-    setup();
-    let correlation_id = CorrelationId::new();
-    let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
-    let (global_state, root_hash) =
-        InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let root_hash = root_hash.to_vec();
-    let engine_config = EngineConfig::new().set_use_payment_code(true);
-    let engine_state = EngineState::new(global_state, engine_config);
-
-    let mut exec_request = ExecRequest::new();
-    {
-        let mut deploys: protobuf::RepeatedField<Deploy> = <protobuf::RepeatedField<Deploy>>::new();
-        deploys.push(test_support::get_mock_deploy());
-
-        exec_request.set_deploys(deploys);
-        exec_request.set_parent_state_hash(root_hash);
-        exec_request.set_protocol_version(test_support::get_protocol_version());
-    }
-
-    let _exec_response_result = engine_state
-        .exec(RequestOptions::new(), exec_request)
         .wait_drop_metadata();
 
     let log_items = BUFFERED_LOGGER

--- a/execution-engine/engine-tests/src/test/mod.rs
+++ b/execution-engine/engine-tests/src/test/mod.rs
@@ -19,6 +19,7 @@ use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::{ProtocolVersion, U512};
 use engine_core::engine_state::genesis::{GenesisAccount, GenesisConfig};
 use engine_shared::motes::Motes;
+use engine_shared::test_utils;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
 use crate::support::test_support;
@@ -46,18 +47,7 @@ lazy_static! {
     };
     pub static ref DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(1);
     pub static ref DEFAULT_PAYMENT: U512 = 100_000_000.into();
-    pub static ref DEFAULT_WASM_COSTS: WasmCosts = WasmCosts {
-        regular: 1,
-        div: 16,
-        mul: 4,
-        mem: 2,
-        initial_mem: 4096,
-        grow_mem: 8192,
-        memcpy: 1,
-        max_stack_height: 64 * 1024,
-        opcodes_mul: 3,
-        opcodes_div: 8,
-    };
+    pub static ref DEFAULT_WASM_COSTS: WasmCosts = test_utils::wasm_costs_mock();
     pub static ref DEFAULT_GENESIS_CONFIG: GenesisConfig = {
         let mint_installer_bytes = test_support::read_wasm_file_bytes(CONTRACT_MINT_INSTALL);
         let pos_installer_bytes = test_support::read_wasm_file_bytes(CONTRACT_POS_INSTALL);

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -4,10 +4,10 @@ use contract_ffi::value::{ProtocolVersion, Value, U512};
 use engine_core::engine_state::genesis::{GenesisAccount, GenesisConfig};
 use engine_core::engine_state::{EngineConfig, SYSTEM_ACCOUNT_ADDR};
 use engine_shared::motes::Motes;
-use engine_wasm_prep::wasm_costs::WasmCosts;
 
 use crate::support::test_support;
 use crate::support::test_support::InMemoryWasmTestBuilder;
+use crate::test::DEFAULT_WASM_COSTS;
 
 const MINT_INSTALL: &str = "mint_install.wasm";
 const POS_INSTALL: &str = "pos_install.wasm";
@@ -53,7 +53,7 @@ fn should_run_genesis_with_chainspec() {
     let pos_installer_bytes = test_support::read_wasm_file_bytes(POS_INSTALL);
     let accounts = vec![account_1, account_2];
     let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
-    let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
+    let wasm_costs = *DEFAULT_WASM_COSTS;
 
     let genesis_config = GenesisConfig::new(
         name,
@@ -138,7 +138,8 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
         let pos_installer_bytes = test_support::read_wasm_file_bytes(POS_INSTALL);
         let accounts = vec![account_1, account_2];
         let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
-        let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
+        let wasm_costs = *DEFAULT_WASM_COSTS;
+
         GenesisConfig::new(
             name,
             TIMESTAMP,
@@ -188,7 +189,8 @@ fn should_fail_if_bad_pos_install_contract_is_provided() {
         let pos_installer_bytes = test_support::read_wasm_file_bytes(BAD_INSTALL);
         let accounts = vec![account_1, account_2];
         let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
-        let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
+        let wasm_costs = *DEFAULT_WASM_COSTS;
+
         GenesisConfig::new(
             name,
             TIMESTAMP,

--- a/execution-engine/engine-tests/src/test/system_contracts/mod.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mod.rs
@@ -6,6 +6,8 @@ mod mint_install;
 mod pos_install;
 #[cfg(test)]
 mod system_contract_urefs_access_rights;
+#[cfg(test)]
+mod upgrade;
 
 #[cfg(test)]
 pub mod proof_of_stake;

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -1,7 +1,6 @@
 use contract_ffi::key::Key;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::{ProtocolVersion, Value, U512};
-use engine_core::engine_state::EngineConfig;
 use engine_grpc_server::engine_server::ipc::DeployCode;
 use engine_shared::transform::Transform;
 use engine_wasm_prep::wasm_costs::WasmCosts;
@@ -39,10 +38,7 @@ fn get_upgraded_wasm_costs() -> WasmCosts {
 fn should_upgrade_only_protocol_version() {
     let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
 
-    let mut builder = {
-        let engine_config = EngineConfig::default().set_use_payment_code(true);
-        InMemoryWasmTestBuilder::new(engine_config)
-    };
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
@@ -98,10 +94,7 @@ fn should_upgrade_only_protocol_version() {
 fn should_upgrade_system_contract() {
     let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
 
-    let mut builder = {
-        let engine_config = EngineConfig::default().set_use_payment_code(true);
-        InMemoryWasmTestBuilder::new(engine_config)
-    };
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
@@ -176,10 +169,7 @@ fn should_upgrade_system_contract() {
 #[ignore]
 #[test]
 fn should_upgrade_wasm_costs() {
-    let mut builder = {
-        let engine_config = EngineConfig::default().set_use_payment_code(true);
-        InMemoryWasmTestBuilder::new(engine_config)
-    };
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
@@ -218,10 +208,7 @@ fn should_upgrade_wasm_costs() {
 fn should_upgrade_system_contract_and_wasm_costs() {
     let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
 
-    let mut builder = {
-        let engine_config = EngineConfig::default().set_use_payment_code(true);
-        InMemoryWasmTestBuilder::new(engine_config)
-    };
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
@@ -311,10 +298,7 @@ fn should_upgrade_system_contract_and_wasm_costs() {
 fn should_not_downgrade() {
     let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
 
-    let mut builder = {
-        let engine_config = EngineConfig::default().set_use_payment_code(true);
-        InMemoryWasmTestBuilder::new(engine_config)
-    };
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
@@ -374,10 +358,7 @@ fn should_not_downgrade() {
 #[ignore]
 #[test]
 fn should_not_skip_major_versions() {
-    let mut builder = {
-        let engine_config = EngineConfig::default().set_use_payment_code(true);
-        InMemoryWasmTestBuilder::new(engine_config)
-    };
+    let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -36,8 +36,6 @@ fn get_upgraded_wasm_costs() -> WasmCosts {
 #[ignore]
 #[test]
 fn should_upgrade_only_protocol_version() {
-    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -1,5 +1,6 @@
 use contract_ffi::key::Key;
 use contract_ffi::value::{ProtocolVersion, Value, U512};
+use engine_core::engine_state::upgrade::ActivationPoint;
 use engine_grpc_server::engine_server::ipc::DeployCode;
 use engine_shared::transform::Transform;
 use engine_wasm_prep::wasm_costs::WasmCosts;
@@ -11,7 +12,7 @@ use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_WASM_COS
 
 const PROTOCOL_VERSION: u64 = 1;
 const NEW_PROTOCOL_VERSION: u64 = 2;
-const DEFAULT_ACTIVATION_POINT: u64 = 1;
+const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;
 const MODIFIED_MINT_UPGRADER_CONTRACT_NAME: &str = "modified_mint_upgrader.wasm";
 const MODIFIED_MINT_CALLER_CONTRACT_NAME: &str = "modified_mint_caller.wasm";
 const PAYMENT_AMOUNT: u64 = 200_000_000;

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -1,0 +1,402 @@
+use contract_ffi::key::Key;
+use contract_ffi::value::account::PublicKey;
+use contract_ffi::value::{ProtocolVersion, Value, U512};
+use engine_core::engine_state::EngineConfig;
+use engine_grpc_server::engine_server::ipc::DeployCode;
+use engine_shared::transform::Transform;
+use engine_wasm_prep::wasm_costs::WasmCosts;
+
+use crate::support::test_support::{
+    self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
+};
+use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_WASM_COSTS};
+
+const PROTOCOL_VERSION: u64 = 1;
+const NEW_PROTOCOL_VERSION: u64 = 2;
+const DEFAULT_ACTIVATION_POINT: u64 = 1;
+const STANDARD_PAYMENT_WASM: &str = "standard_payment.wasm";
+const MODIFIED_MINT_UPGRADER_CONTRACT_NAME: &str = "modified_mint_upgrader.wasm";
+const MODIFIED_MINT_CALLER_CONTRACT_NAME: &str = "modified_mint_caller.wasm";
+const PAYMENT_AMOUNT: u64 = 200_000_000;
+
+fn get_upgraded_wasm_costs() -> WasmCosts {
+    WasmCosts {
+        regular: 1,
+        div: 1,
+        mul: 1,
+        mem: 1,
+        initial_mem: 4096,
+        grow_mem: 8192,
+        memcpy: 1,
+        max_stack_height: 64 * 1024,
+        opcodes_mul: 3,
+        opcodes_div: 8,
+    }
+}
+
+#[ignore]
+#[test]
+fn should_upgrade_only_protocol_version() {
+    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
+
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(upgrade_response.has_success(), "expected success");
+
+    let exec_request_call = {
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_deploy_hash([1; 32])
+            .with_session_code(MODIFIED_MINT_CALLER_CONTRACT_NAME, ())
+            .with_payment_code(STANDARD_PAYMENT_WASM, (U512::from(PAYMENT_AMOUNT),))
+            .with_authorization_keys(&[account_1_public_key])
+            .build();
+
+        ExecuteRequestBuilder::new()
+            .push_deploy(deploy)
+            .with_protocol_version(NEW_PROTOCOL_VERSION)
+            .build()
+    };
+
+    builder
+        .exec_with_exec_request(exec_request_call)
+        .expect_success()
+        .commit();
+
+    let upgraded_wasm_costs = builder
+        .get_engine_state()
+        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .expect("should have costs");
+
+    assert_eq!(
+        *DEFAULT_WASM_COSTS, upgraded_wasm_costs,
+        "upgraded costs should equal original costs"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_upgrade_system_contract() {
+    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
+
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+
+    let mut upgrade_request = {
+        let bytes = test_support::read_wasm_file_bytes(MODIFIED_MINT_UPGRADER_CONTRACT_NAME);
+        let mut installer_code = DeployCode::new();
+        installer_code.set_code(bytes);
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .with_installer_code(installer_code)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(upgrade_response.has_success(), "expected success");
+
+    let exec_request_call = {
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_deploy_hash([1; 32])
+            .with_session_code(MODIFIED_MINT_CALLER_CONTRACT_NAME, ())
+            .with_payment_code(STANDARD_PAYMENT_WASM, (U512::from(PAYMENT_AMOUNT),))
+            .with_authorization_keys(&[account_1_public_key])
+            .build();
+
+        ExecuteRequestBuilder::new()
+            .push_deploy(deploy)
+            .with_protocol_version(NEW_PROTOCOL_VERSION)
+            .build()
+    };
+
+    builder.exec_with_exec_request(exec_request_call);
+
+    let transforms = builder.get_transforms();
+    let transform = &transforms[0];
+
+    let new_keys = if let Some(Transform::AddKeys(keys)) =
+        transform.get(&Key::Account(DEFAULT_ACCOUNT_ADDR))
+    {
+        keys
+    } else {
+        panic!(
+            "expected AddKeys transform for given key but received {:?}",
+            transforms[0]
+        );
+    };
+
+    let version_uref = new_keys
+        .get("output_version")
+        .expect("version_uref should exist");
+
+    builder.commit();
+
+    let version_value: Value = builder
+        .query(None, *version_uref, &[])
+        .expect("should find version_uref value");
+
+    assert_eq!(
+        version_value,
+        Value::String("1.1.0".to_string()),
+        "expected new version endpoint output"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_upgrade_wasm_costs() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+
+    let new_costs = get_upgraded_wasm_costs();
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .with_new_costs(new_costs)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(upgrade_response.has_success(), "expected success");
+
+    let upgraded_wasm_costs = builder
+        .get_engine_state()
+        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .expect("should have upgraded costs");
+
+    assert_eq!(
+        new_costs, upgraded_wasm_costs,
+        "upgraded costs should equal new costs"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_upgrade_system_contract_and_wasm_costs() {
+    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
+
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+
+    let new_costs = get_upgraded_wasm_costs();
+
+    let mut upgrade_request = {
+        let bytes = test_support::read_wasm_file_bytes(MODIFIED_MINT_UPGRADER_CONTRACT_NAME);
+        let mut installer_code = DeployCode::new();
+        installer_code.set_code(bytes);
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .with_installer_code(installer_code)
+            .with_new_costs(new_costs)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(upgrade_response.has_success(), "expected success");
+
+    let exec_request_call = {
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_deploy_hash([1; 32])
+            .with_session_code(MODIFIED_MINT_CALLER_CONTRACT_NAME, ())
+            .with_payment_code(STANDARD_PAYMENT_WASM, (U512::from(PAYMENT_AMOUNT),))
+            .with_authorization_keys(&[account_1_public_key])
+            .build();
+
+        ExecuteRequestBuilder::new()
+            .push_deploy(deploy)
+            .with_protocol_version(NEW_PROTOCOL_VERSION)
+            .build()
+    };
+
+    builder.exec_with_exec_request(exec_request_call);
+
+    let transforms = builder.get_transforms();
+    let transform = &transforms[0];
+
+    let new_keys = if let Some(Transform::AddKeys(keys)) =
+        transform.get(&Key::Account(DEFAULT_ACCOUNT_ADDR))
+    {
+        keys
+    } else {
+        panic!(
+            "expected AddKeys transform for given key but received {:?}",
+            transforms[0]
+        );
+    };
+
+    let version_uref = new_keys
+        .get("output_version")
+        .expect("version_uref should exist");
+
+    builder.commit();
+
+    let version_value: Value = builder
+        .query(None, *version_uref, &[])
+        .expect("should find version_uref value");
+
+    assert_eq!(
+        version_value,
+        Value::String("1.1.0".to_string()),
+        "expected new version endpoint output"
+    );
+
+    let upgraded_wasm_costs = builder
+        .get_engine_state()
+        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .expect("should have upgraded costs");
+
+    assert_eq!(
+        new_costs, upgraded_wasm_costs,
+        "upgraded costs should equal new costs"
+    );
+}
+
+#[ignore]
+#[test]
+fn should_not_downgrade() {
+    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
+
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(upgrade_response.has_success(), "expected success");
+
+    let exec_request_call = {
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_deploy_hash([1; 32])
+            .with_session_code(MODIFIED_MINT_CALLER_CONTRACT_NAME, ())
+            .with_payment_code(STANDARD_PAYMENT_WASM, (U512::from(PAYMENT_AMOUNT),))
+            .with_authorization_keys(&[account_1_public_key])
+            .build();
+
+        ExecuteRequestBuilder::new()
+            .push_deploy(deploy)
+            .with_protocol_version(NEW_PROTOCOL_VERSION)
+            .build()
+    };
+
+    builder
+        .exec_with_exec_request(exec_request_call)
+        .expect_success()
+        .commit();
+
+    let mut downgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_new_protocol_version(PROTOCOL_VERSION)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut downgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(1)
+        .expect("should have response");
+
+    assert!(!upgrade_response.has_success(), "expected failure");
+}
+
+#[ignore]
+#[test]
+fn should_not_skip_major_versions() {
+    let mut builder = {
+        let engine_config = EngineConfig::default().set_use_payment_code(true);
+        InMemoryWasmTestBuilder::new(engine_config)
+    };
+
+    builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+
+    // TODO: when protocol version switches to SemVer, this corresponds to major version
+    let invalid_version = PROTOCOL_VERSION + 2;
+
+    let mut upgrade_request = {
+        UpgradeRequestBuilder::new()
+            .with_current_protocol_version(PROTOCOL_VERSION)
+            .with_new_protocol_version(invalid_version)
+            .with_activation_point(DEFAULT_ACTIVATION_POINT)
+            .build()
+    };
+
+    builder.upgrade_with_upgrade_request(&mut upgrade_request);
+
+    let upgrade_response = builder
+        .get_upgrade_response(0)
+        .expect("should have response");
+
+    assert!(!upgrade_response.has_success(), "expected failure");
+}

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -1,19 +1,17 @@
 use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::{ProtocolVersion, Value, U512};
 use engine_grpc_server::engine_server::ipc::DeployCode;
 use engine_shared::transform::Transform;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
 use crate::support::test_support::{
-    self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
+    self, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
 };
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_WASM_COSTS};
 
 const PROTOCOL_VERSION: u64 = 1;
 const NEW_PROTOCOL_VERSION: u64 = 2;
 const DEFAULT_ACTIVATION_POINT: u64 = 1;
-const STANDARD_PAYMENT_WASM: &str = "standard_payment.wasm";
 const MODIFIED_MINT_UPGRADER_CONTRACT_NAME: &str = "modified_mint_upgrader.wasm";
 const MODIFIED_MINT_CALLER_CONTRACT_NAME: &str = "modified_mint_caller.wasm";
 const PAYMENT_AMOUNT: u64 = 200_000_000;
@@ -71,8 +69,6 @@ fn should_upgrade_only_protocol_version() {
 #[ignore]
 #[test]
 fn should_upgrade_system_contract() {
-    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
@@ -97,23 +93,18 @@ fn should_upgrade_system_contract() {
 
     assert!(upgrade_response.has_success(), "expected success");
 
-    let exec_request_call = {
-        let deploy = DeployItemBuilder::new()
-            .with_address(DEFAULT_ACCOUNT_ADDR)
-            .with_deploy_hash([1; 32])
-            .with_session_code(MODIFIED_MINT_CALLER_CONTRACT_NAME, ())
-            .with_payment_code(STANDARD_PAYMENT_WASM, (U512::from(PAYMENT_AMOUNT),))
-            .with_authorization_keys(&[account_1_public_key])
-            .build();
-
-        ExecuteRequestBuilder::new()
-            .push_deploy(deploy)
-            .with_protocol_version(NEW_PROTOCOL_VERSION)
-            .build()
+    let exec_request = {
+        ExecuteRequestBuilder::standard(
+            DEFAULT_ACCOUNT_ADDR,
+            &MODIFIED_MINT_CALLER_CONTRACT_NAME,
+            (U512::from(PAYMENT_AMOUNT),),
+        )
+        .with_protocol_version(NEW_PROTOCOL_VERSION)
+        .build()
     };
 
     builder
-        .exec_with_exec_request(exec_request_call)
+        .exec_with_exec_request(exec_request)
         .expect_success();
 
     let transforms = builder.get_transforms();
@@ -188,8 +179,6 @@ fn should_upgrade_wasm_costs() {
 #[ignore]
 #[test]
 fn should_upgrade_system_contract_and_wasm_costs() {
-    let account_1_public_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
-
     let mut builder = InMemoryWasmTestBuilder::default();
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
@@ -217,23 +206,18 @@ fn should_upgrade_system_contract_and_wasm_costs() {
 
     assert!(upgrade_response.has_success(), "expected success");
 
-    let exec_request_call = {
-        let deploy = DeployItemBuilder::new()
-            .with_address(DEFAULT_ACCOUNT_ADDR)
-            .with_deploy_hash([1; 32])
-            .with_session_code(MODIFIED_MINT_CALLER_CONTRACT_NAME, ())
-            .with_payment_code(STANDARD_PAYMENT_WASM, (U512::from(PAYMENT_AMOUNT),))
-            .with_authorization_keys(&[account_1_public_key])
-            .build();
-
-        ExecuteRequestBuilder::new()
-            .push_deploy(deploy)
-            .with_protocol_version(NEW_PROTOCOL_VERSION)
-            .build()
+    let exec_request = {
+        ExecuteRequestBuilder::standard(
+            DEFAULT_ACCOUNT_ADDR,
+            &MODIFIED_MINT_CALLER_CONTRACT_NAME,
+            (U512::from(PAYMENT_AMOUNT),),
+        )
+        .with_protocol_version(NEW_PROTOCOL_VERSION)
+        .build()
     };
 
     builder
-        .exec_with_exec_request(exec_request_call)
+        .exec_with_exec_request(exec_request)
         .expect_success();
 
     let transforms = builder.get_transforms();

--- a/execution-engine/engine-tests/src/test/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/upgrade.rs
@@ -34,7 +34,7 @@ fn should_upgrade_do_nothing_to_do_something() {
     {
         let exec_request = {
             let contract_name = format!("{}.wasm", DO_NOTHING_STORED_CONTRACT_NAME);
-            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ())
+            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ()).build()
         };
 
         builder
@@ -70,6 +70,7 @@ fn should_upgrade_do_nothing_to_do_something() {
                 &contract_name,
                 (*do_nothing_stored_uref,),
             )
+            .build()
         };
 
         builder
@@ -87,6 +88,7 @@ fn should_upgrade_do_nothing_to_do_something() {
                 &contract_name,
                 (*do_nothing_stored_uref, PURSE_1),
             )
+            .build()
         };
 
         builder
@@ -122,7 +124,7 @@ fn should_be_able_to_observe_state_transition_across_upgrade() {
     {
         let exec_request = {
             let contract_name = format!("{}.wasm", PURSE_HOLDER_STORED_CONTRACT_NAME);
-            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ())
+            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ()).build()
         };
 
         builder
@@ -172,6 +174,7 @@ fn should_be_able_to_observe_state_transition_across_upgrade() {
         let exec_request = {
             let contract_name = format!("{}.wasm", PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME);
             ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, (*stored_uref,))
+                .build()
         };
 
         builder
@@ -215,7 +218,7 @@ fn should_support_extending_functionality() {
     {
         let exec_request = {
             let contract_name = format!("{}.wasm", PURSE_HOLDER_STORED_CONTRACT_NAME);
-            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ())
+            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ()).build()
         };
 
         builder
@@ -244,6 +247,7 @@ fn should_support_extending_functionality() {
                 &contract_name,
                 (*stored_uref, METHOD_ADD, PURSE_1),
             )
+            .build()
         };
 
         builder
@@ -266,6 +270,7 @@ fn should_support_extending_functionality() {
         let exec_request = {
             let contract_name = format!("{}.wasm", PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME);
             ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, (*stored_uref,))
+                .build()
         };
 
         builder
@@ -293,6 +298,7 @@ fn should_support_extending_functionality() {
                 &contract_name,
                 (*stored_uref, METHOD_REMOVE, PURSE_1),
             )
+            .build()
         };
 
         builder
@@ -326,7 +332,7 @@ fn should_maintain_named_keys_across_upgrade() {
     {
         let exec_request = {
             let contract_name = format!("{}.wasm", PURSE_HOLDER_STORED_CONTRACT_NAME);
-            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ())
+            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ()).build()
         };
 
         builder
@@ -357,6 +363,7 @@ fn should_maintain_named_keys_across_upgrade() {
                 &contract_name,
                 (*stored_uref, METHOD_ADD, purse_name),
             )
+            .build()
         };
 
         builder
@@ -379,6 +386,7 @@ fn should_maintain_named_keys_across_upgrade() {
         let exec_request = {
             let contract_name = format!("{}.wasm", PURSE_HOLDER_STORED_UPGRADER_CONTRACT_NAME);
             ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, (*stored_uref,))
+                .build()
         };
 
         builder
@@ -418,7 +426,7 @@ fn should_maintain_local_state_across_upgrade() {
     {
         let exec_request = {
             let contract_name = format!("{}.wasm", LOCAL_STATE_STORED_CONTRACT_NAME);
-            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ())
+            ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, ()).build()
         };
 
         builder
@@ -443,6 +451,7 @@ fn should_maintain_local_state_across_upgrade() {
         let exec_request = {
             let contract_name = format!("{}.wasm", LOCAL_STATE_STORED_CALLER_CONTRACT_NAME);
             ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, (*stored_uref,))
+                .build()
         };
 
         builder
@@ -467,6 +476,7 @@ fn should_maintain_local_state_across_upgrade() {
         let exec_request = {
             let contract_name = format!("{}.wasm", LOCAL_STATE_STORED_UPGRADER_CONTRACT_NAME);
             ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, (*stored_uref,))
+                .build()
         };
 
         builder
@@ -481,6 +491,7 @@ fn should_maintain_local_state_across_upgrade() {
         let exec_request = {
             let contract_name = format!("{}.wasm", LOCAL_STATE_STORED_CALLER_CONTRACT_NAME);
             ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, &contract_name, (*stored_uref,))
+                .build()
         };
 
         builder

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -1,6 +1,5 @@
 use contract_ffi::bytesrepr;
 use contract_ffi::bytesrepr::{FromBytes, ToBytes, U32_SIZE};
-use contract_ffi::value::ProtocolVersion;
 
 const NUM_FIELDS: usize = 10;
 pub const WASM_COSTS_SIZE_SERIALIZED: usize = NUM_FIELDS * U32_SIZE;
@@ -31,41 +30,6 @@ pub struct WasmCosts {
     /// Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` /
     /// `opcodes_div`
     pub opcodes_div: u32,
-}
-
-impl WasmCosts {
-    pub fn from_version(protocol_version: ProtocolVersion) -> Option<WasmCosts> {
-        match protocol_version.value() {
-            1 => Some(WasmCosts {
-                regular: 1,
-                div: 16,
-                mul: 4,
-                mem: 2,
-                initial_mem: 4096,
-                grow_mem: 8192,
-                memcpy: 1,
-                max_stack_height: 64 * 1024,
-                opcodes_mul: 3,
-                opcodes_div: 8,
-            }),
-            _ => None,
-        }
-    }
-
-    pub fn free() -> WasmCosts {
-        WasmCosts {
-            regular: 0,
-            div: 0,
-            mul: 0,
-            mem: 0,
-            initial_mem: 4096,
-            grow_mem: 8192,
-            memcpy: 0,
-            max_stack_height: 64 * 1024,
-            opcodes_mul: 1,
-            opcodes_div: 1,
-        }
-    }
 }
 
 impl ToBytes for WasmCosts {
@@ -155,12 +119,34 @@ mod tests {
     use engine_shared::test_utils;
 
     use super::{gens, WasmCosts};
-    use contract_ffi::value::ProtocolVersion;
 
     #[test]
     fn should_serialize_and_deserialize() {
-        let v1 = WasmCosts::from_version(ProtocolVersion::new(1)).unwrap();
-        let free = WasmCosts::free();
+        let v1 = WasmCosts {
+            regular: 1,
+            div: 16,
+            mul: 4,
+            mem: 2,
+            initial_mem: 4096,
+            grow_mem: 8192,
+            memcpy: 1,
+            max_stack_height: 64 * 1024,
+            opcodes_mul: 3,
+            opcodes_div: 8,
+        };
+
+        let free = WasmCosts {
+            regular: 0,
+            div: 0,
+            mul: 0,
+            mem: 0,
+            initial_mem: 4096,
+            grow_mem: 8192,
+            memcpy: 0,
+            max_stack_height: 64 * 1024,
+            opcodes_mul: 1,
+            opcodes_div: 1,
+        };
         assert!(test_utils::test_serialization_roundtrip(&v1));
         assert!(test_utils::test_serialization_roundtrip(&free));
     }

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -118,35 +118,12 @@ mod tests {
 
     use engine_shared::test_utils;
 
-    use super::{gens, WasmCosts};
+    use super::gens;
 
     #[test]
     fn should_serialize_and_deserialize() {
-        let v1 = WasmCosts {
-            regular: 1,
-            div: 16,
-            mul: 4,
-            mem: 2,
-            initial_mem: 4096,
-            grow_mem: 8192,
-            memcpy: 1,
-            max_stack_height: 64 * 1024,
-            opcodes_mul: 3,
-            opcodes_div: 8,
-        };
-
-        let free = WasmCosts {
-            regular: 0,
-            div: 0,
-            mul: 0,
-            mem: 0,
-            initial_mem: 4096,
-            grow_mem: 8192,
-            memcpy: 0,
-            max_stack_height: 64 * 1024,
-            opcodes_mul: 1,
-            opcodes_div: 1,
-        };
+        let v1 = test_utils::wasm_costs_mock();
+        let free = test_utils::wasm_costs_free();
         assert!(test_utils::test_serialization_roundtrip(&v1));
         assert!(test_utils::test_serialization_roundtrip(&free));
     }


### PR DESCRIPTION
This PR implements the ability to upgrade the protocol version, wasm costs, and / or system contracts, per the [Upgrading System Contracts Specification](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/139854367/Upgrading+System+Contracts+Specification)

https://casperlabs.atlassian.net/browse/EE-671

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR includes a suite of tests and related contracts.
- [X] This PR is assigned.