### PR TITLE
NODE-907: Change Bond to use BigInt for stake

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -17,6 +17,7 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.comm.gossiping
 import io.casperlabs.ipc
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.models.Weight
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block.BlockStorage
@@ -39,7 +40,7 @@ trait MultiParentCasper[F[_]] {
   // This is the weight of faults that have been accumulated so far.
   // We want the clique oracle to give us a fault tolerance that is greater than
   // this initial fault weight combined with our fault tolerance threshold t.
-  def normalizedInitialFault(weights: Map[Validator, Long]): F[Float]
+  def normalizedInitialFault(weights: Map[Validator, Weight]): F[Float]
   def lastFinalizedBlock: F[Block]
   def faultToleranceThreshold: Float
 }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -27,7 +27,7 @@ import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.ipc
 import io.casperlabs.ipc.ValidateRequest
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.models.{Message, SmartContractEngineError}
+import io.casperlabs.models.{Message, SmartContractEngineError, Weight}
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.BlockMsgWithTransform
@@ -549,14 +549,14 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
   def dag: F[DagRepresentation[F]] =
     DagStorage[F].getRepresentation
 
-  def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =
+  def normalizedInitialFault(weights: Map[Validator, Weight]): F[Float] =
     for {
       state   <- Cell[F, CasperState].read
       tracker = state.equivocationsTracker
     } yield tracker.keySet
       .flatMap(weights.get)
       .sum
-      .toFloat / weightMapTotal(weights)
+      .toFloat / weightMapTotal(weights).toFloat
 
   /** After a block is executed we can try to execute the other blocks in the buffer that dependent on it. */
   private def reAttemptBuffer(

--- a/casper/src/main/scala/io/casperlabs/casper/finality/CommitteeWithConsensusValue.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/CommitteeWithConsensusValue.scala
@@ -1,9 +1,10 @@
 package io.casperlabs.casper.finality
 
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
+import io.casperlabs.models.Weight
 
 case class CommitteeWithConsensusValue(
     validator: Set[Validator],
-    quorum: Long,
+    quorum: Weight,
     consensusValue: BlockHash
 )

--- a/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetectorUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetectorUtil.scala
@@ -69,7 +69,7 @@ object FinalityDetectorUtil {
       blockDag: DagRepresentation[F],
       block: Message,
       validators: Set[Validator]
-  ): F[Map[Validator, Long]] =
+  ): F[Map[Validator, Level]] =
     panoramaOfBlockByValidators(blockDag, block, validators)
       .map(_.mapValues(_.rank))
 
@@ -142,7 +142,7 @@ object FinalityDetectorUtil {
       validatorsToIndex: Map[Validator, Int],
       blockSummary: Message,
       equivocationsTracker: EquivocationsTracker
-  ): F[MutableSeq[Long]] =
+  ): F[MutableSeq[Level]] =
     FinalityDetectorUtil
       .panoramaDagLevelsOfBlock(
         dag,

--- a/casper/src/main/scala/io/casperlabs/casper/finality/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/package.scala
@@ -1,0 +1,5 @@
+package io.casperlabs.casper
+
+package object finality {
+  type Level = Long
+}

--- a/casper/src/main/scala/io/casperlabs/casper/finality/singlesweep/Committee.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/singlesweep/Committee.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.casper.finality.singlesweep
 
 import io.casperlabs.casper.Estimator.Validator
+import io.casperlabs.models.Weight
 
-case class Committee(validators: Set[Validator], quorum: Long)
+case class Committee(validators: Set[Validator], quorum: Weight)

--- a/casper/src/main/scala/io/casperlabs/casper/finality/singlesweep/FinalityDetector.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/singlesweep/FinalityDetector.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper.finality.singlesweep
 
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
+import io.casperlabs.models.Weight
 import io.casperlabs.storage.dag.DagRepresentation
 
 trait FinalityDetector[F[_]] {
@@ -26,5 +27,6 @@ object FinalityDetector {
 
   // Calculate threshold value as described in the specification.
   // Note that validator weights (`q` and `n`) are normalized to 1.
-  private[casper] def calculateThreshold(q: Long, n: Long): Float = (2.0f * q - n) / (2 * n)
+  private[casper] def calculateThreshold(q: Weight, n: Weight): Float =
+    (2.0f * q.toFloat - n.toFloat) / (2 * n.toFloat)
 }

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrixState.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrixState.scala
@@ -1,13 +1,15 @@
 package io.casperlabs.casper.finality.votingmatrix
 
 import io.casperlabs.casper.Estimator.Validator
+import io.casperlabs.casper.finality.Level
 import io.casperlabs.casper.finality.votingmatrix.VotingMatrix.Vote
+import io.casperlabs.models.Weight
 import scala.collection.mutable.{IndexedSeq => MutableSeq}
 
 private[votingmatrix] case class VotingMatrixState(
-    votingMatrix: MutableSeq[MutableSeq[Long]],
+    votingMatrix: MutableSeq[MutableSeq[Level]],
     firstLevelZeroVotes: MutableSeq[Option[Vote]],
     validatorToIdx: Map[Validator, Int],
-    weightMap: Map[Validator, Long],
+    weightMap: Map[Validator, Weight],
     validators: MutableSeq[Validator]
 )

--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -48,12 +48,14 @@ object Genesis {
 
       // Sorted list of bonded validators.
       bonds = genesisConfig.accounts
+        .sortBy { x =>
+          x.publicKey -> x.getBondedAmount.value
+        }
         .collect {
           case account if account.bondedAmount.isDefined && account.getBondedAmount.value != "0" =>
-            PublicKey(account.publicKey.toByteArray) -> account.getBondedAmount.value.toLong
+            PublicKey(account.publicKey.toByteArray) -> account.bondedAmount
         }
         .toSeq
-        .sorted
         .map {
           case (pk, stake) =>
             val validator = ByteString.copyFrom(pk)

--- a/casper/src/main/scala/io/casperlabs/casper/util/BondingUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/BondingUtil.scala
@@ -5,6 +5,8 @@ import java.io.PrintWriter
 import cats.effect.{Resource, Sync}
 import cats.implicits._
 import com.github.ghik.silencer.silent
+import io.casperlabs.casper.consensus, consensus.state
+import com.google.protobuf.ByteString
 
 object BondingUtil {
   @silent("is never used")
@@ -24,6 +26,16 @@ object BondingUtil {
         pw => Sync[F].delay { pw.close() }
       )
     file.use(pw => Sync[F].delay { pw.println(content) })
+  }
+
+  type Bond = consensus.Bond
+
+  object Bond {
+    def apply(validator: ByteString, stake: Int) =
+      consensus.Bond(validator).withStake(state.BigInt(stake.toString, 512))
+
+    def unapply(bond: consensus.Bond) =
+      consensus.Bond.unapply(bond)
   }
 
 }

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -19,6 +19,7 @@ import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.hash.Blake2b256
 import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.ipc
+import io.casperlabs.models.Weight
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block.BlockStorage
@@ -671,7 +672,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       val slashedValidatorBond =
         bonds(block).find(_.validatorPublicKey == justification.validatorPublicKey)
       slashedValidatorBond match {
-        case Some(bond) => bond.stake > 0
+        case Some(bond) => Weight(bond.stake) > 0
         case None       => false
       }
     }

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -7,7 +7,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.consensus._
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.models.ArbitraryConsensus
+import io.casperlabs.models.{ArbitraryConsensus, Weight}
 import io.casperlabs.shared.{Log, Time}
 import io.casperlabs.storage.deploy.{
   DeployStorage,
@@ -194,10 +194,10 @@ object AutoProposerTest {
     override def estimator(
         dag: DagRepresentation[F],
         lm: Map[ByteString, ByteString]
-    ): F[List[ByteString]]                                                        = ???
-    override def dag: F[DagRepresentation[F]]                                     = ???
-    override def normalizedInitialFault(weights: Map[ByteString, Long]): F[Float] = ???
-    override def lastFinalizedBlock: F[Block]                                     = ???
-    override def faultToleranceThreshold                                          = 0f
+    ): F[List[ByteString]]                                                          = ???
+    override def dag: F[DagRepresentation[F]]                                       = ???
+    override def normalizedInitialFault(weights: Map[ByteString, Weight]): F[Float] = ???
+    override def lastFinalizedBlock: F[Block]                                       = ???
+    override def faultToleranceThreshold                                            = 0f
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ForkchoiceTest.scala
@@ -3,12 +3,13 @@ package io.casperlabs.casper
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
-import io.casperlabs.casper.consensus.Bond
 import io.casperlabs.casper.equivocations.{EquivocationDetector, EquivocationsTracker}
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
 import io.casperlabs.casper.util.DagOperations
+import io.casperlabs.casper.util.BondingUtil.Bond
+import io.casperlabs.models.Weight
 import io.casperlabs.storage.dag.DagRepresentation
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -26,6 +27,7 @@ class ForkchoiceTest
     with GeneratorDrivenPropertyChecks
     with BlockGenerator
     with StorageFixture {
+
   "Estimator on empty latestMessages" should "return the genesis regardless of DAG" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage =>
       val v1     = generateValidator("V1")
@@ -354,9 +356,9 @@ class ForkchoiceTest
       val weightMap = bonds.map {
         case Bond(validator, stake) =>
           if (equivocators.contains(validator))
-            (validator, 0L)
+            (validator, Weight.Zero)
           else {
-            (validator, stake)
+            (validator, Weight(stake))
           }
       }.toMap
       val expectScores = supporterForBlocks.mapValues(_.map(weightMap).sum)

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -5,7 +5,6 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.api.BlockAPI
-import io.casperlabs.casper.consensus.Bond
 import io.casperlabs.casper.equivocations.EquivocationsTracker
 import io.casperlabs.casper.finality.singlesweep.{
   FinalityDetector,
@@ -13,6 +12,7 @@ import io.casperlabs.casper.finality.singlesweep.{
 }
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper._
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.storage.BlockMsgWithTransform
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -12,6 +12,7 @@ import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, HashSetCasperTestNode, StorageFixture}
 import io.casperlabs.casper.scalatestcontrib._
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.casper.util.{CasperLabsProtocolVersions, ProtoUtil}
 import io.casperlabs.casper.util.execengine.ExecEngineUtilTest.prepareDeploys
 import io.casperlabs.casper.util.execengine.{
@@ -556,7 +557,7 @@ class ValidationTest
         generateValidator("V3")
       )
       val bonds = validators.zipWithIndex.map {
-        case (v, i) => Bond(v, 2L * i.toLong + 1L)
+        case (v, i) => Bond(v, 2 * i + 1)
       }
 
       val emptyEquivocationsTracker = EquivocationsTracker.empty

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -16,6 +16,7 @@ import io.casperlabs.casper.finality.singlesweep.{
 }
 import io.casperlabs.casper.helper.{NoOpsCasperEffect, StorageFixture}
 import io.casperlabs.casper.util.ProtoUtil
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.catscontrib.Fs2Compiler
 import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.crypto.Keys

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlocksResponseAPITest.scala
@@ -15,6 +15,7 @@ import io.casperlabs.casper.finality.singlesweep.{
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper._
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.storage.BlockMsgWithTransform
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -16,6 +16,7 @@ import io.casperlabs.casper.util._
 import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.models.Weight
 import io.casperlabs.p2p.EffectsTestInstances._
 import io.casperlabs.shared.Time
 import io.casperlabs.storage.BlockMsgWithTransform
@@ -143,7 +144,7 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   ): F[List[BlockHash]] =
     underlying.estimator(dag, latestMessagesHashes)
   def dag: F[DagRepresentation[F]] = underlying.dag
-  def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] =
+  def normalizedInitialFault(weights: Map[Validator, Weight]): F[Float] =
     underlying.normalizedInitialFault(weights)
   def lastFinalizedBlock: F[Block] = underlying.lastFinalizedBlock
   def faultToleranceThreshold      = underlying.faultToleranceThreshold

--- a/casper/src/test/scala/io/casperlabs/casper/finality/singlesweep/FinalityDetectorBySingleSweepTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/singlesweep/FinalityDetectorBySingleSweepTest.scala
@@ -2,11 +2,12 @@ package io.casperlabs.casper.finality.singlesweep
 
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
-import io.casperlabs.casper.consensus.Bond
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.casper.scalatestcontrib._
+import io.casperlabs.models.Weight
 import io.casperlabs.p2p.EffectsTestInstances.LogStub
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
@@ -254,7 +255,9 @@ class FinalityDetectorBySingleSweepTest
                         levelZeroMsgs,
                         3,
                         3,
-                        bonds.map(bond => (bond.validatorPublicKey, bond.stake)).toMap
+                        bonds
+                          .map(bond => (bond.validatorPublicKey, Weight(bond.stake)))
+                          .toMap
                       )
         (blockLevelTags, validatorLevel) = sweepResult
         _                                = validatorLevel.contains(v3) shouldBe false

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -6,12 +6,13 @@ import cats.mtl.FunctorRaise
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
-import io.casperlabs.casper.consensus.{Block, Bond}
+import io.casperlabs.casper.consensus.{Block}
 import io.casperlabs.casper.equivocations.{EquivocationDetector, EquivocationsTracker}
 import io.casperlabs.casper.finality.CommitteeWithConsensusValue
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.casper.{validation, CasperState, InvalidBlock}
 import io.casperlabs.p2p.EffectsTestInstances.LogStub
 import io.casperlabs.shared.{Cell, Log, Time}

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrixTest.scala
@@ -5,13 +5,14 @@ import cats.mtl.MonadState
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.{BlockHash, Validator}
-import io.casperlabs.casper.consensus.{Block, Bond}
+import io.casperlabs.casper.consensus.{Block}
 import io.casperlabs.casper.equivocations.EquivocationsTracker
 import io.casperlabs.casper.finality.votingmatrix.VotingMatrix.VotingMatrix
 import io.casperlabs.casper.finality.{CommitteeWithConsensusValue, FinalityDetectorUtil}
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
 import io.casperlabs.casper.util.ProtoUtil
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.models.Message
 import io.casperlabs.p2p.EffectsTestInstances.LogStub

--- a/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/genesis/GenesisTest.scala
@@ -12,6 +12,7 @@ import io.casperlabs.casper.util.{CasperLabsProtocolVersions, ProtoUtil}
 import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.crypto.Keys
 import io.casperlabs.ipc
+import io.casperlabs.models.Weight
 import io.casperlabs.p2p.EffectsTestInstances.LogStub
 import io.casperlabs.shared.PathOps.RichPath
 import io.casperlabs.shared.{Log}
@@ -48,7 +49,7 @@ class GenesisTest extends FlatSpec with Matchers with StorageFixture {
       val validatorsMap =
         accounts.collect {
           case (key, _, bond) if bond > 0 =>
-            (Keys.PublicKey(java.util.Base64.getDecoder.decode(key)), bond.toLong)
+            (Keys.PublicKey(java.util.Base64.getDecoder.decode(key)), Weight(bond))
         }.toMap
 
       implicit val casperSmartContractsApi = HashSetCasperTestNode.simpleEEApi[Task](validatorsMap)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -8,6 +8,7 @@ import io.casperlabs.casper.Estimator.{BlockHash, Validator}
 import io.casperlabs.casper.consensus.{Block, Deploy}
 import io.casperlabs.casper.{BlockStatus, CreateBlockStatus, MultiParentCasper}
 import io.casperlabs.ipc.TransformEntry
+import io.casperlabs.models.Weight
 import io.casperlabs.storage._
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.dag._
@@ -37,12 +38,12 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
       latestMessageHashes: Map[ByteString, ByteString]
   ): F[List[BlockHash]] =
     estimatorFunc.pure[F]
-  def createBlock: F[CreateBlockStatus]                               = CreateBlockStatus.noNewDeploys.pure[F]
-  def dag: F[DagRepresentation[F]]                                    = DagStorage[F].getRepresentation
-  def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
-  def lastFinalizedBlock: F[Block]                                    = Block().pure[F]
-  def fetchDependencies: F[Unit]                                      = ().pure[F]
-  def faultToleranceThreshold                                         = 0f
+  def createBlock: F[CreateBlockStatus]                                 = CreateBlockStatus.noNewDeploys.pure[F]
+  def dag: F[DagRepresentation[F]]                                      = DagStorage[F].getRepresentation
+  def normalizedInitialFault(weights: Map[Validator, Weight]): F[Float] = 0f.pure[F]
+  def lastFinalizedBlock: F[Block]                                      = Block().pure[F]
+  def fetchDependencies: F[Unit]                                        = ().pure[F]
+  def faultToleranceThreshold                                           = 0f
 }
 
 object NoOpsCasperEffect {

--- a/casper/src/test/scala/io/casperlabs/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/CasperUtilTest.scala
@@ -2,13 +2,14 @@ package io.casperlabs.casper.util
 
 import cats.implicits._
 import com.google.protobuf.ByteString
-import io.casperlabs.casper.consensus.{Block, Bond}
+import io.casperlabs.casper.consensus.{Block}
 import io.casperlabs.casper.equivocations.EquivocationsTracker
 import io.casperlabs.casper.finality.FinalityDetectorUtil
 import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
 import io.casperlabs.casper.scalatestcontrib._
+import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.casper.util.ProtoUtil._
 import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.models.Message

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/SynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/SynchronizerSpec.scala
@@ -8,6 +8,7 @@ import eu.timepit.refined.api.Refined
 import eu.timepit.refined.auto._
 import eu.timepit.refined.numeric._
 import io.casperlabs.models.BlockImplicits._
+import io.casperlabs.casper.consensus.state
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.casper.consensus.{BlockSummary, Bond, GenesisCandidate}
 import io.casperlabs.comm.discovery.Node
@@ -149,7 +150,8 @@ class SynchronizerSpec
         }
         val target    = dag.last.blockHash
         val ancestors = collectAncestors(Set(target), target)
-        val bonds     = dag.map(_.validatorPublicKey).distinct.map(Bond(_, 1))
+        val bonds =
+          dag.map(_.validatorPublicKey).distinct.map(Bond(_).withStake(state.BigInt("1", 512)))
         val subdag = dag.filter(x => ancestors(x.blockHash)).map { summary =>
           summary
             .withHeader(summary.getHeader.withState(summary.state.withBonds(bonds)))

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -159,8 +159,8 @@ const DeploysTable = observer(
                 {deploy.getIsError() ? (
                   <Icon name="times-circle" color="red" />
                 ) : (
-                  <Icon name="check-circle" color="green" />
-                )}
+                    <Icon name="check-circle" color="green" />
+                  )}
               </td>
               <td>{deploy.getErrorMessage()}</td>
             </tr>
@@ -204,7 +204,8 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
           );
         // Genesis doesn't have a validator.
         return (
-          (validatorBond && validatorBond.getStake().toLocaleString()) || null
+          (validatorBond && validatorBond.getStake() && Number(validatorBond.getStake()!.getValue()).toLocaleString()) ||
+          null
         );
       })()
     ],

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -15,6 +15,7 @@ import { DagStepButtons } from './BlockList';
 import { Link } from 'react-router-dom';
 import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
+import { number } from 'prop-types';
 
 interface Props {
   dag: DagContainer;
@@ -54,7 +55,7 @@ export default class Explorer extends RefreshableComponent<Props, {}> {
                 if (
                   current &&
                   current.getSummary()!.getBlockHash_asB64() ===
-                    block.getSummary()!.getBlockHash_asB64()
+                  block.getSummary()!.getBlockHash_asB64()
                 ) {
                   dag.selectedBlock = undefined;
                 } else {
@@ -167,7 +168,7 @@ class BlockDetails extends React.Component<{
               );
             // Genesis doesn't have a validator.
             return (
-              (validatorBond && validatorBond.getStake().toLocaleString()) ||
+              (validatorBond && validatorBond.getStake() && Number(validatorBond.getStake()!.getValue()).toLocaleString()) ||
               null
             );
           })()

--- a/integration-testing/test/test_bonding.py
+++ b/integration-testing/test/test_bonding.py
@@ -26,7 +26,7 @@ def assert_pre_state_of_network(network: OneNodeNetwork, stakes: List[int]):
     genesis_block = blocks[0]
     item = list(
         filter(
-            lambda x: x.stake in stakes
+            lambda x: int(x.stake.value) in stakes
             and x.validator_public_key == node0.from_address,
             genesis_block.summary.header.state.bonds,
         )
@@ -55,7 +55,7 @@ def test_bonding(one_node_network_fn):
     public_key = node1.genesis_account.public_key_hex
     item = list(
         filter(
-            lambda x: x.stake == bonding_amount
+            lambda x: int(x.stake.value) == bonding_amount
             and x.validator_public_key == public_key,
             block_ds.summary.header.state.bonds,
         )
@@ -90,7 +90,7 @@ def test_double_bonding(one_node_network_fn):
     public_key = node1.genesis_account.public_key_hex
     item = list(
         filter(
-            lambda x: x.stake == bonding_amount + bonding_amount
+            lambda x: int(x.stake.value) == bonding_amount + bonding_amount
             and x.validator_public_key == public_key,
             block_ds.summary.header.state.bonds,
         )
@@ -121,7 +121,7 @@ def test_invalid_bonding(one_node_network_fn):
     public_key = node1.genesis_account.public_key_hex
     item = list(
         filter(
-            lambda x: x.stake == bonding_amount
+            lambda x: int(x.stake.value) == bonding_amount
             and x.validator_public_key == public_key,
             block_ds.summary.header.state.bonds,
         )
@@ -155,7 +155,7 @@ def test_unbonding(one_node_network_fn):
     block_ds = parse_show_block(block2)
     item = list(
         filter(
-            lambda x: x.stake == bonding_amount
+            lambda x: int(x.stake.value) == bonding_amount
             and x.validator_public_key == public_key,
             block_ds.summary.header.state.bonds,
         )
@@ -193,7 +193,7 @@ def test_partial_amount_unbonding(one_node_network_fn):
     block_ds = parse_show_block(block2)
     item = list(
         filter(
-            lambda x: x.stake == bonding_amount - unbond_amount
+            lambda x: int(x.stake.value) == bonding_amount - unbond_amount
             and x.validator_public_key == public_key,
             block_ds.summary.header.state.bonds,
         )
@@ -210,7 +210,7 @@ def test_invalid_unbonding(one_node_network_fn):
     def get_bonded_list(node, block):
         return list(
             filter(
-                lambda x: x.stake == bonding_amount
+                lambda x: int(x.stake.value) == bonding_amount
                 and x.validator_public_key == node.genesis_account.public_key_hex,
                 block.summary.header.state.bonds,
             )

--- a/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
@@ -24,8 +24,10 @@ object BlockImplicits {
     def validatorBlockSeqNum: Int          = block.getHeader.validatorBlockSeqNum
     def validatorPublicKey: ByteString     = block.getHeader.validatorPublicKey
     def rank: Long                         = block.getHeader.rank
-    def weightMap: Map[ByteString, Long] =
-      block.getHeader.getState.bonds.map(b => (b.validatorPublicKey, b.stake)).toMap
+    def weightMap: Map[ByteString, Weight] =
+      block.getHeader.getState.bonds
+        .map(b => (b.validatorPublicKey, Weight(b.stake)))
+        .toMap
   }
 
   implicit class BlockSummaryOps(val summary: BlockSummary) extends AnyVal {
@@ -45,8 +47,10 @@ object BlockImplicits {
     def validatorBlockSeqNum: Int          = summary.getHeader.validatorBlockSeqNum
     def validatorPublicKey: ByteString     = summary.getHeader.validatorPublicKey
     def rank: Long                         = summary.getHeader.rank
-    def weightMap: Map[ByteString, Long] =
-      summary.getHeader.getState.bonds.map(b => (b.validatorPublicKey, b.stake)).toMap
+    def weightMap: Map[ByteString, Weight] =
+      summary.getHeader.getState.bonds
+        .map(b => (b.validatorPublicKey, Weight(b.stake)))
+        .toMap
   }
 
   implicit class BlockSummaryObjectOps(val blockSummary: BlockSummary.type) extends AnyVal {

--- a/models/src/main/scala/io/casperlabs/models/Message.scala
+++ b/models/src/main/scala/io/casperlabs/models/Message.scala
@@ -55,8 +55,9 @@ object Message {
     lazy val secondaryParents =
       if (blockSummary.getHeader.parentHashes.isEmpty) Seq.empty
       else blockSummary.getHeader.parentHashes.tail
-    lazy val weightMap = blockSummary.getHeader.getState.bonds.map {
-      case Bond(validatorPk, stake) => validatorPk -> stake
+
+    lazy val weightMap: Map[ByteString, Weight] = blockSummary.getHeader.getState.bonds.map {
+      case Bond(validatorPk, stake) => validatorPk -> Weight(stake)
     }.toMap
   }
 

--- a/models/src/main/scala/io/casperlabs/models/Weight.scala
+++ b/models/src/main/scala/io/casperlabs/models/Weight.scala
@@ -1,0 +1,20 @@
+package io.casperlabs.models
+
+import io.casperlabs.casper.consensus.state
+
+object Weight {
+  object Implicits {
+    implicit class RichBigInt(i: BigInt) {
+      def *(d: Double): BigInt =
+        BigDecimal(i.toDouble * d).setScale(0, BigDecimal.RoundingMode.CEILING).toBigInt
+    }
+  }
+
+  val Zero = BigInt(0)
+
+  def apply(stake: Option[state.BigInt]) =
+    stake.fold(Zero)(x => BigInt(x.value))
+
+  def apply(i: Int) =
+    BigInt(i)
+}

--- a/models/src/main/scala/io/casperlabs/models/package.scala
+++ b/models/src/main/scala/io/casperlabs/models/package.scala
@@ -1,0 +1,5 @@
+package io.casperlabs
+
+package object models {
+  type Weight = BigInt
+}

--- a/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
+++ b/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
@@ -113,7 +113,9 @@ trait ArbitraryConsensus {
     for {
       pk    <- genKey
       stake <- arbitrary[Long]
-    } yield Bond().withValidatorPublicKey(pk).withStake(stake)
+    } yield Bond()
+      .withValidatorPublicKey(pk)
+      .withStake(state.BigInt(stake.toString, bitWidth = 512))
   }
 
   implicit def arbBlock(implicit c: ConsensusConfig): Arbitrary[Block] = Arbitrary {

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -177,8 +177,9 @@ message Block {
 }
 
 message Bond {
+    reserved 2; // Original bond was uint64.
     bytes validator_public_key = 1;
-    uint64 stake = 2;
+    state.BigInt stake = 3;
 }
 
 

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -202,7 +202,7 @@ object ExecutionEngineService {
     def apply(ipcCommitResult: io.casperlabs.ipc.CommitResult): CommitResult = {
       // XXX: EE returns bonds as BigInt but we treat it as Long.
       val validators = ipcCommitResult.bondedValidators.map(
-        b => Bond(b.validatorPublicKey, b.getStake.value.toLong)
+        b => Bond(b.validatorPublicKey, b.stake)
       )
       new CommitResult(ipcCommitResult.poststateHash, validators)
     }


### PR DESCRIPTION
### Overview
Builds on https://github.com/CasperLabs/CasperLabs/pull/1240 

Changes the data type we use in `message Bond` in `consensus.proto` for stake from `uint64` to `state.BigInt` to match the `accounts.csv` spec.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-907

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
