### PR TITLE
EE-673: remove exec endpoint

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -438,77 +438,6 @@ where
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
-    pub fn run_deploy_item<A, P: Preprocessor<A>, E: Executor<A>>(
-        &self,
-        session: ExecutableDeployItem,
-        payment: ExecutableDeployItem,
-        address: Key,
-        authorization_keys: BTreeSet<PublicKey>,
-        blocktime: BlockTime,
-        deploy_hash: [u8; 32],
-        prestate_hash: Blake2bHash,
-        protocol_version: ProtocolVersion,
-        correlation_id: CorrelationId,
-        executor: &E,
-        preprocessor: &P,
-    ) -> Result<ExecutionResult, RootNotFound> {
-        self.deploy(
-            session,
-            payment,
-            address,
-            authorization_keys,
-            blocktime,
-            deploy_hash,
-            prestate_hash,
-            protocol_version,
-            correlation_id,
-            executor,
-            preprocessor,
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    pub fn run_deploy<A, P: Preprocessor<A>, E: Executor<A>>(
-        &self,
-        session_module_bytes: &[u8],
-        session_args: &[u8],
-        payment_module_bytes: &[u8],
-        payment_args: &[u8],
-        address: Key,
-        authorization_keys: BTreeSet<PublicKey>,
-        blocktime: BlockTime,
-        deploy_hash: [u8; 32],
-        prestate_hash: Blake2bHash,
-        protocol_version: ProtocolVersion,
-        correlation_id: CorrelationId,
-        executor: &E,
-        preprocessor: &P,
-    ) -> Result<ExecutionResult, RootNotFound> {
-        let session = ExecutableDeployItem::ModuleBytes {
-            module_bytes: session_module_bytes.into(),
-            args: session_args.into(),
-        };
-        let payment = ExecutableDeployItem::ModuleBytes {
-            module_bytes: payment_module_bytes.into(),
-            args: payment_args.into(),
-        };
-
-        self.deploy(
-            session,
-            payment,
-            address,
-            authorization_keys,
-            blocktime,
-            deploy_hash,
-            prestate_hash,
-            protocol_version,
-            correlation_id,
-            executor,
-            preprocessor,
-        )
-    }
-
     pub fn get_module<A, P: Preprocessor<A>>(
         &self,
         tracking_copy: Rc<RefCell<TrackingCopy<<S as StateProvider>::Reader>>>,
@@ -612,7 +541,7 @@ where
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn deploy<A, P: Preprocessor<A>, E: Executor<A>>(
+    pub fn deploy<A, P: Preprocessor<A>, E: Executor<A>>(
         &self,
         session: ExecutableDeployItem,
         payment: ExecutableDeployItem,

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -151,67 +151,6 @@ where
         grpc::SingleResponse::completed(response)
     }
 
-    fn exec(
-        &self,
-        _request_options: ::grpc::RequestOptions,
-        exec_request: ipc::ExecRequest,
-    ) -> grpc::SingleResponse<ipc::ExecResponse> {
-        let start = Instant::now();
-        let correlation_id = CorrelationId::new();
-
-        let protocol_version = exec_request.get_protocol_version().into();
-
-        // TODO: don't unwrap
-        let prestate_hash: Blake2bHash = exec_request.get_parent_state_hash().try_into().unwrap();
-
-        let blocktime = BlockTime(exec_request.get_block_time());
-
-        // TODO: don't unwrap
-        let wasm_costs = WasmCosts::from_version(protocol_version).unwrap();
-
-        let deploys = exec_request.get_deploys();
-
-        let preprocessor: WasmiPreprocessor = WasmiPreprocessor::new(wasm_costs);
-
-        let executor = WasmiExecutor;
-
-        let deploys_result: Result<Vec<ipc::DeployResult>, ipc::RootNotFound> = run_deploys(
-            &self,
-            &executor,
-            &preprocessor,
-            prestate_hash,
-            blocktime,
-            deploys,
-            protocol_version,
-            correlation_id,
-        );
-
-        let exec_response = match deploys_result {
-            Ok(deploy_results) => {
-                let mut exec_response = ipc::ExecResponse::new();
-                let mut exec_result = ipc::ExecResult::new();
-                exec_result.set_deploy_results(protobuf::RepeatedField::from_vec(deploy_results));
-                exec_response.set_success(exec_result);
-                exec_response
-            }
-            Err(error) => {
-                logging::log_error("deploy results error: RootNotFound");
-                let mut exec_response = ipc::ExecResponse::new();
-                exec_response.set_missing_parent(error);
-                exec_response
-            }
-        };
-
-        log_duration(
-            correlation_id,
-            METRIC_DURATION_EXEC,
-            TAG_RESPONSE_EXEC,
-            start.elapsed(),
-        );
-
-        grpc::SingleResponse::completed(exec_response)
-    }
-
     fn execute(
         &self,
         _request_options: ::grpc::RequestOptions,
@@ -670,107 +609,6 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn run_deploys<A, S, E, P>(
-    engine_state: &EngineState<S>,
-    executor: &E,
-    preprocessor: &P,
-    prestate_hash: Blake2bHash,
-    blocktime: BlockTime,
-    deploys: &[ipc::Deploy],
-    protocol_version: ProtocolVersion,
-    correlation_id: CorrelationId,
-) -> Result<Vec<ipc::DeployResult>, ipc::RootNotFound>
-where
-    S: StateProvider,
-    E: Executor<A>,
-    P: Preprocessor<A>,
-    EngineError: From<S::Error>,
-    S::Error: Into<engine_core::execution::Error>,
-{
-    // We want to treat RootNotFound error differently b/c it should short-circuit
-    // the execution of ALL deploys within the block. This is because all of them
-    // share the same prestate and all of them would fail.
-    // Iterator (Result<_, _> + collect()) will short circuit the execution
-    // when run_deploy returns Err.
-    deploys
-        .iter()
-        .map(|deploy| {
-            let session = deploy.get_session();
-            let session_module_bytes = &session.code;
-            let session_args = &session.args;
-
-            let payment = deploy.get_payment();
-            let payment_module_bytes = &payment.code;
-            let payment_args = &payment.args;
-
-            let address = {
-                let address_len = deploy.address.len();
-                if address_len != EXPECTED_PUBLIC_KEY_LENGTH {
-                    let err = EngineError::InvalidPublicKeyLength {
-                        expected: EXPECTED_PUBLIC_KEY_LENGTH,
-                        actual: address_len,
-                    };
-                    let failure = ExecutionResult::precondition_failure(err);
-                    return Ok(failure.into());
-                }
-                let mut dest = [0; EXPECTED_PUBLIC_KEY_LENGTH];
-                dest.copy_from_slice(&deploy.address);
-                Key::Account(dest)
-            };
-
-            // Parse all authorization keys from IPC into a vector
-            let authorized_keys: BTreeSet<PublicKey> = {
-                let maybe_keys: Result<BTreeSet<_>, EngineError> = deploy
-                    .authorization_keys
-                    .iter()
-                    .map(|key_bytes| {
-                        // Try to convert an element of bytes into a possibly
-                        // valid PublicKey with error handling
-                        PublicKey::try_from(key_bytes.as_slice()).map_err(|_| {
-                            EngineError::InvalidPublicKeyLength {
-                                expected: EXPECTED_PUBLIC_KEY_LENGTH,
-                                actual: key_bytes.len(),
-                            }
-                        })
-                    })
-                    .collect();
-
-                match maybe_keys {
-                    Ok(keys) => keys,
-                    Err(error) => return Ok(ExecutionResult::precondition_failure(error).into()),
-                }
-            };
-
-            let deploy_hash = {
-                let mut buff = [0u8; 32];
-                let hash_slice = deploy.get_deploy_hash();
-                buff.copy_from_slice(hash_slice);
-                buff
-            };
-
-            engine_state
-                .run_deploy(
-                    session_module_bytes,
-                    session_args,
-                    payment_module_bytes,
-                    payment_args,
-                    address,
-                    authorized_keys,
-                    blocktime,
-                    deploy_hash,
-                    prestate_hash,
-                    protocol_version,
-                    correlation_id,
-                    executor,
-                    preprocessor,
-                )
-                .map(Into::into)
-                .map_err(Into::into)
-        })
-        .collect()
-}
-
-#[allow(clippy::too_many_arguments)]
 fn execute_deploys<A, S, E, P>(
     engine_state: &EngineState<S>,
     executor: &E,
@@ -796,7 +634,7 @@ where
     deploys
         .iter()
         .map(|deploy| {
-            let session_payload = match deploy.get_session().to_owned().payload {
+            let session = match deploy.get_session().to_owned().payload {
                 Some(payload) => payload.into(),
                 None => {
                     return Ok(
@@ -805,7 +643,7 @@ where
                 }
             };
 
-            let payment_payload = match deploy.get_payment().to_owned().payload {
+            let payment = match deploy.get_payment().to_owned().payload {
                 Some(payload) => payload.into(),
                 None => {
                     return Ok(
@@ -860,9 +698,9 @@ where
             };
 
             engine_state
-                .run_deploy_item(
-                    session_payload,
-                    payment_payload,
+                .deploy(
+                    session,
+                    payment,
                     address,
                     authorization_keys,
                     blocktime,

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -21,7 +21,7 @@ use engine_core::engine_state::utils::WasmiBytes;
 use engine_core::engine_state::{EngineConfig, EngineState, MAX_PAYMENT, SYSTEM_ACCOUNT_ADDR};
 use engine_core::execution::{self, MINT_NAME, POS_NAME};
 use engine_grpc_server::engine_server::ipc::{
-    CommitRequest, Deploy, DeployCode, DeployItem, DeployPayload, DeployResult,
+    CommitRequest, DeployCode, DeployItem, DeployPayload, DeployResult,
     DeployResult_ExecutionResult, DeployResult_PreconditionFailure, ExecuteRequest,
     ExecuteResponse, GenesisResponse, QueryRequest, StoredContractHash, StoredContractName,
     StoredContractURef,
@@ -300,13 +300,18 @@ pub fn get_protocol_version() -> ProtocolVersion {
     protocol_version
 }
 
-pub fn get_mock_deploy() -> Deploy {
-    let mut deploy = Deploy::new();
+pub fn get_mock_deploy() -> DeployItem {
+    let mut deploy = DeployItem::new();
     deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
     deploy.set_gas_price(1);
-    let mut deploy_code = DeployCode::new();
-    deploy_code.set_code(test_utils::create_empty_wasm_module_bytes());
-    deploy.set_session(deploy_code);
+    let deploy_payload = {
+        let mut deploy_code = DeployCode::new();
+        deploy_code.set_code(test_utils::create_empty_wasm_module_bytes());
+        let mut deploy_payload = DeployPayload::new();
+        deploy_payload.set_deploy_code(deploy_code);
+        deploy_payload
+    };
+    deploy.set_session(deploy_payload);
     deploy.set_deploy_hash([1u8; 32].to_vec());
     deploy
 }

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -10,7 +10,7 @@ use engine_shared::test_utils;
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
 
 use engine_grpc_server::engine_server::ipc::{
-    CommitRequest, Deploy, ExecRequest, QueryRequest, ValidateRequest,
+    CommitRequest, DeployItem, ExecuteRequest, QueryRequest, ValidateRequest,
 };
 use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use engine_grpc_server::engine_server::state::{Key, Key_Address};
@@ -98,18 +98,19 @@ fn should_exec_with_metrics() {
     let engine_config = EngineConfig::new().set_use_payment_code(true);
     let engine_state = EngineState::new(global_state, engine_config);
 
-    let mut exec_request = ExecRequest::new();
+    let mut execute_request = ExecuteRequest::new();
     {
-        let mut deploys: protobuf::RepeatedField<Deploy> = <protobuf::RepeatedField<Deploy>>::new();
+        let mut deploys: protobuf::RepeatedField<DeployItem> =
+            <protobuf::RepeatedField<DeployItem>>::new();
         deploys.push(test_support::get_mock_deploy());
 
-        exec_request.set_deploys(deploys);
-        exec_request.set_parent_state_hash(root_hash);
-        exec_request.set_protocol_version(test_support::get_protocol_version());
+        execute_request.set_deploys(deploys);
+        execute_request.set_parent_state_hash(root_hash);
+        execute_request.set_protocol_version(test_support::get_protocol_version());
     }
 
     let _exec_response_result = engine_state
-        .exec(RequestOptions::new(), exec_request)
+        .execute(RequestOptions::new(), execute_request)
         .wait_drop_metadata();
 
     let log_items = BUFFERED_LOGGER

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -68,20 +68,6 @@ message DeployItem {
     bytes deploy_hash = 9;
 }
 
-message ExecRequest {
-    bytes parent_state_hash = 1;
-    uint64 block_time = 2;
-    repeated Deploy deploys = 3;
-    io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 4;
-}
-
-message ExecResponse {
-    oneof result {
-        ExecResult success = 1;
-        RootNotFound missing_parent = 2;
-    }
-}
-
 message ExecuteRequest {
     bytes parent_state_hash = 1;
     uint64 block_time = 2;
@@ -374,7 +360,6 @@ message UpgradeResponse {
 // Definition of the service.
 // ExecutionEngine implements server part while Consensus implements client part.
 service ExecutionEngineService {
-    rpc exec (ExecRequest) returns (ExecResponse) {}
     rpc commit (CommitRequest) returns (CommitResponse) {}
     rpc query (QueryRequest) returns (QueryResponse) {}
     rpc validate (ValidateRequest) returns (ValidateResponse) {}


### PR DESCRIPTION
This PR removes the deprecated `exec` ipc endpoint, in favor of the replacement `execute` endpoint.

https://casperlabs.atlassian.net/browse/EE-673

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] An earlier PR ([EE-700](https://github.com/CasperLabs/CasperLabs/pull/1182)) switched all EE comm tests with execution behavior to use the `execute` endpoint.
- [X] This PR is assigned.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.