### PR TITLE
EE-704: Do not store mint and pos references in named keys

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -2247,6 +2247,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-contracts-access"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.17.0",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution-engine/contract-ffi/src/contract_api/error.rs
+++ b/execution-engine/contract-ffi/src/contract_api/error.rs
@@ -72,6 +72,8 @@ pub enum Error {
     NoAccessRights,
     /// Optional data was unexpectedly `None`.
     None,
+    /// Returns when contract tries to obtain URef to a system contract that does not exist.
+    InvalidSystemContract,
     /// Error specific to Proof of Stake contract.
     ProofOfStake(u8),
     /// User-specified value.  The internal `u16` value is added to `u16::MAX as u32 + 1` when an
@@ -99,6 +101,7 @@ impl From<Error> for u32 {
             Error::Transfer => 15,
             Error::NoAccessRights => 16,
             Error::None => 17,
+            Error::InvalidSystemContract => 18,
             Error::ProofOfStake(value) => POS_ERROR_OFFSET + u32::from(value),
             Error::User(value) => RESERVED_ERROR_MAX + 1 + u32::from(value),
         }
@@ -127,6 +130,7 @@ impl Debug for Error {
             Error::Transfer => write!(f, "Error::Transfer")?,
             Error::NoAccessRights => write!(f, "Error::NoAccessRights")?,
             Error::None => write!(f, "Error::None")?,
+            Error::InvalidSystemContract => write!(f, "Error::InvalidSystemContract")?,
             Error::ProofOfStake(value) => write!(f, "Error::ProofOfStake({})", value)?,
             Error::User(value) => write!(f, "Error::User({})", value)?,
         }

--- a/execution-engine/contract-ffi/src/lib.rs
+++ b/execution-engine/contract-ffi/src/lib.rs
@@ -136,6 +136,11 @@ mod ext_ffi {
             key_ptr: *const u8,
             key_size: usize,
         ) -> i32;
+        pub fn get_system_contract(
+            system_contract_index: u32,
+            dest_ptr: *mut u8,
+            dest_size: usize,
+        ) -> i32;
     }
 }
 

--- a/execution-engine/contract-ffi/src/system_contracts/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mod.rs
@@ -7,3 +7,6 @@
 //! the supporting code i.e. mint.
 pub mod error;
 pub mod mint;
+pub mod system_contract;
+
+pub use system_contract::SystemContract;

--- a/execution-engine/contract-ffi/src/system_contracts/system_contract.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/system_contract.rs
@@ -1,0 +1,73 @@
+use crate::contract_api::Error;
+use alloc::string::{String, ToString};
+use core::convert::TryFrom;
+
+/// System contracts used to query host for system contract ref
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum SystemContract {
+    Mint,
+    ProofOfStake,
+}
+
+impl Into<u32> for SystemContract {
+    fn into(self) -> u32 {
+        match self {
+            SystemContract::Mint => 0,
+            SystemContract::ProofOfStake => 1,
+        }
+    }
+}
+
+impl TryFrom<u32> for SystemContract {
+    type Error = Error;
+    fn try_from(value: u32) -> Result<SystemContract, Self::Error> {
+        match value {
+            0 => Ok(SystemContract::Mint),
+            1 => Ok(SystemContract::ProofOfStake),
+            _ => Err(Error::InvalidSystemContract),
+        }
+    }
+}
+
+impl ToString for SystemContract {
+    fn to_string(&self) -> String {
+        match *self {
+            SystemContract::Mint => "mint".to_string(),
+            SystemContract::ProofOfStake => "pos".to_string(),
+        }
+    }
+}
+
+#[test]
+fn get_index_of_mint_contract() {
+    let index: u32 = SystemContract::Mint.into();
+    assert_eq!(index, 0u32);
+    assert_eq!(SystemContract::Mint.to_string(), "mint");
+}
+
+#[test]
+fn get_index_of_pos_contract() {
+    let index: u32 = SystemContract::ProofOfStake.into();
+    assert_eq!(index, 1u32);
+    assert_eq!(SystemContract::ProofOfStake.to_string(), "pos");
+}
+
+#[test]
+fn create_mint_variant_from_int() {
+    let mint = SystemContract::try_from(0).ok().unwrap();
+    assert_eq!(mint, SystemContract::Mint);
+}
+
+#[test]
+fn create_pos_variant_from_int() {
+    let pos = SystemContract::try_from(0).ok().unwrap();
+    assert_eq!(pos, SystemContract::Mint);
+}
+
+#[test]
+fn create_unknown_system_contract_variant() {
+    assert!(SystemContract::try_from(2).is_err());
+    assert!(SystemContract::try_from(3).is_err());
+    assert!(SystemContract::try_from(10).is_err());
+    assert!(SystemContract::try_from(u32::max_value()).is_err());
+}

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -23,7 +23,6 @@ const PLACEHOLDER_KEY: Key = Key::Hash([0u8; 32]);
 const POS_BONDING_PURSE: &str = "pos_bonding_purse";
 const POS_PAYMENT_PURSE: &str = "pos_payment_purse";
 const POS_REWARDS_PURSE: &str = "pos_rewards_purse";
-const MINT_NAME: &str = "mint";
 const POS_FUNCTION_NAME: &str = "pos_ext";
 
 #[repr(u32)]
@@ -68,9 +67,6 @@ pub extern "C" fn call() {
         })
         .map(|key| (key, PLACEHOLDER_KEY))
         .collect();
-
-    // Include the mint contract in its named_keys
-    named_keys.insert(String::from(MINT_NAME), Key::URef(mint_uref));
 
     let total_bonds: U512 = genesis_validators.values().fold(U512::zero(), |x, y| x + y);
 

--- a/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
@@ -5,39 +5,19 @@ extern crate alloc;
 extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
-use alloc::string::String;
 
-use contract_ffi::contract_api::pointers::ContractPointer;
 use contract_ffi::contract_api::{self, Error};
-use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
-const MINT_NAME: &str = "mint";
 const ENTRY_FUNCTION_NAME: &str = "delegate";
 const CONTRACT_NAME: &str = "do_nothing_stored";
-
-#[repr(u16)]
-enum CustomError {
-    MintHash = 0,
-}
 
 #[no_mangle]
 pub extern "C" fn delegate() {}
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let mint_uref = match contract_api::get_mint() {
-        ContractPointer::Hash(_) => contract_api::revert(Error::User(CustomError::MintHash as u16)),
-        ContractPointer::URef(turef) => turef.into(),
-    };
-
-    let named_keys = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(String::from(MINT_NAME), Key::URef(mint_uref));
-        tmp
-    };
-
-    let key = contract_api::store_function(ENTRY_FUNCTION_NAME, named_keys)
+    let key = contract_api::store_function(ENTRY_FUNCTION_NAME, BTreeMap::new())
         .into_turef()
         .unwrap_or_revert_with(Error::UnexpectedContractPointerVariant)
         .into();

--- a/execution-engine/contracts/test/modified-mint-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-upgrader/src/lib.rs
@@ -12,7 +12,6 @@ enum CustomError {
     ContractPointerHash = 1,
 }
 
-pub const MINT_NAME: &str = "mint";
 pub const EXT_FUNCTION_NAME: &str = "modified_mint_ext";
 
 #[no_mangle]

--- a/execution-engine/contracts/test/named-keys/src/lib.rs
+++ b/execution-engine/contracts/test/named-keys/src/lib.rs
@@ -13,7 +13,7 @@ use contract_ffi::value::U512;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let initi_uref_num = 2; // TODO: this is very brittle as it breaks whenever we add another default uref
+    let initi_uref_num = 0; // TODO: this is very brittle as it breaks whenever we add another default uref
 
     // Account starts with two known urefs: mint uref & pos uref
     if contract_api::list_named_keys().len() != initi_uref_num {

--- a/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
@@ -9,12 +9,9 @@ extern crate contract_ffi;
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
 
-use contract_ffi::contract_api::pointers::ContractPointer;
 use contract_ffi::contract_api::{self, Error};
-use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
-const MINT_NAME: &str = "mint";
 const ENTRY_FUNCTION_NAME: &str = "apply_method";
 const CONTRACT_NAME: &str = "purse_holder_stored";
 pub const METHOD_ADD: &str = "add";
@@ -29,12 +26,11 @@ enum Args {
 
 #[repr(u16)]
 enum CustomError {
-    MintHash = 0,
-    MissingMethodNameArg = 1,
-    InvalidMethodNameArg = 2,
-    MissingPurseNameArg = 3,
-    InvalidPurseNameArg = 4,
-    UnknownMethodName = 5,
+    MissingMethodNameArg = 0,
+    InvalidMethodNameArg = 1,
+    MissingPurseNameArg = 2,
+    InvalidPurseNameArg = 3,
+    UnknownMethodName = 4,
 }
 
 fn purse_name() -> String {
@@ -62,18 +58,7 @@ pub extern "C" fn apply_method() {
 #[cfg(not(feature = "lib"))]
 #[no_mangle]
 pub extern "C" fn call() {
-    let mint_uref = match contract_api::get_mint() {
-        ContractPointer::Hash(_) => contract_api::revert(Error::User(CustomError::MintHash as u16)),
-        ContractPointer::URef(turef) => turef.into(),
-    };
-
-    let named_keys = {
-        let mut tmp = BTreeMap::new();
-        tmp.insert(String::from(MINT_NAME), Key::URef(mint_uref));
-        tmp
-    };
-
-    let key = contract_api::store_function(ENTRY_FUNCTION_NAME, named_keys)
+    let key = contract_api::store_function(ENTRY_FUNCTION_NAME, BTreeMap::new())
         .into_turef()
         .unwrap_or_revert_with(Error::UnexpectedContractPointerVariant)
         .into();

--- a/execution-engine/contracts/test/system-contracts-access/Cargo.toml
+++ b/execution-engine/contracts/test/system-contracts-access/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "system-contracts-access"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@papierski.net>"]
+edition = "2018"
+
+[lib]
+name = "system_contracts_access"
+crate-type = ["cdylib"]
+
+[features]
+default = []
+std = ["contract-ffi/std" ]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/system-contracts-access/src/lib.rs
+++ b/execution-engine/contracts/test/system-contracts-access/src/lib.rs
@@ -1,0 +1,83 @@
+#![no_std]
+
+extern crate contract_ffi;
+
+use contract_ffi::contract_api::pointers::ContractPointer;
+use contract_ffi::contract_api::{self, Error as ApiError};
+use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::value::account::PublicKey;
+
+#[repr(u16)]
+enum Error {
+    NonEmptyNamedKeys = 100,
+    MintContractIsNotURef = 101,
+    PosContractIsNotURef = 102,
+    InvalidMintAccessRights = 103,
+    MintHasNoAccessRights = 104,
+    InvalidPosAccessRights = 105,
+    PosHasNoAccessRights = 106,
+}
+
+impl Into<ApiError> for Error {
+    fn into(self) -> ApiError {
+        ApiError::User(self as u16)
+    }
+}
+
+const SYSTEM_ADDR: [u8; 32] = [0; 32];
+
+/// Extracts URef from ContractPointer for the purpose of further validation
+fn extract_uref_from_contract_pointer(contract_pointer: ContractPointer) -> Option<URef> {
+    match contract_pointer.into_turef() {
+        Some(turef) => Some(URef::new(turef.addr(), turef.access_rights())),
+        None => None,
+    }
+}
+
+fn delegate() {
+    // Regardless of the context none of pos/mint contracts should be present
+
+    // Step 1 - Named keys should be empty regardless of the context (system/genesis/user)
+    let named_keys = contract_api::list_named_keys();
+    if !named_keys.is_empty() {
+        contract_api::revert(Error::NonEmptyNamedKeys);
+    }
+
+    // Step 2 - Mint and PoS should be URefs and they should have valid access rights
+    let mint_contract = contract_api::get_mint();
+
+    let expected_access_rights = if contract_api::get_caller() == PublicKey::new(SYSTEM_ADDR) {
+        // System account receives read/add/write access
+        AccessRights::READ_ADD_WRITE
+    } else {
+        // User receives read only
+        AccessRights::READ
+    };
+
+    let pos_contract = contract_api::get_pos();
+
+    let mint_uref = extract_uref_from_contract_pointer(mint_contract)
+        .unwrap_or_else(|| contract_api::revert(Error::MintContractIsNotURef));
+    match mint_uref.access_rights() {
+        Some(access_rights) if access_rights != expected_access_rights => {
+            contract_api::revert(Error::InvalidMintAccessRights)
+        }
+        Some(_) => {}
+        None => contract_api::revert(Error::MintHasNoAccessRights),
+    }
+
+    let pos_uref = extract_uref_from_contract_pointer(pos_contract)
+        .unwrap_or_else(|| contract_api::revert(Error::PosContractIsNotURef));
+    match pos_uref.access_rights() {
+        Some(access_rights) if access_rights != expected_access_rights => {
+            contract_api::revert(Error::InvalidPosAccessRights)
+        }
+        Some(_) => {}
+        None => contract_api::revert(Error::PosHasNoAccessRights),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    delegate();
+}

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -42,7 +42,7 @@ use self::genesis::{
 use crate::engine_state::error::Error::MissingSystemContractError;
 use crate::engine_state::upgrade::{UpgradeConfig, UpgradeResult};
 use crate::execution::AddressGenerator;
-use crate::execution::{self, Executor, WasmiExecutor, MINT_NAME, POS_NAME};
+use crate::execution::{self, Executor, WasmiExecutor};
 use crate::tracking_copy::{TrackingCopy, TrackingCopyExt};
 use crate::KnownKeys;
 
@@ -88,8 +88,18 @@ where
         &self,
         protocol_version: ProtocolVersion,
     ) -> Result<Option<WasmCosts>, Error> {
+        match self.get_protocol_data(protocol_version)? {
+            Some(protocol_data) => Ok(Some(*protocol_data.wasm_costs())),
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_protocol_data(
+        &self,
+        protocol_version: ProtocolVersion,
+    ) -> Result<Option<ProtocolData>, Error> {
         match self.state.get_protocol_data(protocol_version) {
-            Ok(Some(protocol_data)) => Ok(Some(*protocol_data.wasm_costs())),
+            Ok(Some(protocol_data)) => Ok(Some(protocol_data)),
             Err(error) => Err(Error::ExecError(error.into())),
             _ => Ok(None),
         }
@@ -281,15 +291,20 @@ where
                     .and_then(|args| args.to_bytes())
                     .expect("args should parse")
             };
-            let mut named_keys = {
-                let mut ret = BTreeMap::new();
-                ret.insert(MINT_NAME.to_string(), Key::URef(mint_reference));
-                ret
-            };
+            let mut named_keys = BTreeMap::new();
             let authorization_keys: BTreeSet<PublicKey> = BTreeSet::new();
             let install_deploy_hash = install_deploy_hash.into();
             let address_generator = Rc::clone(&address_generator);
             let tracking_copy = Rc::clone(&tracking_copy);
+
+            // Constructs a partial protocol data with already known urefs to pass the validation
+            // step
+            let partial_protocol_data = ProtocolData::new(
+                Default::default(),
+                mint_reference,
+                // This is used as unknown key
+                URef::new([0; 32], AccessRights::READ),
+            );
 
             executor.better_exec(
                 proof_of_stake_installer_module,
@@ -306,7 +321,7 @@ where
                 correlation_id,
                 tracking_copy,
                 phase,
-                ProtocolData::default(),
+                partial_protocol_data,
             )?
         };
 
@@ -329,22 +344,10 @@ where
         //
 
         // Create known keys for chainspec accounts
-        let account_named_keys = {
-            let mut ret = BTreeMap::new();
-            let m_attenuated = URef::new(mint_reference.addr(), AccessRights::READ);
-            let p_attenuated = URef::new(proof_of_stake_reference.addr(), AccessRights::READ);
-            ret.insert(MINT_NAME.to_string(), Key::URef(m_attenuated));
-            ret.insert(POS_NAME.to_string(), Key::URef(p_attenuated));
-            ret
-        };
+        let account_named_keys = BTreeMap::new();
 
         // Create known keys for system account
-        let system_account_named_keys = {
-            let mut ret = BTreeMap::new();
-            ret.insert(MINT_NAME.to_string(), Key::URef(mint_reference));
-            ret.insert(POS_NAME.to_string(), Key::URef(proof_of_stake_reference));
-            ret
-        };
+        let system_account_named_keys = BTreeMap::new();
 
         // Create accounts
         {
@@ -534,15 +537,7 @@ where
                 }
             };
 
-            let keys = &mut BTreeMap::new();
-            keys.insert(
-                MINT_NAME.to_string(),
-                Key::URef(current_protocol_data.mint()),
-            );
-            keys.insert(
-                POS_NAME.to_string(),
-                Key::URef(current_protocol_data.proof_of_stake()),
-            );
+            let mut keys = BTreeMap::new();
 
             let initial_base_key = Key::Account(SYSTEM_ACCOUNT_ADDR);
             let authorization_keys = {
@@ -575,7 +570,7 @@ where
             WasmiExecutor.better_exec(
                 upgrade_installer_module,
                 &args,
-                keys,
+                &mut keys,
                 initial_base_key,
                 &system_account,
                 authorization_keys,

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -13,7 +13,4 @@ pub use self::runtime::{
     extract_access_rights_from_keys, extract_access_rights_from_urefs, instance_and_memory, Runtime,
 };
 
-pub const MINT_NAME: &str = "mint";
-pub const POS_NAME: &str = "pos";
-
 pub(crate) const FN_STORE_ID_INITIAL: u32 = 0;

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -437,6 +437,15 @@ where
                 let ret = self.upgrade_contract_at_uref(name_ptr, name_size, key_ptr, key_size)?;
                 Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))
             }
+
+            FunctionIndex::GetSystemContractIndex => {
+                // args(0) = system contract index
+                // args(1) = dest pointer for storing serialized result
+                // args(2) = dest pointer size
+                let (system_contract_index, dest_ptr, dest_size) = Args::parse(args)?;
+                let ret = self.get_system_contract(system_contract_index, dest_ptr, dest_size)?;
+                Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))
+            }
         }
     }
 }

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -20,7 +20,7 @@ use contract_ffi::value::{Account, ProtocolVersion, Value, U512};
 use engine_shared::gas::Gas;
 use engine_storage::global_state::StateReader;
 
-use super::{Error, MINT_NAME, POS_NAME};
+use super::Error;
 use crate::engine_state::SYSTEM_ACCOUNT_ADDR;
 use crate::resolvers::create_module_resolver;
 use crate::resolvers::memory_resolver::MemoryResolver;
@@ -783,25 +783,7 @@ where
 
         match self.mint_transfer(mint_contract_key, source, target_purse_id, amount) {
             Ok(_) => {
-                let named_keys = vec![
-                    (
-                        String::from(MINT_NAME),
-                        Key::from(self.get_mint_contract_uref()),
-                    ),
-                    (
-                        String::from(POS_NAME),
-                        Key::from(self.get_pos_contract_uref()),
-                    ),
-                ]
-                .into_iter()
-                .map(|(name, key)| {
-                    if let Some(uref) = key.as_uref() {
-                        (name, Key::URef(URef::new(uref.addr(), AccessRights::READ)))
-                    } else {
-                        (name, key)
-                    }
-                })
-                .collect();
+                let named_keys = BTreeMap::new();
                 let account = Account::create(target_addr, named_keys, target_purse_id);
                 self.context.write_account(target_key, account)?;
                 Ok(Ok(TransferredTo::NewAccount))

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -41,6 +41,7 @@ pub enum FunctionIndex {
     GetBalanceIndex = 34,
     GetPhaseIndex = 35,
     UpgradeContractAtURef = 36,
+    GetSystemContractIndex = 37,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -189,6 +189,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
                 FunctionIndex::UpgradeContractAtURef.into(),
             ),
+            "get_system_contract" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
+                FunctionIndex::GetSystemContractIndex.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -19,6 +19,7 @@ use contract_ffi::value::{Contract, ProtocolVersion, Value};
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::{CorrelationId, Validated};
 use engine_storage::global_state::StateReader;
+use engine_storage::protocol_data::ProtocolData;
 
 use crate::engine_state::execution_effect::ExecutionEffect;
 use crate::execution::{AddressGenerator, Error};
@@ -51,6 +52,7 @@ pub struct RuntimeContext<'a, R> {
     protocol_version: ProtocolVersion,
     correlation_id: CorrelationId,
     phase: Phase,
+    protocol_data: ProtocolData,
 }
 
 impl<'a, R: StateReader<Key, Value>> RuntimeContext<'a, R>
@@ -75,6 +77,7 @@ where
         protocol_version: ProtocolVersion,
         correlation_id: CorrelationId,
         phase: Phase,
+        protocol_data: ProtocolData,
     ) -> Self {
         RuntimeContext {
             state,
@@ -93,6 +96,7 @@ where
             protocol_version,
             correlation_id,
             phase,
+            protocol_data,
         }
     }
 
@@ -820,5 +824,9 @@ where
             .borrow_mut()
             .write(validated_key, validated_value);
         Ok(())
+    }
+
+    pub fn protocol_data(&self) -> ProtocolData {
+        self.protocol_data
     }
 }

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -122,6 +122,7 @@ fn mock_runtime_context<'a>(
         ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         Phase::Session,
+        Default::default(),
     )
 }
 
@@ -435,6 +436,7 @@ fn contract_key_addable_valid() {
         ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         PHASE,
+        Default::default(),
     );
 
     let uref_name = "NewURef".to_owned();
@@ -496,6 +498,7 @@ fn contract_key_addable_invalid() {
         ProtocolVersion::V1_0_0,
         CorrelationId::new(),
         PHASE,
+        Default::default(),
     );
 
     let uref_name = "NewURef".to_owned();

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -1,17 +1,31 @@
 use contract_ffi::bytesrepr;
 use contract_ffi::bytesrepr::{FromBytes, ToBytes};
-use contract_ffi::uref::{URef, UREF_SIZE_SERIALIZED};
+use contract_ffi::uref::{AccessRights, URef, UREF_SIZE_SERIALIZED};
 use engine_wasm_prep::wasm_costs::{WasmCosts, WASM_COSTS_SIZE_SERIALIZED};
 
 const PROTOCOL_DATA_SIZE_SERIALIZED: usize =
     WASM_COSTS_SIZE_SERIALIZED + UREF_SIZE_SERIALIZED + UREF_SIZE_SERIALIZED;
 
 /// Represents a protocol's data. Intended to be associated with a given protocol version.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ProtocolData {
     wasm_costs: WasmCosts,
     mint: URef,
     proof_of_stake: URef,
+}
+
+/// Provides a default instance with non existing urefs and empty costs table.
+///
+/// Used in contexts where PoS or Mint contract is not ready yet, and pos, and
+/// mint installers are ran. For use with caution.
+impl Default for ProtocolData {
+    fn default() -> ProtocolData {
+        ProtocolData {
+            wasm_costs: WasmCosts::default(),
+            mint: URef::new([0; 32], AccessRights::READ),
+            proof_of_stake: URef::new([0; 32], AccessRights::READ),
+        }
+    }
 }
 
 impl ProtocolData {

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -19,6 +19,7 @@ use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
 use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
 use engine_storage::global_state::StateProvider;
+use engine_storage::protocol_data::ProtocolData;
 use engine_wasm_prep::WasmiPreprocessor;
 
 use crate::support::test_support::{self, WasmTestBuilder};
@@ -100,6 +101,7 @@ where
         protocol_version,
         correlation_id,
         phase,
+        ProtocolData::default(),
     );
 
     let wasm_bytes = test_support::read_wasm_file_bytes(wasm_file);

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -591,17 +591,7 @@ fn should_produce_same_transforms_by_uref_or_named_uref() {
 
     let stored_payment_contract_uref = {
         // get pos contract public key
-        let pos_uref = {
-            let account = builder_by_uref
-                .get_account(DEFAULT_ACCOUNT_ADDR)
-                .expect("genesis account should exist");
-            account
-                .named_keys()
-                .get("pos")
-                .and_then(Key::as_uref)
-                .expect("should have pos uref")
-                .to_owned()
-        };
+        let pos_uref = builder_by_uref.get_pos_contract_uref();
 
         // find the contract write transform, then get the uref from its key
         // the pos contract gets re-written when the refund purse uref is removed from

--- a/execution-engine/engine-tests/src/test/system_contracts/mod.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mod.rs
@@ -11,3 +11,6 @@ mod upgrade;
 
 #[cfg(test)]
 pub mod proof_of_stake;
+
+#[cfg(test)]
+pub mod system_contracts_access;

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -17,7 +17,7 @@ const DEPLOY_HASH_2: [u8; 32] = [2u8; 32];
 const N_VALIDATORS: u8 = 5;
 
 // one named_key for each validator, one for the mint and three for the purses
-const EXPECTED_KNOWN_KEYS_LEN: usize = (N_VALIDATORS as usize) + 1 + 3;
+const EXPECTED_KNOWN_KEYS_LEN: usize = (N_VALIDATORS as usize) + 3;
 
 const POS_BONDING_PURSE: &str = "pos_bonding_purse";
 const POS_PAYMENT_PURSE: &str = "pos_payment_purse";

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
@@ -1,0 +1,42 @@
+use contract_ffi::value::U512;
+
+use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
+use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+
+const CONTRACT_SYSTEM_CONTRACTS_ACCESS: &str = "system_contracts_access.wasm";
+const CONTRACT_TRANSFER_TO_ACCOUNT_01: &str = "transfer_to_account_01.wasm";
+
+const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];
+
+lazy_static! {
+    static ref ACCOUNT_1_INITIAL_BALANCE: U512 = *DEFAULT_PAYMENT * 10;
+}
+
+fn run_test_with_address(builder: &mut InMemoryWasmTestBuilder, address: [u8; 32]) {
+    let exec_request =
+        ExecuteRequestBuilder::standard(address, CONTRACT_SYSTEM_CONTRACTS_ACCESS, ()).build();
+
+    builder.exec(exec_request).expect_success().commit();
+}
+
+#[ignore]
+#[test]
+fn should_verify_system_contracts_access_rights_default() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    let exec_request_1 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT_01,
+        (ACCOUNT_1_ADDR, *ACCOUNT_1_INITIAL_BALANCE),
+    )
+    .build();
+
+    builder
+        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .exec(exec_request_1)
+        .expect_success()
+        .commit();
+
+    run_test_with_address(&mut builder, DEFAULT_ACCOUNT_ADDR);
+    run_test_with_address(&mut builder, ACCOUNT_1_ADDR);
+}

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -5,7 +5,7 @@ const NUM_FIELDS: usize = 10;
 pub const WASM_COSTS_SIZE_SERIALIZED: usize = NUM_FIELDS * U32_SIZE;
 
 // Taken (partially) from parity-ethereum
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct WasmCosts {
     /// Default opcode cost
     pub regular: u32,


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

- Removes mint/pos contract from default named keys for given account
- Adds test that makes sure both genesis and accounts created through transferring tokens does not have default keys + they are given valid uref with stripped down access rights (READ) for both mint and pos contract.
- PoS and Mint are always referred to through `ProtocolData` on both host side and exposed to contract devs through new FFI `get_system_contract`


### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-704

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
