### PR TITLE
OP-758: build node contracts before packaging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -539,7 +539,7 @@ steps:
 
 - name: package-sbt-artifacts-merge
   commands:
-  - "make build-client-contracts"
+  - "make build-client-contracts build-node-contracts"
   - "sbt update test client/debian:packageBin client/universal:packageZipTarball client/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball node/rpm:packageBin node/docker:publishLocal client/docker:publishLocal"
   - "mkdir -p artifacts/${DRONE_BRANCH}"
   - "cp client/target/casperlabs-client_*_all.deb client/target/universal/*.tgz artifacts/${DRONE_BRANCH}"
@@ -792,7 +792,7 @@ name: on-tag
 steps:
 - name: package-sbt-artifacts-tag
   commands:
-  - "make build-client-contracts"
+  - "make build-client-contracts build-node-contracts"
   - "sbt update test client/debian:packageBin client/universal:packageZipTarball client/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball node/rpm:packageBin"
   - "mkdir -p artifacts/${DRONE_BRANCH}"
   - "cp client/target/casperlabs-client_*_all.deb client/target/universal/*.tgz artifacts/${DRONE_BRANCH}"


### PR DESCRIPTION
### Overview
Builds the node contracts before packaging to ensure the chainspec contracts are bundled into the node.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-758

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
