### PR TITLE
NODE-925: Do not delete executed deploys when discarding

### DIFF
--- a/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
@@ -55,8 +55,10 @@ import scala.concurrent.duration._
     * Marks deploys as discarded that were added as pending more than 'now - expirationPeriod' time ago. */
   def markAsDiscarded(expirationPeriod: FiniteDuration): F[Unit]
 
-  /** Deletes discarded deploys that are older than 'now - expirationPeriod'.
-    * @return Number of deleted deploys */
+  /** Deletes discarded deploys from buffer that are older than 'now - expirationPeriod'.
+    * Won't delete bodies of deploys which were [[addAsExecuted]] before.
+    * Otherwise all the data will be deleted.
+    * @return Number of deleted deploys from buffer minus those who [[addAsExecuted]] */
   def cleanupDiscarded(expirationPeriod: FiniteDuration): F[Int]
 
   def clear(): F[Unit]

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -164,11 +164,11 @@ class SQLiteDeployStorage[F[_]: Metrics: Time: Sync](chunkSize: Int)(
         _ <- Update[ByteString](s"DELETE FROM buffered_deploys WHERE hash=?").updateMany(hashes)
         deletedNum <- Update[ByteString](
                        s"""|DELETE
-                  |FROM deploys
-                  |WHERE hash = ?
-                  |  AND NOT EXISTS(SELECT 1
-                  |                 FROM deploy_process_results dpr
-                  |                 WHERE deploys.hash = dpr.deploy_hash)""".stripMargin
+                           |FROM deploys
+                           |WHERE hash = ?
+                           |  AND NOT EXISTS(SELECT 1
+                           |                 FROM deploy_process_results dpr
+                           |                 WHERE deploys.hash = dpr.deploy_hash)""".stripMargin
                      ).updateMany(hashes)
       } yield deletedNum
 

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -162,8 +162,15 @@ class SQLiteDeployStorage[F[_]: Metrics: Time: Sync](chunkSize: Int)(
                    .query[ByteString]
                    .to[List]
         _ <- Update[ByteString](s"DELETE FROM buffered_deploys WHERE hash=?").updateMany(hashes)
-        _ <- Update[ByteString](s"DELETE FROM deploys WHERE hash=?").updateMany(hashes)
-      } yield hashes.size
+        deletedNum <- Update[ByteString](
+                       s"""|DELETE
+                  |FROM deploys
+                  |WHERE hash = ?
+                  |  AND NOT EXISTS(SELECT 1
+                  |                 FROM deploy_process_results dpr
+                  |                 WHERE deploys.hash = dpr.deploy_hash)""".stripMargin
+                     ).updateMany(hashes)
+      } yield deletedNum
 
     for {
       now        <- Time[F].currentMillis


### PR DESCRIPTION
### Overview
Fixes a bug:
It was possible to delete bodies of executed deploys preventing reconstruction a block in the future.

1. Add a block
2. Block is orphaned
3. Deploys get discarded because of timeout causing deletion of bodies

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-925

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
