### PR TITLE
NODE-933: Delayed finalization

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -238,8 +238,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
                         }
                         .map(_.flatten.distinct)
 
-        lastFinalizedBlockHash <- LastFinalizedBlockHashContainer[F].get
-        lastFinalizedBlock     <- dag.lookup(lastFinalizedBlockHash).map(_.get)
+        lastFinalizedBlock <- (LastFinalizedBlockHashContainer[F].get >>= dag.lookup).map(_.get)
 
         finalizedBlockHashes <- blockHashes.filterA { blockHash =>
                                  // NODE-930. To be replaced when we implement finality streams.

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -946,7 +946,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block1)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(0)
+      _                     = pendingOrProcessedNum should be(1)
 
       Created(block7) <- nodes(0).casperEff
                           .deploy(deployDatas(6)) *> nodes(0).casperEff.createBlock
@@ -956,7 +956,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block2)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 4 and block 7
+      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 4 and block 7
 
       Created(block8) <- nodes(1).casperEff
                           .deploy(deployDatas(7)) *> nodes(1).casperEff.createBlock
@@ -966,7 +966,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block3)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 4 and block 7
+      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 4 and block 7
 
       Created(block9) <- nodes(2).casperEff
                           .deploy(deployDatas(8)) *> nodes(2).casperEff.createBlock
@@ -976,7 +976,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block4)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 7
+      _                     = pendingOrProcessedNum should be(1) // deploys contained in block 7
 
       Created(block10) <- nodes(0).casperEff
                            .deploy(deployDatas(9)) *> nodes(0).casperEff.createBlock
@@ -986,7 +986,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
 
       _                     <- checkLastFinalizedBlock(nodes(0), block5)
       pendingOrProcessedNum <- nodes(0).deployStorage.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(0) // deploys contained in block 7 and block 10
+      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 7 and block 10
 
       _ <- nodes.map(_.tearDown()).toList.sequence
     } yield ()
@@ -1028,7 +1028,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     } yield assert(!block.body.get.deploys.head.isError)
   }
 
-  ignore should "put orphaned deploys back into the pending deploy buffer" in effectTest {
+  it should "put orphaned deploys back into the pending deploy buffer" in effectTest {
     for {
       nodes <- networkEff(
                 validatorKeys.take(2),


### PR DESCRIPTION
### Overview
Instead of immediately declaring a block final during the removal of deploys from the processed buffer, it is considered final if it's older than the last finalized block.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-933

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
