### PR TITLE
CON-478: Create ballots

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
@@ -17,58 +17,73 @@ import scala.util.control.NonFatal
   * we have more than a certain number of new deploys in the buffer. */
 class AutoProposer[F[_]: Bracket[?[_], Throwable]: Time: Log: Metrics: MultiParentCasperRef: DeployStorageReader](
     checkInterval: FiniteDuration,
+    ballotInterval: FiniteDuration,
     accInterval: FiniteDuration,
     accCount: Int,
     blockApiLock: Semaphore[F]
 ) {
+  val accIntervalMillis    = accInterval.toMillis
+  val ballotIntervalMillis = ballotInterval.toMillis
 
-  private def run(): F[Unit] = {
-    val accElapsedMillis = accInterval.toMillis
+  private def run(lastCreatedBlockTimestamp: Long): F[Unit] = {
 
     def loop(
         // Deploys we tried to propose last time.
         prevDeploys: Set[ByteString],
         // Time we saw the first new deploys after an auto-proposal.
-        startMillis: Long
+        startMillis: Long,
+        // Time we proposed a block.
+        lastProposeMillis: Long
     ): F[Unit] = {
 
       val snapshot = for {
         currentMillis <- Time[F].currentMillis
         deploys       <- DeployStorageReader[F].readPendingHashes.map(_.toSet)
-      } yield (currentMillis, currentMillis - startMillis, deploys)
+      } yield (currentMillis, deploys)
 
       snapshot flatMap {
         // Reset time when we see a new deploy.
-        case (currentMillis, _, deploys) if deploys.nonEmpty && startMillis == 0 =>
-          Time[F].sleep(checkInterval) >> loop(prevDeploys, currentMillis)
+        case (currentMillis, deploys) if deploys.nonEmpty && startMillis == 0 =>
+          Time[F].sleep(checkInterval) >> loop(prevDeploys, currentMillis, lastProposeMillis)
 
-        case (_, elapsedMillis, deploys)
+        case (currentMillis, deploys)
             if deploys.nonEmpty
               && deploys != prevDeploys
-              && (elapsedMillis >= accElapsedMillis || deploys.size >= accCount) =>
+              && (currentMillis - startMillis >= accIntervalMillis || deploys.size >= accCount) =>
           Log[F].info(
-            s"Proposing block after ${elapsedMillis} ms with ${deploys.size} pending deploys."
+            s"Proposing a block after ${currentMillis - startMillis} ms with ${deploys.size} pending deploys."
           ) *>
-            tryPropose() >>
-            loop(deploys, 0)
+            tryPropose(false) >>= { hasProposed =>
+            loop(deploys, 0, if (hasProposed) currentMillis else lastProposeMillis)
+          }
+
+        case (currentMillis, deploys)
+            if currentMillis - lastProposeMillis >= ballotIntervalMillis =>
+          Log[F].info(
+            s"Proposing a block or ballot after ${lastProposeMillis - startMillis} ms."
+          ) *>
+            tryPropose(true) >> { hasProposed =>
+            loop(deploys, 0, if (hasProposed) currentMillis else lastProposeMillis)
+          }
 
         case _ =>
-          Time[F].sleep(checkInterval) >> loop(prevDeploys, startMillis)
+          Time[F].sleep(checkInterval) >> loop(prevDeploys, startMillis, lastProposeMillis)
       }
     }
 
-    loop(Set.empty, 0) onError {
+    loop(Set.empty, 0, lastCreatedBlockTimestamp) onError {
       case NonFatal(ex) =>
         Log[F].error(s"Auto-proposal stopped unexpectedly.", ex)
     }
   }
 
-  private def tryPropose(): F[Unit] =
+  /** Try to propose a block or ballot. Return true if anything was created. */
+  private def tryPropose(canCreateBallot: Boolean): F[Boolean] =
     BlockAPI.propose(blockApiLock).flatMap { blockHash =>
-      Log[F].info(s"Proposed block ${PrettyPrinter.buildString(blockHash)}")
+      Log[F].info(s"Proposed block ${PrettyPrinter.buildString(blockHash)}").as(true)
     } handleErrorWith {
       case NonFatal(ex) =>
-        Log[F].error(s"Could not propose block.", ex)
+        Log[F].error(s"Could not propose block.", ex).as(false)
     }
 }
 
@@ -77,14 +92,18 @@ object AutoProposer {
   /** Start the proposal loop in the background. */
   def apply[F[_]: Concurrent: Time: Log: Metrics: MultiParentCasperRef: DeployStorageReader](
       checkInterval: FiniteDuration,
+      ballotInterval: FiniteDuration,
       accInterval: FiniteDuration,
       accCount: Int,
-      blockApiLock: Semaphore[F]
+      blockApiLock: Semaphore[F],
+      lastCreatedBlockTimestamp: Long
   ): Resource[F, AutoProposer[F]] =
     Resource[F, AutoProposer[F]] {
       for {
-        ap    <- Sync[F].delay(new AutoProposer(checkInterval, accInterval, accCount, blockApiLock))
-        fiber <- Concurrent[F].start(ap.run())
+        ap <- Sync[F].delay(
+               new AutoProposer(checkInterval, ballotInterval, accInterval, accCount, blockApiLock)
+             )
+        fiber <- Concurrent[F].start(ap.run(lastCreatedBlockTimestamp))
       } yield ap -> fiber.cancel
     }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -31,8 +31,8 @@ trait MultiParentCasper[F[_]] {
       dag: DagRepresentation[F],
       latestMessages: Map[ByteString, ByteString]
   ): F[List[ByteString]]
-  def estimator(dag: DagRepresentation[F]): F[A]
-  def createBlock(canCreateBallot: Boolean): F[CreateBlockStatus]
+  def createMessage(canCreateBallot: Boolean): F[CreateBlockStatus]
+  def createBlock: F[CreateBlockStatus] = createMessage(false) // Left for the sake of unit tests.
   def dag: F[DagRepresentation[F]]
   // This is the weight of faults that have been accumulated so far.
   // We want the clique oracle to give us a fault tolerance that is greater than

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.casper
 
+import cats.data.NonEmptyList
 import cats.effect.Concurrent
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
@@ -30,7 +31,7 @@ trait MultiParentCasper[F[_]] {
   def estimator(
       dag: DagRepresentation[F],
       latestMessages: Map[ByteString, ByteString]
-  ): F[List[ByteString]]
+  ): F[NonEmptyList[ByteString]]
   def createMessage(canCreateBallot: Boolean): F[CreateBlockStatus]
   def createBlock: F[CreateBlockStatus] = createMessage(false) // Left for the sake of unit tests.
   def dag: F[DagRepresentation[F]]

--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -31,9 +31,8 @@ trait MultiParentCasper[F[_]] {
       dag: DagRepresentation[F],
       latestMessages: Map[ByteString, ByteString]
   ): F[List[ByteString]]
-  def createBlock: F[CreateBlockStatus]
-  ////
-
+  def estimator(dag: DagRepresentation[F]): F[A]
+  def createBlock(canCreateBallot: Boolean): F[CreateBlockStatus]
   def dag: F[DagRepresentation[F]]
   // This is the weight of faults that have been accumulated so far.
   // We want the clique oracle to give us a fault tolerance that is greater than

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -27,8 +27,8 @@ final case class CasperConf(
     standalone: Boolean,
     autoProposeEnabled: Boolean,
     autoProposeCheckInterval: FiniteDuration,
-    autoProposeMaxInterval: FiniteDuration,
-    autoProposeMaxCount: Int,
+    autoProposeAccInterval: FiniteDuration,
+    autoProposeAccCount: Int,
     maxBlockSizeBytes: Int
 ) extends SubConfig
 

--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -27,6 +27,7 @@ final case class CasperConf(
     standalone: Boolean,
     autoProposeEnabled: Boolean,
     autoProposeCheckInterval: FiniteDuration,
+    autoProposeBallotInterval: FiniteDuration,
     autoProposeAccInterval: FiniteDuration,
     autoProposeAccCount: Int,
     maxBlockSizeBytes: Int

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.casper
 
+import cats.data.NonEmptyList
 import cats.Monad
 import cats.implicits._
 import com.google.protobuf.ByteString
@@ -35,7 +36,7 @@ object Estimator {
       genesis: BlockHash,
       latestMessageHashes: Map[Validator, BlockHash],
       equivocationsTracker: EquivocationsTracker
-  ): F[List[BlockHash]] = {
+  ): F[NonEmptyList[BlockHash]] = {
 
     /** Finds children of the block b that have been scored by the LMD algorithm.
       * If no children exist (block B is the tip) return the block.
@@ -86,7 +87,7 @@ object Estimator {
       sortedSecParents = secondaryParents
         .sortBy(b => scores.getOrElse(b, 0L) -> b.toStringUtf8)
         .reverse
-    } yield newMainParent +: sortedSecParents
+    } yield NonEmptyList(newMainParent, sortedSecParents)
   }
 
   /** Computes scores for LMD GHOST.

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -391,7 +391,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
    *  TODO: Make this return Either so that we get more information about why not block was
    *  produced (no deploys, already processing, no validator id)
    */
-  def createBlock(canCreateBallot: Boolean): F[CreateBlockStatus] = validatorId match {
+  def createMessage(canCreateBallot: Boolean): F[CreateBlockStatus] = validatorId match {
     case Some(ValidatorIdentity(publicKey, privateKey, sigAlgorithm)) =>
       Metrics[F].timer("createBlock") {
         for {

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -629,7 +629,8 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
         rank,
         validatorId,
         privateKey,
-        sigAlgorithm
+        sigAlgorithm,
+        messageType = Block.MessageType.BALLOT
       )
       CreateBlockStatus.created(block)
     }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -615,22 +615,19 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
       // Start numbering from 1 (validator's first block seqNum = 1)
       val validatorSeqNum =
         latestMessages.get(ByteString.copyFrom(validatorId)).fold(0)(_.validatorMsgSeqNum + 1)
-      val block = ProtoUtil.block(
+      val block = ProtoUtil.ballot(
         justifications,
         parent.getHeader.getState.preStateHash,
-        parent.getHeader.getState.postStateHash,
         parent.getHeader.getState.bonds,
-        Nil,
         protocolVersion,
-        List(parent.blockHash),
+        parent.blockHash,
         validatorSeqNum,
         chainId,
         now,
         rank,
         validatorId,
         privateKey,
-        sigAlgorithm,
-        messageType = Block.MessageType.BALLOT
+        sigAlgorithm
       )
       CreateBlockStatus.created(block)
     }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -391,7 +391,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
    *  TODO: Make this return Either so that we get more information about why not block was
    *  produced (no deploys, already processing, no validator id)
    */
-  def createBlock: F[CreateBlockStatus] = validatorId match {
+  def createBlock(canCreateBallot: Boolean): F[CreateBlockStatus] = validatorId match {
     case Some(ValidatorIdentity(publicKey, privateKey, sigAlgorithm)) =>
       Metrics[F].timer("createBlock") {
         for {
@@ -415,7 +415,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
           justifications   = toJustification(bondedLatestMsgs.values.toSeq)
           rank             = ProtoUtil.nextRank(bondedLatestMsgs.values.toSeq)
           protocolVersion  <- CasperLabsProtocolVersions[F].versionAt(rank)
-          proposal <- if (remainingHashes.nonEmpty || parents.length > 1) {
+          proposal <- if (remainingHashes.nonEmpty || parents.length > 1 || canCreateBallot) {
                        createProposal(
                          latestMessages,
                          merged,

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -83,7 +83,8 @@ object BlockAPI {
   }
 
   def propose[F[_]: Bracket[?[_], Throwable]: MultiParentCasperRef: Log: Metrics](
-      blockApiLock: Semaphore[F]
+      blockApiLock: Semaphore[F],
+      canCreateBallot: Boolean
   ): F[ByteString] = {
     def raise[A](ex: ServiceError.Exception): F[ByteString] =
       MonadThrowable[F].raiseError(ex)
@@ -93,7 +94,7 @@ object BlockAPI {
         case true =>
           for {
             _          <- Metrics[F].incrementCounter("create-blocks")
-            maybeBlock <- casper.createBlock
+            maybeBlock <- casper.createMessage(canCreateBallot)
             result <- maybeBlock match {
                        case Created(block) =>
                          for {

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -422,8 +422,7 @@ object ProtoUtil {
       rank: Long,
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
-      sigAlgorithm: SignatureAlgorithm,
-      messageType: Block.MessageType = Block.MessageType.BLOCK
+      sigAlgorithm: SignatureAlgorithm
   ): Block = {
     val body = Block.Body().withDeploys(deploys)
     val postState = Block
@@ -443,9 +442,54 @@ object ProtoUtil {
       chainId = chainId,
       creator = publicKey,
       validatorSeqNum = validatorSeqNum
-    ).withMessageType(messageType)
+    )
 
     val unsigned = unsignedBlockProto(body, header)
+    signBlock(
+      unsigned,
+      privateKey,
+      sigAlgorithm
+    )
+  }
+
+  /* Creates a signed ballot */
+  def ballot(
+      justifications: Seq[Justification],
+      stateHash: ByteString,
+      bondedValidators: Seq[Bond],
+      protocolVersion: ProtocolVersion,
+      parent: ByteString,
+      validatorSeqNum: Int,
+      chainId: String,
+      now: Long,
+      rank: Long,
+      publicKey: Keys.PublicKey,
+      privateKey: Keys.PrivateKey,
+      sigAlgorithm: SignatureAlgorithm
+  ): Block = {
+    val body = Block.Body()
+
+    val postState = Block
+      .GlobalState()
+      .withPreStateHash(stateHash)
+      .withPostStateHash(stateHash)
+      .withBonds(bondedValidators)
+
+    val header = blockHeader(
+      body,
+      parentHashes = List(parent),
+      justifications = justifications,
+      state = postState,
+      rank = rank,
+      protocolVersion = protocolVersion.value,
+      timestamp = now,
+      chainId = chainId,
+      creator = publicKey,
+      validatorSeqNum = validatorSeqNum
+    ).withMessageType(Block.MessageType.BALLOT)
+
+    val unsigned = unsignedBlockProto(body, header)
+
     signBlock(
       unsigned,
       privateKey,

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -422,7 +422,8 @@ object ProtoUtil {
       rank: Long,
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
-      sigAlgorithm: SignatureAlgorithm
+      sigAlgorithm: SignatureAlgorithm,
+      messageType: Block.MessageType = Block.MessageType.BLOCK
   ): Block = {
     val body = Block.Body().withDeploys(deploys)
     val postState = Block
@@ -442,7 +443,7 @@ object ProtoUtil {
       chainId = chainId,
       creator = publicKey,
       validatorSeqNum = validatorSeqNum
-    )
+    ).withMessageType(messageType)
 
     val unsigned = unsignedBlockProto(body, header)
     signBlock(

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -370,16 +370,6 @@ object ExecEngineUtil {
   }
 
   def merge[F[_]: MonadThrowable: BlockStorage](
-      candidateParentBlocks: List[Block],
-      dag: DagRepresentation[F]
-  ): F[MergeResult[TransformMap, Block]] =
-    NonEmptyList.fromList(candidateParentBlocks) map { blocks =>
-      merge[F](blocks, dag).map(x => x: MergeResult[TransformMap, Block])
-    } getOrElse {
-      MergeResult.empty[TransformMap, Block].pure[F]
-    }
-
-  def merge[F[_]: MonadThrowable: BlockStorage](
       candidateParentBlocks: NonEmptyList[Block],
       dag: DagRepresentation[F]
   ): F[MergeResult.Result[TransformMap, Block]] = {

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -114,6 +114,8 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       _ <- timestamp(summary)
       _ <- blockNumber(summary, dag)
       _ <- sequenceNumber(summary, dag)
+      // TODO: Validate that blocks only have block parents and ballots have a single parent which is a block.
+
       // Checks that need the body.
       _ <- blockHash(block)
       _ <- deployCount(block)

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -599,8 +599,8 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
 
     for {
       tipHashes            <- Estimator.tips[F](dag, genesisHash, latestMessagesHashes, equivocationsTracker)
-      _                    <- Log[F].debug(s"Estimated tips are ${printHashes(tipHashes)}")
-      tips                 <- tipHashes.toVector.traverse(ProtoUtil.unsafeGetBlock[F])
+      _                    <- Log[F].debug(s"Estimated tips are ${printHashes(tipHashes.toList)}")
+      tips                 <- tipHashes.traverse(ProtoUtil.unsafeGetBlock[F])
       merged               <- ExecEngineUtil.merge[F](tips, dag)
       computedParentHashes = merged.parents.map(_.blockHash)
       parentHashes         = ProtoUtil.parentHashes(b)

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -34,9 +34,9 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
 
   val waitForCheck = Timer[Task].sleep(10 * DefaultCheckInterval)
 
-  it should "propose if more than max-count deploys are accumulated within max-interval" in TestFixture(
-    maxInterval = 5.seconds,
-    maxCount = 2
+  it should "propose if more than acc-count deploys are accumulated within acc-interval" in TestFixture(
+    accInterval = 5.seconds,
+    accCount = 2
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -49,9 +49,9 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
     } yield ()
   }
 
-  it should "propose if less than max-count deploys are accumulated after max-interval" in TestFixture(
-    maxInterval = 250.millis,
-    maxCount = 10
+  it should "propose if less than acc-count deploys are accumulated after acc-interval" in TestFixture(
+    accInterval = 250.millis,
+    accCount = 10
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -64,8 +64,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   }
 
   it should "not propose if none of the thresholds are reached" in TestFixture(
-    maxInterval = 1.second,
-    maxCount = 2
+    accInterval = 1.second,
+    accCount = 2
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -76,8 +76,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   }
 
   it should "not propose if there are no new deploys" in TestFixture(
-    maxInterval = 1.second,
-    maxCount = 1
+    accInterval = 1.second,
+    accCount = 1
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -96,8 +96,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   }
 
   it should "not stop if the proposal fails" in TestFixture(
-    maxInterval = 1.second,
-    maxCount = 1
+    accInterval = 1.second,
+    accCount = 1
   ) { _ => implicit casperRef => implicit deployStorage =>
     val defectiveCasper = new MockMultiParentCasper[Task]() {
       override def createBlock: Task[CreateBlockStatus] =
@@ -134,8 +134,8 @@ object AutoProposerTest {
   object TestFixture {
     def apply(
         checkInterval: FiniteDuration = DefaultCheckInterval,
-        maxInterval: FiniteDuration,
-        maxCount: Int
+        accInterval: FiniteDuration,
+        accCount: Int
     )(
         f: AutoProposer[Task] => MultiParentCasperRef[Task] => DeployStorage[Task] => Task[Unit]
     ): Unit = {
@@ -147,8 +147,8 @@ object AutoProposerTest {
         blockApiLock                                    <- Resource.liftF(Semaphore[Task](1))
         proposer <- AutoProposer[Task](
                      checkInterval = checkInterval,
-                     maxInterval = maxInterval,
-                     maxCount = maxCount,
+                     accInterval = accInterval,
+                     accCount = accCount,
                      blockApiLock = blockApiLock
                    )
       } yield (proposer, emptyRef, deployStorage)

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -3,6 +3,7 @@ package io.casperlabs.casper
 import cats.effect._
 import cats.effect.concurrent._
 import cats.implicits._
+import cats.data.NonEmptyList
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.consensus._
@@ -226,7 +227,7 @@ object AutoProposerTest {
     override def estimator(
         dag: DagRepresentation[F],
         lm: Map[ByteString, ByteString]
-    ): F[List[ByteString]]                                                        = ???
+    ): F[NonEmptyList[ByteString]]                                                = ???
     override def dag: F[DagRepresentation[F]]                                     = ???
     override def normalizedInitialFault(weights: Map[ByteString, Long]): F[Float] = ???
     override def lastFinalizedBlock: F[Block]                                     = ???

--- a/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
@@ -148,7 +148,7 @@ class ForkchoiceTest
                        EquivocationsTracker.empty
                      )
         _      = forkchoice.head should be(b6.blockHash)
-        result = forkchoice(1) should be(b8.blockHash)
+        result = forkchoice.tail.head should be(b8.blockHash)
       } yield result
   }
 
@@ -215,7 +215,7 @@ class ForkchoiceTest
                        EquivocationsTracker.empty
                      )
         _      = forkchoice.head should be(b8.blockHash)
-        result = forkchoice(1) should be(b7.blockHash)
+        result = forkchoice.tail.head should be(b7.blockHash)
       } yield result
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -160,21 +160,26 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
     for {
       deploy <- ProtoUtil.basicDeploy[Task]()
       // A ballot on top of genesis should not be built upon by the upcoming block.
-      _ <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
+      createBlockResult0 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
+      Created(ballot1)   = createBlockResult0
+      _                  <- MultiParentCasper[Task].addBlock(ballot1)
 
       _                  <- MultiParentCasper[Task].deploy(deploy)
       createBlockResult1 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
       Created(block1)    = createBlockResult1
+      _                  = Message.fromBlock(block1).get shouldBe a[Message.Block]
       _                  = ProtoUtil.parentHashes(block1).head shouldBe genesis.blockHash
       _                  <- MultiParentCasper[Task].addBlock(block1)
 
       createBlockResult2 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
       Created(ballot2)   = createBlockResult2
       _                  = ProtoUtil.parentHashes(ballot2).head shouldBe block1.blockHash
+      _                  <- MultiParentCasper[Task].addBlock(ballot2)
 
       createBlockResult3 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
       Created(ballot3)   = createBlockResult3
       _                  = ProtoUtil.parentHashes(ballot3).head shouldBe block1.blockHash
+      _                  <- MultiParentCasper[Task].addBlock(ballot3)
 
       _ <- node.tearDown()
     } yield ()

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -163,6 +163,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       createBlockResult0 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
       Created(ballot1)   = createBlockResult0
       _                  <- MultiParentCasper[Task].addBlock(ballot1)
+      _                  = Message.fromBlock(ballot1).get shouldBe a[Message.Ballot]
 
       _                  <- MultiParentCasper[Task].deploy(deploy)
       createBlockResult1 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
@@ -174,11 +175,13 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       createBlockResult2 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
       Created(ballot2)   = createBlockResult2
       _                  = ProtoUtil.parentHashes(ballot2).head shouldBe block1.blockHash
+      _                  = Message.fromBlock(ballot2).get shouldBe a[Message.Ballot]
       _                  <- MultiParentCasper[Task].addBlock(ballot2)
 
       createBlockResult3 <- MultiParentCasper[Task].createMessage(canCreateBallot = true)
       Created(ballot3)   = createBlockResult3
       _                  = ProtoUtil.parentHashes(ballot3).head shouldBe block1.blockHash
+      _                  = Message.fromBlock(ballot3).get shouldBe a[Message.Ballot]
       _                  <- MultiParentCasper[Task].addBlock(ballot3)
 
       _ <- node.tearDown()

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -194,7 +194,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       dag                  <- MultiParentCasper[Task].dag
       latestMessageHashes  <- dag.latestMessageHashes
       estimate             <- MultiParentCasper[Task].estimator(dag, latestMessageHashes)
-      _                    = estimate shouldBe IndexedSeq(signedBlock.blockHash)
+      _                    = estimate.toList shouldBe List(signedBlock.blockHash)
       _                    = node.tearDown()
     } yield ()
   }
@@ -235,7 +235,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       latestMessageHashes   <- dag.latestMessageHashes
       estimate              <- MultiParentCasper[Task].estimator(dag, latestMessageHashes)
 
-      _ = estimate shouldBe IndexedSeq(signedBlock2.blockHash)
+      _ = estimate.toList shouldBe List(signedBlock2.blockHash)
       _ <- node.tearDown()
     } yield ()
   }

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -147,9 +147,9 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def lastFinalizedBlock: F[Block] = underlying.lastFinalizedBlock
   def faultToleranceThreshold      = underlying.faultToleranceThreshold
 
-  override def createBlock: F[CreateBlockStatus] =
+  override def createMessage(canCreateBallot: Boolean): F[CreateBlockStatus] =
     for {
-      result <- underlying.createBlock
+      result <- underlying.createMessage(canCreateBallot)
       _      <- implicitly[Time[F]].sleep(5.seconds)
     } yield result
 

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -72,10 +72,10 @@ class CreateBlockAPITest extends FlatSpec with Matchers with GossipServiceCasper
     ): Task[(Either[Throwable, ByteString], Either[Throwable, ByteString])] =
       for {
         t1 <- (BlockAPI.deploy[Task](deploys.head) *> BlockAPI
-               .propose[Task](blockApiLock)).start
+               .propose[Task](blockApiLock, canCreateBallot = false)).start
         _ <- Time[Task].sleep(2.second)
         t2 <- (BlockAPI.deploy[Task](deploys.last) *> BlockAPI
-               .propose[Task](blockApiLock)).start //should fail because other not done
+               .propose[Task](blockApiLock, canCreateBallot = false)).start //should fail because other not done
         r1 <- t1.join.attempt
         r2 <- t2.join.attempt
       } yield (r1, r2)
@@ -111,7 +111,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers with GossipServiceCasper
       for {
         d <- ProtoUtil.basicDeploy[Task]()
         _ <- BlockAPI.deploy[Task](d)
-        _ <- BlockAPI.propose[Task](blockApiLock)
+        _ <- BlockAPI.propose[Task](blockApiLock, canCreateBallot = false)
         _ <- BlockAPI.deploy[Task](d)
       } yield ()
 

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -1,7 +1,7 @@
 package io.casperlabs.casper.api
 
 import cats.Monad
-import cats.data.EitherT
+import cats.data.{EitherT, NonEmptyList}
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import com.github.ghik.silencer.silent
@@ -139,7 +139,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def estimator(
       dag: DagRepresentation[F],
       latestMessagesHashes: Map[ByteString, ByteString]
-  ): F[List[BlockHash]] =
+  ): F[NonEmptyList[BlockHash]] =
     underlying.estimator(dag, latestMessagesHashes)
   def dag: F[DagRepresentation[F]] = underlying.dag
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -11,6 +11,7 @@ import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.state.ProtocolVersion
 import io.casperlabs.casper.util.ProtoUtil
+import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.{computeDeploysCheckpoint, StateHash}
 import io.casperlabs.casper.util.execengine.{DeploysCheckpoint, ExecEngineUtil}
 import io.casperlabs.catscontrib.MonadThrowable
@@ -80,7 +81,7 @@ object BlockGenerator {
         parents.nonEmpty || (parents.isEmpty && b == genesis),
         "Received a different genesis block."
       )
-      merged <- ExecEngineUtil.merge[F](parents, dag)
+      merged <- ExecutionEngineServiceStub.merge[F](parents, dag)
       implicit0(deploySelection: DeploySelection[F]) = DeploySelection.create[F](
         5 * 1024 * 1024
       )

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.casper.helper
 
+import cats.data.NonEmptyList
 import cats.Applicative
 import cats.effect.Sync
 import cats.implicits._
@@ -16,7 +17,7 @@ import scala.collection.mutable.{Map => MutableMap}
 
 class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
     private val blockStorage: MutableMap[BlockHash, BlockMsgWithTransform],
-    estimatorFunc: List[BlockHash]
+    estimatorFunc: NonEmptyList[BlockHash]
 ) extends MultiParentCasper[F] {
 
   def store: Map[BlockHash, BlockMsgWithTransform] = blockStorage.toMap
@@ -35,7 +36,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
   def estimator(
       dag: DagRepresentation[F],
       latestMessageHashes: Map[ByteString, ByteString]
-  ): F[List[BlockHash]] =
+  ): F[NonEmptyList[BlockHash]] =
     estimatorFunc.pure[F]
   def createMessage(canCreateBallot: Boolean): F[CreateBlockStatus] =
     CreateBlockStatus.noNewDeploys.pure[F]
@@ -49,7 +50,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
 object NoOpsCasperEffect {
   def apply[F[_]: Sync: BlockStorage: DagStorage](
       blockStorage: Map[BlockHash, BlockMsgWithTransform] = Map.empty,
-      estimatorFunc: List[BlockHash] = List(Block().blockHash)
+      estimatorFunc: NonEmptyList[BlockHash] = NonEmptyList.one(Block().blockHash)
   ): F[NoOpsCasperEffect[F]] =
     for {
       _ <- blockStorage.toList.traverse_ {
@@ -59,10 +60,10 @@ object NoOpsCasperEffect {
   def apply[F[_]: Sync: BlockStorage: DagStorage](): F[NoOpsCasperEffect[F]] =
     apply(
       Map(Block().blockHash -> BlockMsgWithTransform().withBlockMessage(Block())),
-      List(Block().blockHash)
+      NonEmptyList.one(Block().blockHash)
     )
   def apply[F[_]: Sync: BlockStorage: DagStorage](
       blockStorage: Map[BlockHash, BlockMsgWithTransform]
   ): F[NoOpsCasperEffect[F]] =
-    apply(blockStorage, List(Block().blockHash))
+    apply(blockStorage, NonEmptyList.one(Block().blockHash))
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -37,7 +37,8 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
       latestMessageHashes: Map[ByteString, ByteString]
   ): F[List[BlockHash]] =
     estimatorFunc.pure[F]
-  def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]
+  def createMessage(canCreateBallot: Boolean): F[CreateBlockStatus] =
+    CreateBlockStatus.noNewDeploys.pure[F]
   def dag: F[DagRepresentation[F]]                                    = DagStorage[F].getRepresentation
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
   def lastFinalizedBlock: F[Block]                                    = Block().pure[F]

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper.util.execengine
 
 import cats.Id
+import cats.data.NonEmptyList
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.DeploySelection.DeploySelection
@@ -450,15 +451,13 @@ object ExecEngineUtilTest {
         candidates: Vector[OpDagNode]
     )(implicit order: Ordering[OpDagNode]): (OpMap[Int], Vector[OpDagNode]) = {
       val merged = ExecEngineUtil.abstractMerge[Id, OpMap[Int], OpDagNode, Int](
-        candidates,
+        NonEmptyList.fromListUnsafe(candidates.toList),
         getParents,
         getEffect,
         identity
       )
 
       merged match {
-        case ExecEngineUtil.MergeResult.EmptyMerge =>
-          throw new RuntimeException("No candidates were given to merge!")
         case ExecEngineUtil.MergeResult.Result(head, effect, tail) => (effect, head +: tail)
       }
     }

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecutionEngineServiceStub.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecutionEngineServiceStub.scala
@@ -1,9 +1,11 @@
 package io.casperlabs.casper.util.execengine
 
+import cats.data.NonEmptyList
 import cats.Applicative
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
+import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.casper
 import io.casperlabs.casper.consensus.state.{Unit => _, _}
 import io.casperlabs.casper.consensus.{Block, Bond}
@@ -24,8 +26,20 @@ import scala.util.Either
 object ExecutionEngineServiceStub {
   type Bonds = Map[PublicKey, Long]
 
+  import ExecEngineUtil.{MergeResult, TransformMap}
+
   implicit def functorRaiseInvalidBlock[F[_]: Sync] =
     casper.validation.raiseValidateErrorThroughApplicativeError[F]
+
+  def merge[F[_]: MonadThrowable: BlockStorage](
+      candidateParentBlocks: List[Block],
+      dag: DagRepresentation[F]
+  ): F[MergeResult[TransformMap, Block]] =
+    NonEmptyList.fromList(candidateParentBlocks) map { blocks =>
+      ExecEngineUtil.merge[F](blocks, dag).map(x => x: MergeResult[TransformMap, Block])
+    } getOrElse {
+      MergeResult.empty[TransformMap, Block].pure[F]
+    }
 
   def validateBlockCheckpoint[F[_]: Sync: Log: BlockStorage: ExecutionEngineService: CasperLabsProtocolVersions](
       b: Block,
@@ -39,7 +53,7 @@ object ExecutionEngineServiceStub {
     implicit val validation = new ValidationImpl[F]
     (for {
       parents      <- ProtoUtil.unsafeGetParents[F](b)
-      merged       <- ExecEngineUtil.merge[F](parents, dag)
+      merged       <- ExecutionEngineServiceStub.merge[F](parents, dag)
       preStateHash <- ExecEngineUtil.computePrestate[F](merged)
       effects      <- ExecEngineUtil.effectsForBlock[F](b, preStateHash)
       _            <- Validation[F].transactions(b, preStateHash, effects)

--- a/models/src/main/scala/io/casperlabs/models/Message.scala
+++ b/models/src/main/scala/io/casperlabs/models/Message.scala
@@ -17,7 +17,7 @@ import scala.util.{Failure, Success, Try}
   * This way we can do necessary validation of protobuf fields (like existence of required fields)
   * and represent different messages in type-safe way.
   */
-trait Message {
+sealed trait Message {
   type Id = ByteString
   val messageHash: Id
   val validatorId: ByteString

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -198,6 +198,9 @@ auto-propose-enabled = false
 # Time between proposal checks.
 auto-propose-check-interval = "1second"
 
+# Maximum time to allow before proposing a ballot or block.
+auto-propose-ballot-interval = "1minute"
+
 # Time to accumulate deploys before proposing.
 auto-propose-acc-interval = "5seconds"
 

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -199,10 +199,10 @@ auto-propose-enabled = false
 auto-propose-check-interval = "1second"
 
 # Time to accumulate deploys before proposing.
-auto-propose-max-interval = "5seconds"
+auto-propose-acc-interval = "5seconds"
 
 # Number of deploys to accumulate before proposing.
-auto-propose-max-count = 10
+auto-propose-acc-count = 10
 
 # Maximum block size in bytes
 max-block-size-bytes = 10485760

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -220,8 +220,8 @@ class NodeRuntime private[node] (
         // so that the operator can turn it on/off on the fly.
         _ <- AutoProposer[Task](
               checkInterval = conf.casper.autoProposeCheckInterval,
-              maxInterval = conf.casper.autoProposeMaxInterval,
-              maxCount = conf.casper.autoProposeMaxCount,
+              accInterval = conf.casper.autoProposeAccInterval,
+              accCount = conf.casper.autoProposeAccCount,
               blockApiLock = blockApiLock
             ).whenA(conf.casper.autoProposeEnabled)
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -220,6 +220,7 @@ class NodeRuntime private[node] (
         // so that the operator can turn it on/off on the fly.
         _ <- AutoProposer[Task](
               checkInterval = conf.casper.autoProposeCheckInterval,
+              ballotInterval = conf.casper.autoProposeBallotInterval,
               accInterval = conf.casper.autoProposeAccInterval,
               accCount = conf.casper.autoProposeAccCount,
               blockApiLock = blockApiLock

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcControlService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcControlService.scala
@@ -18,7 +18,10 @@ object GrpcControlService {
       new ControlGrpcMonix.ControlService {
         override def propose(request: ProposeRequest): Task[ProposeResponse] =
           TaskLike[F].toTask {
-            BlockAPI.propose[F](blockApiLock).map(ProposeResponse().withBlockHash(_))
+            // Agreed that it won't be possible to create ballots through the API.
+            BlockAPI
+              .propose[F](blockApiLock, canCreateBallot = false)
+              .map(ProposeResponse().withBlockHash(_))
           }
       }
     }

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -264,6 +264,9 @@ private[configuration] final case class Options private (
     @scallop
     val casperAutoProposeCheckInterval =
       gen[FiniteDuration]("Time between proposal checks.")
+    @scallop
+    val casperAutoProposeBallotInterval =
+      gen[FiniteDuration]("Maximum time to allow before trying to propose a ballot or block.")
 
     @scallop
     val casperAutoProposeAccInterval =

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -266,11 +266,11 @@ private[configuration] final case class Options private (
       gen[FiniteDuration]("Time between proposal checks.")
 
     @scallop
-    val casperAutoProposeMaxInterval =
+    val casperAutoProposeAccInterval =
       gen[FiniteDuration]("Time to accumulate deploys before proposing.")
 
     @scallop
-    val casperAutoProposeMaxCount =
+    val casperAutoProposeAccCount =
       gen[Int]("Number of deploys to accumulate before proposing.")
 
     @scallop

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -66,8 +66,8 @@ chain-spec-path = "/tmp/test"
 standalone = false
 auto-propose-enabled = false
 auto-propose-check-interval = "1second"
-auto-propose-max-interval = "1second"
-auto-propose-max-count = 1
+auto-propose-acc-interval = "1second"
+auto-propose-acc-count = 1
 max-block-size-bytes = 1
 
 [blockstorage]

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -66,6 +66,7 @@ chain-spec-path = "/tmp/test"
 standalone = false
 auto-propose-enabled = false
 auto-propose-check-interval = "1second"
+auto-propose-ballot-interval = "1second"
 auto-propose-acc-interval = "1second"
 auto-propose-acc-count = 1
 max-block-size-bytes = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -108,8 +108,8 @@ class ConfigurationSpec
       standalone = false,
       autoProposeEnabled = false,
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
-      autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),
-      autoProposeMaxCount = 1,
+      autoProposeAccInterval = FiniteDuration(1, TimeUnit.SECONDS),
+      autoProposeAccCount = 1,
       maxBlockSizeBytes = 1
     )
     val tls = Tls(

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -108,6 +108,7 @@ class ConfigurationSpec
       standalone = false,
       autoProposeEnabled = false,
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
+      autoProposeBallotInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeAccInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeAccCount = 1,
       maxBlockSizeBytes = 1


### PR DESCRIPTION
### Overview
Creates a ballot/block if a block could not be proposed for longer then T milliseconds based on just deploys.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-478

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
We discussed separately with @goral09 and decided that as @zie1ony asked we'll leave the `propose` endpoint for now and also leave the `hack/docker` setup with auto-propose disabled, however user will not be able to create ballots using `propose`, it's only available via auto-propose, if enabled.

Opened against the fresh `new-consensus` feature branch.