### PR TITLE
OP-750: bump 0.16.0 -> 0.17.0

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -4,14 +4,14 @@
 name = "add-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "add-update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -26,21 +26,21 @@ dependencies = [
 name = "args-multi"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "args-u32"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "args-u512"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ dependencies = [
 name = "authorized-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -167,14 +167,14 @@ dependencies = [
 name = "bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "bonding-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -238,7 +238,7 @@ name = "casperlabs-engine-core"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
  "casperlabs-engine-wasm-prep 0.1.0",
@@ -262,7 +262,7 @@ dependencies = [
 name = "casperlabs-engine-grpc-server"
 version = "0.8.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
@@ -299,7 +299,7 @@ version = "0.2.0"
 dependencies = [
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "casperlabs-engine-wasm-prep 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -318,7 +318,7 @@ dependencies = [
 name = "casperlabs-engine-storage"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-wasm-prep 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -334,7 +334,7 @@ dependencies = [
 name = "casperlabs-engine-tests"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-grpc-server 0.8.0",
  "casperlabs-engine-shared 0.2.0",
@@ -355,7 +355,7 @@ dependencies = [
 name = "casperlabs-engine-wasm-prep"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "casperlabs-engine-shared 0.2.0",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -381,7 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "check-system-contract-urefs-access-rights"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -429,7 +429,7 @@ dependencies = [
 name = "combined-contracts-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -441,35 +441,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "counter-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "counter-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "create-accounts"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "create-named-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "create-purse-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -498,7 +498,7 @@ name = "create-test-node-shared"
 version = "0.1.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -620,7 +620,7 @@ dependencies = [
 name = "deserialize-error"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -635,14 +635,14 @@ dependencies = [
 name = "direct-revert-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "direct-revert-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -659,28 +659,28 @@ dependencies = [
 name = "do-nothing"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "do-nothing-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "do-nothing-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "do-nothing-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "create-purse-01 0.1.0",
 ]
 
@@ -688,105 +688,105 @@ dependencies = [
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-401-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-401-regression-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-441-rng-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-460-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-532-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-536-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-539-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-549-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-572-regression-create"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-572-regression-escalate"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-584-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-597-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-598-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "ee-601-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -798,21 +798,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "endless-loop"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "err-standard-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "err-transfer-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -839,14 +839,14 @@ dependencies = [
 name = "faucet"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "finalize-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -899,56 +899,56 @@ dependencies = [
 name = "get-arg"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-blocktime"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-caller-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-caller-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-caller-subcall"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-phase"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "get-phase-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1015,14 +1015,14 @@ dependencies = [
 name = "hello-name-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "hello-name-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1150,7 +1150,7 @@ dependencies = [
 name = "key-management-thresholds"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1172,14 +1172,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "list-known-urefs-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "list-known-urefs-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1206,14 +1206,14 @@ dependencies = [
 name = "local-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "local-state-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "local-state 0.1.0",
 ]
 
@@ -1221,14 +1221,14 @@ dependencies = [
 name = "local-state-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "local-state-stored-upgraded"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "local-state 0.1.0",
 ]
 
@@ -1236,7 +1236,7 @@ dependencies = [
 name = "local-state-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "local-state-stored-upgraded 0.1.0",
 ]
 
@@ -1269,21 +1269,21 @@ dependencies = [
 name = "mailing-list-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "mailing-list-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "main-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1321,7 +1321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mint-install"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "mint-token 0.1.0",
 ]
 
@@ -1329,14 +1329,14 @@ dependencies = [
 name = "mint-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1381,7 +1381,7 @@ dependencies = [
 name = "modified-mint"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "mint-token 0.1.0",
 ]
 
@@ -1389,14 +1389,14 @@ dependencies = [
 name = "modified-mint-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "modified-mint-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "modified-mint 0.1.0",
 ]
 
@@ -1404,14 +1404,14 @@ dependencies = [
 name = "named-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "named-purse-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1563,14 +1563,14 @@ dependencies = [
 name = "payment-from-named-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "payment-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1582,35 +1582,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pos"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "pos-bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "pos-finalize-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "pos-get-payment-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "pos-install"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
  "pos 0.1.0",
 ]
 
@@ -1618,7 +1618,7 @@ dependencies = [
 name = "pos-refund-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1712,21 +1712,21 @@ dependencies = [
 name = "purse-holder-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "purse-holder-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "purse-holder-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1972,7 +1972,7 @@ dependencies = [
 name = "refund-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -1992,7 +1992,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "remove-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ dependencies = [
 name = "revert"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2127,14 +2127,14 @@ dependencies = [
 name = "set-key-thresholds"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "simple-transfer"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2166,21 +2166,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "standard-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "standard-payment-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "state-initializer"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2200,14 +2200,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subcall-revert-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "subcall-revert-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2272,7 +2272,7 @@ dependencies = [
 name = "test-mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2555,63 +2555,63 @@ dependencies = [
 name = "transfer-main-purse-to-new-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-account-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-to-account-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-to-account-02"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-to-account-it"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "transfer-to-existing-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2638,14 +2638,14 @@ dependencies = [
 name = "unbonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
 name = "unbonding-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]
@@ -2676,7 +2676,7 @@ dependencies = [
 name = "update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.16.0",
+ "casperlabs-contract-ffi 0.17.0",
 ]
 
 [[package]]

--- a/execution-engine/contract-ffi/Cargo.toml
+++ b/execution-engine/contract-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-contract-ffi"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."


### PR DESCRIPTION
### Overview
Bumps the FFI 0.16.0 -> 0.17.0

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-750

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
