### PR TITLE
[WIP] CON-490: Change return type of `latestMessages` to return multiple messages per validator.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -29,7 +29,7 @@ trait MultiParentCasper[F[_]] {
   def deploy(deployData: Deploy): F[Either[Throwable, Unit]]
   def estimator(
       dag: DagRepresentation[F],
-      latestMessages: Map[ByteString, ByteString]
+      latestMessages: Map[ByteString, Set[ByteString]]
   ): F[List[ByteString]]
   def createBlock: F[CreateBlockStatus]
   ////
@@ -45,15 +45,6 @@ trait MultiParentCasper[F[_]] {
 
 object MultiParentCasper extends MultiParentCasperInstances {
   def apply[F[_]](implicit instance: MultiParentCasper[F]): MultiParentCasper[F] = instance
-
-  def forkChoiceTip[F[_]: MultiParentCasper: MonadThrowable: BlockStorage]: F[Block] =
-    for {
-      dag            <- MultiParentCasper[F].dag
-      latestMessages <- dag.latestMessageHashes
-      tipHashes      <- MultiParentCasper[F].estimator(dag, latestMessages)
-      tipHash        = tipHashes.head
-      tip            <- ProtoUtil.unsafeGetBlock[F](tipHash)
-    } yield tip
 }
 
 sealed abstract class MultiParentCasperInstances {

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -341,7 +341,7 @@ object DagOperations {
       starters: List[BlockHash]
   ): F[BlockHash] = {
     implicit val blocksOrdering = DagOperations.blockTopoOrderingDesc
-    import io.casperlabs.casper.util.implicits.{eqMessageSummary, showBlockHash}
+    import io.casperlabs.casper.util.implicits.eqMessageSummary
     def lookup[A](f: A => BlockHash): A => F[Message] =
       el =>
         dag

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -615,7 +615,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
             val estimateString =
               computedParentHashes.map(hash => PrettyPrinter.buildString(hash)).mkString(",")
             val justificationString = latestMessagesHashes.values
-              .map(hash => PrettyPrinter.buildString(hash))
+              .map(hashes => hashes.map(PrettyPrinter.buildString).mkString("[", ",", "]"))
               .mkString(",")
             val message =
               s"block parents ${parentsString} did not match estimate ${estimateString} based on justification ${justificationString}."

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -193,7 +193,7 @@ object AutoProposerTest {
     override def contains(block: Block): F[Boolean]     = ???
     override def estimator(
         dag: DagRepresentation[F],
-        lm: Map[ByteString, ByteString]
+        lm: Map[ByteString, Set[ByteString]]
     ): F[List[ByteString]]                                                        = ???
     override def dag: F[DagRepresentation[F]]                                     = ???
     override def normalizedInitialFault(weights: Map[ByteString, Long]): F[Float] = ???

--- a/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
@@ -81,7 +81,7 @@ class ForkchoiceTest
         forkchoice <- Estimator.tips[Task](
                        dag,
                        genesis.blockHash,
-                       Map.empty[Estimator.Validator, Estimator.BlockHash],
+                       Map.empty,
                        EquivocationsTracker.empty
                      )
       } yield forkchoice.head should be(genesis.blockHash)
@@ -280,7 +280,7 @@ class ForkchoiceTest
       dag: DagRepresentation[Task],
       bonds: Seq[Bond],
       supporterForBlocks: Map[BlockHash, Seq[Validator]],
-      latestMessageHashes: Map[Validator, BlockHash]
+      latestMessageHashes: Map[Validator, Set[BlockHash]]
   ): Unit = {
     val equivocatorsGen: Gen[Set[Validator]] =
       for {
@@ -289,7 +289,7 @@ class ForkchoiceTest
       } yield idx.map(_.validatorPublicKey).toSet
 
     val lca = DagOperations
-      .latestCommonAncestorsMainParent(dag, latestMessageHashes.values.toList)
+      .latestCommonAncestorsMainParent(dag, latestMessageHashes.values.flatten.toList)
       .runSyncUnsafe(1.second)
 
     forAll(equivocatorsGen) { equivocators: Set[Validator] =>

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -139,7 +139,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def deploy(d: Deploy): F[Either[Throwable, Unit]] = underlying.deploy(d)
   def estimator(
       dag: DagRepresentation[F],
-      latestMessagesHashes: Map[ByteString, ByteString]
+      latestMessagesHashes: Map[ByteString, Set[ByteString]]
   ): F[List[BlockHash]] =
     underlying.estimator(dag, latestMessagesHashes)
   def dag: F[DagRepresentation[F]] = underlying.dag

--- a/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
@@ -88,7 +88,7 @@ class EquivocationDetectorTest
       state          <- casperState.read
       _ <- EquivocationDetector.detectVisibleFromJustifications(
             dag,
-            latestMessages.mapValues(_.messageHash),
+            latestMessages.mapValues(_.map(_.messageHash)),
             state.equivocationsTracker
           ) shouldBeF visibleEquivocatorExpected
     } yield block

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -217,7 +217,8 @@ class FinalityDetectorByVotingMatrixTest
                        Seq(genesis.blockHash),
                        genesis.blockHash,
                        v1,
-                       bonds
+                       bonds,
+                       HashMap(v1 -> genesis.blockHash)
                      )
           _ = c1 shouldBe None
           (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
@@ -225,7 +226,7 @@ class FinalityDetectorByVotingMatrixTest
                        genesis.blockHash,
                        v2,
                        bonds,
-                       HashMap(v1 -> b1.blockHash)
+                       HashMap(v1 -> b1.blockHash, v2 -> genesis.blockHash)
                      )
           _ = c2 shouldBe None
           (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
@@ -233,7 +234,7 @@ class FinalityDetectorByVotingMatrixTest
                        genesis.blockHash,
                        v3,
                        bonds,
-                       HashMap(v1 -> b1.blockHash, v2 -> b2.blockHash)
+                       HashMap(v1 -> b1.blockHash, v2 -> b2.blockHash, v3 -> genesis.blockHash)
                      )
           _ = c3 shouldBe None
           (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrixTest.scala
@@ -116,7 +116,8 @@ class VotingMatrixTest extends FlatSpec with Matchers with BlockGenerator with S
                  Seq(genesis.blockHash),
                  genesis.blockHash,
                  v1,
-                 updatedBonds
+                 updatedBonds,
+                 justifications = Map(v1 -> genesis.blockHash)
                )
           _ <- checkWeightMap(Map(v1 -> 10, v2 -> 10)) // don't change, because b1 haven't finalized
           _ <- checkMatrix(
@@ -137,7 +138,8 @@ class VotingMatrixTest extends FlatSpec with Matchers with BlockGenerator with S
                  Seq(genesis.blockHash),
                  genesis.blockHash,
                  v2,
-                 bonds
+                 bonds,
+                 justifications = Map(v2 -> genesis.blockHash)
                )
           _ <- checkMatrix(
                 Map(

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -100,7 +100,30 @@ trait BlockGenerator {
       parentsHashList: Seq[BlockHash],
       creator: Validator = ByteString.EMPTY,
       bonds: Seq[Bond] = Seq.empty[Bond],
-      justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
+      justifications: collection.Map[Validator, BlockHash] = HashMap.empty,
+      deploys: Seq[ProcessedDeploy] = Seq.empty[ProcessedDeploy],
+      postStateHash: ByteString = ByteString.EMPTY,
+      chainId: String = "casperlabs",
+      preStateHash: ByteString = ByteString.EMPTY,
+      messageType: Block.MessageType = Block.MessageType.BLOCK
+  ): F[Block] =
+    createBlockNew[F](
+      parentsHashList,
+      creator,
+      bonds,
+      justifications.mapValues(Set(_)),
+      deploys,
+      postStateHash,
+      chainId,
+      preStateHash,
+      messageType
+    )
+
+  def createBlockNew[F[_]: MonadThrowable: Time: IndexedDagStorage](
+      parentsHashList: Seq[BlockHash],
+      creator: Validator = ByteString.EMPTY,
+      bonds: Seq[Bond] = Seq.empty[Bond],
+      justifications: collection.Map[Validator, Set[BlockHash]] = HashMap.empty,
       deploys: Seq[ProcessedDeploy] = Seq.empty[ProcessedDeploy],
       postStateHash: ByteString = ByteString.EMPTY,
       chainId: String = "casperlabs",
@@ -116,7 +139,8 @@ trait BlockGenerator {
         .withBonds(bonds)
       body = Block.Body().withDeploys(deploys)
       dag  <- IndexedDagStorage[F].getRepresentation
-      // Every parent should also include in the justification,by doing this we can avoid passing parameter justifications when creating block in test
+      // Every parent should also include in the justification,
+      // by doing this we can avoid passing parameter justifications when creating block in test
       updatedJustifications <- parentsHashList.toList.foldLeftM(justifications) {
                                 case (acc, b) =>
                                   dag
@@ -126,14 +150,22 @@ trait BlockGenerator {
                                         if (acc.contains(block.validatorId)) {
                                           acc
                                         } else {
-                                          acc + (block.validatorId -> block.messageHash)
+                                          acc
+                                            .get(block.validatorId)
+                                            .fold(
+                                              acc.updated(block.validatorId, Set(block.messageHash))
+                                            )(
+                                              s =>
+                                                acc
+                                                  .updated(block.validatorId, s + block.messageHash)
+                                            )
                                         }
                                       }
                                     )
                               }
-      serializedJustifications = updatedJustifications.toList.map {
-        case (creator: Validator, latestBlockHash: BlockHash) =>
-          Block.Justification(creator, latestBlockHash)
+      serializedJustifications = updatedJustifications.toList.flatMap {
+        case (creator: Validator, hashes) =>
+          hashes.map(hash => Block.Justification(creator, hash))
       }
       validatorSeqNum <- if (parentsHashList.isEmpty) 0.pure[F]
                         else
@@ -141,7 +173,8 @@ trait BlockGenerator {
       rank <- if (parentsHashList.isEmpty) 0L.pure[F]
              else
                updatedJustifications.values.toList
-                 .traverse(hash => dag.lookup(hash).map(_.get))
+                 .flatTraverse(_.toList.traverse(dag.lookup(_)))
+                 .map(_.flatten)
                  .map(ProtoUtil.nextRank(_))
       header = ProtoUtil
         .blockHeader(
@@ -170,9 +203,29 @@ trait BlockGenerator {
       postStateHash: ByteString = ByteString.EMPTY,
       chainId: String = "casperlabs",
       preStateHash: ByteString = ByteString.EMPTY
+  ): F[Block] = createAndStoreBlockNew[F](
+    parentsHashList,
+    creator,
+    bonds,
+    justifications.mapValues(Set(_)),
+    deploys,
+    postStateHash,
+    chainId,
+    preStateHash
+  )
+
+  def createAndStoreBlockNew[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage](
+      parentsHashList: Seq[BlockHash],
+      creator: Validator = ByteString.EMPTY,
+      bonds: Seq[Bond] = Seq.empty[Bond],
+      justifications: collection.Map[Validator, Set[BlockHash]],
+      deploys: Seq[ProcessedDeploy] = Seq.empty[ProcessedDeploy],
+      postStateHash: ByteString = ByteString.EMPTY,
+      chainId: String = "casperlabs",
+      preStateHash: ByteString = ByteString.EMPTY
   ): F[Block] =
     for {
-      block <- createBlock[F](
+      block <- createBlockNew[F](
                 parentsHashList = parentsHashList,
                 creator = creator,
                 bonds = bonds,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -379,7 +379,7 @@ object GossipServiceCasperTestNodeFactory {
                              for {
                                dag    <- casper.dag
                                latest <- dag.latestMessageHashes
-                             } yield latest.values.toList
+                             } yield latest.values.flatten.toList
 
                            override def validate(blockSummary: consensus.BlockSummary): F[Unit] =
                              for {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -34,7 +34,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
   def deploy(r: Deploy): F[Either[Throwable, Unit]] = Applicative[F].pure(Right(()))
   def estimator(
       dag: DagRepresentation[F],
-      latestMessageHashes: Map[ByteString, ByteString]
+      latestMessageHashes: Map[ByteString, Set[ByteString]]
   ): F[List[BlockHash]] =
     estimatorFunc.pure[F]
   def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]

--- a/casper/src/test/scala/io/casperlabs/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/CasperUtilTest.scala
@@ -2,6 +2,7 @@ package io.casperlabs.casper.util
 
 import cats.implicits._
 import com.google.protobuf.ByteString
+import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus.{Block, Bond}
 import io.casperlabs.casper.equivocations.EquivocationsTracker
 import io.casperlabs.casper.finality.FinalityDetectorUtil
@@ -13,6 +14,7 @@ import io.casperlabs.casper.util.ProtoUtil._
 import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.models.Message
 import io.casperlabs.p2p.EffectsTestInstances.LogStub
+import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.storage.dag._
 import monix.eval.Task
 import org.scalatest.{Assertion, FlatSpec, Matchers}

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -577,7 +577,7 @@ package object gossiping {
                              casper <- unsafeGetCasper[F]
                              dag    <- casper.dag
                              latest <- dag.latestMessageHashes
-                           } yield latest.values.toList
+                           } yield latest.values.flatten.toList
 
                          override def validate(blockSummary: BlockSummary): F[Unit] =
                            Validation[F].blockSummary(blockSummary, chainId)

--- a/storage/src/main/resources/db/migration/V20191004_490__Redefine_validator_latest_messages.sql
+++ b/storage/src/main/resources/db/migration/V20191004_490__Redefine_validator_latest_messages.sql
@@ -1,0 +1,8 @@
+DROP TABLE validator_latest_messages;
+
+CREATE TABLE validator_latest_messages
+(
+    validator  BLOB    NOT NULL,
+    block_hash BLOB    NOT NULL,
+    FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
+);

--- a/storage/src/main/resources/db/migration/V20191004_490__Redefine_validator_latest_messages.sql
+++ b/storage/src/main/resources/db/migration/V20191004_490__Redefine_validator_latest_messages.sql
@@ -4,5 +4,6 @@ CREATE TABLE validator_latest_messages
 (
     validator  BLOB    NOT NULL,
     block_hash BLOB    NOT NULL,
+    PRIMARY KEY (validator, block_hash),
     FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
-);
+) WITHOUT ROWID;

--- a/storage/src/main/resources/db/migration/V20191004_490__Redefine_validator_latest_messages.sql
+++ b/storage/src/main/resources/db/migration/V20191004_490__Redefine_validator_latest_messages.sql
@@ -1,9 +1,14 @@
-DROP TABLE validator_latest_messages;
-
-CREATE TABLE validator_latest_messages
+CREATE TABLE latest_messages
 (
     validator  BLOB    NOT NULL,
     block_hash BLOB    NOT NULL,
     PRIMARY KEY (validator, block_hash),
     FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
 ) WITHOUT ROWID;
+
+INSERT INTO latest_messages (validator, block_hash)
+SELECT validator, block_hash FROM validator_latest_messages;
+
+DROP TABLE validator_latest_messages;
+
+ALTER TABLE latest_messages RENAME TO validator_latest_messages;

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -167,16 +167,16 @@ object SQLiteStorage {
       override def topoSortTail(tailLength: Int): Stream[F, Vector[BlockHash]] =
         dagStorage.topoSortTail(tailLength)
 
-      override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
+      override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
         dagStorage.latestMessageHash(validator)
 
-      override def latestMessage(validator: Validator): F[Option[Message]] =
+      override def latestMessage(validator: Validator): F[Set[Message]] =
         dagStorage.latestMessage(validator)
 
-      override def latestMessageHashes: F[Map[Validator, BlockHash]] =
+      override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
         dagStorage.latestMessageHashes
 
-      override def latestMessages: F[Map[Validator, Message]] =
+      override def latestMessages: F[Map[Validator, Set[Message]]] =
         dagStorage.latestMessages
     }
 }

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -107,15 +107,16 @@ class CachingDagStorage[F[_]: Sync](
   override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]] =
     underlying.topoSortTail(tailLength)
 
-  override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
+  override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
     underlying.latestMessageHash(validator)
 
-  override def latestMessage(validator: Validator): F[Option[Message]] =
+  override def latestMessage(validator: Validator): F[Set[Message]] =
     underlying.latestMessage(validator)
 
-  override def latestMessageHashes: F[Map[Validator, BlockHash]] = underlying.latestMessageHashes
+  override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
+    underlying.latestMessageHashes
 
-  override def latestMessages: F[Map[Validator, Message]] = underlying.latestMessages
+  override def latestMessages: F[Map[Validator, Set[Message]]] = underlying.latestMessages
 }
 
 object CachingDagStorage {

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -47,16 +47,16 @@ object DagStorage {
     abstract override def contains(blockHash: BlockHash): F[Boolean] =
       incAndMeasure("contains", super.contains(blockHash))
 
-    abstract override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
+    abstract override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
       incAndMeasure("latestMessageHash", super.latestMessageHash(validator))
 
-    abstract override def latestMessage(validator: Validator): F[Option[Message]] =
+    abstract override def latestMessage(validator: Validator): F[Set[Message]] =
       incAndMeasure("latestMessage", super.latestMessage(validator))
 
-    abstract override def latestMessageHashes: F[Map[Validator, BlockHash]] =
+    abstract override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
       incAndMeasure("latestMessageHashes", super.latestMessageHashes)
 
-    abstract override def latestMessages: F[Map[Validator, Message]] =
+    abstract override def latestMessages: F[Map[Validator, Set[Message]]] =
       incAndMeasure("latestMessages", super.latestMessages)
 
     abstract override def topoSort(
@@ -92,10 +92,10 @@ trait DagRepresentation[F[_]] {
 
   def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]]
 
-  def latestMessageHash(validator: Validator): F[Option[BlockHash]]
-  def latestMessage(validator: Validator): F[Option[Message]]
-  def latestMessageHashes: F[Map[Validator, BlockHash]]
-  def latestMessages: F[Map[Validator, Message]]
+  def latestMessageHash(validator: Validator): F[Set[BlockHash]]
+  def latestMessage(validator: Validator): F[Set[Message]]
+  def latestMessageHashes: F[Map[Validator, Set[BlockHash]]]
+  def latestMessages: F[Map[Validator, Set[Message]]]
 }
 
 object DagRepresentation {

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -49,38 +49,25 @@ class SQLiteDagStorage[F[_]: Bracket[?[_], Throwable]](
       )
 
     val latestMessagesQuery = {
-      if (block.isGenesisLike) {
-        val newValidators = block.state.bonds
-          .map(_.validatorPublicKey)
-          .toSet
-          .diff(block.justifications.map(_.validatorPublicKey).toSet)
-          .toList
-        // Will ignore existing entries, because genesis should only be the first block and can't be added twice
-        Update[(Validator, BlockHash)](
-          """|INSERT OR IGNORE INTO validator_latest_messages
-             |(validator, block_hash)
-             |VALUES (?, ?)""".stripMargin
-        ).updateMany(newValidators.map((_, blockSummary.blockHash)))
-      } else {
-        // Validator's latest message as seen from block's justifications.
-        // Assumes that validator's block always includes in its justifications previous message from its creator.
-        val validatorLatestMessage =
-          blockSummary.justifications.find(_.validatorPublicKey == blockSummary.validatorPublicKey)
-        validatorLatestMessage.fold {
-          // No previous message visible from the justifications.
-          // This is the first block from this validator (at least according to the creator of the message).
-          sql""" INSERT INTO validator_latest_messages (validator, block_hash)
+      // Genesis is not created by a validator.
+      if (!block.isGenesisLike) {
+        blockSummary.justifications
+          .find(_.validatorPublicKey == blockSummary.validatorPublicKey)
+          .fold {
+            // No previous message visible from the justifications.
+            // This is the first block from this validator (at least according to the creator of the message).
+            sql""" INSERT INTO validator_latest_messages (validator, block_hash)
                  VALUES (${blockSummary.validatorPublicKey}, ${blockSummary.blockHash})""".stripMargin.update.run
-        } { lastMessage =>
-          // Insert if new block doesn't cite latest message (this is an equivocation).
-          // Otherwise, update entry.
-          sql"""|DELETE FROM validator_latest_messages
-               |WHERE validator = ${blockSummary.validatorPublicKey}
-               |AND block_hash = ${lastMessage.latestBlockHash}""".stripMargin.update.run >>
-            sql"""|INSERT OR IGNORE INTO validator_latest_messages (validator, block_hash)
-                |VALUES (${blockSummary.validatorPublicKey}, ${blockSummary.blockHash})""".stripMargin.update.run
-        }
-      }
+          } { lastMessage =>
+            // Insert if new block doesn't cite latest message (this is an equivocation).
+            // Otherwise, update entry.
+            sql"""|DELETE FROM validator_latest_messages
+                  |WHERE validator = ${blockSummary.validatorPublicKey}
+                  |AND block_hash = ${lastMessage.latestBlockHash}""".stripMargin.update.run >>
+              sql"""|INSERT OR IGNORE INTO validator_latest_messages (validator, block_hash)
+                    |VALUES (${blockSummary.validatorPublicKey}, ${blockSummary.blockHash})""".stripMargin.update.run
+          }
+      } else ().pure[ConnectionIO]
     }
 
     val topologicalSortingQuery =


### PR DESCRIPTION
### Overview
The previous implementation assumed that there can be only one "latest message" per validator in the DAG (validator's swimlane is a chain). This is incorrect as with every equivocation validator has a new "latest message" (definition of the latest message is that it is not cited in justifications of another block by that validator).

This PR updates the interfaces and SQL (schema, queries) so that `latestMessage(validatorId)` returns `Set[BlockHash]`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-490

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
