### PR TITLE
NODE-905: Deploy status API

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -8,7 +8,7 @@ import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
-import io.casperlabs.casper.{BlockStatus => _, _}
+import io.casperlabs.casper._
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.info._
 import io.casperlabs.casper.finality.singlesweep.FinalityDetector
@@ -198,14 +198,14 @@ object BlockAPI {
       maybeBlock: Option[Block]
   ): BlockInfo = {
     val maybeStats = maybeBlock.map { block =>
-      BlockStatus
+      BlockInfo.Status
         .Stats()
         .withBlockSizeBytes(block.serializedSize)
         .withDeployErrorCount(
           block.getBody.deploys.count(_.isError)
         )
     }
-    val status = BlockStatus(stats = maybeStats)
+    val status = BlockInfo.Status(stats = maybeStats)
     BlockInfo()
       .withSummary(summary)
       .withStatus(status)

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -30,6 +30,7 @@ message BlockStatus {
 message DeployInfo {
     io.casperlabs.casper.consensus.Deploy deploy = 1;
     repeated ProcessingResult processing_results = 2;
+    Status status = 3;
 
     message ProcessingResult {
         BlockInfo block_info = 1;
@@ -43,5 +44,18 @@ message DeployInfo {
         BASIC = 0;
         // Includes the body with the code.
         FULL = 1;
+    }
+
+    enum State {
+        UNDEFINED = 0;
+        PENDING = 1;
+        PROCESSED = 2;
+        FINALIZED = 3;
+        DISCARDED = 4;
+    }
+
+    message Status {
+        State state = 1;
+        string message = 2;
     }
 }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -5,7 +5,7 @@ import "io/casperlabs/casper/consensus/consensus.proto";
 
 message BlockInfo {
     io.casperlabs.casper.consensus.BlockSummary summary = 1;
-    BlockStatus status = 2;
+    Status status = 2;
 
     enum View {
         // Only includes information which is based on the header.
@@ -14,18 +14,19 @@ message BlockInfo {
         // for example the size, number of errors in deploys, etc.
         FULL = 1;
     }
-}
 
-message BlockStatus {
-    float fault_tolerance = 1;
-    Stats stats = 2;
+    message Status {
+        float fault_tolerance = 1;
+        Stats stats = 2;
 
-    // Statistics derived from the full block.
-    message Stats {
-        uint32 block_size_bytes = 1;
-        uint32 deploy_error_count = 2;
+        // Statistics derived from the full block.
+        message Stats {
+            uint32 block_size_bytes = 1;
+            uint32 deploy_error_count = 2;
+        }
     }
 }
+
 
 message DeployInfo {
     io.casperlabs.casper.consensus.Deploy deploy = 1;
@@ -48,14 +49,22 @@ message DeployInfo {
 
     enum State {
         UNDEFINED = 0;
+        // Waiting to be included in a block. Deploys can go back to pending
+        // if the block it was included in got orphaned.
         PENDING = 1;
+        // Included in one or more blocks, waiting to be finalized, or potentially
+        // orphaned and re-queued.
         PROCESSED = 2;
+        // The block the deploy was included has been finalized along with all the deploys in it.
         FINALIZED = 3;
+        // Deploys get discarded if their account doesn't exist, or their TTL expires.
+        // They will be removed after a grace period to free up space.
         DISCARDED = 4;
     }
 
     message Status {
         State state = 1;
+        // Potential explanation for the current state of the deploy, e.g. the reason it got discarded.
         string message = 2;
     }
 }

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -5,6 +5,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import doobie.util.transactor.Transactor
 import io.casperlabs.casper.consensus.{Block, BlockSummary, Deploy}
+import io.casperlabs.casper.consensus.info.DeployInfo
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Message
 import io.casperlabs.shared.Time
@@ -89,11 +90,17 @@ object SQLiteStorage {
 
       override def sizePendingOrProcessed(): F[Long] = deployStorage.sizePendingOrProcessed()
 
-      override def getByHashes(l: Set[ByteString]): Stream[F, Deploy] = deployStorage.getByHashes(l)
+      override def getByHash(hash: ByteString): F[Option[Deploy]] = deployStorage.getByHash(hash)
+
+      override def getByHashes(hashes: Set[ByteString]): Stream[F, Deploy] =
+        deployStorage.getByHashes(hashes)
 
       override def getProcessingResults(
           hash: ByteString
       ): F[List[(BlockHash, Block.ProcessedDeploy)]] = deployStorage.getProcessingResults(hash)
+
+      override def getBufferedStatus(hash: ByteString): F[Option[DeployInfo.Status]] =
+        deployStorage.getBufferedStatus(hash)
 
       override def getRepresentation: F[DagRepresentation[F]] = dagStorage.getRepresentation
 

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
@@ -3,6 +3,7 @@ package io.casperlabs.storage.deploy
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus.{Block, Deploy}
+import io.casperlabs.casper.consensus.info.DeployInfo
 import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
 import simulacrum.typeclass
 
@@ -84,10 +85,15 @@ import scala.concurrent.duration._
 
   def sizePendingOrProcessed(): F[Long]
 
-  def getByHashes(l: Set[ByteString]): fs2.Stream[F, Deploy]
+  def getByHash(hash: ByteString): F[Option[Deploy]]
+
+  def getByHashes(hashes: Set[ByteString]): fs2.Stream[F, Deploy]
 
   /** @return List of blockHashes and processing results in descendant order by execution time (block creation timestamp)*/
   def getProcessingResults(hash: ByteString): F[List[(BlockHash, ProcessedDeploy)]]
+
+  /** Read the status of a deploy from the buffer, if it's still in it. */
+  def getBufferedStatus(hash: ByteString): F[Option[DeployInfo.Status]]
 }
 
 @typeclass trait DeployStorage[F[_]] extends DeployStorageWriter[F] with DeployStorageReader[F] {}
@@ -151,10 +157,17 @@ object DeployStorage {
     override def sizePendingOrProcessed(): F[Long] =
       reader.sizePendingOrProcessed()
 
-    override def getByHashes(l: Set[ByteString]): fs2.Stream[F, Deploy] = reader.getByHashes(l)
+    override def getByHash(hash: ByteString): F[Option[Deploy]] =
+      reader.getByHash(hash)
+
+    override def getByHashes(hashes: Set[ByteString]): fs2.Stream[F, Deploy] =
+      reader.getByHashes(hashes)
 
     override def getProcessingResults(hash: BlockHash): F[List[(BlockHash, ProcessedDeploy)]] =
       reader.getProcessingResults(hash)
+
+    override def getBufferedStatus(hash: ByteString): F[Option[DeployInfo.Status]] =
+      reader.getBufferedStatus(hash)
 
     override def clear(): F[Unit] = writer.clear()
 

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -165,7 +165,8 @@ class SQLiteDeployStorage[F[_]: Metrics: Time: Sync](chunkSize: Int)(
 
   override def markAsDiscardedByHashes(hashesAndReasons: List[(ByteString, String)]): F[Unit] =
     setStatus(hashesAndReasons.map {
-      case (h, r) => (h, r.some)
+      case (h, r) =>
+        (h, r.some)
     }, DiscardedStatusCode, PendingStatusCode)
 
   override def cleanupDiscarded(expirationPeriod: FiniteDuration): F[Int] = {

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
@@ -3,6 +3,7 @@ package io.casperlabs.storage.deploy
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, Deploy}
+import io.casperlabs.casper.consensus.info.DeployInfo
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.models.ArbitraryConsensus
 import monix.eval.Task
@@ -96,24 +97,55 @@ trait DeployStorageSpec
               _ <- add2.attempt.foreachL(_ shouldBe an[Right[_, _]])
               _ <- read
                     .foreachL(
-                      _.sortedByHash should contain theSameElementsAs List(d1, d2).sortedByHash
+                      _ should contain theSameElementsAs List(d1, d2)
                     )
             } yield ()
           }
       )
     }
 
-    "addAsPending + addAsProcessed + getByHashes" should {
+    "addAsPending + addAsProcessed + (getByHashes | getByHash)" should {
       "return the same list of deploys" in forAll(deploysGen()) { deploys =>
         testFixture { (reader, writer) =>
           val idx                  = scala.util.Random.nextInt(deploys.size)
           val (pending, processed) = deploys.splitAt(idx)
           val deployHashes         = deploys.map(_.deployHash)
           for {
-            _   <- writer.addAsPending(pending)
-            _   <- writer.addAsProcessed(processed)
-            all <- reader.getByHashes(deployHashes.toSet).compile.toList
-            _   = assert(deploys.sortedByHash == all.sortedByHash)
+            _    <- writer.addAsPending(pending)
+            _    <- writer.addAsProcessed(processed)
+            all1 <- reader.getByHashes(deployHashes.toSet).compile.toList
+            all2 <- deployHashes.toList.traverse(reader.getByHash).map(_.flatten)
+            _    = all1 should contain theSameElementsAs deploys
+            _    = all2 should contain theSameElementsAs deploys
+          } yield ()
+
+        }
+      }
+    }
+
+    "getBufferedStatus" should {
+      "return return the status from the buffer" in forAll { (deploy: Deploy) =>
+        testFixture { (reader, writer) =>
+          def checkSome(state: DeployInfo.State, msg: String = "") =
+            reader.getBufferedStatus(deploy.deployHash) map {
+              _ shouldBe Some(DeployInfo.Status(state, msg))
+            }
+          def checkNone() =
+            reader.getBufferedStatus(deploy.deployHash) map {
+              _ shouldBe None
+            }
+
+          for {
+            _ <- checkNone()
+            _ <- writer.addAsPending(List(deploy))
+            _ <- checkSome(DeployInfo.State.PENDING)
+            _ <- writer.markAsProcessedByHashes(List(deploy.deployHash))
+            _ <- checkSome(DeployInfo.State.PROCESSED)
+            _ <- writer.markAsFinalizedByHashes(List(deploy.deployHash))
+            _ <- checkNone()
+            _ <- writer.addAsPending(List(deploy))
+            _ <- writer.markAsDiscardedByHashes(List(deploy.deployHash -> "Testing"))
+            _ <- checkSome(DeployInfo.State.DISCARDED, "Testing")
           } yield ()
 
         }

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
@@ -124,7 +124,7 @@ trait DeployStorageSpec
     }
 
     "getBufferedStatus" should {
-      "return return the status from the buffer" in forAll { (deploy: Deploy) =>
+      "return the status from the buffer" in forAll { (deploy: Deploy) =>
         testFixture { (reader, writer) =>
           def checkSome(state: DeployInfo.State, msg: String = "") =
             reader.getBufferedStatus(deploy.deployHash) map {

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/MockDeployStorage.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/MockDeployStorage.scala
@@ -36,6 +36,7 @@ class MockDeployStorage[F[_]: Sync: Log](
             pd.getDeploy,
             Metadata(
               if (pd.isError) ExecutionErrorStatusCode else ExecutionSuccessStatusCode,
+              "",
               now,
               now,
               Nil
@@ -52,7 +53,7 @@ class MockDeployStorage[F[_]: Sync: Log](
 
   override def getProcessingResults(hash: ByteString): F[List[(BlockHash, Block.ProcessedDeploy)]] =
     deploysWithMetadataRef.get.map(_.collect {
-      case (d, Metadata(_, _, _, processingResults)) if d.deployHash == hash => processingResults
+      case (d, Metadata(_, _, _, _, processingResults)) if d.deployHash == hash => processingResults
     }.toList.flatten)
 
   override def addAsPending(deploys: List[Deploy]): F[Unit] =
@@ -71,7 +72,7 @@ class MockDeployStorage[F[_]: Sync: Log](
     deploysWithMetadataRef.update(
       deploys
         .map(
-          d => (d, Metadata(status, now, now, Nil))
+          d => (d, Metadata(status, "", now, now, Nil))
         )
         .toMap ++ _
     )
@@ -79,21 +80,21 @@ class MockDeployStorage[F[_]: Sync: Log](
   override def markAsPendingByHashes(hashes: List[ByteString]): F[Unit] =
     logOperation(
       s"markAsPending(hashes = ${hashesToString(hashes)})",
-      setStatus(hashes, PendingStatusCode, ProcessedStatusCode)
+      setStatus(hashes.map(_ -> ""), PendingStatusCode, ProcessedStatusCode)
     )
 
   override def markAsProcessedByHashes(hashes: List[ByteString]): F[Unit] =
     logOperation(
       s"markAsProcessed(hashes = ${hashesToString(hashes)})",
-      setStatus(hashes, ProcessedStatusCode, PendingStatusCode)
+      setStatus(hashes.map(_ -> ""), ProcessedStatusCode, PendingStatusCode)
     )
 
   override def markAsFinalizedByHashes(hashes: List[ByteString]): F[Unit] =
     logOperation(
       s"markAsFinalized(hashes = ${hashesToString(hashes)})",
       deploysWithMetadataRef.update(_.filter {
-        case (deploy, Metadata(`ProcessedStatusCode`, _, _, _))
-            if hashes.toSet(deploy.deployHash) =>
+        case (deploy, Metadata(`ProcessedStatusCode`, _, _, _, _))
+            if hashes.contains(deploy.deployHash) =>
           false
         case _ => true
       })
@@ -102,26 +103,35 @@ class MockDeployStorage[F[_]: Sync: Log](
   override def markAsDiscardedByHashes(hashesAndReasons: List[(ByteString, String)]): F[Unit] =
     logOperation(
       s"markAsDiscarded(hashes = ${hashesToString(hashesAndReasons.map(_._1))})",
-      setStatus(hashesAndReasons.map(_._1), DiscardedStatusCode, PendingStatusCode)
+      setStatus(hashesAndReasons, DiscardedStatusCode, PendingStatusCode)
     )
 
-  private def setStatus(hashes: List[ByteString], newStatus: Int, prevStatus: Int): F[Unit] =
+  private def setStatus(
+      hashesAndReasons: Seq[(ByteString, String)],
+      newStatus: Int,
+      prevStatus: Int
+  ): F[Unit] = {
+    val updates = hashesAndReasons.toMap
     deploysWithMetadataRef.update(_.map {
-      case (deploy, Metadata(`prevStatus`, _, createdAt, processingResults))
-          if hashes.toSet(deploy.deployHash) =>
-        (deploy, Metadata(newStatus, now, createdAt, processingResults))
+      case (deploy, Metadata(`prevStatus`, _, _, createdAt, processingResults))
+          if updates contains deploy.deployHash =>
+        (
+          deploy,
+          Metadata(newStatus, updates(deploy.deployHash), now, createdAt, processingResults)
+        )
       case x => x
     }) >> logCurrentState()
+  }
 
   override def markAsDiscarded(expirationPeriod: FiniteDuration): F[Unit] =
     logOperation(
       s"markAsDiscarded(expirationPeriod = ${expirationPeriod.toCoarsest.toString()})",
       deploysWithMetadataRef.update(_.map {
-        case (deploy, Metadata(`PendingStatusCode`, updatedAt, createdAt, processingResults))
+        case (deploy, Metadata(`PendingStatusCode`, _, updatedAt, createdAt, processingResults))
             if updatedAt < now - expirationPeriod.toMillis =>
           (
             deploy,
-            Metadata(DiscardedStatusCode, now, createdAt, processingResults)
+            Metadata(DiscardedStatusCode, "Expired.", now, createdAt, processingResults)
           )
         case x => x
       })
@@ -129,7 +139,7 @@ class MockDeployStorage[F[_]: Sync: Log](
 
   override def cleanupDiscarded(expirationPeriod: FiniteDuration): F[Int] = {
     val selectDiscarding: ((Deploy, Metadata)) => Boolean = (_: (Deploy, Metadata)) match {
-      case (_, Metadata(`DiscardedStatusCode`, updatedAt, _, processingResults))
+      case (_, Metadata(`DiscardedStatusCode`, _, updatedAt, _, processingResults))
           if updatedAt < now - expirationPeriod.toMillis && processingResults.isEmpty =>
         true
       case _ => false
@@ -180,7 +190,7 @@ class MockDeployStorage[F[_]: Sync: Log](
 
   private def readByStatus(status: Int): F[List[Deploy]] =
     deploysWithMetadataRef.get.map(_.collect {
-      case (deploy, Metadata(`status`, _, _, _)) => deploy
+      case (deploy, Metadata(`status`, _, _, _, _)) => deploy
     }.toList)
 
   override def sizePendingOrProcessed(): F[Long] =
@@ -188,21 +198,22 @@ class MockDeployStorage[F[_]: Sync: Log](
 
   override def getPendingOrProcessed(hash: ByteString): F[Option[Deploy]] =
     deploysWithMetadataRef.get.map(_.collectFirst {
-      case (d, Metadata(`PendingStatusCode` | `ProcessedStatusCode`, _, _, _))
+      case (d, Metadata(`PendingStatusCode` | `ProcessedStatusCode`, _, _, _, _))
           if d.deployHash == hash =>
         d
     })
 
   override def getBufferedStatus(hash: ByteString): F[Option[DeployInfo.Status]] =
     deploysWithMetadataRef.get.map(_.collectFirst {
-      case (d, Metadata(status, _, _, _)) if d.deployHash == hash =>
+      case (d, Metadata(status, msg, _, _, _)) if d.deployHash == hash =>
         DeployInfo.Status(
           state = status match {
             case `PendingStatusCode`   => DeployInfo.State.PENDING
             case `ProcessedStatusCode` => DeployInfo.State.PROCESSED
             case `DiscardedStatusCode` => DeployInfo.State.DISCARDED
             case _                     => DeployInfo.State.UNDEFINED
-          }
+          },
+          message = msg
         )
     })
 
@@ -267,6 +278,7 @@ class MockDeployStorage[F[_]: Sync: Log](
 object MockDeployStorage {
   case class Metadata(
       status: Int,
+      message: String,
       updatedAt: Long,
       createdAt: Long,
       processingResults: List[(ByteString, Block.ProcessedDeploy)]


### PR DESCRIPTION
### Overview
Exposes the status from the deploy buffer via `CasperService.GetDeployInfo`. 

Changes: 
* Adds `DeployStorage.getByHash`
* Adds `DeployStorage.getBufferedStatus`
* `BlockAPI.getDeployInfo` used to return `None` for discarded deploys; now it will return `Some` as long as the deploy exists, with potentially more info.
* `BlockAPI.getDeployInfo` no longer retrieves the full block to look for the deploy processing results.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-905

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
@piokuc this might be useful for testing.
