### PR TITLE
NODE-942: Check the timestamp of all justifications.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -318,25 +318,26 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       currentTime  <- Time[F].currentMillis
       timestamp    = b.timestamp
       beforeFuture = currentTime + ValidationImpl.DRIFT >= timestamp
-      latestParentTimestamp <- b.parentHashes.toList.foldM(0L) {
-                                case (latestTimestamp, parentHash) =>
-                                  ProtoUtil
-                                    .unsafeGetBlockSummary[F](parentHash)
-                                    .map(parent => {
-                                      val timestamp =
-                                        parent.header.fold(latestTimestamp)(_.timestamp)
-                                      math.max(latestTimestamp, timestamp)
-                                    })
-                              }
-      afterLatestParent = timestamp >= latestParentTimestamp
-      _ <- if (beforeFuture && afterLatestParent) {
+      dependencies = b.parentHashes ++ b.getHeader.justifications.map(_.latestBlockHash)
+      latestJustificationTimestamp <- dependencies.distinct.toList.foldM(0L) {
+                                       case (latestTimestamp, blockHash) =>
+                                         ProtoUtil
+                                           .unsafeGetBlockSummary[F](blockHash)
+                                           .map(block => {
+                                             val timestamp =
+                                               block.header.fold(latestTimestamp)(_.timestamp)
+                                             math.max(latestTimestamp, timestamp)
+                                           })
+                                     }
+      afterLatestJustification = timestamp >= latestJustificationTimestamp
+      _ <- if (beforeFuture && afterLatestJustification) {
             Applicative[F].unit
           } else {
             for {
               _ <- Log[F].warn(
                     ignore(
                       b,
-                      s"block timestamp $timestamp is not between latest parent block time and current time."
+                      s"block timestamp $timestamp is not between latest justification block time and current time."
                     )
                   )
               _ <- FunctorRaise[F, InvalidBlock].raise[Unit](InvalidUnslashableBlock)

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -319,18 +319,18 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       timestamp    = b.timestamp
       beforeFuture = currentTime + ValidationImpl.DRIFT >= timestamp
       dependencies = b.parentHashes ++ b.getHeader.justifications.map(_.latestBlockHash)
-      latestJustificationTimestamp <- dependencies.distinct.toList.foldM(0L) {
-                                       case (latestTimestamp, blockHash) =>
-                                         ProtoUtil
-                                           .unsafeGetBlockSummary[F](blockHash)
-                                           .map(block => {
-                                             val timestamp =
-                                               block.header.fold(latestTimestamp)(_.timestamp)
-                                             math.max(latestTimestamp, timestamp)
-                                           })
-                                     }
-      afterLatestJustification = timestamp >= latestJustificationTimestamp
-      _ <- if (beforeFuture && afterLatestJustification) {
+      latestDependencyTimestamp <- dependencies.distinct.toList.foldM(0L) {
+                                    case (latestTimestamp, blockHash) =>
+                                      ProtoUtil
+                                        .unsafeGetBlockSummary[F](blockHash)
+                                        .map(block => {
+                                          val timestamp =
+                                            block.header.fold(latestTimestamp)(_.timestamp)
+                                          math.max(latestTimestamp, timestamp)
+                                        })
+                                  }
+      afterLatestDependency = timestamp >= latestDependencyTimestamp
+      _ <- if (beforeFuture && afterLatestDependency) {
             Applicative[F].unit
           } else {
             for {

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -85,9 +85,12 @@ class ValidationTest
   def createChain[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage](
       length: Int,
       bonds: Seq[Bond] = Seq.empty[Bond],
-      creator: Validator = ByteString.EMPTY
+      creator: Validator = ByteString.EMPTY,
+      maybeGenesis: Option[Block] = None
   ): F[Block] =
-    (0 until length).foldLeft(createAndStoreBlock[F](Seq.empty, bonds = bonds)) {
+    (0 until length).foldLeft(
+      maybeGenesis.fold(createAndStoreBlock[F](Seq.empty, bonds = bonds))(_.pure[F])
+    ) {
       case (block, _) =>
         for {
           bprev         <- block
@@ -388,6 +391,30 @@ class ValidationTest
               )
               .attempt shouldBeF Left(InvalidUnslashableBlock)
         _      <- ValidationImpl[Task].timestamp(block).attempt shouldBeF Right(())
+        _      = log.warns.size should be(1)
+        result = log.warns.head.contains("block timestamp") should be(true)
+      } yield result
+  }
+
+  it should "not accept blocks that were published before justification time" in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      for {
+        _       <- createChain[Task](3, creator = ByteString.copyFrom(Array[Byte](1)))
+        genesis <- dagStorage.lookupByIdUnsafe(0)
+        // Create a new block on top of genesis which will use the previous ones as justifications.
+        _ <- createChain[Task](
+              1,
+              creator = ByteString.copyFrom(Array[Byte](2)),
+              maybeGenesis = Some(genesis)
+            )
+        block4                  <- dagStorage.lookupByIdUnsafe(4)
+        modifiedTimestampHeader = block4.header.get.withTimestamp(genesis.getHeader.timestamp + 1)
+        _ <- ValidationImpl[Task]
+              .timestamp(
+                block4.withHeader(modifiedTimestampHeader)
+              )
+              .attempt shouldBeF Left(InvalidUnslashableBlock)
+        _      <- ValidationImpl[Task].timestamp(block4).attempt shouldBeF Right(())
         _      = log.warns.size should be(1)
         result = log.warns.head.contains("block timestamp") should be(true)
       } yield result


### PR DESCRIPTION
### Overview
The node only checked that a block's timestamp is ahead of its parents', not that it's ahead of all of its justifications.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-942

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
