### PR TITLE
EE-676: Semantic Versioning for ProtocolVersion

### DIFF
--- a/execution-engine/contract-ffi/benches/bytesrepr_bench.rs
+++ b/execution-engine/contract-ffi/benches/bytesrepr_bench.rs
@@ -359,7 +359,7 @@ fn make_purse_id() -> PurseId {
 
 fn make_contract() -> Contract {
     let named_keys = make_named_keys();
-    Contract::new(vec![0u8; 1024], named_keys, ProtocolVersion::new(1))
+    Contract::new(vec![0u8; 1024], named_keys, ProtocolVersion::V1_0_0)
 }
 
 fn make_account() -> Account {

--- a/execution-engine/contract-ffi/src/gens.rs
+++ b/execution-engine/contract-ffi/src/gens.rs
@@ -110,17 +110,21 @@ prop_compose! {
 }
 
 pub fn contract_arb() -> impl Strategy<Value = Contract> {
-    any::<u64>().prop_flat_map(move |u64arb| {
+    protocol_version_arb().prop_flat_map(move |protocol_version_arb| {
         named_keys_arb(20).prop_flat_map(move |urefs| {
-            vec(any::<u8>(), 1..1000).prop_map(move |body| {
-                Contract::new(body, urefs.clone(), ProtocolVersion::new(u64arb))
-            })
+            vec(any::<u8>(), 1..1000)
+                .prop_map(move |body| Contract::new(body, urefs.clone(), protocol_version_arb))
         })
     })
 }
 
+pub fn sem_ver_arb() -> impl Strategy<Value = SemVer> {
+    (any::<u32>(), any::<u32>(), any::<u32>())
+        .prop_map(|(major, minor, patch)| SemVer::new(major, minor, patch))
+}
+
 pub fn protocol_version_arb() -> impl Strategy<Value = ProtocolVersion> {
-    prop_oneof![Just(ProtocolVersion::new(1)),]
+    sem_ver_arb().prop_map(ProtocolVersion::new)
 }
 
 pub fn u128_arb() -> impl Strategy<Value = U128> {

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod contract;
 pub mod protocol_version;
+mod semver;
 pub mod uint;
 
 use crate::bytesrepr::{
@@ -17,6 +18,7 @@ use core::mem::size_of;
 pub use self::account::Account;
 pub use self::contract::Contract;
 pub use self::protocol_version::ProtocolVersion;
+pub use self::semver::SemVer;
 pub use self::uint::{U128, U256, U512};
 
 #[derive(PartialEq, Eq, Clone, Debug)]

--- a/execution-engine/contract-ffi/src/value/protocol_version.rs
+++ b/execution-engine/contract-ffi/src/value/protocol_version.rs
@@ -1,61 +1,82 @@
+use core::cmp::Ordering;
 use uint::core_::fmt;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-pub struct ProtocolVersion(u64);
+use super::SemVer;
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord)]
+pub struct ProtocolVersion(SemVer);
 
 impl ProtocolVersion {
-    pub fn new(version: u64) -> ProtocolVersion {
+    pub const V1_0_0: ProtocolVersion = ProtocolVersion(SemVer {
+        major: 1,
+        minor: 0,
+        patch: 0,
+    });
+
+    pub fn new(version: SemVer) -> ProtocolVersion {
         ProtocolVersion(version)
     }
 
+    pub fn from_parts(major: u32, minor: u32, patch: u32) -> ProtocolVersion {
+        let sem_ver = SemVer::new(major, minor, patch);
+        Self::new(sem_ver)
+    }
+
     #[allow(clippy::trivially_copy_pass_by_ref)] //TODO: remove attr after switch to SemVer
-    pub fn value(&self) -> u64 {
+    pub fn value(&self) -> SemVer {
         self.0
     }
 }
 
 impl fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.0)
+        self.0.fmt(f)
+    }
+}
+
+impl PartialOrd for ProtocolVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.value().cmp(&other.value()))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::value::semver::SemVer;
     use crate::value::ProtocolVersion;
 
     #[test]
     fn should_be_able_to_get_instance() {
-        let initial_value = 1;
+        let initial_value = SemVer::new(1, 0, 0);
         let item = ProtocolVersion::new(initial_value);
         assert_eq!(initial_value, item.value(), "should have equal value")
     }
 
     #[test]
     fn should_be_able_to_compare_two_instances() {
-        let lhs = ProtocolVersion::new(1);
-        let rhs = ProtocolVersion::new(1);
+        let lhs = ProtocolVersion::new(SemVer::new(1, 0, 0));
+        let rhs = ProtocolVersion::new(SemVer::new(1, 0, 0));
         assert_eq!(lhs, rhs, "should be equal");
-        let rhs = ProtocolVersion::new(2);
+        let rhs = ProtocolVersion::new(SemVer::new(2, 0, 0));
         assert_ne!(lhs, rhs, "should not be equal")
     }
 
     #[test]
     fn should_be_able_to_default() {
         let defaulted = ProtocolVersion::default();
-        let expected = ProtocolVersion::new(0);
+        let expected = ProtocolVersion::new(SemVer::new(0, 0, 0));
         assert_eq!(defaulted, expected, "should be equal")
     }
 
     #[test]
     fn should_be_able_to_compare_relative_value() {
-        let lhs = ProtocolVersion::new(2);
-        let rhs = ProtocolVersion::new(1);
+        let lhs = ProtocolVersion::new(SemVer::new(2, 0, 0));
+        let rhs = ProtocolVersion::new(SemVer::new(1, 0, 0));
         assert!(lhs > rhs, "should be gt");
-        let rhs = ProtocolVersion::new(2);
+        let rhs = ProtocolVersion::new(SemVer::new(2, 0, 0));
         assert!(lhs >= rhs, "should be gte");
         assert!(lhs <= rhs, "should be lte");
-        let lhs = ProtocolVersion::new(1);
+        let lhs = ProtocolVersion::new(SemVer::new(1, 0, 0));
         assert!(lhs < rhs, "should be lt");
     }
 }

--- a/execution-engine/contract-ffi/src/value/semver.rs
+++ b/execution-engine/contract-ffi/src/value/semver.rs
@@ -1,9 +1,8 @@
-use std::fmt;
-use std::hash::{Hash, Hasher};
+use core::cmp::Ordering;
+use core::fmt;
+use core::hash::{Hash, Hasher};
 
-use serde::{Serialize, Serializer};
-
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Eq, Ord)]
 pub struct SemVer {
     pub major: u32,
     pub minor: u32,
@@ -40,12 +39,20 @@ impl Hash for SemVer {
     }
 }
 
-impl Serialize for SemVer {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let s = format!("{}.{}.{}", self.major, self.minor, self.patch);
-        serializer.serialize_str(&s)
+impl Default for SemVer {
+    fn default() -> Self {
+        Self::new(0, 0, 0)
+    }
+}
+
+impl PartialOrd for SemVer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl PartialEq for SemVer {
+    fn eq(&self, other: &SemVer) -> bool {
+        self.major.eq(&other.major) && self.minor.eq(&other.minor) && self.patch.eq(&other.patch)
     }
 }

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -22,7 +22,7 @@ use contract_ffi::system_contracts::mint;
 use contract_ffi::uref::URef;
 use contract_ffi::uref::{AccessRights, UREF_ADDR_SIZE};
 use contract_ffi::value::account::{BlockTime, PublicKey, PurseId};
-use contract_ffi::value::{Account, ProtocolVersion, Value, U512};
+use contract_ffi::value::{Account, ProtocolVersion, SemVer, Value, U512};
 use engine_shared::gas::Gas;
 use engine_shared::motes::Motes;
 use engine_shared::newtypes::{Blake2bHash, CorrelationId, Validated};
@@ -108,7 +108,7 @@ where
     ) -> Result<GenesisResult, Error> {
         assert_eq!(
             protocol_version.value(),
-            1,
+            SemVer::V1_0_0,
             "legacy genesis only supports protocol version 1"
         );
 
@@ -485,7 +485,7 @@ where
         // 3.1.1.1.1.4 new protocol version must be exactly 1 version higher than current
         let new_protocol_version = upgrade_config.new_protocol_version();
         // TODO: when ProtocolVersion switches to SemVer, replace with a more robust impl per spec
-        if new_protocol_version.value() != current_protocol_version.value() + 1 {
+        if new_protocol_version.value().major != current_protocol_version.value().major + 1 {
             return Err(Error::InvalidProtocolVersion(new_protocol_version));
         }
         // 3.1.1.1.1.6 resolve wasm CostTable for new protocol version
@@ -557,7 +557,7 @@ where
                 let bytes: Vec<u8> = upgrade_config
                     .new_protocol_version()
                     .value()
-                    .to_le_bytes()
+                    .to_bytes()?
                     .to_vec();
                 Blake2bHash::new(&bytes).into()
             };

--- a/execution-engine/engine-core/src/resolvers/mod.rs
+++ b/execution-engine/engine-core/src/resolvers/mod.rs
@@ -16,7 +16,7 @@ pub fn create_module_resolver(
     protocol_version: ProtocolVersion,
 ) -> Result<impl ModuleImportResolver + MemoryResolver, ResolverError> {
     // TODO: revisit how protocol_version check here is meant to combine with upgrade
-    if protocol_version >= ProtocolVersion::new(1) {
+    if protocol_version >= ProtocolVersion::V1_0_0 {
         return Ok(v1_resolver::RuntimeModuleImportResolver::default());
     }
     Err(ResolverError::UnknownProtocolVersion(protocol_version))
@@ -29,5 +29,5 @@ fn resolve_invalid_module() {
 
 #[test]
 fn protocol_version_1_always_resolves() {
-    assert!(create_module_resolver(ProtocolVersion::new(1)).is_ok());
+    assert!(create_module_resolver(ProtocolVersion::V1_0_0).is_ok());
 }

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -119,7 +119,7 @@ fn mock_runtime_context<'a>(
         Gas::default(),
         0,
         Rc::new(RefCell::new(address_generator)),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         Phase::Session,
     )
@@ -195,7 +195,7 @@ fn store_contract_with_uref_valid() {
     let contract = Value::Contract(Contract::new(
         Vec::new(),
         iter::once(("ValidURef".to_owned(), uref)).collect(),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
     ));
 
     let query_result = test(access_rights, |mut rc| {
@@ -220,7 +220,7 @@ fn store_contract_with_uref_forged() {
     let contract = Value::Contract(Contract::new(
         Vec::new(),
         iter::once(("ForgedURef".to_owned(), uref)).collect(),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
     ));
 
     let query_result = test(HashMap::new(), |mut rc| {
@@ -240,7 +240,7 @@ fn store_contract_under_uref_valid() {
     let contract: Value = Contract::new(
         Vec::new(),
         iter::once(("ValidURef".to_owned(), contract_uref)).collect(),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
     )
     .into();
 
@@ -264,7 +264,7 @@ fn store_contract_under_uref_forged() {
     let mut rng = AddressGenerator::new(DEPLOY_HASH, PHASE);
     let contract_uref = create_uref(&mut rng, AccessRights::READ_WRITE);
     let contract: Value =
-        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::new(1)).into();
+        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::V1_0_0).into();
 
     let query_result = test(HashMap::new(), |mut rc| {
         rc.write_gs(contract_uref, contract.clone())
@@ -281,7 +281,7 @@ fn store_contract_uref_invalid_access() {
     let contract_uref = create_uref(&mut rng, AccessRights::READ);
     let access_rights = extract_access_rights_from_keys(vec![contract_uref]);
     let contract: Value =
-        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::new(1)).into();
+        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::V1_0_0).into();
 
     let query_result = test(access_rights, |mut rc| {
         rc.write_gs(contract_uref, contract.clone())
@@ -406,7 +406,7 @@ fn contract_key_addable_valid() {
     let mut rng = rand::thread_rng();
     let contract_key = random_contract_key(&mut rng);
     let contract: Value =
-        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::new(1)).into();
+        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::V1_0_0).into();
     let tc = Rc::new(RefCell::new(mock_tc(account_key, account.clone())));
     // Store contract in the GlobalState so that we can mainpulate it later.
     tc.borrow_mut().write(
@@ -432,7 +432,7 @@ fn contract_key_addable_valid() {
         Gas::default(),
         0,
         Rc::new(RefCell::new(address_generator)),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         PHASE,
     );
@@ -447,7 +447,7 @@ fn contract_key_addable_valid() {
     let updated_contract: Value = Contract::new(
         Vec::new(),
         iter::once((uref_name, uref)).collect(),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
     )
     .into();
 
@@ -468,7 +468,7 @@ fn contract_key_addable_invalid() {
     let contract_key = random_contract_key(&mut rng);
     let other_contract_key = random_contract_key(&mut rng);
     let contract: Value =
-        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::new(1)).into();
+        Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::V1_0_0).into();
     let tc = Rc::new(RefCell::new(mock_tc(account_key, account.clone())));
     // Store contract in the GlobalState so that we can mainpulate it later.
     tc.borrow_mut().write(
@@ -493,7 +493,7 @@ fn contract_key_addable_invalid() {
         Gas::default(),
         0,
         Rc::new(RefCell::new(address_generator)),
-        ProtocolVersion::new(1),
+        ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         PHASE,
     );

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -384,7 +384,7 @@ proptest! {
         let correlation_id = CorrelationId::new();
         let mut named_keys = BTreeMap::new();
         named_keys.insert(name.clone(), k);
-        let contract: Value = Contract::new(body, named_keys, ProtocolVersion::new(1)).into();
+        let contract: Value = Contract::new(body, named_keys, ProtocolVersion::V1_0_0).into();
         let contract_key = Key::Hash(hash);
 
         let (gs, root_hash) = InMemoryGlobalState::from_pairs(
@@ -464,7 +464,7 @@ proptest! {
         // create contract which knows about value
         let mut contract_named_keys = BTreeMap::new();
         contract_named_keys.insert(state_name.clone(), k);
-        let contract: Value = Contract::new(body, contract_named_keys, ProtocolVersion::new(1)).into();
+        let contract: Value = Contract::new(body, contract_named_keys, ProtocolVersion::V1_0_0).into();
         let contract_key = Key::Hash(hash);
 
         // create account which knows about contract

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -50,7 +50,7 @@ const TAG_RESPONSE_VALIDATE: &str = "validate_response";
 const TAG_RESPONSE_GENESIS: &str = "genesis_response";
 const TAG_RESPONSE_UPGRADE: &str = "upgrade_response";
 
-const DEFAULT_PROTOCOL_VERSION: u64 = 1;
+const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
 
 // Idea is that Engine will represent the core of the execution engine project.
 // It will act as an entry point for execution of Wasm binaries.
@@ -224,10 +224,11 @@ where
 
         // TODO
         let protocol_version = {
-            if commit_request.get_protocol_version().value < DEFAULT_PROTOCOL_VERSION {
-                ProtocolVersion::new(DEFAULT_PROTOCOL_VERSION)
+            let protocol_version = commit_request.get_protocol_version().into();
+            if protocol_version < DEFAULT_PROTOCOL_VERSION {
+                DEFAULT_PROTOCOL_VERSION
             } else {
-                ProtocolVersion::new(commit_request.get_protocol_version().value)
+                protocol_version
             }
         };
 

--- a/execution-engine/engine-shared/src/lib.rs
+++ b/execution-engine/engine-shared/src/lib.rs
@@ -17,7 +17,6 @@ pub mod logging;
 pub mod motes;
 pub mod newtypes;
 pub mod os;
-pub mod semver;
 pub mod socket;
 pub mod test_utils;
 pub mod transform;

--- a/execution-engine/engine-shared/src/logging/log_message.rs
+++ b/execution-engine/engine-shared/src/logging/log_message.rs
@@ -4,11 +4,11 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, SecondsFormat, Utc};
-use serde::Serialize;
+use contract_ffi::value::SemVer;
+use serde::{Serialize, Serializer};
 
 use crate::logging::log_level::{LogLevel, LogPriority};
 use crate::logging::log_settings::{HostName, LogSettingsProvider, ProcessId, ProcessName};
-use crate::semver::SemVer;
 
 const MESSAGE_TYPE: &str = "ee-structured";
 
@@ -22,7 +22,7 @@ pub struct LogMessage {
     pub log_level: LogLevel,
     pub priority: LogPriority,
     pub message_type: MessageType,
-    pub message_type_version: SemVer,
+    pub message_type_version: MessageTypeVersion,
     pub message_id: MessageId,
     pub description: String,
     pub properties: MessageProperties,
@@ -43,7 +43,7 @@ impl LogMessage {
             .entry(MESSAGE_TEMPLATE_KEY.to_string())
             .or_insert_with(|| message_template.clone());
         let message_type = MessageType::new(MESSAGE_TYPE.to_string());
-        let message_type_version = SemVer::V1_0_0;
+        let message_type_version: MessageTypeVersion = Default::default();
         let process_id = log_settings_provider.get_process_id();
         let process_name = log_settings_provider.get_process_name();
         let host_name = log_settings_provider.get_host_name();
@@ -114,6 +114,43 @@ impl fmt::Display for LogMessage {
             level = self.log_level,
             description = self.description
         )
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct MessageTypeVersion(SemVer);
+
+impl MessageTypeVersion {
+    pub fn new(major: u32, minor: u32, patch: u32) -> MessageTypeVersion {
+        MessageTypeVersion(SemVer::new(major, minor, patch))
+    }
+}
+
+impl fmt::Display for MessageTypeVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Hash for MessageTypeVersion {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
+
+impl Default for MessageTypeVersion {
+    fn default() -> Self {
+        MessageTypeVersion(SemVer::V1_0_0)
+    }
+}
+
+impl Serialize for MessageTypeVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}.{}.{}", self.0.major, self.0.minor, self.0.patch);
+        serializer.serialize_str(&s)
     }
 }
 

--- a/execution-engine/engine-storage/src/protocol_data_store/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/tests/proptests.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeMap;
 use std::ops::RangeInclusive;
 
+use contract_ffi::gens as gens_ext;
 use contract_ffi::value::ProtocolVersion;
 use lmdb::DatabaseFlags;
 use proptest::collection;
-use proptest::num;
 use proptest::prelude::proptest;
-use proptest::strategy::Strategy;
 use tempfile;
 
 use crate::protocol_data::{gens, ProtocolData};
@@ -50,14 +49,14 @@ fn lmdb_roundtrip_succeeds(inputs: BTreeMap<ProtocolVersion, ProtocolData>) -> b
 proptest! {
     #[test]
     fn prop_in_memory_roundtrip_succeeds(
-        m in collection::btree_map(num::u64::ANY.prop_map(ProtocolVersion::new), gens::protocol_data_arb(), get_range())
+        m in collection::btree_map(gens_ext::protocol_version_arb(), gens::protocol_data_arb(), get_range())
     ) {
         assert!(in_memory_roundtrip_succeeds(m))
     }
 
     #[test]
     fn prop_lmdb_roundtrip_succeeds(
-        m in collection::btree_map(num::u64::ANY.prop_map(ProtocolVersion::new), gens::protocol_data_arb(), get_range())
+        m in collection::btree_map(gens_ext::protocol_version_arb(), gens::protocol_data_arb(), get_range())
     ) {
         assert!(lmdb_roundtrip_succeeds(m))
     }

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -24,7 +24,6 @@ use std::rc::Rc;
 use crate::test::DEFAULT_WASM_COSTS;
 
 const INIT_FN_STORE_ID: u32 = 0;
-const INIT_PROTOCOL_VERSION: u64 = 1;
 
 /// This function allows executing the contract stored in the given `wasm_file`, while capturing the
 /// output. It is essentially the same functionality as `Executor::exec`, but the return value of
@@ -66,7 +65,7 @@ where
     let gas_counter = Gas::default();
     let fn_store_id = INIT_FN_STORE_ID;
     let gas_limit = Gas::from_u64(std::u64::MAX);
-    let protocol_version = ProtocolVersion::new(INIT_PROTOCOL_VERSION);
+    let protocol_version = ProtocolVersion::V1_0_0;
     let correlation_id = CorrelationId::new();
     let arguments: Vec<Vec<u8>> = args.parse().expect("should be able to serialize args");
     let base_key = Key::Account(address);

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -15,7 +15,7 @@ use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
 use contract_ffi::value::account::{Account, PublicKey, PurseId};
 use contract_ffi::value::contract::Contract;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::value::{SemVer, Value, U512};
 use engine_core::engine_state::genesis::{GenesisAccount, GenesisConfig};
 use engine_core::engine_state::{EngineConfig, EngineState, SYSTEM_ACCOUNT_ADDR};
 use engine_core::execution::{self, MINT_NAME, POS_NAME};
@@ -29,7 +29,7 @@ use engine_grpc_server::engine_server::ipc::{
 use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use engine_grpc_server::engine_server::mappings::{CommitTransforms, MappingError};
 use engine_grpc_server::engine_server::state::ProtocolVersion;
-use engine_grpc_server::engine_server::transforms;
+use engine_grpc_server::engine_server::{state, transforms};
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::Blake2bHash;
 use engine_shared::os::get_page_size;
@@ -249,10 +249,15 @@ impl ExecuteRequestBuilder {
         self
     }
 
-    pub fn with_protocol_version(mut self, version: u64) -> Self {
-        let mut protocol_version = ProtocolVersion::new();
-        protocol_version.set_value(version);
-        self.execute_request.set_protocol_version(protocol_version);
+    pub fn with_protocol_version(
+        mut self,
+        protocol_version: contract_ffi::value::ProtocolVersion,
+    ) -> Self {
+        let mut protocol = state::ProtocolVersion::new();
+        protocol.set_major(protocol_version.value().major);
+        protocol.set_minor(protocol_version.value().minor);
+        protocol.set_patch(protocol_version.value().patch);
+        self.execute_request.set_protocol_version(protocol);
         self
     }
 
@@ -286,14 +291,21 @@ impl Default for ExecuteRequestBuilder {
         let deploy_items = vec![];
         let mut execute_request = ExecuteRequest::new();
         execute_request.set_block_time(DEFAULT_BLOCK_TIME);
-        let mut protocol_version = ProtocolVersion::new();
-        protocol_version.set_value(1);
-        execute_request.set_protocol_version(protocol_version);
+        execute_request.set_protocol_version(get_protocol_version());
         ExecuteRequestBuilder {
             deploy_items,
             execute_request,
         }
     }
+}
+
+pub fn get_protocol_version() -> ProtocolVersion {
+    let mut protocol_version: ProtocolVersion = ProtocolVersion::new();
+    let sem_ver = SemVer::V1_0_0;
+    protocol_version.set_major(sem_ver.major);
+    protocol_version.set_minor(sem_ver.minor);
+    protocol_version.set_patch(sem_ver.patch);
+    protocol_version
 }
 
 pub struct UpgradeRequestBuilder {
@@ -315,20 +327,30 @@ impl UpgradeRequestBuilder {
         self
     }
 
-    pub fn with_current_protocol_version(mut self, protocol_version: u64) -> Self {
+    pub fn with_current_protocol_version(
+        mut self,
+        protocol_version: contract_ffi::value::ProtocolVersion,
+    ) -> Self {
         self.current_protocol_version = {
-            let mut ret = ProtocolVersion::new();
-            ret.set_value(protocol_version);
-            ret
+            let mut protocol = ProtocolVersion::new();
+            protocol.set_major(protocol_version.value().major);
+            protocol.set_minor(protocol_version.value().minor);
+            protocol.set_patch(protocol_version.value().patch);
+            protocol
         };
         self
     }
 
-    pub fn with_new_protocol_version(mut self, protocol_version: u64) -> Self {
+    pub fn with_new_protocol_version(
+        mut self,
+        protocol_version: contract_ffi::value::ProtocolVersion,
+    ) -> Self {
         self.new_protocol_version = {
-            let mut ret = ProtocolVersion::new();
-            ret.set_value(protocol_version);
-            ret
+            let mut protocol = ProtocolVersion::new();
+            protocol.set_major(protocol_version.value().major);
+            protocol.set_minor(protocol_version.value().minor);
+            protocol.set_patch(protocol_version.value().patch);
+            protocol
         };
         self
     }

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -637,7 +637,7 @@ fn should_produce_same_transforms_by_uref_or_named_uref() {
 #[test]
 fn should_have_equivalent_transforms_with_stored_contract_pointers() {
     let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
-    let payment_purse_amount = 1_000_000_000;
+    let payment_purse_amount = 100_000_000;
     let transferred_amount = 1;
 
     let stored_transforms = {

--- a/execution-engine/engine-tests/src/test/mod.rs
+++ b/execution-engine/engine-tests/src/test/mod.rs
@@ -45,7 +45,7 @@ lazy_static! {
         ret.push(genesis_account);
         ret
     };
-    pub static ref DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::new(1);
+    pub static ref DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
     pub static ref DEFAULT_PAYMENT: U512 = 100_000_000.into();
     pub static ref DEFAULT_WASM_COSTS: WasmCosts = test_utils::wasm_costs_mock();
     pub static ref DEFAULT_GENESIS_CONFIG: GenesisConfig = {

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -15,7 +15,6 @@ const BAD_INSTALL: &str = "standard_payment.wasm";
 
 const CHAIN_NAME: &str = "Jeremiah";
 const TIMESTAMP: u64 = 0;
-const PROTOCOL_VERSION: u64 = 1;
 const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
 const ACCOUNT_2_ADDR: [u8; 32] = [2u8; 32];
 const ACCOUNT_1_BONDED_AMOUNT: u64 = 1_000_000;
@@ -52,7 +51,7 @@ fn should_run_genesis_with_chainspec() {
     let mint_installer_bytes = test_support::read_wasm_file_bytes(MINT_INSTALL);
     let pos_installer_bytes = test_support::read_wasm_file_bytes(POS_INSTALL);
     let accounts = vec![account_1, account_2];
-    let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
+    let protocol_version = ProtocolVersion::V1_0_0;
     let wasm_costs = *DEFAULT_WASM_COSTS;
 
     let genesis_config = GenesisConfig::new(
@@ -134,7 +133,7 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
         let mint_installer_bytes = test_support::read_wasm_file_bytes(BAD_INSTALL);
         let pos_installer_bytes = test_support::read_wasm_file_bytes(POS_INSTALL);
         let accounts = vec![account_1, account_2];
-        let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
+        let protocol_version = ProtocolVersion::V1_0_0;
         let wasm_costs = *DEFAULT_WASM_COSTS;
 
         GenesisConfig::new(
@@ -182,7 +181,7 @@ fn should_fail_if_bad_pos_install_contract_is_provided() {
         let mint_installer_bytes = test_support::read_wasm_file_bytes(MINT_INSTALL);
         let pos_installer_bytes = test_support::read_wasm_file_bytes(BAD_INSTALL);
         let accounts = vec![account_1, account_2];
-        let protocol_version = ProtocolVersion::new(PROTOCOL_VERSION);
+        let protocol_version = ProtocolVersion::V1_0_0;
         let wasm_costs = *DEFAULT_WASM_COSTS;
 
         GenesisConfig::new(

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -10,8 +10,7 @@ use crate::support::test_support::{
 };
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_WASM_COSTS};
 
-const PROTOCOL_VERSION: u64 = 1;
-const NEW_PROTOCOL_VERSION: u64 = 2;
+const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
 const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;
 const MODIFIED_MINT_UPGRADER_CONTRACT_NAME: &str = "modified_mint_upgrader.wasm";
 const MODIFIED_MINT_CALLER_CONTRACT_NAME: &str = "modified_mint_caller.wasm";
@@ -39,10 +38,12 @@ fn should_upgrade_only_protocol_version() {
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
+    let new_protocol_version = ProtocolVersion::from_parts(2, 0, 0);
+
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(PROTOCOL_VERSION)
-            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .build()
     };
@@ -57,7 +58,7 @@ fn should_upgrade_only_protocol_version() {
 
     let upgraded_wasm_costs = builder
         .get_engine_state()
-        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .wasm_costs(new_protocol_version)
         .expect("should have result")
         .expect("should have costs");
 
@@ -72,6 +73,8 @@ fn should_upgrade_only_protocol_version() {
 fn should_upgrade_system_contract() {
     let mut builder = InMemoryWasmTestBuilder::default();
 
+    let new_protocol_version = ProtocolVersion::from_parts(2, 0, 0);
+
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
     let mut upgrade_request = {
@@ -80,7 +83,7 @@ fn should_upgrade_system_contract() {
         installer_code.set_code(bytes);
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(PROTOCOL_VERSION)
-            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_installer_code(installer_code)
             .build()
@@ -92,7 +95,10 @@ fn should_upgrade_system_contract() {
         .get_upgrade_response(0)
         .expect("should have response");
 
-    assert!(upgrade_response.has_success(), "expected success");
+    assert!(
+        upgrade_response.has_success(),
+        "upgrade_response expected success"
+    );
 
     let exec_request = {
         ExecuteRequestBuilder::standard(
@@ -100,7 +106,7 @@ fn should_upgrade_system_contract() {
             &MODIFIED_MINT_CALLER_CONTRACT_NAME,
             (U512::from(PAYMENT_AMOUNT),),
         )
-        .with_protocol_version(NEW_PROTOCOL_VERSION)
+        .with_protocol_version(new_protocol_version)
         .build()
     };
 
@@ -144,12 +150,14 @@ fn should_upgrade_wasm_costs() {
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
+    let new_protocol_version = ProtocolVersion::from_parts(2, 0, 0);
+
     let new_costs = get_upgraded_wasm_costs();
 
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(PROTOCOL_VERSION)
-            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_new_costs(new_costs)
             .build()
@@ -165,7 +173,7 @@ fn should_upgrade_wasm_costs() {
 
     let upgraded_wasm_costs = builder
         .get_engine_state()
-        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .wasm_costs(new_protocol_version)
         .expect("should have result")
         .expect("should have upgraded costs");
 
@@ -182,6 +190,8 @@ fn should_upgrade_system_contract_and_wasm_costs() {
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
+    let new_protocol_version = ProtocolVersion::from_parts(2, 0, 0);
+
     let new_costs = get_upgraded_wasm_costs();
 
     let mut upgrade_request = {
@@ -190,7 +200,7 @@ fn should_upgrade_system_contract_and_wasm_costs() {
         installer_code.set_code(bytes);
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(PROTOCOL_VERSION)
-            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .with_installer_code(installer_code)
             .with_new_costs(new_costs)
@@ -211,7 +221,7 @@ fn should_upgrade_system_contract_and_wasm_costs() {
             &MODIFIED_MINT_CALLER_CONTRACT_NAME,
             (U512::from(PAYMENT_AMOUNT),),
         )
-        .with_protocol_version(NEW_PROTOCOL_VERSION)
+        .with_protocol_version(new_protocol_version)
         .build()
     };
 
@@ -249,7 +259,7 @@ fn should_upgrade_system_contract_and_wasm_costs() {
 
     let upgraded_wasm_costs = builder
         .get_engine_state()
-        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .wasm_costs(new_protocol_version)
         .expect("should have result")
         .expect("should have upgraded costs");
 
@@ -266,10 +276,12 @@ fn should_not_downgrade() {
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
+    let new_protocol_version = ProtocolVersion::from_parts(2, 0, 0);
+
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()
             .with_current_protocol_version(PROTOCOL_VERSION)
-            .with_new_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_new_protocol_version(new_protocol_version)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .build()
     };
@@ -284,7 +296,7 @@ fn should_not_downgrade() {
 
     let upgraded_wasm_costs = builder
         .get_engine_state()
-        .wasm_costs(ProtocolVersion::new(NEW_PROTOCOL_VERSION))
+        .wasm_costs(new_protocol_version)
         .expect("should have result")
         .expect("should have costs");
 
@@ -295,7 +307,7 @@ fn should_not_downgrade() {
 
     let mut downgrade_request = {
         UpgradeRequestBuilder::new()
-            .with_current_protocol_version(NEW_PROTOCOL_VERSION)
+            .with_current_protocol_version(new_protocol_version)
             .with_new_protocol_version(PROTOCOL_VERSION)
             .with_activation_point(DEFAULT_ACTIVATION_POINT)
             .build()
@@ -317,8 +329,10 @@ fn should_not_skip_major_versions() {
 
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
-    // TODO: when protocol version switches to SemVer, this corresponds to major version
-    let invalid_version = PROTOCOL_VERSION + 2;
+    let sem_ver = PROTOCOL_VERSION.value();
+
+    let invalid_version =
+        ProtocolVersion::from_parts(sem_ver.major + 2, sem_ver.minor, sem_ver.patch);
 
     let mut upgrade_request = {
         UpgradeRequestBuilder::new()

--- a/node/src/main/resources/chainspec/genesis/manifest.toml
+++ b/node/src/main/resources/chainspec/genesis/manifest.toml
@@ -10,7 +10,7 @@ name = "casperlabs-devnet"
 timestamp = 0
 
 # Later will be replaced by semver.
-protocol-version = 1
+protocol-version = "1.0.0"
 
 # Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint_install.wasm"


### PR DESCRIPTION
This PR alters the ProtocolVersion concept in EE to use Semantic Versioning (SemVer) instead of a single number.

https://casperlabs.atlassian.net/browse/EE-676

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR adds a new test.
- [X] This PR is assigned.

NOTE: the semver-protocol-version branch is behind dev, and at least one feature (EE upgrades) that depends on ProtocolVersion based logic has merged to dev in the interim. Either as part of the merge to dev or as a followup PR some additional work must be done in the EE once the minor and patch versions are available.

Alternately, if the feature branch were rebased on dev, I could close this PR and open a new one taking into account the current state of EE in dev.