### PR TITLE
NODE-926: Fix DownloadManager memory leak

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GossipServiceServer.scala
@@ -86,7 +86,10 @@ class GossipServiceServer[F[_]: Concurrent: Par: Log: Metrics](
       }
 
   /** Synchronize and download any missing blocks to get to the new ones.
-    * This method will complete when all the downloads are ready. */
+    * This method will in itself not block on the results, just return a
+    * list of deferred handles that the caller can decide to wait upon,
+    * which some uses cases do, but mostly we expect to let them complete
+    * asynchronously in the background. */
   private def sync(
       source: Node,
       newBlockHashes: Set[ByteString],

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/InitialSynchronizationSpec.scala
@@ -216,6 +216,7 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
     def hasBlock(blockHash: ByteString)        = ???
     def getBlockSummary(blockHash: ByteString) = ???
     def getBlock(blockHash: ByteString)        = ???
+    def listTips                               = ???
   }
 
   object MockSynchronizer extends Synchronizer[Task] {
@@ -225,12 +226,6 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
 
   object MockDownloadManager extends DownloadManager[Task] {
     def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean) = ???
-  }
-
-  object MockConsensus extends GossipServiceServer.Consensus[Task] {
-    def onPending(dag: Vector[BlockSummary]) = ???
-    def onDownloaded(blockHash: ByteString)  = ???
-    def listTips                             = ???
   }
 
   object MockGenesisApprover extends GenesisApprover[Task] {
@@ -246,7 +241,6 @@ object InitialSynchronizationSpec extends ArbitraryConsensus {
         MockBackend,
         MockSynchronizer,
         MockDownloadManager,
-        MockConsensus,
         MockGenesisApprover,
         0,
         MockSemaphore


### PR DESCRIPTION
### Overview
Every time the node synchronized with another one after it has been notified about a block in `GossipServiceServer`, it scheduled every `BlockSummary` in the missing DAG to be downloaded and attached callbacks to when the downloads finished. The closure of that callback held a reference to the full summaries, which were identical but different instances then on previous schedules. When the downloads didn't happen because the node got slow, this data kept accumulating in memory. 

The PR rerranges things so that the callbacks are not necessary, the `DownloadManager` will do the notifications itself. This has the benefit that they will only be called once. There will also only be at most one `Deferred` per download item, not an ever longer list as it's scheduled more and more.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-926

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
