### PR TITLE
NO-TICKET: correcting a misnamed variant

### DIFF
--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -429,7 +429,7 @@ where
                 Ok(None)
             }
 
-            FunctionIndex::UpgradeContractAtURef => {
+            FunctionIndex::UpgradeContractAtURefIndex => {
                 // args(0) = pointer to name in Wasm memory
                 // args(1) = size of name in Wasm memory
                 // args(2) = pointer to key in Wasm memory

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -40,7 +40,7 @@ pub enum FunctionIndex {
     TransferFromPurseToPurseIndex = 33,
     GetBalanceIndex = 34,
     GetPhaseIndex = 35,
-    UpgradeContractAtURef = 36,
+    UpgradeContractAtURefIndex = 36,
     GetSystemContractIndex = 37,
 }
 

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -187,7 +187,7 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
             ),
             "upgrade_contract_at_uref" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 4][..], Some(ValueType::I32)),
-                FunctionIndex::UpgradeContractAtURef.into(),
+                FunctionIndex::UpgradeContractAtURefIndex.into(),
             ),
             "get_system_contract" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),


### PR DESCRIPTION
This PR corrects a misnamed variant in the ffi function index.

This is unticketed work.

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.