### PR TITLE
Simple equivocation slashing in the PoS contract.

### DIFF
--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -105,7 +105,7 @@ impl URef {
 
     /// Creates a [`URef`] from an id and optional access rights.  [`URef::new`]
     /// is the preferred constructor for most common use-cases.
-    #[cfg(feature = "gens")]
+    #[cfg(any(test, feature = "gens"))]
     pub(crate) fn unsafe_new(
         id: [u8; UREF_ADDR_SIZE],
         maybe_access_rights: Option<AccessRights>,


### PR DESCRIPTION
### Overview

Slashed funds are not moved at all for now: They are just kept by the PoS contract forever, and never paid out.

Closes #1228.

### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/browse/CON-529

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

This only becomes effective once the `step` function is actually called in each block by the execution engine, and the new equivocators are passed in.