### PR TITLE
EE-714: remove old genesis

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -35,7 +35,7 @@ PACKAGED_SYSTEM_CONTRACTS = mint_install.wasm pos_install.wasm
 all: build build-contracts
 
 .PHONY: build
-build: $(SYSTEM_CONTRACTS)
+build:
 	$(CARGO) build $(CARGO_FLAGS)
 
 build-contract/%:
@@ -67,7 +67,7 @@ build-contracts: \
 build-integration-contracts: $(INTEGRATION_CONTRACTS)
 
 .PHONY: test
-test: $(SYSTEM_CONTRACTS)
+test:
 	$(CARGO) test $(CARGO_FLAGS) --all -- --nocapture
 
 .PHONY: test-contracts
@@ -88,8 +88,8 @@ lint:
 
 .PHONY: check
 check: \
-	check-format \
 	build \
+	check-format \
 	lint \
 	test \
 	test-contracts
@@ -100,14 +100,14 @@ clean:
 	$(CARGO) clean
 
 .PHONY: deb
-deb: $(SYSTEM_CONTRACTS)
+deb:
 	cd engine-grpc-server && $(CARGO) deb
 
 engine-grpc-server/.rpm:
 	cd engine-grpc-server && $(CARGO) rpm init
 
 .PHONY: rpm
-rpm: engine-grpc-server/.rpm $(SYSTEM_CONTRACTS)
+rpm: engine-grpc-server/.rpm
 	cd engine-grpc-server && $(CARGO) rpm build
 
 target/system-contracts.tar.gz: $(SYSTEM_CONTRACTS)

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -10,7 +10,7 @@ use grpc::SingleResponse;
 
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{BlockTime, PublicKey};
-use contract_ffi::value::{ProtocolVersion, U512};
+use contract_ffi::value::ProtocolVersion;
 use engine_core::engine_state::error::Error as EngineError;
 use engine_core::engine_state::execution_result::ExecutionResult;
 use engine_core::engine_state::genesis::{GenesisConfig, GenesisResult};
@@ -395,161 +395,12 @@ where
         grpc::SingleResponse::completed(validate_result)
     }
 
-    #[allow(dead_code)]
     fn run_genesis(
-        &self,
-        _request_options: ::grpc::RequestOptions,
-        genesis_request: ipc::GenesisRequest,
-    ) -> ::grpc::SingleResponse<ipc::GenesisResponse> {
-        let start = Instant::now();
-        let correlation_id = CorrelationId::new();
-
-        let genesis_account_addr = {
-            let address = genesis_request.get_address();
-            if address.len() != 32 {
-                let err_msg =
-                    "genesis account public key has to be exactly 32 bytes long.".to_string();
-                logging::log_error(&err_msg);
-
-                let mut genesis_response = ipc::GenesisResponse::new();
-                let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                genesis_deploy_error.set_message(err_msg);
-                genesis_response.set_failed_deploy(genesis_deploy_error);
-
-                log_duration(
-                    correlation_id,
-                    METRIC_DURATION_GENESIS,
-                    TAG_RESPONSE_GENESIS,
-                    start.elapsed(),
-                );
-
-                return grpc::SingleResponse::completed(genesis_response);
-            }
-
-            let mut ret = [0u8; 32];
-            ret.clone_from_slice(address);
-            ret
-        };
-
-        let initial_motes: U512 = match genesis_request.get_initial_motes().try_into() {
-            Ok(initial_motes) => initial_motes,
-            Err(err) => {
-                let err_msg = format!("{:?}", err);
-                logging::log_error(&err_msg);
-
-                let mut genesis_response = ipc::GenesisResponse::new();
-                let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                genesis_deploy_error.set_message(err_msg);
-                genesis_response.set_failed_deploy(genesis_deploy_error);
-
-                log_duration(
-                    correlation_id,
-                    METRIC_DURATION_GENESIS,
-                    TAG_RESPONSE_GENESIS,
-                    start.elapsed(),
-                );
-
-                return grpc::SingleResponse::completed(genesis_response);
-            }
-        };
-
-        let mint_code_bytes = genesis_request.get_mint_code().get_code();
-
-        let proof_of_stake_code_bytes = genesis_request.get_proof_of_stake_code().get_code();
-
-        let genesis_validators_result: Result<Vec<(PublicKey, U512)>, MappingError> =
-            genesis_request
-                .get_genesis_validators()
-                .iter()
-                .map(TryInto::try_into)
-                .collect();
-
-        let genesis_validators = match genesis_validators_result {
-            Ok(validators) => validators,
-            Err(error) => {
-                logging::log_error(&error.to_string());
-
-                let genesis_deploy_error = {
-                    let mut tmp = ipc::GenesisDeployError::new();
-                    tmp.set_message(error.to_string());
-                    tmp
-                };
-                let mut genesis_response = ipc::GenesisResponse::new();
-                genesis_response.set_failed_deploy(genesis_deploy_error);
-
-                log_duration(
-                    correlation_id,
-                    METRIC_DURATION_GENESIS,
-                    TAG_RESPONSE_GENESIS,
-                    start.elapsed(),
-                );
-
-                return grpc::SingleResponse::completed(genesis_response);
-            }
-        };
-
-        let protocol_version = genesis_request.get_protocol_version().into();
-
-        let genesis_response = {
-            let mut genesis_response = ipc::GenesisResponse::new();
-
-            match self.commit_genesis(
-                correlation_id,
-                genesis_account_addr,
-                initial_motes,
-                mint_code_bytes,
-                proof_of_stake_code_bytes,
-                genesis_validators,
-                protocol_version,
-            ) {
-                Ok(GenesisResult::Success {
-                    post_state_hash,
-                    effect,
-                }) => {
-                    let success_message = format!("run_genesis successful: {}", post_state_hash);
-                    log_info(&success_message);
-
-                    let mut genesis_result = ipc::GenesisResult::new();
-                    genesis_result.set_poststate_hash(post_state_hash.to_vec());
-                    genesis_result.set_effect(effect.into());
-                    genesis_response.set_success(genesis_result);
-                }
-                Ok(genesis_result) => {
-                    let err_msg = genesis_result.to_string();
-                    logging::log_error(&err_msg);
-
-                    let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                    genesis_deploy_error.set_message(err_msg);
-                    genesis_response.set_failed_deploy(genesis_deploy_error);
-                }
-                Err(err) => {
-                    let err_msg = err.to_string();
-                    logging::log_error(&err_msg);
-
-                    let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                    genesis_deploy_error.set_message(err_msg);
-                    genesis_response.set_failed_deploy(genesis_deploy_error);
-                }
-            }
-
-            genesis_response
-        };
-
-        log_duration(
-            correlation_id,
-            METRIC_DURATION_GENESIS,
-            TAG_RESPONSE_GENESIS,
-            start.elapsed(),
-        );
-
-        grpc::SingleResponse::completed(genesis_response)
-    }
-
-    fn run_genesis_with_chainspec(
         &self,
         _request_options: ::grpc::RequestOptions,
         genesis_config: ipc::ChainSpec_GenesisConfig,
     ) -> ::grpc::SingleResponse<ipc::GenesisResponse> {
+        let start = Instant::now();
         let correlation_id = CorrelationId::new();
 
         let genesis_config: GenesisConfig = match genesis_config.try_into() {
@@ -566,44 +417,50 @@ where
             }
         };
 
-        let genesis_response =
-            match self.commit_genesis_with_chainspec(correlation_id, genesis_config) {
-                Ok(GenesisResult::Success {
-                    post_state_hash,
-                    effect,
-                }) => {
-                    let success_message =
-                        format!("run_genesis_with_chainspec successful: {}", post_state_hash);
-                    log_info(&success_message);
+        let genesis_response = match self.commit_genesis(correlation_id, genesis_config) {
+            Ok(GenesisResult::Success {
+                post_state_hash,
+                effect,
+            }) => {
+                let success_message =
+                    format!("run_genesis_with_chainspec successful: {}", post_state_hash);
+                log_info(&success_message);
 
-                    let mut genesis_response = ipc::GenesisResponse::new();
-                    let mut genesis_result = ipc::GenesisResult::new();
-                    genesis_result.set_poststate_hash(post_state_hash.to_vec());
-                    genesis_result.set_effect(effect.into());
-                    genesis_response.set_success(genesis_result);
-                    genesis_response
-                }
-                Ok(genesis_result) => {
-                    let err_msg = genesis_result.to_string();
-                    logging::log_error(&err_msg);
+                let mut genesis_response = ipc::GenesisResponse::new();
+                let mut genesis_result = ipc::GenesisResult::new();
+                genesis_result.set_poststate_hash(post_state_hash.to_vec());
+                genesis_result.set_effect(effect.into());
+                genesis_response.set_success(genesis_result);
+                genesis_response
+            }
+            Ok(genesis_result) => {
+                let err_msg = genesis_result.to_string();
+                logging::log_error(&err_msg);
 
-                    let mut genesis_response = ipc::GenesisResponse::new();
-                    let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                    genesis_deploy_error.set_message(err_msg);
-                    genesis_response.set_failed_deploy(genesis_deploy_error);
-                    genesis_response
-                }
-                Err(err) => {
-                    let err_msg = err.to_string();
-                    logging::log_error(&err_msg);
+                let mut genesis_response = ipc::GenesisResponse::new();
+                let mut genesis_deploy_error = ipc::GenesisDeployError::new();
+                genesis_deploy_error.set_message(err_msg);
+                genesis_response.set_failed_deploy(genesis_deploy_error);
+                genesis_response
+            }
+            Err(err) => {
+                let err_msg = err.to_string();
+                logging::log_error(&err_msg);
 
-                    let mut genesis_response = ipc::GenesisResponse::new();
-                    let mut genesis_deploy_error = ipc::GenesisDeployError::new();
-                    genesis_deploy_error.set_message(err_msg);
-                    genesis_response.set_failed_deploy(genesis_deploy_error);
-                    genesis_response
-                }
-            };
+                let mut genesis_response = ipc::GenesisResponse::new();
+                let mut genesis_deploy_error = ipc::GenesisDeployError::new();
+                genesis_deploy_error.set_message(err_msg);
+                genesis_response.set_failed_deploy(genesis_deploy_error);
+                genesis_response
+            }
+        };
+
+        log_duration(
+            correlation_id,
+            METRIC_DURATION_GENESIS,
+            TAG_RESPONSE_GENESIS,
+            start.elapsed(),
+        );
 
         grpc::SingleResponse::completed(genesis_response)
     }

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -639,7 +639,7 @@ where
 
         let genesis_response = self
             .engine_state
-            .run_genesis_with_chainspec(RequestOptions::new(), genesis_config_proto)
+            .run_genesis(RequestOptions::new(), genesis_config_proto)
             .wait_drop_metadata()
             .expect("Unable to get genesis response");
 

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -234,17 +234,6 @@ message ValidateRequest {
     io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 2;
 }
 
-message GenesisRequest {
-    // genesis account public key, length 32 bytes
-    bytes address = 1;
-    io.casperlabs.casper.consensus.state.BigInt initial_motes = 2;
-    uint64 timestamp = 3;
-    DeployCode mint_code = 4;
-    DeployCode proof_of_stake_code = 5;
-    repeated Bond genesis_validators = 6;
-    io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 7;
-}
-
 message GenesisResult {
     bytes poststate_hash = 1;
     ExecutionEffect effect = 2;
@@ -363,8 +352,7 @@ service ExecutionEngineService {
     rpc commit (CommitRequest) returns (CommitResponse) {}
     rpc query (QueryRequest) returns (QueryResponse) {}
     rpc validate (ValidateRequest) returns (ValidateResponse) {}
-    rpc run_genesis (GenesisRequest) returns (GenesisResponse) {}
     rpc execute (ExecuteRequest) returns (ExecuteResponse) {}
-    rpc run_genesis_with_chainspec (ChainSpec.GenesisConfig) returns (GenesisResponse) {}
-    rpc upgrade(UpgradeRequest) returns (UpgradeResponse) {}
+    rpc run_genesis (ChainSpec.GenesisConfig) returns (GenesisResponse) {}
+    rpc upgrade (UpgradeRequest) returns (UpgradeResponse) {}
 }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -125,7 +125,7 @@ class GrpcExecutionEngineService[F[_]: Defer: Sync: Log: TaskLift: Metrics] priv
   override def runGenesis(
       genesisConfig: GenesisConfig
   ): F[Either[Throwable, GenesisResult]] =
-    sendMessage(genesisConfig, _.runGenesisWithChainspec) {
+    sendMessage(genesisConfig, _.runGenesis) {
       _.result match {
         case GenesisResponse.Result.Success(result) =>
           Right(result)


### PR DESCRIPTION
### Overview
This PR removes replaces the old `run_genesis` with `run_genesis_with_chainspec`, keeping the original name.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-714

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Tagging @aakoshh as I touched some Scala.
