### PR TITLE
EE-701: Fix explorer named keys.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -384,6 +384,7 @@ steps:
     changeset:
       includes:
       - "**/.drone.yml"
+      - "**/**.proto"
       - "explorer/**"
   depends_on:
   - rust-compile-test-bors

--- a/explorer/ui/src/services/CasperService.ts
+++ b/explorer/ui/src/services/CasperService.ts
@@ -26,7 +26,7 @@ export default class CasperService {
     // Point at either at a URL on a different port where grpcwebproxy is listening,
     // or use nginx to serve the UI files, the API and gRPC all on the same port without CORS.
     private url: string
-  ) {}
+  ) { }
 
   getDeployInfo(deployHash: ByteArray): Promise<DeployInfo> {
     return new Promise<DeployInfo>((resolve, reject) => {
@@ -185,7 +185,7 @@ export default class CasperService {
       );
 
       const mintPublic = account
-        .getKnownUrefsList()
+        .getNamedKeysList()
         .find(x => x.getName() === 'mint')!;
 
       const mintQuery = QueryUref(mintPublic.getKey()!.getUref()!);


### PR DESCRIPTION
### Overview
Drone didn't run the explorer so the rename of `known_urefs` to `named_keys` didn't fail the build, but the app is broken.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-701

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
