### PR TITLE
NO_TICKET: Bump Python client version to 0.4.3

### DIFF
--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -168,7 +168,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.4.2",
+    version="0.4.3",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",


### PR DESCRIPTION
### Overview
This PR bumps version of the Python client to 0.4.3.

Release includes fix for wrong deploy timestamp.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
