### PR TITLE
CON-478: Rename auto-propose options.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -27,8 +27,8 @@ final case class CasperConf(
     standalone: Boolean,
     autoProposeEnabled: Boolean,
     autoProposeCheckInterval: FiniteDuration,
-    autoProposeMaxInterval: FiniteDuration,
-    autoProposeMaxCount: Int,
+    autoProposeAccInterval: FiniteDuration,
+    autoProposeAccCount: Int,
     maxBlockSizeBytes: Int
 ) extends SubConfig
 

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -34,9 +34,9 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
 
   val waitForCheck = Timer[Task].sleep(10 * DefaultCheckInterval)
 
-  it should "propose if more than max-count deploys are accumulated within max-interval" in TestFixture(
-    maxInterval = 5.seconds,
-    maxCount = 2
+  it should "propose if more than acc-count deploys are accumulated within acc-interval" in TestFixture(
+    accInterval = 5.seconds,
+    accCount = 2
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -49,9 +49,9 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
     } yield ()
   }
 
-  it should "propose if less than max-count deploys are accumulated after max-interval" in TestFixture(
-    maxInterval = 250.millis,
-    maxCount = 10
+  it should "propose if less than acc-count deploys are accumulated after acc-interval" in TestFixture(
+    accInterval = 250.millis,
+    accCount = 10
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -64,8 +64,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   }
 
   it should "not propose if none of the thresholds are reached" in TestFixture(
-    maxInterval = 1.second,
-    maxCount = 2
+    accInterval = 1.second,
+    accCount = 2
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -76,8 +76,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   }
 
   it should "not propose if there are no new deploys" in TestFixture(
-    maxInterval = 1.second,
-    maxCount = 1
+    accInterval = 1.second,
+    accCount = 1
   ) { _ => implicit casperRef => implicit deployStorage =>
     for {
       casper <- MockMultiParentCasper[Task]
@@ -96,8 +96,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   }
 
   it should "not stop if the proposal fails" in TestFixture(
-    maxInterval = 1.second,
-    maxCount = 1
+    accInterval = 1.second,
+    accCount = 1
   ) { _ => implicit casperRef => implicit deployStorage =>
     val defectiveCasper = new MockMultiParentCasper[Task]() {
       override def createBlock: Task[CreateBlockStatus] =
@@ -134,8 +134,8 @@ object AutoProposerTest {
   object TestFixture {
     def apply(
         checkInterval: FiniteDuration = DefaultCheckInterval,
-        maxInterval: FiniteDuration,
-        maxCount: Int
+        accInterval: FiniteDuration,
+        accCount: Int
     )(
         f: AutoProposer[Task] => MultiParentCasperRef[Task] => DeployStorage[Task] => Task[Unit]
     ): Unit = {
@@ -147,8 +147,8 @@ object AutoProposerTest {
         blockApiLock                                    <- Resource.liftF(Semaphore[Task](1))
         proposer <- AutoProposer[Task](
                      checkInterval = checkInterval,
-                     maxInterval = maxInterval,
-                     maxCount = maxCount,
+                     accInterval = accInterval,
+                     accCount = accCount,
                      blockApiLock = blockApiLock
                    )
       } yield (proposer, emptyRef, deployStorage)

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -199,10 +199,10 @@ auto-propose-enabled = false
 auto-propose-check-interval = "1second"
 
 # Time to accumulate deploys before proposing.
-auto-propose-max-interval = "5seconds"
+auto-propose-acc-interval = "5seconds"
 
 # Number of deploys to accumulate before proposing.
-auto-propose-max-count = 10
+auto-propose-acc-count = 10
 
 # Maximum block size in bytes
 max-block-size-bytes = 10485760

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -220,8 +220,8 @@ class NodeRuntime private[node] (
         // so that the operator can turn it on/off on the fly.
         _ <- AutoProposer[Task](
               checkInterval = conf.casper.autoProposeCheckInterval,
-              maxInterval = conf.casper.autoProposeMaxInterval,
-              maxCount = conf.casper.autoProposeMaxCount,
+              accInterval = conf.casper.autoProposeAccInterval,
+              accCount = conf.casper.autoProposeAccCount,
               blockApiLock = blockApiLock
             ).whenA(conf.casper.autoProposeEnabled)
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -266,11 +266,11 @@ private[configuration] final case class Options private (
       gen[FiniteDuration]("Time between proposal checks.")
 
     @scallop
-    val casperAutoProposeMaxInterval =
+    val casperAutoProposeAccInterval =
       gen[FiniteDuration]("Time to accumulate deploys before proposing.")
 
     @scallop
-    val casperAutoProposeMaxCount =
+    val casperAutoProposeAccCount =
       gen[Int]("Number of deploys to accumulate before proposing.")
 
     @scallop

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -66,8 +66,8 @@ chain-spec-path = "/tmp/test"
 standalone = false
 auto-propose-enabled = false
 auto-propose-check-interval = "1second"
-auto-propose-max-interval = "1second"
-auto-propose-max-count = 1
+auto-propose-acc-interval = "1second"
+auto-propose-acc-count = 1
 max-block-size-bytes = 1
 
 [blockstorage]

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -108,8 +108,8 @@ class ConfigurationSpec
       standalone = false,
       autoProposeEnabled = false,
       autoProposeCheckInterval = FiniteDuration(1, TimeUnit.SECONDS),
-      autoProposeMaxInterval = FiniteDuration(1, TimeUnit.SECONDS),
-      autoProposeMaxCount = 1,
+      autoProposeAccInterval = FiniteDuration(1, TimeUnit.SECONDS),
+      autoProposeAccCount = 1,
       maxBlockSizeBytes = 1
     )
     val tls = Tls(


### PR DESCRIPTION
### Overview
Renames the options `--server-auto-propose-max-interval` and `--server-auto-propose-max-count` to `-acc-interval` and `-acc-count` because I found it unintuitive in the presence of the `-ballot-interval` in https://github.com/CasperLabs/CasperLabs/pull/1197

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-478

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.

### Notes
Creating this against `dev` so people don't get caught out when eventually the names change, when we merge `new-consensus`.
