### PR TITLE
NODE-873: Call upgrade before deploy execution

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -8,19 +8,20 @@ import io.casperlabs.casper.DeploySelection.DeploySelection
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.finality.singlesweep.FinalityDetector
+import io.casperlabs.casper.util.CasperLabsProtocolVersions
 import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.casper.util.execengine.ExecEngineUtil
 import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.casper.validation.Validation
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.comm.gossiping
+import io.casperlabs.ipc
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block.BlockStorage
 import io.casperlabs.storage.dag.{DagRepresentation, DagStorage}
 import io.casperlabs.storage.deploy.DeployStorage
-import io.casperlabs.casper.util.CasperLabsProtocolVersions
 
 trait MultiParentCasper[F[_]] {
   //// Brought from Casper trait
@@ -78,6 +79,7 @@ sealed abstract class MultiParentCasperInstances {
       genesisPreState: StateHash,
       genesisEffects: ExecEngineUtil.TransformMap,
       chainId: String,
+      upgrades: Seq[ipc.ChainSpec.UpgradePoint],
       relaying: gossiping.Relaying[F]
   ): F[MultiParentCasper[F]] =
     for {
@@ -86,13 +88,14 @@ sealed abstract class MultiParentCasperInstances {
                                                                               genesisPreState,
                                                                               genesisEffects
                                                                             )
-      statelessExecutor <- MultiParentCasperImpl.StatelessExecutor.create[F](chainId)
+      statelessExecutor <- MultiParentCasperImpl.StatelessExecutor.create[F](chainId, upgrades)
       casper <- MultiParentCasperImpl.create[F](
                  statelessExecutor,
                  MultiParentCasperImpl.Broadcaster.fromGossipServices(validatorId, relaying),
                  validatorId,
                  genesis,
                  chainId,
+                 upgrades,
                  blockProcessingLock
                )
     } yield casper

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -872,9 +872,7 @@ object MultiParentCasperImpl {
         chainId: String,
         upgrades: Seq[ipc.ChainSpec.UpgradePoint]
     ): F[StatelessExecutor[F]] =
-      for {
-        _ <- establishMetrics[F]
-      } yield new StatelessExecutor[F](chainId, upgrades)
+      establishMetrics[F] as new StatelessExecutor[F](chainId, upgrades)
   }
 
   /** Encapsulating all methods that might use peer-to-peer communication. */

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -42,10 +42,12 @@ object ExecEngineUtil {
       merged: MergeResult[TransformMap, Block],
       deployStream: fs2.Stream[F, Deploy],
       blocktime: Long,
-      protocolVersion: state.ProtocolVersion
+      protocolVersion: state.ProtocolVersion,
+      rank: Long,
+      upgrades: Seq[ChainSpec.UpgradePoint]
   ): F[DeploysCheckpoint] =
     for {
-      preStateHash <- computePrestate[F](merged)
+      preStateHash <- computePrestate[F](merged, rank, upgrades)
       pdr <- DeploySelection[F].select(
               (preStateHash, blocktime, protocolVersion, deployStream)
             )
@@ -216,20 +218,51 @@ object ExecEngineUtil {
     }
   }
 
+  /** Compute the post state hash of the merged state, which is to be the pre-state
+    * of the block we are creating or validating, by committing all the changes of
+    * the secondary parents they made on top of the main parent. Then apply any
+    * upgrades which were activated at the point we are building the next block on.
+    */
   def computePrestate[F[_]: MonadError[?[_], Throwable]: ExecutionEngineService](
-      merged: MergeResult[TransformMap, Block]
-  ): F[StateHash] = merged match {
-    case MergeResult.EmptyMerge => ExecutionEngineService[F].emptyStateHash.pure[F] //no parents
-    case MergeResult.Result(soleParent, _, others) if others.isEmpty =>
-      ProtoUtil.postStateHash(soleParent).pure[F] //single parent
-    case MergeResult.Result(initParent, nonFirstParentsCombinedEffect, _) => //multiple parents
-      val prestate        = ProtoUtil.postStateHash(initParent)
-      val protocolVersion = initParent.getHeader.getProtocolVersion
-      MonadError[F, Throwable]
-        .rethrow(
-          ExecutionEngineService[F].commit(prestate, nonFirstParentsCombinedEffect, protocolVersion)
-        )
-        .map(_.postStateHash)
+      merged: MergeResult[TransformMap, Block],
+      rank: Long, // Rank of the block we are creating on top of the parents; can be way ahead because of justifications.
+      upgrades: Seq[ChainSpec.UpgradePoint]
+  ): F[StateHash] = {
+    val mergedStateHash: F[StateHash] = merged match {
+      case MergeResult.EmptyMerge =>
+        ExecutionEngineService[F].emptyStateHash.pure[F] //no parents
+
+      case MergeResult.Result(soleParent, _, others) if others.isEmpty =>
+        ProtoUtil.postStateHash(soleParent).pure[F] //single parent
+
+      case MergeResult.Result(initParent, nonFirstParentsCombinedEffect, _) => //multiple parents
+        val prestate        = ProtoUtil.postStateHash(initParent)
+        val protocolVersion = initParent.getHeader.getProtocolVersion
+        ExecutionEngineService[F]
+          .commit(prestate, nonFirstParentsCombinedEffect, protocolVersion)
+          .rethrow
+          .map(_.postStateHash)
+    }
+
+    mergedStateHash.flatMap { postStateHash =>
+      if (merged.parents.nonEmpty) {
+        val protocolVersion = merged.parents.head.getHeader.getProtocolVersion
+        val maxRank         = merged.parents.map(_.getHeader.rank).max
+        val activatedUpgrades = upgrades.filter { u =>
+          maxRank < u.getActivationPoint.rank && u.getActivationPoint.rank <= rank
+        }
+        activatedUpgrades.toList.foldLeftM(postStateHash) {
+          case (postStateHash, upgrade) =>
+            ExecutionEngineService[F]
+              .upgrade(postStateHash, upgrade, protocolVersion)
+              .rethrow
+              .map(_.postStateHash)
+          // NOTE: We are dropping the effects here, so they won't be part of the block.
+        }
+      } else {
+        postStateHash.pure[F]
+      }
+    }
   }
 
   type TransformMap = Seq[TransformEntry]

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -251,41 +251,23 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       treatAsGenesis: Boolean = false
   ): F[Boolean] =
     if (b.blockHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block hash is empty."))
-      } yield false
+      Log[F].warn(ignore(b, s"block hash is empty.")).as(false)
     } else if (b.header.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block header is missing."))
-      } yield false
+      Log[F].warn(ignore(b, s"block header is missing.")).as(false)
     } else if (b.getSignature.sig.isEmpty && !treatAsGenesis) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block signature is empty."))
-      } yield false
+      Log[F].warn(ignore(b, s"block signature is empty.")).as(false)
     } else if (!b.getSignature.sig.isEmpty && treatAsGenesis) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block signature is not empty on Genesis."))
-      } yield false
+      Log[F].warn(ignore(b, s"block signature is not empty on Genesis.")).as(false)
     } else if (b.getSignature.sigAlgorithm.isEmpty && !treatAsGenesis) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block signature algorithm is not empty on Genesis."))
-      } yield false
+      Log[F].warn(ignore(b, s"block signature algorithm is not empty on Genesis.")).as(false)
     } else if (!b.getSignature.sigAlgorithm.isEmpty && treatAsGenesis) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block signature algorithm is empty."))
-      } yield false
+      Log[F].warn(ignore(b, s"block signature algorithm is empty.")).as(false)
     } else if (b.chainId.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block chain identifier is empty."))
-      } yield false
+      Log[F].warn(ignore(b, s"block chain identifier is empty.")).as(false)
     } else if (b.state.postStateHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block post state hash is empty."))
-      } yield false
+      Log[F].warn(ignore(b, s"block post state hash is empty.")).as(false)
     } else if (b.bodyHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block new code hash is empty."))
-      } yield false
+      Log[F].warn(ignore(b, s"block new code hash is empty.")).as(false)
     } else {
       true.pure[F]
     }

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -319,6 +319,7 @@ object DeploySelectionTest {
       ) => F[Either[Throwable, Seq[DeployResult]]]
   ): ExecutionEngineService[F] = ExecutionEngineServiceStub.mock(
     (_) => raiseNotImplemented[F, Either[Throwable, GenesisResult]],
+    (_, _, _) => raiseNotImplemented[F, Either[Throwable, UpgradeResult]],
     execFunc,
     (_, _) => raiseNotImplemented[F, Either[Throwable, CommitResult]],
     (_, _, _) => raiseNotImplemented[F, Either[Throwable, Value]]

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -992,7 +992,9 @@ class ValidationTest
                               ExecEngineUtil.MergeResult.empty,
                               fs2.Stream.fromIterator[Task, Deploy](deploys.toIterator),
                               System.currentTimeMillis,
-                              ProtocolVersion(1)
+                              ProtocolVersion(1),
+                              rank = 0,
+                              upgrades = Nil
                             )
         DeploysCheckpoint(
           preStateHash,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -89,7 +89,9 @@ object BlockGenerator {
                  merged,
                  fs2.Stream.fromIterator(deploys.toIterator),
                  b.getHeader.timestamp,
-                 ProtocolVersion(1)
+                 ProtocolVersion(1),
+                 rank = 0,
+                 upgrades = Nil
                )
     } yield result
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -76,11 +76,12 @@ class GossipServiceCasperTestNode[F[_]](
   // - the download manager tries to validate a block
   implicit val casperEff: MultiParentCasperImpl[F] =
     new MultiParentCasperImpl[F](
-      new MultiParentCasperImpl.StatelessExecutor[F](chainId),
+      new MultiParentCasperImpl.StatelessExecutor[F](chainId, upgrades = Nil),
       MultiParentCasperImpl.Broadcaster.fromGossipServices(Some(validatorId), relaying),
       Some(validatorId),
       genesis,
       chainId,
+      upgrades = Nil,
       blockProcessingLock,
       faultToleranceThreshold = faultToleranceThreshold
     )

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -272,6 +272,15 @@ object HashSetCasperTestNode {
           _.map(cr => GenesisResult(cr.postStateHash).withEffect(ExecutionEffect()))
         }
 
+      override def upgrade(
+          prestate: ByteString,
+          upgrade: ipc.ChainSpec.UpgradePoint,
+          protocolVersion: ProtocolVersion
+      ): F[Either[Throwable, UpgradeResult]] =
+        commit(emptyStateHash, Seq.empty, protocolVersion).map {
+          _.map(cr => UpgradeResult(cr.postStateHash).withEffect(ExecutionEffect()))
+        }
+
       override def commit(
           prestate: ByteString,
           effects: Seq[TransformEntry],

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -277,9 +277,7 @@ object HashSetCasperTestNode {
           upgrade: ipc.ChainSpec.UpgradePoint,
           protocolVersion: ProtocolVersion
       ): F[Either[Throwable, UpgradeResult]] =
-        commit(emptyStateHash, Seq.empty, protocolVersion).map {
-          _.map(cr => UpgradeResult(cr.postStateHash).withEffect(ExecutionEffect()))
-        }
+        UpgradeResult(prestate).withEffect(ExecutionEffect()).asRight[Throwable].pure[F]
 
       override def commit(
           prestate: ByteString,

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -131,7 +131,9 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
                           ExecEngineUtil.MergeResult.empty,
                           fs2.Stream.fromIterator[Task, consensus.Deploy](deploy.toIterator),
                           blocktime,
-                          protocolVersion
+                          protocolVersion,
+                          rank = 0,
+                          upgrades = Nil
                         )
       DeploysCheckpoint(_, _, _, result, _) = computeResult
     } yield result
@@ -170,6 +172,7 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
       val failedExecEEService: ExecutionEngineService[Task] =
         mock[Task](
           (_) => new Throwable("failed when run genesis").asLeft.pure[Task],
+          (_, _, _) => new Throwable("failed when run upgrade").asLeft.pure[Task],
           (_, _, _, _) => new Throwable("failed when exec deploys").asLeft.pure[Task],
           (_, _) => new Throwable("failed when commit transform").asLeft.pure[Task],
           (_, _, _) => SmartContractEngineError("unimplemented").asLeft.pure[Task]
@@ -178,6 +181,7 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
       val failedCommitEEService: ExecutionEngineService[Task] =
         mock[Task](
           (_) => new Throwable("failed when run genesis").asLeft.pure[Task],
+          (_, _, _) => new Throwable("failed when run upgrade").asLeft.pure[Task],
           (_, _, deploys, _) =>
             Task.now {
               def getExecutionEffect(deploy: ipc.DeployItem) = {

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -125,39 +125,35 @@ class GrpcExecutionEngineService[F[_]: Defer: Sync: Log: TaskLift: Metrics] priv
   override def runGenesis(
       genesisConfig: GenesisConfig
   ): F[Either[Throwable, GenesisResult]] =
-    for {
-      response <- sendMessage(genesisConfig, _.runGenesisWithChainspec) {
-                   _.result match {
-                     case GenesisResponse.Result.Success(result) =>
-                       Right(result)
-                     case GenesisResponse.Result.FailedDeploy(error) =>
-                       Left(new SmartContractEngineError(error.message))
-                     case GenesisResponse.Result.Empty =>
-                       Left(new SmartContractEngineError("empty response"))
-                   }
-                 }
-    } yield response
+    sendMessage(genesisConfig, _.runGenesisWithChainspec) {
+      _.result match {
+        case GenesisResponse.Result.Success(result) =>
+          Right(result)
+        case GenesisResponse.Result.FailedDeploy(error) =>
+          Left(new SmartContractEngineError(error.message))
+        case GenesisResponse.Result.Empty =>
+          Left(new SmartContractEngineError("empty response"))
+      }
+    }
 
   def upgrade(
       prestate: ByteString,
       upgrade: UpgradePoint,
       protocolVersion: ProtocolVersion
   ): F[Either[Throwable, UpgradeResult]] =
-    for {
-      response <- sendMessage(
-                   UpgradeRequest(prestate, Some(upgrade), Some(protocolVersion)),
-                   _.upgrade
-                 ) {
-                   _.result match {
-                     case UpgradeResponse.Result.Success(result) =>
-                       Right(result)
-                     case UpgradeResponse.Result.FailedDeploy(error) =>
-                       Left(new SmartContractEngineError(error.message))
-                     case UpgradeResponse.Result.Empty =>
-                       Left(new SmartContractEngineError("empty response"))
-                   }
-                 }
-    } yield response
+    sendMessage(
+      UpgradeRequest(prestate, Some(upgrade), Some(protocolVersion)),
+      _.upgrade
+    ) {
+      _.result match {
+        case UpgradeResponse.Result.Success(result) =>
+          Right(result)
+        case UpgradeResponse.Result.FailedDeploy(error) =>
+          Left(new SmartContractEngineError(error.message))
+        case UpgradeResponse.Result.Empty =>
+          Left(new SmartContractEngineError("empty response"))
+      }
+    }
 
   override def commit(
       prestate: ByteString,


### PR DESCRIPTION
### Overview
Calls the EE upgrade endpoint during the calculation of the pre-state-hash of a block if new upgrades are activated.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-873

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The effects returned by the EE are discarded. Don't know if that's okay or we should store them.
Contrary to the spec there can be multiple upgrades at any point because the ranks can jump ahead and skip a bunch if the parents are older than the justifications.
