### PR TITLE
NODE-927: Preload dag storage cache

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -294,10 +294,8 @@ object BlockAPI {
             MonadThrowable[F].raiseError(InvalidArgument(StorageError.errorMessage(ex)))
           case ex: IllegalArgumentException =>
             MonadThrowable[F].raiseError(InvalidArgument(ex.getMessage))
-        } map { ranksOfHashes =>
-          ranksOfHashes.flatten.reverse.map(h => Base16.encode(h.toByteArray))
-        } flatMap { hashes =>
-          hashes.toList.flatTraverse(getBlockInfoOpt[F](_, full).map(_.toList))
+        } flatMap { summariesByRank =>
+          summariesByRank.flatten.reverse.toList.traverse(makeBlockInfo[F](_, full))
         }
     }
 

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -159,12 +159,12 @@ object SQLiteStorage {
       override def topoSort(
           startBlockNumber: Long,
           endBlockNumber: Long
-      ): Stream[F, Vector[BlockHash]] = dagStorage.topoSort(startBlockNumber, endBlockNumber)
+      ): Stream[F, Vector[BlockSummary]] = dagStorage.topoSort(startBlockNumber, endBlockNumber)
 
-      override def topoSort(startBlockNumber: Long): Stream[F, Vector[BlockHash]] =
+      override def topoSort(startBlockNumber: Long): Stream[F, Vector[BlockSummary]] =
         dagStorage.topoSort(startBlockNumber)
 
-      override def topoSortTail(tailLength: Int): Stream[F, Vector[BlockHash]] =
+      override def topoSortTail(tailLength: Int): Stream[F, Vector[BlockSummary]] =
         dagStorage.topoSortTail(tailLength)
 
       override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -98,13 +98,13 @@ class CachingDagStorage[F[_]: Sync](
   override def topoSort(
       startBlockNumber: Long,
       endBlockNumber: Long
-  ): fs2.Stream[F, Vector[BlockHash]] = underlying.topoSort(startBlockNumber, endBlockNumber)
+  ): fs2.Stream[F, Vector[BlockSummary]] = underlying.topoSort(startBlockNumber, endBlockNumber)
 
   /** Return ranks of blocks in the DAG from a start index to the end. */
-  override def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockHash]] =
+  override def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockSummary]] =
     underlying.topoSort(startBlockNumber)
 
-  override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]] =
+  override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockSummary]] =
     underlying.topoSortTail(tailLength)
 
   override def latestMessageHash(validator: Validator): F[Option[BlockHash]] =

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -3,7 +3,7 @@ package io.casperlabs.storage.dag
 import cats.Monad
 import cats.implicits._
 import com.google.protobuf.ByteString
-import io.casperlabs.casper.consensus.Block
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.metrics.Metered
 import io.casperlabs.models.Message
 import io.casperlabs.storage.block.BlockStorage.BlockHash
@@ -62,14 +62,14 @@ object DagStorage {
     abstract override def topoSort(
         startBlockNumber: Long,
         endBlockNumber: Long
-    ): fs2.Stream[F, Vector[BlockHash]] =
+    ): fs2.Stream[F, Vector[BlockSummary]] =
       fs2.Stream.eval(m.incrementCounter("topoSort")) >> super
         .topoSort(startBlockNumber, endBlockNumber)
 
-    abstract override def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockHash]] =
+    abstract override def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockSummary]] =
       fs2.Stream.eval(m.incrementCounter("topoSort")) >> super.topoSort(startBlockNumber)
 
-    abstract override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]] =
+    abstract override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockSummary]] =
       fs2.Stream.eval(m.incrementCounter("topoSortTail")) >> super.topoSortTail(tailLength)
   }
 
@@ -84,13 +84,13 @@ trait DagRepresentation[F[_]] {
   def lookup(blockHash: BlockHash): F[Option[Message]]
   def contains(blockHash: BlockHash): F[Boolean]
 
-  /** Return the ranks of blocks in the DAG between start and end, inclusive. */
-  def topoSort(startBlockNumber: Long, endBlockNumber: Long): fs2.Stream[F, Vector[BlockHash]]
+  /** Return block summaries with ranks in the DAG between start and end, inclusive. */
+  def topoSort(startBlockNumber: Long, endBlockNumber: Long): fs2.Stream[F, Vector[BlockSummary]]
 
-  /** Return ranks of blocks in the DAG from a start index to the end. */
-  def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockHash]]
+  /** Return block summaries with ranks of blocks in the DAG from a start index to the end. */
+  def topoSort(startBlockNumber: Long): fs2.Stream[F, Vector[BlockSummary]]
 
-  def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockHash]]
+  def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockSummary]]
 
   def latestMessageHash(validator: Validator): F[Option[BlockHash]]
   def latestMessage(validator: Validator): F[Option[Message]]


### PR DESCRIPTION
### Overview
Stores data in `CachingDagStorage` not only on inserts but also on lookups. 
We hope that it will improve performance. During lookups (but not inserts) caches not only a single block but its neighborhood - blocks from the past and future. 
The radius of the neighborhood is configurable during construction.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-927

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
