### PR TITLE
EE-719: align system_contracts module

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/error.rs
+++ b/execution-engine/contract-ffi/src/contract_api/error.rs
@@ -1,13 +1,19 @@
 use core::fmt::{self, Debug, Formatter};
 use core::{u16, u8};
 
+use crate::system_contracts::{mint, pos};
+
 /// All `Error` variants defined in this library other than `Error::User` will convert to a `u32`
 /// value less than or equal to `RESERVED_ERROR_MAX`.
-const RESERVED_ERROR_MAX: u32 = u16::MAX as u32;
+const RESERVED_ERROR_MAX: u32 = u16::MAX as u32; // 0..=65535
 
 /// Proof of Stake errors (defined in "contracts/system/pos/src/error.rs") will have this value
 /// added to them when being converted to a `u32`.
-const POS_ERROR_OFFSET: u32 = RESERVED_ERROR_MAX - u8::MAX as u32;
+const POS_ERROR_OFFSET: u32 = RESERVED_ERROR_MAX - u8::MAX as u32; // 65280..=65535
+
+/// Mint errors (defined in "contracts/system/mint/src/error.rs") will have this value
+/// added to them when being converted to a `u32`.
+const MINT_ERROR_OFFSET: u32 = (POS_ERROR_OFFSET - 1) - u8::MAX as u32; // 65024..=65279
 
 /// Variants to be passed to `contract_api::revert()`.
 ///
@@ -54,8 +60,6 @@ pub enum Error {
     Read,
     /// The given key returned a `None` value.
     ValueNotFound,
-    /// Failed to initialize a mint purse.
-    MintFailure,
     /// Invalid purse name given.
     InvalidPurseName,
     /// Invalid purse retrieved.
@@ -72,11 +76,25 @@ pub enum Error {
     NoAccessRights,
     /// Optional data was unexpectedly `None`.
     None,
+    /// Error specific to Mint contract.
+    Mint(u8),
     /// Error specific to Proof of Stake contract.
     ProofOfStake(u8),
     /// User-specified value.  The internal `u16` value is added to `u16::MAX as u32 + 1` when an
     /// `Error::User` is converted to a `u32`.
     User(u16),
+}
+
+impl From<mint::Error> for Error {
+    fn from(error: mint::Error) -> Self {
+        Error::Mint(error as u8)
+    }
+}
+
+impl From<pos::Error> for Error {
+    fn from(error: pos::Error) -> Self {
+        Error::ProofOfStake(error as u8)
+    }
 }
 
 impl From<Error> for u32 {
@@ -90,15 +108,15 @@ impl From<Error> for u32 {
             Error::UnexpectedContractPointerVariant => 6,
             Error::Read => 7,
             Error::ValueNotFound => 8,
-            Error::MintFailure => 9,
-            Error::InvalidPurseName => 10,
-            Error::InvalidPurse => 11,
-            Error::MissingArgument => 12,
-            Error::InvalidArgument => 13,
-            Error::UpgradeContractAtURef => 14,
-            Error::Transfer => 15,
-            Error::NoAccessRights => 16,
-            Error::None => 17,
+            Error::InvalidPurseName => 9,
+            Error::InvalidPurse => 10,
+            Error::MissingArgument => 11,
+            Error::InvalidArgument => 12,
+            Error::UpgradeContractAtURef => 13,
+            Error::Transfer => 14,
+            Error::NoAccessRights => 15,
+            Error::None => 16,
+            Error::Mint(value) => MINT_ERROR_OFFSET + u32::from(value),
             Error::ProofOfStake(value) => POS_ERROR_OFFSET + u32::from(value),
             Error::User(value) => RESERVED_ERROR_MAX + 1 + u32::from(value),
         }
@@ -118,7 +136,6 @@ impl Debug for Error {
             }
             Error::Read => write!(f, "Error::Read")?,
             Error::ValueNotFound => write!(f, "Error::ValueNotFound")?,
-            Error::MintFailure => write!(f, "Error::MintFailure")?,
             Error::InvalidPurseName => write!(f, "Error::InvalidPurseName")?,
             Error::InvalidPurse => write!(f, "Error::InvalidPurse")?,
             Error::MissingArgument => write!(f, "Error::MissingArgument")?,
@@ -127,6 +144,7 @@ impl Debug for Error {
             Error::Transfer => write!(f, "Error::Transfer")?,
             Error::NoAccessRights => write!(f, "Error::NoAccessRights")?,
             Error::None => write!(f, "Error::None")?,
+            Error::Mint(value) => write!(f, "Error::Mint({})", value)?,
             Error::ProofOfStake(value) => write!(f, "Error::ProofOfStake({})", value)?,
             Error::User(value) => write!(f, "Error::User({})", value)?,
         }
@@ -152,18 +170,19 @@ pub fn result_from(value: i32) -> Result<(), Error> {
         6 => Err(Error::UnexpectedContractPointerVariant),
         7 => Err(Error::Read),
         8 => Err(Error::ValueNotFound),
-        9 => Err(Error::MintFailure),
-        10 => Err(Error::InvalidPurseName),
-        11 => Err(Error::InvalidPurse),
-        12 => Err(Error::MissingArgument),
-        13 => Err(Error::InvalidArgument),
-        14 => Err(Error::UpgradeContractAtURef),
-        15 => Err(Error::Transfer),
-        16 => Err(Error::NoAccessRights),
-        17 => Err(Error::None),
+        9 => Err(Error::InvalidPurseName),
+        10 => Err(Error::InvalidPurse),
+        11 => Err(Error::MissingArgument),
+        12 => Err(Error::InvalidArgument),
+        13 => Err(Error::UpgradeContractAtURef),
+        14 => Err(Error::Transfer),
+        15 => Err(Error::NoAccessRights),
+        16 => Err(Error::None),
         _ => {
             if value > RESERVED_ERROR_MAX as i32 && value <= (2 * RESERVED_ERROR_MAX + 1) as i32 {
                 Err(Error::User(value as u16))
+            } else if value >= MINT_ERROR_OFFSET as i32 && value < POS_ERROR_OFFSET as i32 {
+                Err(Error::Mint(value as u8))
             } else if value >= POS_ERROR_OFFSET as i32 {
                 Err(Error::ProofOfStake(value as u8))
             } else {
@@ -185,12 +204,19 @@ mod tests {
 
     #[test]
     fn error() {
+        assert_eq!(65_024_u32, Error::Mint(0).into()); // MINT_ERROR_OFFSET == 65,024
+        assert_eq!(65_279_u32, Error::Mint(u8::MAX).into());
         assert_eq!(65_280_u32, Error::ProofOfStake(0).into()); // POS_ERROR_OFFSET == 65,280
         assert_eq!(65_535_u32, Error::ProofOfStake(u8::MAX).into());
         assert_eq!(65_536_u32, Error::User(0).into()); // u16::MAX + 1
         assert_eq!(131_071_u32, Error::User(u16::MAX).into()); // 2 * u16::MAX + 1
 
         assert_eq!("Error::GetURef [1]", &format!("{:?}", Error::GetURef));
+        assert_eq!("Error::Mint(0) [65024]", &format!("{:?}", Error::Mint(0)));
+        assert_eq!(
+            "Error::Mint(255) [65279]",
+            &format!("{:?}", Error::Mint(u8::MAX))
+        );
         assert_eq!(
             "Error::ProofOfStake(0) [65280]",
             &format!("{:?}", Error::ProofOfStake(0))
@@ -214,7 +240,6 @@ mod tests {
         round_trip(Err(Error::UnexpectedContractPointerVariant));
         round_trip(Err(Error::Read));
         round_trip(Err(Error::ValueNotFound));
-        round_trip(Err(Error::MintFailure));
         round_trip(Err(Error::InvalidPurseName));
         round_trip(Err(Error::InvalidPurse));
         round_trip(Err(Error::MissingArgument));

--- a/execution-engine/contract-ffi/src/system_contracts/error.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/error.rs
@@ -1,13 +1,20 @@
-use crate::system_contracts::mint;
+use super::{mint, pos};
 
 /// An aggregate enum error with variants for each system contract's error.
 #[derive(Debug)]
 pub enum Error {
-    MintError(mint::error::Error),
+    MintError(mint::Error),
+    PosError(pos::Error),
 }
 
-impl From<mint::error::Error> for Error {
-    fn from(error: mint::error::Error) -> Error {
+impl From<mint::Error> for Error {
+    fn from(error: mint::Error) -> Error {
         Error::MintError(error)
+    }
+}
+
+impl From<pos::Error> for Error {
+    fn from(error: pos::Error) -> Error {
+        Error::PosError(error)
     }
 }

--- a/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
@@ -9,7 +9,7 @@ use crate::system_contracts::mint::purse_id::PurseIdError;
 /// An enum error that is capable of carrying a value across FFI-Host
 /// boundary.
 #[derive(Fail, Debug, Copy, Clone, PartialEq, Eq)]
-#[repr(u32)]
+#[repr(u8)]
 pub enum Error {
     #[fail(display = "Insufficient funds")]
     InsufficientFunds = 0,
@@ -47,38 +47,38 @@ impl From<PurseIdError> for Error {
 }
 
 /// The error type returned when a construction
-pub struct TryFromDeserializedU32Error(());
+pub struct TryFromU8ForError(());
 
-impl TryFrom<u32> for Error {
-    type Error = TryFromDeserializedU32Error;
+impl TryFrom<u8> for Error {
+    type Error = TryFromU8ForError;
 
-    fn try_from(value: u32) -> Result<Self, Self::Error> {
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            d if d == Error::InsufficientFunds as u32 => Ok(Error::InsufficientFunds),
-            d if d == Error::SourceNotFound as u32 => Ok(Error::SourceNotFound),
-            d if d == Error::DestNotFound as u32 => Ok(Error::DestNotFound),
-            d if d == Error::InvalidURef as u32 => Ok(Error::InvalidURef),
-            d if d == Error::InvalidAccessRights as u32 => Ok(Error::InvalidAccessRights),
-            d if d == Error::MissingArgument as u32 => Ok(Error::MissingArgument),
-            d if d == Error::InvalidArgument as u32 => Ok(Error::InvalidArgument),
-            d if d == Error::InvalidNonEmptyPurseCreation as u32 => {
+            d if d == Error::InsufficientFunds as u8 => Ok(Error::InsufficientFunds),
+            d if d == Error::SourceNotFound as u8 => Ok(Error::SourceNotFound),
+            d if d == Error::DestNotFound as u8 => Ok(Error::DestNotFound),
+            d if d == Error::InvalidURef as u8 => Ok(Error::InvalidURef),
+            d if d == Error::InvalidAccessRights as u8 => Ok(Error::InvalidAccessRights),
+            d if d == Error::MissingArgument as u8 => Ok(Error::MissingArgument),
+            d if d == Error::InvalidArgument as u8 => Ok(Error::InvalidArgument),
+            d if d == Error::InvalidNonEmptyPurseCreation as u8 => {
                 Ok(Error::InvalidNonEmptyPurseCreation)
             }
-            _ => Err(TryFromDeserializedU32Error(())),
+            _ => Err(TryFromU8ForError(())),
         }
     }
 }
 
 impl ToBytes for Error {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let value = *self as u32;
+        let value = *self as u8;
         value.to_bytes()
     }
 }
 
 impl FromBytes for Error {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (value, rem): (u32, _) = FromBytes::from_bytes(bytes)?;
+        let (value, rem): (u8, _) = FromBytes::from_bytes(bytes)?;
         let error: Error = value
             .try_into()
             // In case an Error variant is unable to be determined it would

--- a/execution-engine/contract-ffi/src/system_contracts/mint/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mint/mod.rs
@@ -1,2 +1,5 @@
-pub mod error;
-pub mod purse_id;
+mod error;
+mod purse_id;
+
+pub use error::Error;
+pub use purse_id::PurseIdError;

--- a/execution-engine/contract-ffi/src/system_contracts/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mod.rs
@@ -5,5 +5,8 @@
 //!
 //! Naming of the modules is related to actual system contract that is user of
 //! the supporting code i.e. mint.
-pub mod error;
+mod error;
 pub mod mint;
+pub mod pos;
+
+pub use error::Error;

--- a/execution-engine/contract-ffi/src/system_contracts/pos/error.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/pos/error.rs
@@ -1,7 +1,5 @@
 use core::result;
 
-use contract_ffi::contract_api::Error as ApiError;
-
 #[derive(Debug, PartialEq)]
 // TODO: Split this up into user errors vs. system errors.
 #[repr(u8)]
@@ -43,12 +41,6 @@ pub enum Error {
     FailedTransferToRewardsPurse,
     FailedTransferToAccountPurse,
     SetRefundPurseCalledOutsidePayment,
-}
-
-impl From<Error> for ApiError {
-    fn from(error: Error) -> Self {
-        ApiError::ProofOfStake(error as u8)
-    }
 }
 
 pub type Result<T> = result::Result<T, Error>;

--- a/execution-engine/contract-ffi/src/system_contracts/pos/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/pos/mod.rs
@@ -1,0 +1,5 @@
+mod error;
+
+pub use error::Error;
+pub use error::PurseLookupError;
+pub use error::Result;

--- a/execution-engine/contracts/system/mint-token/src/internal_purse_id.rs
+++ b/execution-engine/contracts/system/mint-token/src/internal_purse_id.rs
@@ -1,5 +1,5 @@
 use contract_ffi::contract_api;
-use contract_ffi::system_contracts::mint::purse_id::PurseIdError;
+use contract_ffi::system_contracts::mint::PurseIdError;
 use contract_ffi::uref::URef;
 
 pub struct WithdrawId([u8; 32]);

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -20,7 +20,7 @@ use core::convert::TryInto;
 
 use contract_ffi::contract_api::{self, Error as ApiError};
 use contract_ffi::key::Key;
-use contract_ffi::system_contracts::mint::error::Error;
+use contract_ffi::system_contracts::mint::Error;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::account::KEY_SIZE;

--- a/execution-engine/contracts/system/mint-token/src/mint.rs
+++ b/execution-engine/contracts/system/mint-token/src/mint.rs
@@ -1,7 +1,7 @@
+use contract_ffi::system_contracts::mint::Error;
 use contract_ffi::value::U512;
 
 use crate::capabilities::{Addable, Readable, Writable};
-use contract_ffi::system_contracts::mint::error::Error;
 
 pub trait Mint<A, RW>
 where

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -98,10 +98,8 @@ pub extern "C" fn call() {
 }
 
 fn mint_purse(mint: &ContractPointer, amount: U512) -> PurseId {
-    let result: Result<URef, mint::error::Error> =
+    let result: Result<URef, mint::Error> =
         contract_api::call_contract(mint.clone(), &("mint", amount), &vec![]);
 
-    result
-        .map(PurseId::new)
-        .unwrap_or_else(|_| contract_api::revert(Error::MintFailure))
+    result.map(PurseId::new).unwrap_or_revert()
 }

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -5,7 +5,6 @@ extern crate alloc;
 
 extern crate contract_ffi;
 
-mod error;
 mod queue;
 mod stakes;
 
@@ -15,12 +14,12 @@ use alloc::vec::Vec;
 use contract_ffi::contract_api;
 use contract_ffi::execution::Phase;
 use contract_ffi::key::Key;
+use contract_ffi::system_contracts::pos::{Error, PurseLookupError, Result};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::account::{BlockTime, PublicKey, PurseId};
 use contract_ffi::value::U512;
 
-use crate::error::{Error, PurseLookupError, Result};
 use crate::queue::{QueueEntry, QueueLocal, QueueProvider};
 use crate::stakes::{ContractStakes, StakesProvider};
 
@@ -366,12 +365,12 @@ mod tests {
     use std::cell::RefCell;
     use std::iter;
 
+    use contract_ffi::system_contracts::pos::Result;
     use contract_ffi::value::{
         account::{BlockTime, PublicKey},
         U512,
     };
 
-    use crate::error::Result;
     use crate::queue::{Queue, QueueProvider};
     use crate::stakes::{Stakes, StakesProvider};
     use crate::{bond, step, unbond, BOND_DELAY, UNBOND_DELAY};

--- a/execution-engine/contracts/system/pos/src/queue.rs
+++ b/execution-engine/contracts/system/pos/src/queue.rs
@@ -7,7 +7,7 @@ use contract_ffi::contract_api;
 use contract_ffi::value::account::{BlockTime, PublicKey};
 use contract_ffi::value::{Value, U512};
 
-use crate::error::{Error, Result};
+use contract_ffi::system_contracts::pos::{Error, Result};
 
 const BONDING_KEY: u8 = 1;
 const UNBONDING_KEY: u8 = 2;
@@ -182,10 +182,10 @@ impl ToBytes for Queue {
 
 #[cfg(test)]
 mod tests {
+    use contract_ffi::system_contracts::pos::Error;
     use contract_ffi::value::account::{BlockTime, PublicKey};
     use contract_ffi::value::U512;
 
-    use crate::error::Error;
     use crate::queue::{Queue, QueueEntry};
 
     const KEY1: [u8; 32] = [1; 32];

--- a/execution-engine/contracts/system/pos/src/stakes.rs
+++ b/execution-engine/contracts/system/pos/src/stakes.rs
@@ -4,9 +4,8 @@ use core::fmt::Write;
 
 use contract_ffi::contract_api;
 use contract_ffi::key::Key;
+use contract_ffi::system_contracts::pos::{Error, Result};
 use contract_ffi::value::{account::PublicKey, U512};
-
-use crate::error::{Error, Result};
 
 use super::{MAX_DECREASE, MAX_INCREASE, MAX_REL_DECREASE, MAX_REL_INCREASE, MAX_SPREAD};
 
@@ -195,9 +194,9 @@ impl Stakes {
 
 #[cfg(test)]
 mod tests {
+    use contract_ffi::system_contracts::pos::Error;
     use contract_ffi::value::{account::PublicKey, U512};
 
-    use crate::error::Error;
     use crate::stakes::Stakes;
 
     const KEY1: [u8; 32] = [1; 32];

--- a/execution-engine/contracts/test/mint-purse/src/lib.rs
+++ b/execution-engine/contracts/test/mint-purse/src/lib.rs
@@ -19,10 +19,10 @@ enum Error {
     BalanceMismatch,
 }
 
-fn mint_purse(amount: U512) -> Result<PurseId, mint::error::Error> {
+fn mint_purse(amount: U512) -> Result<PurseId, mint::Error> {
     let mint = contract_api::get_mint();
 
-    let result: Result<URef, mint::error::Error> =
+    let result: Result<URef, mint::Error> =
         contract_api::call_contract(mint, &("mint", amount), &vec![]);
 
     result.map(PurseId::new)

--- a/execution-engine/contracts/test/modified-mint/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint/src/lib.rs
@@ -9,7 +9,7 @@ extern crate mint_token;
 use alloc::string::{String, ToString};
 
 use contract_ffi::contract_api::{self, Error as ApiError};
-use contract_ffi::system_contracts::mint::error::Error;
+use contract_ffi::system_contracts::mint::Error;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::uref::{AccessRights, URef};
 use contract_ffi::value::U512;

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
     #[fail(display = "Serialization error: {}", _0)]
     SerializationError(bytesrepr::Error),
     #[fail(display = "Mint error: {}", _0)]
-    MintError(mint::error::Error),
+    MintError(mint::Error),
 }
 
 impl From<engine_wasm_prep::PreprocessingError> for Error {
@@ -70,8 +70,8 @@ impl From<bytesrepr::Error> for Error {
     }
 }
 
-impl From<mint::error::Error> for Error {
-    fn from(error: mint::error::Error) -> Self {
+impl From<mint::Error> for Error {
+    fn from(error: mint::Error) -> Self {
         Error::MintError(error)
     }
 }

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -398,7 +398,7 @@ where
                 };
 
                 // ...call the Mint's "mint" endpoint to create purse with tokens...
-                let mint_result: Result<URef, mint::error::Error> = executor.better_exec(
+                let mint_result: Result<URef, mint::Error> = executor.better_exec(
                     module,
                     &args,
                     &mut named_keys_exec,

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -39,7 +39,7 @@ pub enum Error {
     RemoveKeyFailure(RemoveKeyFailure),
     UpdateKeyFailure(UpdateKeyFailure),
     SetThresholdFailure(SetThresholdFailure),
-    SystemContractError(system_contracts::error::Error),
+    SystemContractError(system_contracts::Error),
     DeploymentAuthorizationFailure,
     ExpectedReturnValue,
     UnexpectedReturnValue,
@@ -113,8 +113,8 @@ impl From<SetThresholdFailure> for Error {
     }
 }
 
-impl From<system_contracts::error::Error> for Error {
-    fn from(error: system_contracts::error::Error) -> Error {
+impl From<system_contracts::Error> for Error {
+    fn from(error: system_contracts::Error) -> Error {
         Error::SystemContractError(error)
     }
 }

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -757,10 +757,10 @@ where
 
         // This will deserialize `host_buf` into the Result type which carries
         // mint contract error.
-        let result: Result<(), mint::error::Error> = deserialize(&self.host_buf)?;
+        let result: Result<(), mint::Error> = deserialize(&self.host_buf)?;
         // Wraps mint error into a more general error type through an aggregate
         // system contracts Error.
-        Ok(result.map_err(system_contracts::error::Error::from)?)
+        Ok(result.map_err(system_contracts::Error::from)?)
     }
 
     /// Creates a new account at a given public key, transferring a given amount


### PR DESCRIPTION
### Overview
This PR...
- moves the Proof of Stake `Error` enum into `contract_ffi::system_contracts::pos`
- moves the `contract_ffi::system_contracts::{mint, pos}::Error` enum converters into the `contract_api::error` module.
- integrates handling of `contract_ffi::system_contracts::mint::Error` in `contract_api::Error`, similar to the way we handle `contract_ffi::system_contracts::pos::Error`, removing the `MintFailure` variant.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-719

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
