### PR TITLE
NODE-784: Test new genesis

### DIFF
--- a/integration-testing/casperlabs_local_net/casperlabs_network.py
+++ b/integration-testing/casperlabs_local_net/casperlabs_network.py
@@ -135,14 +135,18 @@ class CasperLabsNetwork:
             cl_node = CasperLabsNode(self, config)
             self.cl_nodes.append(cl_node)
 
-    def add_new_node_to_network(self) -> None:
+    def add_new_node_to_network(self, generate_config=None) -> None:
         kp = self.get_key()
-        config = DockerConfig(
-            self.docker_client,
-            node_private_key=kp.private_key,
-            node_account=kp,
-            grpc_encryption=self.grpc_encryption,
-            behind_proxy=self.behind_proxy,
+        config = (
+            generate_config
+            and generate_config(kp)
+            or DockerConfig(
+                self.docker_client,
+                node_private_key=kp.private_key,
+                node_account=kp,
+                grpc_encryption=self.grpc_encryption,
+                behind_proxy=self.behind_proxy,
+            )
         )
         self.add_cl_node(config)
         self.wait_method(wait_for_approved_block_received_handler_state, 1)
@@ -305,6 +309,32 @@ class TwoNodeNetwork(CasperLabsNetwork):
         )
         self.add_bootstrap(config)
         self.add_new_node_to_network()
+
+
+class TwoNodeWithDifferentAccountsCSVNetwork(CasperLabsNetwork):
+    def create_cl_network(self):
+        kp = self.get_key()
+        config = DockerConfig(
+            self.docker_client,
+            node_private_key=kp.private_key,
+            node_public_key=kp.public_key,
+            network=self.create_docker_network(),
+            node_account=kp,
+            grpc_encryption=self.grpc_encryption,
+        )
+        self.add_bootstrap(config)
+        self.add_new_node_to_network(
+            (
+                lambda kp: DockerConfig(
+                    self.docker_client,
+                    node_private_key=kp.private_key,
+                    node_account=kp,
+                    grpc_encryption=self.grpc_encryption,
+                    behind_proxy=self.behind_proxy,
+                    dodgy_accounts_csv=True,
+                )
+            )
+        )
 
 
 class EncryptedTwoNodeNetwork(TwoNodeNetwork):

--- a/integration-testing/casperlabs_local_net/casperlabs_network.py
+++ b/integration-testing/casperlabs_local_net/casperlabs_network.py
@@ -323,6 +323,7 @@ class TwoNodeWithDifferentAccountsCSVNetwork(CasperLabsNetwork):
             grpc_encryption=self.grpc_encryption,
         )
         self.add_bootstrap(config)
+        # Create accounts.csv of the second node with different bond amounts.
         self.add_new_node_to_network(
             (
                 lambda kp: DockerConfig(
@@ -331,7 +332,7 @@ class TwoNodeWithDifferentAccountsCSVNetwork(CasperLabsNetwork):
                     node_account=kp,
                     grpc_encryption=self.grpc_encryption,
                     behind_proxy=self.behind_proxy,
-                    dodgy_accounts_csv=True,
+                    bond_amount=lambda i, n: n + 3 * i,
                 )
             )
         )

--- a/integration-testing/casperlabs_local_net/docker_config.py
+++ b/integration-testing/casperlabs_local_net/docker_config.py
@@ -41,6 +41,9 @@ class DockerConfig:
     grpc_encryption: bool = False
     is_read_only: bool = False
     behind_proxy: bool = False
+    # For the genesis test: we want to see what happens if a one node has
+    # different accounts.txt
+    dodgy_accounts_csv: bool = False
 
     def __post_init__(self):
         if self.rand_str is None:

--- a/integration-testing/casperlabs_local_net/docker_config.py
+++ b/integration-testing/casperlabs_local_net/docker_config.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Callable
 from docker import DockerClient
 
 
@@ -14,6 +14,13 @@ DEFAULT_NODE_ENV = {
     "CL_SERVER_NO_UPNP": "true",
     "CL_VERSION": "test",
 }
+
+
+def default_bond_amount(i, n):
+    """
+    Default amount for the i-th out of n bonding accounts in accounts.csv.
+    """
+    return n + 2 * i
 
 
 @dataclass
@@ -41,9 +48,8 @@ class DockerConfig:
     grpc_encryption: bool = False
     is_read_only: bool = False
     behind_proxy: bool = False
-    # For the genesis test: we want to see what happens if a one node has
-    # different accounts.txt
-    dodgy_accounts_csv: bool = False
+    # Function that returns bonds amount for each account to be placed in accounts.csv.
+    bond_amount: Callable = default_bond_amount
 
     def __post_init__(self):
         if self.rand_str is None:

--- a/integration-testing/casperlabs_local_net/docker_node.py
+++ b/integration-testing/casperlabs_local_net/docker_node.py
@@ -259,13 +259,11 @@ class DockerNode(LoggingDockerBase):
         if os.path.exists(self.host_mount_dir):
             shutil.rmtree(self.host_mount_dir)
         shutil.copytree(str(self.resources_folder), self.host_mount_dir)
-        if self.config.dodgy_accounts_csv:
-            self.create_genesis_accounts_file(bonds_amount=lambda i, n: n + 3 * i)
-        else:
-            self.create_genesis_accounts_file()
+        self.create_genesis_accounts_file()
 
     # TODO: Should be changed to using validator-id from accounts
-    def create_genesis_accounts_file(self, bonds_amount=lambda i, n: n + 2 * i) -> None:
+    def create_genesis_accounts_file(self) -> None:
+        bond_amount = self.config.bond_amount
         N = self.NUMBER_OF_BONDS
         # Creating a file where the node is expecting to see overrides, i.e. at ~/.casperlabs/chainspec/genesis
         path = f"{self.host_chainspec_dir}/genesis/accounts.csv"
@@ -279,7 +277,7 @@ class DockerNode(LoggingDockerBase):
                 Account(i)
                 for i in range(FIRST_VALIDATOR_ACCOUNT, FIRST_VALIDATOR_ACCOUNT + N)
             ):
-                bond = bonds_amount(i, N)
+                bond = bond_amount(i, N)
                 f.write(f"{pair.public_key},0,{bond}\n")
 
     def cleanup(self):

--- a/integration-testing/casperlabs_local_net/wait.py
+++ b/integration-testing/casperlabs_local_net/wait.py
@@ -3,8 +3,6 @@ import re
 import time
 from casperlabs_local_net.errors import NonZeroExitCodeError
 from typing import List
-
-import pytest
 import typing_extensions
 
 from casperlabs_local_net.client_parser import parse_show_blocks
@@ -361,7 +359,7 @@ def wait_on_using_wall_clock_time(
         time.sleep(iteration_duration)
         elapsed = elapsed + iteration_duration
 
-    pytest.fail("Failed to satisfy {} after {}s".format(predicate, elapsed))
+    raise Exception("Failed to satisfy {} after {}s".format(predicate, elapsed))
 
 
 def wait_for_block_contains(
@@ -490,7 +488,7 @@ def wait_using_wall_clock_time_or_fail(
             wait_using_wall_clock_time(predicate, timeout)
             return
         except WaitTimeoutError:
-            pytest.fail("Failed to satisfy {} after {}s".format(predicate, timeout))
+            raise Exception("Failed to satisfy {} after {}s".format(predicate, timeout))
         except NonZeroExitCodeError:
             logging.info("not ready")
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -17,6 +17,7 @@ from casperlabs_local_net.casperlabs_network import (
     EncryptedTwoNodeNetwork,
     ReadOnlyNodeNetwork,
     InterceptedTwoNodeNetwork,
+    TwoNodeWithDifferentAccountsCSVNetwork,
 )
 from docker.client import DockerClient
 
@@ -90,6 +91,13 @@ def encrypted_one_node_network(docker_client_fixture):
 @pytest.fixture()
 def two_node_network(docker_client_fixture):
     with TwoNodeNetwork(docker_client_fixture) as tnn:
+        tnn.create_cl_network()
+        yield tnn
+
+
+@pytest.fixture()
+def two_node_with_different_accounts_csv_network(docker_client_fixture):
+    with TwoNodeWithDifferentAccountsCSVNetwork(docker_client_fixture) as tnn:
         tnn.create_cl_network()
         yield tnn
 

--- a/integration-testing/test/test_genesis.py
+++ b/integration-testing/test/test_genesis.py
@@ -1,0 +1,24 @@
+from pytest import raises
+from casperlabs_local_net.wait import wait_for_block_hash_propagated_to_all_nodes
+
+
+def test(two_node_with_different_accounts_csv_network):
+    """
+    Check that two nodes started with different accounts.csv
+    will create different genesis blocks
+    and will not exchange blocks, effectively not becoming part of one network.
+    """
+    nodes = two_node_with_different_accounts_csv_network.docker_nodes
+
+    account = nodes[0].genesis_account
+
+    nodes[0].client.deploy(
+        session_contract="test_helloname.wasm",
+        from_address=account.public_key_hex,
+        public_key=account.public_key_path,
+        private_key=account.private_key_path,
+    )
+    block_hash = nodes[0].client.propose()
+    with raises(Exception) as excinfo:
+        wait_for_block_hash_propagated_to_all_nodes(nodes, block_hash)
+    assert "Failed to satisfy" in str(excinfo.value)


### PR DESCRIPTION
This PR adds integration test for the scenario where two nodes are started with different `accounts.csv`. They should create different genesis blocks and never successfully exchange any blocks, effectively not forming a network.

Scenario where the genesis process is successful is tested by different tests where after the genesis blocks created on one node are successfully propagated to other nodes in the network.

### Overview
https://casperlabs.atlassian.net/browse/NODE-784

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
