### PR TITLE
NODE-923: Fix race condition in latest messages again after merges.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -394,7 +394,6 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
           //which are bonded validators in the chosen parent. This is safe because
           //any latest message not from a bonded validator will not change the
           //final fork-choice.
-          latestMessages   <- dag.latestMessages
           bondedLatestMsgs = latestMessages.filter { case (v, _) => bondedValidators.contains(v) }
           justifications   = toJustification(bondedLatestMsgs.values.toSeq)
           rank             = ProtoUtil.nextRank(bondedLatestMsgs.values.toSeq)


### PR DESCRIPTION
### Overview
https://github.com/CasperLabs/CasperLabs/commit/05fa86d130f98c9770fc84b8a32b29027547382d fixed a race condition where the latest messages we were use during the estimation of `tips` and later what we put into the `justifications` allowed further blocks to arrive. Unfortunately the same bug was reintroduced by the big feature branch merges: https://github.com/CasperLabs/CasperLabs/blame/c72f527569caeb16b106e86b1c5ca62f01ebed22/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala#L393

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-923

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Example error:
```
Ignoring block 229f7b1260... 
because block parents  d0e44b356e...,2345f6d5f4...,e4de8bcc0f... 
did not match estimate dc1a161b37...,2345f6d5f4...,d0e44b356e...,95daf8a9c5... 
based on justification dc1a161b37...,2345f6d5f4...,d0e44b356e...,95daf8a9c5...,58c91cc5f5...,
...
Could not propose.
```
I visually inspected the DAG in Clarity and e4de is the parent of 95da, which can be explained by the bug.