### PR TITLE
NODE-970: Fix unresolved scalafmt bug

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -6,5 +6,5 @@ style = default
 rewrite.rules = [PreferCurlyFors, RedundantBraces, SortImports]
 align = most
 maxColumn = 100
-version = 2.1.0
+version = 2.1.1
 docstrings = ScalaDoc

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
@@ -126,5 +126,5 @@ object FinalityDetectorVotingMatrix {
       lock                 <- Semaphore[F](1)
       votingMatrix         <- VotingMatrix.create[F](dag, finalizedBlock, equivocationsTracker)
       votingMatrixWithLock = synchronizedVotingMatrix(lock, votingMatrix)
-    } yield new FinalityDetectorVotingMatrix[F](rFTT)(Concurrent[F], Log[F], votingMatrixWithLock)
+    } yield new FinalityDetectorVotingMatrix[F](rFTT) (Concurrent[F], Log[F], votingMatrixWithLock)
 }

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -171,7 +171,7 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
       logEff                 = new LogStub[Task]()
       casperRef              <- MultiParentCasperRef.of[Task]
       _                      <- casperRef.set(casperEffect)
-      finalityDetectorEffect = new FinalityDetectorBySingleSweepImpl[Task]()(Sync[Task], logEff)
+      finalityDetectorEffect = new FinalityDetectorBySingleSweepImpl[Task]() (Sync[Task], logEff)
     } yield (logEff, casperRef, finalityDetectorEffect)
 
   private def emptyEffects(
@@ -194,6 +194,6 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
       logEff                 = new LogStub[Task]()
       casperRef              <- MultiParentCasperRef.of[Task]
       _                      <- casperRef.set(casperEffect)
-      finalityDetectorEffect = new FinalityDetectorBySingleSweepImpl[Task]()(Sync[Task], logEff)
+      finalityDetectorEffect = new FinalityDetectorBySingleSweepImpl[Task]() (Sync[Task], logEff)
     } yield (logEff, casperRef, finalityDetectorEffect)
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -55,7 +55,7 @@ class GossipServiceCasperTestNode[F[_]](
       sk,
       genesis,
       maybeMakeEE
-    )(concurrentF, blockStorage, dagStorage, deployStorage, metricEff, casperState) {
+    ) (concurrentF, blockStorage, dagStorage, deployStorage, metricEff, casperState) {
   implicit val safetyOracleEff: FinalityDetector[F] = new FinalityDetectorBySingleSweepImpl[F]
 
   val ownValidatorKey = validatorId match {
@@ -144,7 +144,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
             faultToleranceThreshold,
             relaying = relaying,
             gossipService = new TestGossipService[F]()
-          )(
+          ) (
             concurrentF,
             blockStorage,
             dagStorage,
@@ -228,7 +228,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                   relaying = relaying,
                   gossipService = gossipService,
                   maybeMakeEE = maybeMakeEE
-                )(
+                ) (
                   concurrentF,
                   blockStorage,
                   dagStorage,

--- a/comm/src/main/scala/io/casperlabs/comm/CachedConnections.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/CachedConnections.scala
@@ -45,7 +45,7 @@ object CachedConnections {
   def apply[F[_]: Concurrent: Metrics, T]: F[ConnectionsCache[F, T]] =
     for {
       connections <- Cell.mvarCell[F, TransportState](TransportState.empty)
-    } yield new CachedConnections[F, T](connections)(_)
+    } yield new CachedConnections[F, T](connections) (_)
 }
 
 object Transport {

--- a/node/src/test/scala/io/casperlabs/node/api/graphql/GraphQLServiceSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/api/graphql/GraphQLServiceSpec.scala
@@ -239,7 +239,7 @@ object GraphQLServiceSpec {
   type Service = Kleisli[Task, Request[Task], Response[Task]]
 
   implicit val concurrentEffectMonix: ConcurrentEffect[Task] =
-    new CatsConcurrentEffectForTask()(global, Task.defaultOptions)
+    new CatsConcurrentEffectForTask() (global, Task.defaultOptions)
 
   implicit val noOpLog: Log[Task] = new NOPLog[Task]
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.7.4"
 
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.0.1")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.0.7")
 addSbtPlugin("com.eed3si9n"       % "sbt-buildinfo"       % "0.9.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-native-packager" % "1.4.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"             % "0.3.7")

--- a/shared/src/main/scala/io/casperlabs/shared/StreamT.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/StreamT.scala
@@ -19,7 +19,8 @@ sealed abstract class StreamT[F[_], +A] { self =>
       case SCons(_, lazyTail) => StreamT.delay(lazyTail.map(_.map(_.drop(n - 1))))
       case SLazy(lazyTail)    => StreamT.delay(lazyTail.map(_.map(_.drop(n))))
       case _: SNil[F]         => StreamT.empty[F, A]
-    } else self
+    }
+    else self
 
   def filter(p: A => Boolean)(implicit functor: Functor[F]): StreamT[F, A] = self match {
     case SCons(curr, lazyTail) =>
@@ -177,7 +178,8 @@ sealed abstract class StreamT[F[_], +A] { self =>
       case SCons(curr, lazyTail) => StreamT.cons(curr, lazyTail.map(_.map(_.take(n - 1))))
       case SLazy(lazyTail)       => StreamT.delay(lazyTail.map(_.map(_.take(n))))
       case _: SNil[F]            => StreamT.empty[F, A]
-    } else StreamT.empty[F, A]
+    }
+    else StreamT.empty[F, A]
 
   def takeWhile(p: A => Boolean)(implicit functor: Functor[F]): StreamT[F, A] = self match {
     case SCons(curr, lazyTail) if p(curr) => StreamT.cons(curr, lazyTail.map(_.map(_.takeWhile(p))))


### PR DESCRIPTION
### Overview
@birchmd found an issue with the `sbt` unable to resolve the `scalafmt` `sbt` plugin.

We didn't notice the issue probably because of something related to the global `sbt` dependencies caches: `~/.ivy2/cache` (prior `1.3.0` `sbt` version) and `~/.coursier/cache` (starting from `1.3.0` `sbt` version). I was able to reproduce the issue after cleaning them up.

Also, it turns out that `sbt-scalafmt` version doesn't match the version of the `scalafmt` itself.
For example, `sbt-scalafmt` with the `2.0.7` version uses `2.1.1` `scalafmt` under the hood and that brings some discrepancy of expecations when we bump versions.
https://github.com/scalameta/sbt-scalafmt/releases/tag/v2.0.7

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-970

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
