### PR TITLE
OP-768: Ignore proto files in node_modules for Rust targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ $(eval VER = $(shell echo $(TAGS_OR_SHA) | grep -oE 'v?[0-9]+(\.[0-9]){1,2}$$' |
 # But with comm/build.rs compiling .proto to .rs every time we build the timestamps are updated as well, so filter those and depend on .proto instead.
 RUST_SRC := $(shell find . -type f \( -name "Cargo.toml" -o -wholename "*/src/*.rs" -o -name "*.proto" \) \
 	| grep -v target \
+	| grep -v node_modules \
 	| grep -v -E '(ipc|transforms).*\.rs')
 SCALA_SRC := $(shell find . -type f \( -wholename "*/src/*.scala" -o -name "*.sbt" \))
 PROTO_SRC := $(shell find protobuf -type f \( -name "*.proto" \) | grep -v node_modules)
@@ -215,7 +216,7 @@ cargo-native-packager/%:
 			--js_out=import_style=commonjs,binary:$(DIR_OUT) \
 			--ts_out=service=false:$(DIR_OUT) \
 			$(DIR_IN)/google/protobuf/empty.proto \
-			$(DIR_IN)/io/casperlabs/casper/consensus/consensus.proto \
+			$(DIR_IN)/io/casperlabs/casper/consensus/consensusa \
 			$(DIR_IN)/io/casperlabs/casper/consensus/info.proto \
 			$(DIR_IN)/io/casperlabs/casper/consensus/state.proto ; \
 		protoc \

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ cargo-native-packager/%:
 			--js_out=import_style=commonjs,binary:$(DIR_OUT) \
 			--ts_out=service=false:$(DIR_OUT) \
 			$(DIR_IN)/google/protobuf/empty.proto \
-			$(DIR_IN)/io/casperlabs/casper/consensus/consensusa \
+			$(DIR_IN)/io/casperlabs/casper/consensus/consensus.proto \
 			$(DIR_IN)/io/casperlabs/casper/consensus/info.proto \
 			$(DIR_IN)/io/casperlabs/casper/consensus/state.proto ; \
 		protoc \


### PR DESCRIPTION
### Overview
Some ephemeral .proto files under node_modules got captured as Rust dependencies by Make.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-768

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
