### PR TITLE
EE-727: Add threads parameter to casperlabs-engine-grpc-server

### DIFF
--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -802,6 +802,7 @@ where
 // WasmError.
 pub fn new<E: ExecutionEngineService + Sync + Send + 'static>(
     socket: &str,
+    thread_count: usize,
     e: E,
 ) -> grpc::ServerBuilder {
     let socket_path = std::path::Path::new(socket);
@@ -814,7 +815,7 @@ pub fn new<E: ExecutionEngineService + Sync + Send + 'static>(
 
     let mut server = grpc::ServerBuilder::new_plain();
     server.http.set_unix_addr(socket.to_owned()).unwrap();
-    server.http.set_cpu_pool_threads(1);
+    server.http.set_cpu_pool_threads(thread_count);
     server.add_service(ipc_grpc::ExecutionEngineServiceServer::new_service_def(e));
     server
 }


### PR DESCRIPTION
### Overview
Adds the ability to specify the number of worker threads the engine gRPC server should run.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-727

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
