### PR TITLE
EE-439: push get_main_purse to ffi

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/account.rs
+++ b/execution-engine/contract-ffi/src/contract_api/account.rs
@@ -1,28 +1,23 @@
-use core::convert::{TryFrom, TryInto};
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 
-use super::runtime::get_caller;
-use super::storage::read_untyped;
 use super::to_ptr;
+use crate::bytesrepr::deserialize;
+use crate::contract_api::alloc_bytes;
 use crate::ext_ffi;
-use crate::key::Key;
 pub use crate::value::account::PublicKey;
 use crate::value::account::{
     ActionType, AddKeyFailure, PurseId, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
-    Weight,
+    Weight, PURSE_ID_SIZE_SERIALIZED,
 };
-use crate::value::Account;
 
 pub fn get_main_purse() -> PurseId {
-    // TODO: this could be more efficient, bringing the entire account
-    // object across the host/wasm boundary only to use 32 bytes of
-    // its data is pretty bad. A native FFI (as opposed to a library
-    // API) would get around this problem. However, this solution
-    // works for the time being.
-    // https://casperlabs.atlassian.net/browse/EE-439
-    let account_pk = get_caller();
-    let key = Key::Account(account_pk.value());
-    let account: Account = read_untyped(&key).unwrap().unwrap().try_into().unwrap();
-    account.purse_id()
+    let dest_ptr = alloc_bytes(PURSE_ID_SIZE_SERIALIZED);
+    let bytes = unsafe {
+        ext_ffi::get_main_purse(dest_ptr);
+        Vec::from_raw_parts(dest_ptr, PURSE_ID_SIZE_SERIALIZED, PURSE_ID_SIZE_SERIALIZED)
+    };
+    deserialize(&bytes).unwrap()
 }
 
 pub fn set_action_threshold(

--- a/execution-engine/contract-ffi/src/contract_api/account.rs
+++ b/execution-engine/contract-ffi/src/contract_api/account.rs
@@ -5,6 +5,7 @@ use super::to_ptr;
 use crate::bytesrepr::deserialize;
 use crate::contract_api::alloc_bytes;
 use crate::ext_ffi;
+use crate::unwrap_or_revert::UnwrapOrRevert;
 pub use crate::value::account::PublicKey;
 use crate::value::account::{
     ActionType, AddKeyFailure, PurseId, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
@@ -17,7 +18,7 @@ pub fn get_main_purse() -> PurseId {
         ext_ffi::get_main_purse(dest_ptr);
         Vec::from_raw_parts(dest_ptr, PURSE_ID_SIZE_SERIALIZED, PURSE_ID_SIZE_SERIALIZED)
     };
-    deserialize(&bytes).unwrap()
+    deserialize(&bytes).unwrap_or_revert()
 }
 
 pub fn set_action_threshold(

--- a/execution-engine/contract-ffi/src/ext_ffi.rs
+++ b/execution-engine/contract-ffi/src/ext_ffi.rs
@@ -95,4 +95,5 @@ extern "C" {
         dest_ptr: *mut u8,
         dest_size: usize,
     ) -> i32;
+    pub fn get_main_purse(dest_ptr: *mut u8);
 }

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -447,6 +447,13 @@ where
                 let ret = self.get_system_contract(system_contract_index, dest_ptr, dest_size)?;
                 Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))
             }
+
+            FunctionIndex::GetMainPurseIndex => {
+                // args(0) = pointer to Wasm memory where to write.
+                let dest_ptr = Args::parse(args)?;
+                self.get_main_purse(dest_ptr)?;
+                Ok(None)
+            }
         }
     }
 }

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -366,6 +366,19 @@ where
         Ok(())
     }
 
+    /// Writes runtime context's account main purse to [dest_ptr] in the Wasm memory.
+    fn get_main_purse(&mut self, dest_ptr: u32) -> Result<(), Trap> {
+        let purse_id = self
+            .context
+            .account()
+            .purse_id()
+            .to_bytes()
+            .map_err(Error::BytesRepr)?;
+        self.memory
+            .set(dest_ptr, &purse_id)
+            .map_err(|e| Error::Interpreter(e).into())
+    }
+
     /// Writes caller (deploy) account public key to [dest_ptr] in the Wasm
     /// memory.
     fn get_caller(&mut self, dest_ptr: u32) -> Result<(), Trap> {

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -42,6 +42,7 @@ pub enum FunctionIndex {
     GetPhaseIndex = 35,
     UpgradeContractAtURef = 36,
     GetSystemContractIndex = 37,
+    GetMainPurseIndex = 38,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -193,6 +193,10 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::GetSystemContractIndex.into(),
             ),
+            "get_main_purse" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 1][..], None),
+                FunctionIndex::GetMainPurseIndex.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",


### PR DESCRIPTION
This PR moves the functionality of getting the main purse of the executing account via a new ffi that returns the PurseId instead of pulling an entire account object across the host boundary.

https://casperlabs.atlassian.net/browse/EE-439

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] This PR is thoroughly tested by pre-existing tests.
- [X] This PR is assigned