### PR TITLE
NODE-943: Fix estimator not eliminating tip choices via secondary parents

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
@@ -277,11 +277,11 @@ class ForkchoiceTest
       )
 
       // DAG:
-      //    = B1 =
-      //  //      \\
-      // G == B2 ==\\=====
-      //            \\    \\
-      //             B3 -- B4
+      //    B1
+      //  //  \\
+      // G      B3 -- B4
+      //  \\         //
+      //    B2 ======
       // The bug in NODE-943 was that B4 did not propagate a score to B3,
       // so we ended up with tips [B4, B1] instead of [B4]
 
@@ -319,8 +319,7 @@ class ForkchoiceTest
                        latestBlocks,
                        EquivocationsTracker.empty
                      )
-        _ = forkchoice.head should be(b4.blockHash)
-        _ = forkchoice should have size 1
+        _ = forkchoice shouldBe List(b4.blockHash)
       } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
@@ -438,7 +438,7 @@ class EquivocationDetectorTest
               rankOfLowestBaseBlockExpect = None,
               visibleEquivocatorExpected = Set.empty
             )
-        _ <- Task.delay(println("Dupa1"))
+        // _ <- Task.delay(println("Dupa1"))
 
         c <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(b.blockHash),
@@ -447,7 +447,7 @@ class EquivocationDetectorTest
               rankOfLowestBaseBlockExpect = 0L.some,
               visibleEquivocatorExpected = Set(v1)
             )
-        _ <- Task.delay(println("Dupa2"))
+        // _ <- Task.delay(println("Dupa2"))
         // this block isn't shown in the diagram
         _ <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(c.blockHash),

--- a/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
@@ -438,7 +438,6 @@ class EquivocationDetectorTest
               rankOfLowestBaseBlockExpect = None,
               visibleEquivocatorExpected = Set.empty
             )
-        // _ <- Task.delay(println("Dupa1"))
 
         c <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(b.blockHash),
@@ -447,7 +446,7 @@ class EquivocationDetectorTest
               rankOfLowestBaseBlockExpect = 0L.some,
               visibleEquivocatorExpected = Set(v1)
             )
-        // _ <- Task.delay(println("Dupa2"))
+
         // this block isn't shown in the diagram
         _ <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(c.blockHash),


### PR DESCRIPTION
### Overview
There was a bug in the estimator that cause blocks to be potentially chosen as tips if they were the last message of a validator and the only other kind of last message which was building on it didn't lead to it via main parent paths. That's because scores only propagate via main parents and it was using the scores to see which children can take over its seat.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-943

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Scores are no longer used for tip selection, only the main fork choice depends on the score. It could be eliminated by another tip, even with 0 score (maybe equivocated), but it will forcefully be added back to the top of the list.
