### PR TITLE
NODE-930: Stub `isFinalized` check to return true when purging deploy buffers.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -946,7 +946,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block1)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(1)
+      _                     = pendingOrProcessedNum should be(0)
 
       Created(block7) <- nodes(0).casperEff
                           .deploy(deployDatas(6)) *> nodes(0).casperEff.createBlock
@@ -956,7 +956,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block2)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 4 and block 7
+      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 4 and block 7
 
       Created(block8) <- nodes(1).casperEff
                           .deploy(deployDatas(7)) *> nodes(1).casperEff.createBlock
@@ -966,7 +966,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block3)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 4 and block 7
+      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 4 and block 7
 
       Created(block9) <- nodes(2).casperEff
                           .deploy(deployDatas(8)) *> nodes(2).casperEff.createBlock
@@ -976,7 +976,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block4)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(1) // deploys contained in block 7
+      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 7
 
       Created(block10) <- nodes(0).casperEff
                            .deploy(deployDatas(9)) *> nodes(0).casperEff.createBlock
@@ -986,7 +986,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block5)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 7 and block 10
+      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 7 and block 10
 
       _ <- nodes.map(_.tearDown()).toList.sequence
     } yield ()
@@ -1028,8 +1028,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield assert(!block.body.get.deploys.head.isError)
   }
 
-  it should "put orphaned deploys back into the pending deploy buffer" in effectTest {
-    // Make a network where we don't validate nonces, I just want the merge conflict.
+  ignore should "put orphaned deploys back into the pending deploy buffer" in effectTest {
     for {
       nodes <- networkEff(
                 validatorKeys.take(2),


### PR DESCRIPTION
### Overview
(copied from Jira)
During our LRT sessions, we've found that there's a tipping point in the node's lifetime where removal of finalized deploys slows down the whole node so much that it goes into a death spiral and never recovers. 

The observable effects are:
1) More DAG cache misses
2) More time spent when removing finalized deploys
3) More deploys accumulated in the deploy buffer (because cron job regularly deploys new contracts to the node)
4) Failing behind the rest of the network (because when a node tries to create a block it's locked and cannot sync with other nodes)
5) Falling behind current tips of the network (this means that when a node tries to sync its cache doesn't have necessary hashes)
6) back to point 1)

The solution proposed here is to stub `isFinalized` check to always return true (in practice it means that once a deploy is included in a block it will be marked as processed and discarded, even if that block gets orphaned later). 

This is only temporary, once we implement finality streams ( CON-393: Specification of stream-based finality APIIN REVIEW ) we will be able to mark blocks/deploys as finalized again and bring back full functionality.



### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-930

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
