### PR TITLE
NO-TICKET: update ProtocolVersion and SemVer newtype autoderive traits

### DIFF
--- a/execution-engine/contract-ffi/src/value/protocol_version.rs
+++ b/execution-engine/contract-ffi/src/value/protocol_version.rs
@@ -1,9 +1,8 @@
-use core::cmp::Ordering;
 use uint::core_::fmt;
 
 use super::SemVer;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ProtocolVersion(SemVer);
 
 impl ProtocolVersion {
@@ -31,12 +30,6 @@ impl ProtocolVersion {
 impl fmt::Display for ProtocolVersion {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-impl PartialOrd for ProtocolVersion {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.value().cmp(&other.value()))
     }
 }
 

--- a/execution-engine/contract-ffi/src/value/semver.rs
+++ b/execution-engine/contract-ffi/src/value/semver.rs
@@ -1,8 +1,6 @@
-use core::cmp::Ordering;
 use core::fmt;
-use core::hash::{Hash, Hasher};
 
-#[derive(Debug, Copy, Clone, Eq, Ord)]
+#[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SemVer {
     pub major: u32,
     pub minor: u32,
@@ -28,31 +26,5 @@ impl SemVer {
 impl fmt::Display for SemVer {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
-    }
-}
-
-impl Hash for SemVer {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.major.hash(state);
-        self.minor.hash(state);
-        self.patch.hash(state);
-    }
-}
-
-impl Default for SemVer {
-    fn default() -> Self {
-        Self::new(0, 0, 0)
-    }
-}
-
-impl PartialOrd for SemVer {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(&other))
-    }
-}
-
-impl PartialEq for SemVer {
-    fn eq(&self, other: &SemVer) -> bool {
-        self.major.eq(&other.major) && self.minor.eq(&other.minor) && self.patch.eq(&other.patch)
     }
 }


### PR DESCRIPTION
This PR removes some trait implementations from ProtocolVersion and SemVer newtypes where an automatically derived implementation is sufficient.

This is unticketed work.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.