### PR TITLE
NODE-669 Test Replay Attack Protection

### DIFF
--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -2,7 +2,9 @@ from typing import Generator
 
 import docker as docker_py
 import pytest
+import shutil
 
+from casperlabs_local_net.common import make_tempdir, random_string
 from casperlabs_local_net.casperlabs_network import (
     CustomConnectionNetwork,
     OneNodeNetwork,
@@ -16,6 +18,13 @@ from casperlabs_local_net.casperlabs_network import (
     ReadOnlyNodeNetwork,
 )
 from docker.client import DockerClient
+
+
+@pytest.fixture(scope="function")
+def deleting_temp_dir():
+    directory = make_tempdir(random_string(6))
+    yield directory
+    shutil.rmtree(directory)
 
 
 @pytest.fixture(scope="session")

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -21,7 +21,7 @@ from docker.client import DockerClient
 
 
 @pytest.fixture(scope="function")
-def deleting_temp_dir():
+def temp_dir():
     directory = make_tempdir(random_string(6))
     yield directory
     shutil.rmtree(directory)

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -673,7 +673,7 @@ def test_cli_scala_help(scala_cli):
     assert 'Subcommand: make-deploy' in output
 
 
-def test_cli_scala_extended_deploy(scala_cli, deleting_temp_dir):
+def test_cli_scala_extended_deploy(scala_cli, temp_dir):
     cli = scala_cli
     account = GENESIS_ACCOUNT
 
@@ -681,8 +681,8 @@ def test_cli_scala_extended_deploy(scala_cli, deleting_temp_dir):
     # when trying to access the same file, perhaps map containers /tmp
     # to a unique hosts's directory.
 
-    unsigned_deploy_path = f'{deleting_temp_dir}/unsigned.deploy'
-    signed_deploy_path = f'{deleting_temp_dir}/signed.deploy'
+    unsigned_deploy_path = f'{temp_dir}/unsigned.deploy'
+    signed_deploy_path = f'{temp_dir}/signed.deploy'
 
     cli('make-deploy',
         '-o', unsigned_deploy_path,
@@ -703,8 +703,9 @@ def test_cli_scala_extended_deploy(scala_cli, deleting_temp_dir):
     assert not deploy_info.processing_results[0].is_error
 
     # Test that replay attacks fail
-    with pytest.raises(NonZeroExitCodeError):
+    with pytest.raises(NonZeroExitCodeError) as excinfo:
         _ = cli('send-deploy', '-i', signed_deploy_path)
+    assert "supersedes Deploy" in excinfo.value.output
 
 
 def test_cli_scala_direct_call_by_hash_and_name(scala_cli):

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1,4 +1,3 @@
-import os
 import logging
 import pytest
 import json
@@ -674,7 +673,7 @@ def test_cli_scala_help(scala_cli):
     assert 'Subcommand: make-deploy' in output
 
 
-def test_cli_scala_extended_deploy(scala_cli):
+def test_cli_scala_extended_deploy(scala_cli, deleting_temp_dir):
     cli = scala_cli
     account = GENESIS_ACCOUNT
 
@@ -682,30 +681,30 @@ def test_cli_scala_extended_deploy(scala_cli):
     # when trying to access the same file, perhaps map containers /tmp
     # to a unique hosts's directory.
 
+    unsigned_deploy_path = f'{deleting_temp_dir}/unsigned.deploy'
+    signed_deploy_path = f'{deleting_temp_dir}/signed.deploy'
+
     cli('make-deploy',
-        '-o', '/tmp/unsigned.deploy',
+        '-o', unsigned_deploy_path,
         '--from', account.public_key_hex,
         '--session', cli.resource(Contract.HELLONAME),
         '--payment', cli.resource(Contract.STANDARD_PAYMENT),
         "--payment-args", cli.payment_json)
 
     cli('sign-deploy',
-        '-i', '/tmp/unsigned.deploy',
-        '-o', '/tmp/signed.deploy',
+        '-i', unsigned_deploy_path,
+        '-o', signed_deploy_path,
         '--private-key', account.private_key_docker_path,
         '--public-key', account.public_key_docker_path)
 
-    deploy_hash = cli('send-deploy', '-i', '/tmp/signed.deploy')
+    deploy_hash = cli('send-deploy', '-i', signed_deploy_path)
     cli('propose')
     deploy_info = cli("show-deploy", deploy_hash)
     assert not deploy_info.processing_results[0].is_error
 
-    # TODO: This never gets cleaned up if assert fails.
-    try:
-        os.remove('/tmp/unsigned.deploy')
-        os.remove('/tmp/signed.deploy')
-    except Exception as e:
-        logging.warning(f"Could not delete temporary files: {str(e)}")
+    # Test that replay attacks fail
+    with pytest.raises(NonZeroExitCodeError):
+        _ = cli('send-deploy', '-i', signed_deploy_path)
 
 
 def test_cli_scala_direct_call_by_hash_and_name(scala_cli):


### PR DESCRIPTION
Corrected the file cleanup with extended deploy.
Added deleting_temp_dir fixture that will stand up a directory in /tmp, yield and then clean up.
Added a second deploy to test replay attack protection

https://casperlabs.atlassian.net/browse/NODE-669

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
