### PR TITLE
EE-649: ipc costs as BigInt / U512 integration

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -699,7 +699,7 @@ where
         if !(self.config.use_payment_code()) {
             // DEPLOY WITH NO PAYMENT
 
-            let session_motes = Motes::from_u64(DEFAULT_SESSION_MOTES);
+            let session_motes = Motes::new(U512::from(DEFAULT_SESSION_MOTES));
 
             let gas_limit = Gas::from_motes(session_motes, CONV_RATE).unwrap_or_default();
 
@@ -724,7 +724,7 @@ where
 
         // --- REMOVE ABOVE --- //
 
-        let max_payment_cost: Motes = Motes::from_u64(MAX_PAYMENT);
+        let max_payment_cost: Motes = Motes::new(U512::from(MAX_PAYMENT));
 
         // Get mint system contract details
         // payment_code_spec_6: system contract validity
@@ -1021,7 +1021,7 @@ where
                 .clone();
 
             let base_key = proof_of_stake_info.key();
-            let gas_limit = Gas::from_u64(std::u64::MAX);
+            let gas_limit = Gas::new(U512::from(std::u64::MAX));
 
             executor.exec_direct(
                 proof_of_stake_module,

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -9,6 +9,7 @@ use contract_ffi::execution::Phase;
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
 use contract_ffi::value::account::{BlockTime, PublicKey};
+use contract_ffi::value::U512;
 use contract_ffi::value::{Account, ProtocolVersion, Value};
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
@@ -166,7 +167,7 @@ impl Executor<Module> for WasmiExecutor {
             // https://casperlabs.atlassian.net/browse/EE-239
             on_fail_charge!(
                 bytesrepr::deserialize(args),
-                Gas::from_u64(args.len() as u64),
+                Gas::new(U512::from(args.len() as u64)),
                 effects_snapshot
             )
         };
@@ -241,7 +242,7 @@ impl Executor<Module> for WasmiExecutor {
         } else {
             on_fail_charge!(
                 bytesrepr::deserialize(args),
-                Gas::from_u64(args.len() as u64),
+                Gas::new(U512::from(args.len() as u64)),
                 effects_snapshot
             )
         };

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -9,16 +9,14 @@ use contract_ffi::execution::Phase;
 use contract_ffi::key::Key;
 use contract_ffi::uref::AccessRights;
 use contract_ffi::value::account::{BlockTime, PublicKey};
-use contract_ffi::value::U512;
 use contract_ffi::value::{Account, ProtocolVersion, Value};
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
 use engine_storage::global_state::StateReader;
 
-use crate::engine_state::execution_result::ExecutionResult;
-
 use super::Error;
 use super::{extract_access_rights_from_keys, instance_and_memory, Runtime};
+use crate::engine_state::execution_result::ExecutionResult;
 use crate::execution::address_generator::AddressGenerator;
 use crate::execution::FN_STORE_ID_INITIAL;
 use crate::runtime_context::RuntimeContext;
@@ -167,7 +165,7 @@ impl Executor<Module> for WasmiExecutor {
             // https://casperlabs.atlassian.net/browse/EE-239
             on_fail_charge!(
                 bytesrepr::deserialize(args),
-                Gas::new(U512::from(args.len() as u64)),
+                Gas::new(args.len().into()),
                 effects_snapshot
             )
         };
@@ -242,7 +240,7 @@ impl Executor<Module> for WasmiExecutor {
         } else {
             on_fail_charge!(
                 bytesrepr::deserialize(args),
-                Gas::new(U512::from(args.len() as u64)),
+                Gas::new(args.len().into()),
                 effects_snapshot
             )
         };

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -224,8 +224,8 @@ where
             }
 
             FunctionIndex::GasFuncIndex => {
-                let gas: u32 = Args::parse(args)?;
-                self.gas(Gas::from_u64(gas.into()))?;
+                let gas_arg: u32 = Args::parse(args)?;
+                self.gas(Gas::new(U512::from(u64::from(gas_arg))))?;
                 Ok(None)
             }
 

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -225,7 +225,7 @@ where
 
             FunctionIndex::GasFuncIndex => {
                 let gas_arg: u32 = Args::parse(args)?;
-                self.gas(Gas::new(U512::from(u64::from(gas_arg))))?;
+                self.gas(Gas::new(gas_arg.into()))?;
                 Ok(None)
             }
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -728,7 +728,7 @@ impl From<ExecutionResult> for ipc::DeployResult {
                 let mut execution_result = ipc::DeployResult_ExecutionResult::new();
                 execution_result.set_effects(ipc_ee);
                 // TODO: executionresult cost should be BIGINT; see https://casperlabs.atlassian.net/browse/EE-649
-                execution_result.set_cost(cost.as_u64());
+                execution_result.set_cost(cost.value().into());
                 deploy_result.set_execution_result(execution_result);
                 deploy_result
             }
@@ -743,7 +743,7 @@ impl From<ExecutionResult> for ipc::DeployResult {
                     // so for the time being they are all reported as "wasm errors".
                     error @ EngineError::InvalidProtocolVersion => {
                         let msg = error.to_string();
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     error @ EngineError::InvalidHashLength { .. } => {
                         precondition_failure(error.to_string())
@@ -761,33 +761,33 @@ impl From<ExecutionResult> for ipc::DeployResult {
                         ExecutionError::DeploymentAuthorizationFailure,
                     ) => precondition_failure(error.to_string()),
                     EngineError::StorageError(storage_err) => {
-                        execution_error(storage_err.to_string(), cost.as_u64(), effect)
+                        execution_error(storage_err.to_string(), cost.value(), effect)
                     }
                     error @ EngineError::AuthorizationError => {
                         precondition_failure(error.to_string())
                     }
                     EngineError::MissingSystemContractError(msg) => {
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     error @ EngineError::InsufficientPaymentError => {
                         let msg = error.to_string();
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     error @ EngineError::DeployError => {
                         let msg = error.to_string();
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     error @ EngineError::FinalizationError => {
                         let msg = error.to_string();
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     error @ EngineError::SerializationError(_) => {
                         let msg = error.to_string();
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     error @ EngineError::MintError(_) => {
                         let msg = error.to_string();
-                        execution_error(msg, cost.as_u64(), effect)
+                        execution_error(msg, cost.value(), effect)
                     }
                     EngineError::ExecError(exec_error) => match exec_error {
                         ExecutionError::GasLimit => {
@@ -800,7 +800,7 @@ impl From<ExecutionResult> for ipc::DeployResult {
                             let exec_result = {
                                 let mut tmp = ipc::DeployResult_ExecutionResult::new();
                                 tmp.set_error(deploy_error);
-                                tmp.set_cost(cost.as_u64());
+                                tmp.set_cost(cost.value().into());
                                 tmp.set_effects(effect.into());
                                 tmp
                             };
@@ -810,11 +810,11 @@ impl From<ExecutionResult> for ipc::DeployResult {
                         }
                         ExecutionError::KeyNotFound(key) => {
                             let msg = format!("Key {:?} not found.", key);
-                            execution_error(msg, cost.as_u64(), effect)
+                            execution_error(msg, cost.value(), effect)
                         }
                         ExecutionError::Revert(status) => {
                             let error_msg = format!("Exit code: {}", status);
-                            execution_error(error_msg, cost.as_u64(), effect)
+                            execution_error(error_msg, cost.value(), effect)
                         }
                         ExecutionError::Interpreter(error) => {
                             // If the error happens during contract execution it's mapped to
@@ -832,15 +832,15 @@ impl From<ExecutionResult> for ipc::DeployResult {
                                     match downcasted_error {
                                         ExecutionError::Revert(status) => {
                                             let errors_msg = format!("Exit code: {}", status);
-                                            execution_error(errors_msg, cost.as_u64(), effect)
+                                            execution_error(errors_msg, cost.value(), effect)
                                         }
                                         ExecutionError::KeyNotFound(key) => {
                                             let errors_msg = format!("Key {:?} not found.", key);
-                                            execution_error(errors_msg, cost.as_u64(), effect)
+                                            execution_error(errors_msg, cost.value(), effect)
                                         }
                                         other => execution_error(
                                             format!("{:?}", other),
-                                            cost.as_u64(),
+                                            cost.value(),
                                             effect,
                                         ),
                                     }
@@ -848,14 +848,14 @@ impl From<ExecutionResult> for ipc::DeployResult {
 
                                 None => {
                                     let msg = format!("{:?}", error);
-                                    execution_error(msg, cost.as_u64(), effect)
+                                    execution_error(msg, cost.value(), effect)
                                 }
                             }
                         }
                         // TODO(mateusz.gorski): Be more specific about execution errors
                         other => {
                             let msg = format!("{:?}", other);
-                            execution_error(msg, cost.as_u64(), effect)
+                            execution_error(msg, cost.value(), effect)
                         }
                     },
                 }
@@ -1061,7 +1061,7 @@ fn precondition_failure(msg: String) -> ipc::DeployResult {
 
 /// Constructs an instance of [[ipc::DeployResult]] with error set to
 /// [[ipc::DeployError_ExecutionError]].
-fn execution_error(msg: String, cost: u64, effect: ExecutionEffect) -> ipc::DeployResult {
+fn execution_error(msg: String, cost: U512, effect: ExecutionEffect) -> ipc::DeployResult {
     let mut deploy_result = ipc::DeployResult::new();
     let deploy_error = {
         let mut tmp = ipc::DeployError::new();
@@ -1073,7 +1073,7 @@ fn execution_error(msg: String, cost: u64, effect: ExecutionEffect) -> ipc::Depl
     let execution_result = {
         let mut tmp = ipc::DeployResult_ExecutionResult::new();
         tmp.set_error(deploy_error);
-        tmp.set_cost(cost);
+        tmp.set_cost(cost.into());
         tmp.set_effects(effect.into());
         tmp
     };
@@ -1134,13 +1134,14 @@ mod tests {
     use super::ipc;
     use super::state;
     use super::transforms;
+    use contract_ffi::value::U512;
 
     // Test that wasm_error function actually returns DeployResult with result set
     // to WasmError
     #[test]
     fn wasm_error_result() {
         let error_msg = "ExecError";
-        let mut result = execution_error(error_msg.to_owned(), 0, Default::default());
+        let mut result = execution_error(error_msg.to_owned(), U512::zero(), Default::default());
         assert!(result.has_execution_result());
         let mut exec_result = result.take_execution_result();
         assert!(exec_result.has_error());
@@ -1179,7 +1180,8 @@ mod tests {
         let mut ipc_deploy_result: ipc::DeployResult = execution_result.into();
         assert!(ipc_deploy_result.has_execution_result());
         let mut success = ipc_deploy_result.take_execution_result();
-        assert_eq!(success.get_cost(), cost.as_u64());
+        let execution_cost: U512 = success.get_cost().try_into().expect("should map to U512");
+        assert_eq!(execution_cost, cost.value());
 
         // Extract transform map from the IPC message and parse it back to the domain
         let ipc_transforms: HashMap<Key, Transform> = {
@@ -1207,7 +1209,8 @@ mod tests {
         let ipc_deploy_result: ipc::DeployResult = execution_failure.into();
         assert!(ipc_deploy_result.has_execution_result());
         let success = ipc_deploy_result.get_execution_result();
-        Gas::from_u64(success.get_cost())
+        let execution_cost: U512 = success.get_cost().try_into().expect("should map to U512");
+        Gas::new(execution_cost)
     }
 
     #[test]
@@ -1267,19 +1270,35 @@ mod tests {
 
     #[test]
     fn revert_error_maps_to_execution_error() {
-        let revert_error = Error::Revert(10);
+        const AMOUNT: u64 = 15;
+        const REVERT: u32 = 10;
+        let revert_error = Error::Revert(REVERT);
         let exec_result = ExecutionResult::Failure {
             error: ExecError(revert_error),
             effect: Default::default(),
-            cost: Gas::from_u64(10),
+            cost: Gas::from_u64(AMOUNT),
         };
         let ipc_result: ipc::DeployResult = exec_result.into();
-        assert!(ipc_result.has_execution_result());
+        assert!(
+            ipc_result.has_execution_result(),
+            "should have execution result"
+        );
         let ipc_execution_result = ipc_result.get_execution_result();
-        assert_eq!(ipc_execution_result.cost, 10);
+        let execution_cost: U512 = ipc_execution_result
+            .get_cost()
+            .try_into()
+            .expect("should map to U512");
         assert_eq!(
-            ipc_execution_result.get_error().get_exec_error().message,
-            "Exit code: 10"
+            execution_cost,
+            U512::from(AMOUNT),
+            "execution cost should equal amount"
+        );
+        assert_eq!(
+            ipc_execution_result
+                .get_error()
+                .get_exec_error()
+                .get_message(),
+            format!("Exit code: {}", REVERT)
         );
     }
 

--- a/execution-engine/engine-shared/src/gas.rs
+++ b/execution-engine/engine-shared/src/gas.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
-use contract_ffi::value::U512;
 use num::Zero;
+
+use contract_ffi::value::U512;
 
 use crate::motes::Motes;
 
@@ -26,16 +27,6 @@ impl Gas {
 
     pub fn checked_add(&self, rhs: Self) -> Option<Self> {
         self.0.checked_add(rhs.value()).map(Self::new)
-    }
-
-    // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
-    pub fn as_u64(&self) -> u64 {
-        self.0.as_u64()
-    }
-
-    // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
-    pub fn from_u64(value: u64) -> Self {
-        Gas(U512::from(value))
     }
 }
 
@@ -101,17 +92,6 @@ mod tests {
     fn should_be_able_to_get_instance_of_gas() {
         let initial_value = 1;
         let gas = Gas::new(U512::from(initial_value));
-        assert_eq!(
-            initial_value,
-            gas.value().as_u64(),
-            "should have equal value"
-        )
-    }
-
-    #[test]
-    fn should_be_able_to_get_instance_from_u64() {
-        let initial_value = 1;
-        let gas = Gas::from_u64(initial_value);
         assert_eq!(
             initial_value,
             gas.value().as_u64(),

--- a/execution-engine/engine-shared/src/motes.rs
+++ b/execution-engine/engine-shared/src/motes.rs
@@ -1,7 +1,8 @@
 use std::fmt;
 
-use contract_ffi::value::U512;
 use num::Zero;
+
+use contract_ffi::value::U512;
 
 use crate::gas::Gas;
 
@@ -25,11 +26,6 @@ impl Motes {
         gas.value()
             .checked_mul(U512::from(conv_rate))
             .map(Self::new)
-    }
-
-    // TODO: remove when possible; see https://casperlabs.atlassian.net/browse/EE-649
-    pub fn from_u64(value: u64) -> Motes {
-        Motes(U512::from(value))
     }
 }
 
@@ -95,17 +91,6 @@ mod tests {
     fn should_be_able_to_get_instance_of_motes() {
         let initial_value = 1;
         let motes = Motes::new(U512::from(initial_value));
-        assert_eq!(
-            initial_value,
-            motes.value().as_u64(),
-            "should have equal value"
-        )
-    }
-
-    #[test]
-    fn should_be_able_to_get_instance_from_u64() {
-        let initial_value = 1;
-        let motes = Motes::from_u64(initial_value);
         assert_eq!(
             initial_value,
             motes.value().as_u64(),

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -1,10 +1,14 @@
-use crate::support::test_support::{self, WasmTestBuilder};
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::convert::TryInto;
+use std::rc::Rc;
+
 use contract_ffi::bytesrepr::{self, FromBytes};
 use contract_ffi::execution::Phase;
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;
 use contract_ffi::value::account::BlockTime;
-use contract_ffi::value::ProtocolVersion;
+use contract_ffi::value::{ProtocolVersion, U512};
 use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
 use engine_core::engine_state::execution_effect::ExecutionEffect;
 use engine_core::engine_state::EngineState;
@@ -17,10 +21,8 @@ use engine_shared::newtypes::CorrelationId;
 use engine_storage::global_state::StateProvider;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 use engine_wasm_prep::WasmiPreprocessor;
-use std::cell::RefCell;
-use std::collections::BTreeSet;
-use std::convert::TryInto;
-use std::rc::Rc;
+
+use crate::support::test_support::{self, WasmTestBuilder};
 
 const INIT_FN_STORE_ID: u32 = 0;
 const INIT_PROTOCOL_VERSION: u64 = 1;
@@ -64,7 +66,7 @@ where
     };
     let gas_counter = Gas::default();
     let fn_store_id = INIT_FN_STORE_ID;
-    let gas_limit = Gas::from_u64(std::u64::MAX);
+    let gas_limit = Gas::new(U512::from(std::u64::MAX));
     let protocol_version = ProtocolVersion::new(INIT_PROTOCOL_VERSION);
     let correlation_id = CorrelationId::new();
     let arguments: Vec<Vec<u8>> = args.parse().expect("should be able to serialize args");

--- a/execution-engine/engine-tests/src/support/test_stored_contract_support.rs
+++ b/execution-engine/engine-tests/src/support/test_stored_contract_support.rs
@@ -218,7 +218,6 @@ impl DeployBuilder {
 impl Default for DeployBuilder {
     fn default() -> Self {
         let mut deploy = DeployItem::new();
-        deploy.set_motes_transferred_in_payment(1_000_000_000);
         deploy.set_gas_price(1);
         DeployBuilder { deploy }
     }
@@ -292,7 +291,6 @@ pub fn get_protocol_version() -> ProtocolVersion {
 pub fn get_mock_deploy() -> DeployItem {
     let mut deploy = DeployItem::new();
     deploy.set_address(MOCKED_ACCOUNT_ADDRESS.to_vec());
-    deploy.set_motes_transferred_in_payment(1000);
     deploy.set_gas_price(1);
     deploy.set_deploy_hash(vec![1; 32]);
     let mut deploy_code = DeployCode::new();

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -376,7 +376,14 @@ pub fn get_exec_costs(exec_response: &ExecResponse) -> Vec<Gas> {
 
     deploy_results
         .iter()
-        .map(|deploy_result| Gas::from_u64(deploy_result.get_execution_result().get_cost()))
+        .map(|deploy_result| {
+            let execution_result = deploy_result.get_execution_result();
+            let cost = execution_result
+                .get_cost()
+                .try_into()
+                .expect("cost should map to U512");
+            Gas::new(cost)
+        })
         .collect()
 }
 

--- a/execution-engine/engine-tests/src/test/deploy/payment_code.rs
+++ b/execution-engine/engine-tests/src/test/deploy/payment_code.rs
@@ -1,20 +1,19 @@
 use std::collections::HashMap;
 use std::convert::TryInto;
 
-use crate::support::test_support::{
-    DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder, GENESIS_INITIAL_BALANCE,
-};
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, PurseId};
 use contract_ffi::value::{Value, U512};
 use engine_core::engine_state::genesis::POS_REWARDS_PURSE;
 use engine_core::engine_state::{EngineConfig, CONV_RATE, MAX_PAYMENT};
+use engine_shared::gas::Gas;
+use engine_shared::motes::Motes;
 use engine_shared::transform::Transform;
 
 use crate::contract_ffi::bytesrepr::ToBytes;
-use crate::support::test_support;
-use engine_shared::gas::Gas;
-use engine_shared::motes::Motes;
+use crate::support::test_support::{
+    self, DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder, GENESIS_INITIAL_BALANCE,
+};
 
 const GENESIS_ADDR: [u8; 32] = [12; 32];
 const ACCOUNT_1_ADDR: [u8; 32] = [42u8; 32];
@@ -75,8 +74,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
         .to_owned();
 
     let error_message = {
-        let execution_result =
-            crate::support::test_support::get_success_result(&account_1_response);
+        let execution_result = test_support::get_success_result(&account_1_response);
         test_support::get_error_message(execution_result)
     };
 
@@ -172,8 +170,8 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
         .expect("there should be a response")
         .clone();
 
-    let execution_result = crate::support::test_support::get_success_result(&response);
-    let error_message = crate::support::test_support::get_error_message(execution_result);
+    let execution_result = test_support::get_success_result(&response);
+    let error_message = test_support::get_error_message(execution_result);
 
     assert_eq!(
         error_message, "Insufficient payment",
@@ -264,8 +262,8 @@ fn should_raise_insufficient_payment_when_payment_code_fails() {
         .expect("there should be a response")
         .clone();
 
-    let execution_result = crate::support::test_support::get_success_result(&response);
-    let error_message = crate::support::test_support::get_error_message(execution_result);
+    let execution_result = test_support::get_success_result(&response);
+    let error_message = test_support::get_error_message(execution_result);
 
     assert_eq!(
         error_message, "Insufficient payment",
@@ -313,8 +311,8 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
         .expect("there should be a response")
         .clone();
 
-    let execution_result = crate::support::test_support::get_success_result(&response);
-    let error_message = crate::support::test_support::get_error_message(execution_result);
+    let execution_result = test_support::get_success_result(&response);
+    let error_message = test_support::get_error_message(execution_result);
 
     assert_eq!(error_message, "GasLimit", "expected gas limit");
 }
@@ -369,7 +367,7 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
         .expect("there should be a response")
         .clone();
 
-    let success_result = crate::support::test_support::get_success_result(&response);
+    let success_result = test_support::get_success_result(&response);
     let cost = success_result
         .get_cost()
         .try_into()
@@ -384,8 +382,8 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
         "no net resources should be gained or lost post-distribution"
     );
 
-    let execution_result = crate::support::test_support::get_success_result(&response);
-    let error_message = crate::support::test_support::get_error_message(execution_result);
+    let execution_result = test_support::get_success_result(&response);
+    let error_message = test_support::get_error_message(execution_result);
 
     assert_eq!(error_message, "GasLimit", "expected gas limit");
 }
@@ -445,7 +443,7 @@ fn should_correctly_charge_when_session_code_fails() {
         .expect("there should be a response")
         .clone();
 
-    let success_result = crate::support::test_support::get_success_result(&response);
+    let success_result = test_support::get_success_result(&response);
     let cost = success_result
         .get_cost()
         .try_into()
@@ -516,7 +514,7 @@ fn should_correctly_charge_when_session_code_succeeds() {
         .expect("there should be a response")
         .clone();
 
-    let success_result = crate::support::test_support::get_success_result(&response);
+    let success_result = test_support::get_success_result(&response);
     let cost = success_result
         .get_cost()
         .try_into()
@@ -803,7 +801,7 @@ fn should_charge_non_main_purse() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_support::get_success_result(&response);
+    let result = test_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -5,18 +5,17 @@ use contract_ffi::key::Key;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::{Value, U512};
 use engine_core::engine_state::{EngineConfig, CONV_RATE};
-use engine_shared::transform::Transform;
-
-use crate::support::test_stored_contract_support::{
-    DeployBuilder, Diff, ExecRequestBuilder, WasmTestBuilder, WasmTestResult,
-    GENESIS_INITIAL_BALANCE,
-};
 use engine_grpc_server::engine_server::ipc::ExecuteRequest;
-
-use crate::support::test_support;
 use engine_shared::gas::Gas;
 use engine_shared::motes::Motes;
+use engine_shared::transform::Transform;
 use std::convert::TryInto;
+
+use crate::support::test_stored_contract_support::{
+    self, DeployBuilder, Diff, ExecRequestBuilder, WasmTestBuilder, WasmTestResult,
+    GENESIS_INITIAL_BALANCE,
+};
+use crate::support::test_support;
 
 const GENESIS_ADDR: [u8; 32] = [12; 32];
 const ACCOUNT_1_ADDR: [u8; 32] = [42u8; 32];
@@ -87,8 +86,7 @@ fn should_exec_non_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let success_result =
-        crate::support::test_stored_contract_support::get_success_result(&response);
+    let success_result = test_stored_contract_support::get_success_result(&response);
     let cost = success_result
         .get_cost()
         .try_into()
@@ -164,7 +162,7 @@ fn should_exec_stored_code_by_hash() {
         "stored_payment_contract_hash should exist"
     );
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -210,7 +208,7 @@ fn should_exec_stored_code_by_hash() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -276,7 +274,7 @@ fn should_exec_stored_code_by_named_hash() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -323,7 +321,7 @@ fn should_exec_stored_code_by_named_hash() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -389,7 +387,7 @@ fn should_exec_stored_code_by_named_uref() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -433,7 +431,7 @@ fn should_exec_stored_code_by_named_uref() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -499,7 +497,7 @@ fn should_exec_payment_and_session_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -531,7 +529,7 @@ fn should_exec_payment_and_session_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -567,7 +565,7 @@ fn should_exec_payment_and_session_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let result = test_stored_contract_support::get_success_result(&response);
     let cost = result.get_cost().try_into().expect("should map to U512");
     let gas = Gas::new(cost);
     let motes_charlie = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
@@ -769,7 +767,7 @@ fn should_produce_same_transforms_as_exec() {
         let config = config.clone();
 
         let request = {
-            let deploy = crate::support::test_support::DeployBuilder::new()
+            let deploy = test_support::DeployBuilder::new()
                 .with_address(genesis_addr)
                 .with_session_code(
                     &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -13,8 +13,10 @@ use crate::support::test_stored_contract_support::{
 };
 use engine_grpc_server::engine_server::ipc::ExecuteRequest;
 
-use crate::support::test_stored_contract_support;
 use crate::support::test_support;
+use engine_shared::gas::Gas;
+use engine_shared::motes::Motes;
+use std::convert::TryInto;
 
 const GENESIS_ADDR: [u8; 32] = [12; 32];
 const ACCOUNT_1_ADDR: [u8; 32] = [42u8; 32];
@@ -85,9 +87,15 @@ fn should_exec_non_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let motes = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
-
-    let tally = U512::from(motes + transferred_amount) + modified_balance;
+    let success_result =
+        crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = success_result
+        .get_cost()
+        .try_into()
+        .expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
+    let tally = motes.value() + U512::from(transferred_amount) + modified_balance;
 
     assert_eq!(
         initial_balance, tally,
@@ -156,7 +164,10 @@ fn should_exec_stored_code_by_hash() {
         "stored_payment_contract_hash should exist"
     );
 
-    let motes_alpha = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let genesis_account = builder
         .get_account(genesis_account_key)
@@ -199,9 +210,15 @@ fn should_exec_stored_code_by_hash() {
         .expect("there should be a response")
         .clone();
 
-    let motes_bravo = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
-    let tally = U512::from(motes_alpha + motes_bravo + transferred_amount) + modified_balance_bravo;
+    let tally = motes_alpha.value()
+        + motes_bravo.value()
+        + U512::from(transferred_amount)
+        + modified_balance_bravo;
 
     assert!(
         modified_balance_alpha < initial_balance,
@@ -259,7 +276,10 @@ fn should_exec_stored_code_by_named_hash() {
         .expect("there should be a response")
         .clone();
 
-    let motes_alpha = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let genesis_account = builder
         .get_account(genesis_account_key)
@@ -303,9 +323,15 @@ fn should_exec_stored_code_by_named_hash() {
         .expect("there should be a response")
         .clone();
 
-    let motes_bravo = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
-    let tally = U512::from(motes_alpha + motes_bravo + transferred_amount) + modified_balance_bravo;
+    let tally = motes_alpha.value()
+        + motes_bravo.value()
+        + U512::from(transferred_amount)
+        + modified_balance_bravo;
 
     assert!(
         modified_balance_alpha < initial_balance,
@@ -363,7 +389,10 @@ fn should_exec_stored_code_by_named_uref() {
         .expect("there should be a response")
         .clone();
 
-    let motes_alpha = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let genesis_account = builder
         .get_account(genesis_account_key)
@@ -404,9 +433,15 @@ fn should_exec_stored_code_by_named_uref() {
         .expect("there should be a response")
         .clone();
 
-    let motes_bravo = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
-    let tally = U512::from(motes_alpha + motes_bravo + transferred_amount) + modified_balance_bravo;
+    let tally = motes_alpha.value()
+        + motes_bravo.value()
+        + U512::from(transferred_amount)
+        + modified_balance_bravo;
 
     assert!(
         modified_balance_alpha < initial_balance,
@@ -464,7 +499,10 @@ fn should_exec_payment_and_session_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let motes_alpha = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     // next store transfer contract
     let exec_request_store_transfer = {
@@ -493,7 +531,10 @@ fn should_exec_payment_and_session_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let motes_bravo = test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
     let transferred_amount = 1;
@@ -526,8 +567,10 @@ fn should_exec_payment_and_session_stored_code() {
         .expect("there should be a response")
         .clone();
 
-    let motes_charlie =
-        test_stored_contract_support::get_success_result(&response).cost * CONV_RATE;
+    let result = crate::support::test_stored_contract_support::get_success_result(&response);
+    let cost = result.get_cost().try_into().expect("should map to U512");
+    let gas = Gas::new(cost);
+    let motes_charlie = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let genesis_account = builder
         .get_account(genesis_account_key)
@@ -536,7 +579,10 @@ fn should_exec_payment_and_session_stored_code() {
 
     let initial_balance: U512 = U512::from(GENESIS_INITIAL_BALANCE);
 
-    let tally = U512::from(motes_alpha + motes_bravo + motes_charlie + transferred_amount)
+    let tally = motes_alpha.value()
+        + motes_bravo.value()
+        + motes_charlie.value()
+        + U512::from(transferred_amount)
         + modified_balance;
 
     assert_eq!(

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
@@ -9,11 +9,14 @@ use engine_core::engine_state::genesis::{POS_PAYMENT_PURSE, POS_REWARDS_PURSE};
 use engine_core::engine_state::MAX_PAYMENT;
 use engine_core::engine_state::{EngineConfig, CONV_RATE};
 
+use crate::support::test_support;
 use crate::support::test_support::{
-    self, DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME,
+    DeployBuilder, ExecRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_BLOCK_TIME,
     STANDARD_PAYMENT_CONTRACT,
 };
 use crate::test::DEFAULT_PAYMENT;
+use engine_shared::gas::Gas;
+use engine_shared::motes::Motes;
 
 const FINALIZE_PAYMENT: &str = "pos_finalize_payment.wasm";
 const LOCAL_REFUND_PURSE: &str = "local_refund_purse";
@@ -110,8 +113,14 @@ fn finalize_payment_should_refund_to_specified_purse() {
     let refund_pre_balance = get_named_account_balance(&builder, GENESIS_ADDR, LOCAL_REFUND_PURSE)
         .unwrap_or_else(U512::zero);
 
-    assert!(get_pos_refund_purse(&builder).is_none()); // refund_purse always starts unset
-    assert!(payment_pre_balance.is_zero()); // payment purse always starts with zero balance
+    assert!(
+        get_pos_refund_purse(&builder).is_none(),
+        "refund_purse should start unset"
+    );
+    assert!(
+        payment_pre_balance.is_zero(),
+        "payment purse should start with zero balance"
+    );
 
     let exec_request = {
         let genesis_public_key = PublicKey::new(GENESIS_ADDR);
@@ -136,25 +145,42 @@ fn finalize_payment_should_refund_to_specified_purse() {
             .get_exec_response(0)
             .expect("there should be a response");
 
-        (test_support::get_success_result(&response).cost * CONV_RATE).into()
+        let success_result = test_support::get_success_result(response);
+        let cost = success_result
+            .get_cost()
+            .try_into()
+            .expect("should map to U512");
+        Motes::from_gas(Gas::new(cost), CONV_RATE)
+            .expect("should have motes")
+            .value()
     };
 
     let payment_post_balance = get_pos_payment_purse_balance(&builder);
     let rewards_post_balance = get_pos_rewards_purse_balance(&builder);
     let refund_post_balance = get_named_account_balance(&builder, GENESIS_ADDR, LOCAL_REFUND_PURSE)
         .expect("should have refund balance");
-
-    assert_eq!(rewards_pre_balance + spent_amount, rewards_post_balance); // validators get paid
+    let expected_amount = rewards_pre_balance + spent_amount;
+    assert_eq!(
+        expected_amount, rewards_post_balance,
+        "validators should get paid; expected: {}, actual: {}",
+        expected_amount, rewards_post_balance
+    );
 
     // user gets refund
     assert_eq!(
         refund_pre_balance + payment_amount - spent_amount,
-        refund_post_balance
+        refund_post_balance,
+        "user should get refund"
     );
 
-    assert!(get_pos_refund_purse(&builder).is_none()); // refund_purse always ends unset
-    assert!(payment_post_balance.is_zero()); // payment purse always ends with
-                                             // zero balance
+    assert!(
+        get_pos_refund_purse(&builder).is_none(),
+        "refund_purse always ends unset"
+    );
+    assert!(
+        payment_post_balance.is_zero(),
+        "payment purse should ends with zero balance"
+    );
 }
 
 // ------------- utility functions -------------------- //


### PR DESCRIPTION
This PR provides the EE wireup for updated ipc messages that use BigInt / U512 type for costs.

https://casperlabs.atlassian.net/browse/EE-649

- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.