### PR TITLE
OP-761: add make setup for ee tag pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -820,6 +820,7 @@ steps:
 - name: package-ee-tag
   commands:
   - "mkdir -p artifacts/${DRONE_BRANCH}"
+  - "make setup -C ./execution-engine"
   - "make cargo-package-all"
   - "cp execution-engine/target/system-contracts.tar.gz artifacts/${DRONE_BRANCH}"
   - "cp execution-engine/target/debian/casperlabs-engine-grpc-server_*.deb artifacts/${DRONE_BRANCH}"


### PR DESCRIPTION
### Overview
Adds make setup for ee packaging step for tagged releases. This brings the step inline with the package-ee step.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-761

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The upload to github on tag failed during release 0.8.0 because this was missing.
