### PR TITLE
NO-TICKET: Re-include pos and mint-token tests in CI

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -68,7 +68,7 @@ build-integration-contracts: $(INTEGRATION_CONTRACTS)
 
 .PHONY: test
 test: $(SYSTEM_CONTRACTS)
-	$(CARGO) test $(CARGO_FLAGS) -- --nocapture
+	$(CARGO) test $(CARGO_FLAGS) --all -- --nocapture
 
 .PHONY: test-contracts
 test-contracts: build-contracts

--- a/execution-engine/contracts/SRE/create-test-node-01/Cargo.toml
+++ b/execution-engine/contracts/SRE/create-test-node-01/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "create_test_node_01"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 create-test-node-shared = { path = "../create-test-node-shared" }

--- a/execution-engine/contracts/SRE/create-test-node-02/Cargo.toml
+++ b/execution-engine/contracts/SRE/create-test-node-02/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "create_test_node_02"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 create-test-node-shared = { path = "../create-test-node-shared" }

--- a/execution-engine/contracts/SRE/create-test-node-03/Cargo.toml
+++ b/execution-engine/contracts/SRE/create-test-node-03/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "create_test_node_03"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 create-test-node-shared = { path = "../create-test-node-shared" }

--- a/execution-engine/contracts/bench/create-accounts/Cargo.toml
+++ b/execution-engine/contracts/bench/create-accounts/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@papierski.net>"]
 edition = "2018"
 
 [lib]
-name = "create_accounts"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/bench/transfer-to-existing-account/Cargo.toml
+++ b/execution-engine/contracts/bench/transfer-to-existing-account/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@papierski.net>"]
 edition = "2018"
 
 [lib]
-name = "transfer_to_existing_account"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/bonding/Cargo.toml
+++ b/execution-engine/contracts/client/bonding/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/named-purse-payment/Cargo.toml
+++ b/execution-engine/contracts/client/named-purse-payment/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/revert/Cargo.toml
+++ b/execution-engine/contracts/client/revert/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/standard-payment-stored/Cargo.toml
+++ b/execution-engine/contracts/client/standard-payment-stored/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/standard-payment/Cargo.toml
+++ b/execution-engine/contracts/client/standard-payment/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/transfer-to-account/Cargo.toml
+++ b/execution-engine/contracts/client/transfer-to-account/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/client/unbonding/Cargo.toml
+++ b/execution-engine/contracts/client/unbonding/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/explorer/faucet/Cargo.toml
+++ b/execution-engine/contracts/explorer/faucet/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Mateusz Górski <mateusz@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "faucet"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/add-associated-key/Cargo.toml
+++ b/execution-engine/contracts/integration/add-associated-key/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/args-multi/Cargo.toml
+++ b/execution-engine/contracts/integration/args-multi/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/args-u32/Cargo.toml
+++ b/execution-engine/contracts/integration/args-u32/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/args-u512/Cargo.toml
+++ b/execution-engine/contracts/integration/args-u512/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/bonding-call/Cargo.toml
+++ b/execution-engine/contracts/integration/bonding-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/combined-contracts-define/Cargo.toml
+++ b/execution-engine/contracts/integration/combined-contracts-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/counter-call/Cargo.toml
+++ b/execution-engine/contracts/integration/counter-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/counter-define/Cargo.toml
+++ b/execution-engine/contracts/integration/counter-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/create-named-purse/Cargo.toml
+++ b/execution-engine/contracts/integration/create-named-purse/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/direct-revert-call/Cargo.toml
+++ b/execution-engine/contracts/integration/direct-revert-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/direct-revert-define/Cargo.toml
+++ b/execution-engine/contracts/integration/direct-revert-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/err-standard-payment/Cargo.toml
+++ b/execution-engine/contracts/integration/err-standard-payment/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/err-transfer-to-account/Cargo.toml
+++ b/execution-engine/contracts/integration/err-transfer-to-account/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/finalize-payment/Cargo.toml
+++ b/execution-engine/contracts/integration/finalize-payment/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/get-caller-call/Cargo.toml
+++ b/execution-engine/contracts/integration/get-caller-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/get-caller-define/Cargo.toml
+++ b/execution-engine/contracts/integration/get-caller-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/hello-name-call/Cargo.toml
+++ b/execution-engine/contracts/integration/hello-name-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/hello-name-define/Cargo.toml
+++ b/execution-engine/contracts/integration/hello-name-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/list-known-urefs-call/Cargo.toml
+++ b/execution-engine/contracts/integration/list-known-urefs-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/list-known-urefs-define/Cargo.toml
+++ b/execution-engine/contracts/integration/list-known-urefs-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/mailing-list-call/Cargo.toml
+++ b/execution-engine/contracts/integration/mailing-list-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/mailing-list-define/Cargo.toml
+++ b/execution-engine/contracts/integration/mailing-list-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = { package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/payment-from-named-purse/Cargo.toml
+++ b/execution-engine/contracts/integration/payment-from-named-purse/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/payment-purse/Cargo.toml
+++ b/execution-engine/contracts/integration/payment-purse/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/refund-purse/Cargo.toml
+++ b/execution-engine/contracts/integration/refund-purse/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/set-key-thresholds/Cargo.toml
+++ b/execution-engine/contracts/integration/set-key-thresholds/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/subcall-revert-call/Cargo.toml
+++ b/execution-engine/contracts/integration/subcall-revert-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/subcall-revert-define/Cargo.toml
+++ b/execution-engine/contracts/integration/subcall-revert-define/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/transfer-to-account-it/Cargo.toml
+++ b/execution-engine/contracts/integration/transfer-to-account-it/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/integration/unbonding-call/Cargo.toml
+++ b/execution-engine/contracts/integration/unbonding-call/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [dependencies]
 contract-ffi = {package = "casperlabs-contract-ffi", path = "../../../../execution-engine/contract-ffi" }

--- a/execution-engine/contracts/integration/update-associated-key/Cargo.toml
+++ b/execution-engine/contracts/integration/update-associated-key/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/profiling/simple-transfer/Cargo.toml
+++ b/execution-engine/contracts/profiling/simple-transfer/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/profiling/state-initializer/Cargo.toml
+++ b/execution-engine/contracts/profiling/state-initializer/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/system/mint-install/Cargo.toml
+++ b/execution-engine/contracts/system/mint-install/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "mint_install"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/system/mint-token/Cargo.toml
+++ b/execution-engine/contracts/system/mint-token/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "mint_token"
 crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
 
 [features]
 default = []

--- a/execution-engine/contracts/system/pos-install/Cargo.toml
+++ b/execution-engine/contracts/system/pos-install/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "pos_install"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/system/pos/Cargo.toml
+++ b/execution-engine/contracts/system/pos/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Andreas Fackler <andreas@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "pos"
 crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
 
 [features]
 default = []

--- a/execution-engine/contracts/system/test-mint-token/Cargo.toml
+++ b/execution-engine/contracts/system/test-mint-token/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "mint_token_test"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/add-update-associated-key/Cargo.toml
+++ b/execution-engine/contracts/test/add-update-associated-key/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io"]
 edition = "2018"
 
 [lib]
-name = "add_update_associated_key"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/authorized-keys/Cargo.toml
+++ b/execution-engine/contracts/test/authorized-keys/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "authorized_keys"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/check-system-contract-urefs-access-rights/Cargo.toml
+++ b/execution-engine/contracts/test/check-system-contract-urefs-access-rights/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/create-purse-01/Cargo.toml
+++ b/execution-engine/contracts/test/create-purse-01/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io"]
 edition = "2018"
 
 [lib]
-name = "create_purse_01"
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/deserialize-error/Cargo.toml
+++ b/execution-engine/contracts/test/deserialize-error/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Mateusz Górski <mateusz@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "deserialize_error"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/do-nothing-stored-caller/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "do_nothing_stored_caller"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "do_nothing_stored_upgrader"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/do-nothing-stored/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing-stored/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "do_nothing_stored"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/do-nothing/Cargo.toml
+++ b/execution-engine/contracts/test/do-nothing/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "do_nothing"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-221-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-221-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@papierski.net>"]
 edition = "2018"
 
 [lib]
-name = "ee_221_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-401-regression-call/Cargo.toml
+++ b/execution-engine/contracts/test/ee-401-regression-call/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "ee_401_regression_call"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-401-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-401-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "ee_401_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-441-rng-state/Cargo.toml
+++ b/execution-engine/contracts/test/ee-441-rng-state/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "ee_441_rng_state"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-460-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-460-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@papierski.net>"]
 edition = "2018"
 
 [lib]
-name = "ee_460_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-532-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-532-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "ee_532_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-536-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-536-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "ee_536_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-539-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-539-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@papierski.net>"]
 edition = "2018"
 
 [lib]
-name = "ee_539_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-549-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-549-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "ee_549_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-572-regression-create/Cargo.toml
+++ b/execution-engine/contracts/test/ee-572-regression-create/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-572-regression-escalate/Cargo.toml
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-584-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-584-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "ee_584_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-597-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-597-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@papierski.net>"]
 edition = "2018"
 
 [lib]
-name = "ee_597_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-598-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-598-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "ee_598_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/ee-601-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-601-regression/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "ee_601_regression"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/endless-loop/Cargo.toml
+++ b/execution-engine/contracts/test/endless-loop/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/get-arg/Cargo.toml
+++ b/execution-engine/contracts/test/get-arg/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "get_arg"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/get-blocktime/Cargo.toml
+++ b/execution-engine/contracts/test/get-blocktime/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>, Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "get_blocktime"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/get-caller-subcall/Cargo.toml
+++ b/execution-engine/contracts/test/get-caller-subcall/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>, Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "get_caller_subcall"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/get-caller/Cargo.toml
+++ b/execution-engine/contracts/test/get-caller/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>, Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "get_caller"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/get-phase-payment/Cargo.toml
+++ b/execution-engine/contracts/test/get-phase-payment/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "get_phase_payment"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/get-phase/Cargo.toml
+++ b/execution-engine/contracts/test/get-phase/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "get_phase"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/key-management-thresholds/Cargo.toml
+++ b/execution-engine/contracts/test/key-management-thresholds/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "key_management_thresholds"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/local-state-stored-caller/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored-caller/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state_stored_caller"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/local-state-stored-upgraded/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored-upgraded/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state_stored_upgraded"
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/local-state-stored-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored-upgrader/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state_stored_upgrader"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/local-state-stored/Cargo.toml
+++ b/execution-engine/contracts/test/local-state-stored/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state_stored"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/local-state/Cargo.toml
+++ b/execution-engine/contracts/test/local-state/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "local_state"
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/main-purse/Cargo.toml
+++ b/execution-engine/contracts/test/main-purse/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>, Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "main_purse"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/mint-purse/Cargo.toml
+++ b/execution-engine/contracts/test/mint-purse/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "mint_purse"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/modified-mint-caller/Cargo.toml
+++ b/execution-engine/contracts/test/modified-mint-caller/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "modified_mint_caller"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/modified-mint-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/modified-mint-upgrader/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "modified_mint_upgrader"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/modified-mint/Cargo.toml
+++ b/execution-engine/contracts/test/modified-mint/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "modified_mint"
 crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/named-keys/Cargo.toml
+++ b/execution-engine/contracts/test/named-keys/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "named_keys"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/pos-bonding/Cargo.toml
+++ b/execution-engine/contracts/test/pos-bonding/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "pos_bonding"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/pos-finalize-payment/Cargo.toml
+++ b/execution-engine/contracts/test/pos-finalize-payment/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "pos_finalize_payment"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/pos-get-payment-purse/Cargo.toml
+++ b/execution-engine/contracts/test/pos-get-payment-purse/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "pos_get_payment_purse"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/pos-refund-purse/Cargo.toml
+++ b/execution-engine/contracts/test/pos-refund-purse/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "pos_refund_purse"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/purse-holder-stored-caller/Cargo.toml
+++ b/execution-engine/contracts/test/purse-holder-stored-caller/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "purse_holder_stored_caller"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/Cargo.toml
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "purse_holder_stored_upgrader"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/purse-holder-stored/Cargo.toml
+++ b/execution-engine/contracts/test/purse-holder-stored/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "purse_holder_stored"
-crate-type = ["cdylib", "lib"]
+crate-type = ["lib", "cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/remove-associated-key/Cargo.toml
+++ b/execution-engine/contracts/test/remove-associated-key/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Ed Hastings <ed@casperlabs.io"]
 edition = "2018"
 
 [lib]
-name = "remove_associated_key"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/transfer-main-purse-to-new-purse/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-main-purse-to-new-purse/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/transfer-purse-to-account-stored/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-purse-to-account-stored/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/transfer-purse-to-account/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-purse-to-account/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-name = "transfer_purse_to_account"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/transfer-purse-to-purse/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "transfer_purse_to_purse"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/transfer-to-account-01/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-to-account-01/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "transfer_to_account_01"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []

--- a/execution-engine/contracts/test/transfer-to-account-02/Cargo.toml
+++ b/execution-engine/contracts/test/transfer-to-account-02/Cargo.toml
@@ -5,8 +5,10 @@ authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 
 [lib]
-name = "transfer_to_account_02"
 crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
 
 [features]
 default = []


### PR DESCRIPTION
### Overview
This PR explicitly removes benchmark, doc test and test targets for all contracts except `pos` and `mint-token`.  These two still include tests, but not benchmarks or doc tests.

This allows us to run `cargo test --all` and not have the output cluttered with many targets which are effectively no-ops.

The PR also removes the needless `[lib][name]` field from all contracts' Cargo.tomls, since the library's name is automatically derived from the package's name with hyphens replaced by underscores.

### Which JIRA ticket does this PR relate to?
Unticketed

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
