### PR TITLE
NODE-969: Fix failing CI sbt build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,6 +14,7 @@
 #  volumes:
 #    - "/var/cache/cl-build/.sbt:/root/.sbt"
 #    - "/var/cache/cl-build/.ivy2:/root/.ivy2"
+#    - "/var/cache/cl-build/.coursier:/root/.coursier"
 
 # Begin
 clone:
@@ -548,6 +549,7 @@ steps:
 - name: package-sbt-artifacts-merge
   commands:
   - "make build-client-contracts build-node-contracts"
+  - "rm -rf project/target project/project/target"
   - "sbt update test client/debian:packageBin client/universal:packageZipTarball client/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball node/rpm:packageBin node/docker:publishLocal client/docker:publishLocal"
   - "mkdir -p artifacts/${DRONE_BRANCH}"
   - "cp client/target/casperlabs-client_*_all.deb client/target/universal/*.tgz artifacts/${DRONE_BRANCH}"


### PR DESCRIPTION
### Overview
https://github.com/CasperLabs/CasperLabs/pull/1247 introduced a bug when Drone couldn't publish changes after PRs were merged into the `dev` branch.

Example: https://drone-auto.casperlabs.io/CasperLabs/CasperLabs/5384

I've found the similar issue https://github.com/sbt/sbt/issues/5142

And the mentioned workaround helped me to fix it locally: https://github.com/sbt/sbt/issues/5142#issuecomment-537031341

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-969

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I've also added a comment about `~/.coursier` cache in addition to `~/.ivy2` since `sbt` switched to it starting from the `1.3.0`. 
https://github.com/sbt/sbt/releases/tag/v1.3.0