### PR TITLE
OP-804: add dependency on tag pipeline mac cleanup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -927,6 +927,9 @@ steps:
     status:
     - failure
     - success
+  depends_on:
+  - mac-ee-tarball-tag
+  - rsync-mac-tarball-tag
 
 volumes:
 - name: docker_sock


### PR DESCRIPTION
### Overview
Found a bug during tag pipeline that allowed the cleanup to run early. This adds a dependency that the mac steps complete first.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-804

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
