### PR TITLE
CON-526: Ensure justification timestamps are not in the future

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -131,12 +131,15 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
           .addEffects(InvalidUnslashableBlock, block, Seq.empty, dag)
           .tupleLeft(InvalidUnslashableBlock: BlockStatus)
 
+    // If the block timstamp is in the future, wait some time before adding it,
+    // so we won't include it as a justification from the future.
     Validation[F].preTimestamp(block).attempt.flatMap {
-      case Right(None) => addBlock(statelessExecutor.validateAndAddBlock)
+      case Right(None) =>
+        addBlock(statelessExecutor.validateAndAddBlock)
       case Right(Some(delay)) =>
-        Time[F].sleep(delay) >> Log[F].info(
+        Log[F].info(
           s"Block ${PrettyPrinter.buildString(block)} is ahead for $delay from now, will retry adding later"
-        ) >> addBlock(statelessExecutor.validateAndAddBlock)
+        ) >> Time[F].sleep(delay) >> addBlock(statelessExecutor.validateAndAddBlock)
       case _ =>
         Log[F].warn(validation.ignore(block, "block timestamp exceeded threshold")) >> addBlock(
           handleInvalidTimestamp
@@ -384,6 +387,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
                 s"${parents.size} parents out of ${tipHashes.size} latest blocks will be used."
               )
           timestamp        <- Time[F].currentMillis
+          _                <- ensureJustificationsInThePast(timestamp, latestMessages)
           remainingHashes  <- remainingDeploysHashes(dag, parents, timestamp) // TODO: Should be streaming all the way down
           bondedValidators = bonds(parents.head).map(_.validatorPublicKey).toSet
           //We ensure that only the justifications given in the block are those
@@ -420,6 +424,23 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
       }
     case None => CreateBlockStatus.readOnlyMode.pure[F]
   }
+
+  // Sanity check, this should never happen because we delay messages from the future.
+  private def ensureJustificationsInThePast(
+      timestamp: Long,
+      latestMessages: Map[DagRepresentation.Validator, Message]
+  ): F[Unit] =
+    latestMessages.values
+      .find {
+        _.timestamp > timestamp
+      }
+      .fold(().pure[F]) { msg =>
+        Log[F].warn(
+          s"Justification is in the future: ${PrettyPrinter
+            .buildString(msg.messageHash)}; ${msg.timestamp} > $timestamp"
+        ) *>
+          functorRaiseInvalidBlock.raise[Unit](InvalidUnslashableBlock)
+      }
 
   def lastFinalizedBlock: F[Block] =
     for {

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -131,7 +131,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
           .addEffects(InvalidUnslashableBlock, block, Seq.empty, dag)
           .tupleLeft(InvalidUnslashableBlock: BlockStatus)
 
-    // If the block timstamp is in the future, wait some time before adding it,
+    // If the block timestamp is in the future, wait some time before adding it,
     // so we won't include it as a justification from the future.
     Validation[F].preTimestamp(block).attempt.flatMap {
       case Right(None) =>

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -435,7 +435,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
         _.timestamp > timestamp
       }
       .fold(().pure[F]) { msg =>
-        Log[F].warn(
+        Log[F].error(
           s"Justification is in the future: ${PrettyPrinter
             .buildString(msg.messageHash)}; ${msg.timestamp} > $timestamp"
         ) *>

--- a/models/src/main/scala/io/casperlabs/models/Message.scala
+++ b/models/src/main/scala/io/casperlabs/models/Message.scala
@@ -21,6 +21,7 @@ trait Message {
   type Id = ByteString
   val messageHash: Id
   val validatorId: ByteString
+  val timestamp: Long
   val parentBlock: Id
   val justifications: Seq[consensus.Block.Justification]
   val rank: Long
@@ -40,6 +41,7 @@ object Message {
   case class Block private (
       messageHash: Message#Id,
       validatorId: ByteString,
+      timestamp: Long,
       parentBlock: Message#Id,
       justifications: Seq[consensus.Block.Justification],
       rank: Long,
@@ -63,6 +65,7 @@ object Message {
   case class Ballot private (
       messageHash: Message#Id,
       validatorId: ByteString,
+      timestamp: Long,
       parentBlock: Message#Id,
       justifications: Seq[consensus.Block.Justification],
       rank: Long,
@@ -77,6 +80,7 @@ object Message {
     try {
       val messageHash        = b.blockHash
       val header             = b.getHeader
+      val timestamp          = header.timestamp
       val parentBlock        = header.parentHashes.headOption.getOrElse(ByteString.EMPTY)
       val validatorId        = header.validatorPublicKey
       val justifications     = header.justifications
@@ -91,6 +95,7 @@ object Message {
             Ballot(
               messageHash,
               validatorId,
+              timestamp,
               parentBlock,
               justifications,
               rank,
@@ -104,6 +109,7 @@ object Message {
             Block(
               messageHash,
               validatorId,
+              timestamp,
               parentBlock,
               justifications,
               rank,


### PR DESCRIPTION
### Overview
Adds a sanity check to `MultiParentCasperImpl.createBlock` to ensure we aren't creating a block with a timestamp higher than its justifications'. This is made impossible by the `preTimestamp` check during `addBlock`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-526

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
