### PR TITLE
NO-TICKET: contract_api unwrap_or_revert fixups

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -11,12 +11,13 @@ use alloc::vec::Vec;
 
 use crate::bytesrepr::ToBytes;
 
+use crate::unwrap_or_revert::UnwrapOrRevert;
 pub use contract_ref::ContractRef;
 pub use error::{i32_from, result_from, Error};
 pub use turef::TURef;
 
 #[allow(clippy::zero_ptr)]
-pub fn alloc_bytes(n: usize) -> *mut u8 {
+fn alloc_bytes(n: usize) -> *mut u8 {
     if n == 0 {
         // cannot allocate with size 0
         0 as *mut u8
@@ -28,15 +29,15 @@ pub fn alloc_bytes(n: usize) -> *mut u8 {
 // I don't know why I need a special version of to_ptr for
 // &str, but the compiler complains if I try to use the polymorphic
 // version with T = str.
-pub fn str_ref_to_ptr(t: &str) -> (*const u8, usize, Vec<u8>) {
-    let bytes = t.to_bytes().expect("Unable to serialize string");
+fn str_ref_to_ptr(t: &str) -> (*const u8, usize, Vec<u8>) {
+    let bytes = t.to_bytes().unwrap_or_revert();
     let ptr = bytes.as_ptr();
     let size = bytes.len();
     (ptr, size, bytes)
 }
 
-pub fn to_ptr<T: ToBytes>(t: &T) -> (*const u8, usize, Vec<u8>) {
-    let bytes = t.to_bytes().expect("Unable to serialize data");
+fn to_ptr<T: ToBytes>(t: &T) -> (*const u8, usize, Vec<u8>) {
+    let bytes = t.to_bytes().unwrap_or_revert();
     let ptr = bytes.as_ptr();
     let size = bytes.len();
     (ptr, size, bytes)

--- a/execution-engine/contract-ffi/src/contract_api/runtime.rs
+++ b/execution-engine/contract-ffi/src/contract_api/runtime.rs
@@ -9,6 +9,7 @@ use crate::bytesrepr::{self, deserialize, FromBytes, ToBytes};
 use crate::execution::{Phase, PHASE_SIZE};
 use crate::ext_ffi;
 use crate::key::Key;
+use crate::unwrap_or_revert::UnwrapOrRevert;
 use crate::uref::URef;
 use crate::value::account::{BlockTime, PublicKey, BLOCKTIME_SER_SIZE};
 use crate::value::{Contract, Value};
@@ -57,7 +58,7 @@ pub fn call_contract<A: ArgsParser, T: FromBytes>(
         ext_ffi::get_call_result(res_ptr);
         Vec::from_raw_parts(res_ptr, res_size, res_size)
     };
-    deserialize(&res_bytes).unwrap()
+    deserialize(&res_bytes).unwrap_or_revert()
 }
 
 /// Takes the name of a function to store and a contract URef, and overwrites the value under
@@ -108,7 +109,7 @@ pub fn get_caller() -> PublicKey {
     let dest_ptr = alloc_bytes(36);
     unsafe { ext_ffi::get_caller(dest_ptr) };
     let bytes = unsafe { Vec::from_raw_parts(dest_ptr, 36, 36) };
-    deserialize(&bytes).unwrap()
+    deserialize(&bytes).unwrap_or_revert()
 }
 
 pub fn get_blocktime() -> BlockTime {
@@ -117,14 +118,14 @@ pub fn get_blocktime() -> BlockTime {
         ext_ffi::get_blocktime(dest_ptr);
         Vec::from_raw_parts(dest_ptr, BLOCKTIME_SER_SIZE, BLOCKTIME_SER_SIZE)
     };
-    deserialize(&bytes).unwrap()
+    deserialize(&bytes).unwrap_or_revert()
 }
 
 pub fn get_phase() -> Phase {
     let dest_ptr = alloc_bytes(PHASE_SIZE);
     unsafe { ext_ffi::get_phase(dest_ptr) };
     let bytes = unsafe { Vec::from_raw_parts(dest_ptr, PHASE_SIZE, PHASE_SIZE) };
-    deserialize(&bytes).unwrap()
+    deserialize(&bytes).unwrap_or_revert()
 }
 
 /// Return the unforgable reference known by the current module under the given
@@ -141,7 +142,7 @@ pub fn get_key(name: &str) -> Option<Key> {
         Vec::from_raw_parts(dest_ptr, key_size, key_size)
     };
     // TODO: better error handling (i.e. pass the `Result` on)
-    deserialize(&key_bytes).unwrap()
+    deserialize(&key_bytes).unwrap_or_revert()
 }
 
 /// Check if the given name corresponds to a known unforgable reference
@@ -171,7 +172,7 @@ pub fn list_named_keys() -> BTreeMap<String, Key> {
         ext_ffi::list_named_keys(dest_ptr);
         Vec::from_raw_parts(dest_ptr, bytes_size, bytes_size)
     };
-    deserialize(&bytes).unwrap()
+    deserialize(&bytes).unwrap_or_revert()
 }
 
 /// Checks if all the keys contained in the given `Value`

--- a/execution-engine/contract-ffi/src/contract_api/storage.rs
+++ b/execution-engine/contract-ffi/src/contract_api/storage.rs
@@ -162,7 +162,7 @@ pub fn new_turef<T: Into<Value>>(init: T) -> TURef<T> {
         ext_ffi::new_uref(key_ptr, value_ptr, value_size); // new_uref creates a URef with ReadWrite access writes
         Vec::from_raw_parts(key_ptr, UREF_SIZE, UREF_SIZE)
     };
-    let key: Key = deserialize(&bytes).unwrap();
+    let key: Key = deserialize(&bytes).unwrap_or_revert();
     if let Key::URef(uref) = key {
         TURef::from_uref(uref).unwrap()
     } else {

--- a/execution-engine/contract-ffi/src/contract_api/system.rs
+++ b/execution-engine/contract-ffi/src/contract_api/system.rs
@@ -9,6 +9,7 @@ use crate::bytesrepr::deserialize;
 use crate::contract_api::error::result_from;
 use crate::ext_ffi;
 use crate::system_contracts::SystemContract;
+use crate::unwrap_or_revert::UnwrapOrRevert;
 use crate::uref::UREF_SIZE_SERIALIZED;
 use crate::value::account::{PublicKey, PurseId, PURSE_ID_SIZE_SERIALIZED};
 use crate::value::U512;
@@ -35,7 +36,7 @@ fn get_system_contract(system_contract: SystemContract) -> ContractRef {
         // Revert for any possible error that happened on host side
         let uref_bytes = result.unwrap_or_else(|e| revert(e));
         // Deserializes a valid URef passed from the host side
-        deserialize(&uref_bytes).unwrap_or_else(|_| revert(Error::Deserialize))
+        deserialize(&uref_bytes).unwrap_or_revert()
     };
     let reference = TURef::from_uref(uref).unwrap_or_else(|_| revert(Error::NoAccessRights));
     ContractRef::TURef(reference)
@@ -63,7 +64,7 @@ pub fn create_purse() -> PurseId {
                 PURSE_ID_SIZE_SERIALIZED,
                 PURSE_ID_SIZE_SERIALIZED,
             );
-            deserialize(&bytes).unwrap()
+            deserialize(&bytes).unwrap_or_revert()
         } else {
             panic!("could not create purse_id")
         }
@@ -84,7 +85,7 @@ pub fn get_balance(purse_id: PurseId) -> Option<U512> {
         Vec::from_raw_parts(dest_ptr, value_size, value_size)
     };
 
-    let balance: U512 = deserialize(&balance_bytes).unwrap_or_else(|_| revert(Error::Deserialize));
+    let balance: U512 = deserialize(&balance_bytes).unwrap_or_revert();
 
     Some(balance)
 }


### PR DESCRIPTION
This PR fixes up various unwraps in contract_api with the new unwrap_or_revert pattern and removes pub from a few functions that no longer need to be public.

This is unticketed work.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.