### PR TITLE
NODE-938: Requeue in create

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1119,10 +1119,12 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
       createB         <- nodes(1).casperEff.createBlock
       Created(blockB) = createB
       // nodes(1) should have more weight than nodes(0) so it should take over
-      _              <- nodes(0).casperEff.addBlock(blockB) shouldBeF Valid
-      pendingDeploys <- nodes(0).deployStorage.readPending
-      _              = pendingDeploys should contain(deployA)
-      _              <- nodes.map(_.tearDown()).toList.sequence
+      _ <- nodes(0).casperEff.addBlock(blockB) shouldBeF Valid
+      // Need to propose a new block, it should again contain deployA
+      createC         <- nodes(0).casperEff.createBlock
+      Created(blockC) = createC
+      _               = blockC.getBody.deploys.map(_.getDeploy) should contain(deployA)
+      _               <- nodes.map(_.tearDown()).toList.sequence
     } yield ()
   }
 

--- a/integration-testing/.gitignore
+++ b/integration-testing/.gitignore
@@ -1,3 +1,4 @@
 /Dockerfile.tmp
 resources/*.wasm
 resources/*.rlib
+client/CasperLabsClient/.eggs

--- a/integration-testing/casperlabs_local_net/wait.py
+++ b/integration-testing/casperlabs_local_net/wait.py
@@ -77,6 +77,11 @@ class FinishedAddingBlock(LogsContainMessage):
         super().__init__(node, f"Finished adding {block[:10]}...")
 
 
+class AddedBlock(LogsContainMessage):
+    def __init__(self, node: DockerNode, block: str) -> None:
+        super().__init__(node, f"Added {block[:10]}...")
+
+
 class RegexBlockRequest:
     regex = None
 
@@ -388,6 +393,11 @@ def wait_for_new_fork_choice_tip_block(
 
 def wait_for_finished_adding_block(node: DockerNode, block: str, timeout_seconds: int):
     predicate = FinishedAddingBlock(node, block)
+    wait_on_using_wall_clock_time(predicate, timeout_seconds)
+
+
+def wait_for_added_block(node: DockerNode, block: str, timeout_seconds: int):
+    predicate = AddedBlock(node, block)
     wait_on_using_wall_clock_time(predicate, timeout_seconds)
 
 

--- a/integration-testing/casperlabs_local_net/wait.py
+++ b/integration-testing/casperlabs_local_net/wait.py
@@ -69,7 +69,12 @@ class ApprovedBlockReceivedHandlerStateEntered(LogsContainOneOf):
 
 class NewForkChoiceTipBlock(LogsContainMessage):
     def __init__(self, node: DockerNode, block: str) -> None:
-        super().__init__(node, f"New fork-choice tip is block {block[:10]}....")
+        super().__init__(node, f"Fork-choice tip is block {block[:10]}....")
+
+
+class FinishedAddingBlock(LogsContainMessage):
+    def __init__(self, node: DockerNode, block: str) -> None:
+        super().__init__(node, f"Finished adding {block[:10]}...")
 
 
 class RegexBlockRequest:
@@ -378,6 +383,11 @@ def wait_for_new_fork_choice_tip_block(
     node: DockerNode, block: str, timeout_seconds: int
 ):
     predicate = NewForkChoiceTipBlock(node, block)
+    wait_on_using_wall_clock_time(predicate, timeout_seconds)
+
+
+def wait_for_finished_adding_block(node: DockerNode, block: str, timeout_seconds: int):
+    predicate = FinishedAddingBlock(node, block)
     wait_on_using_wall_clock_time(predicate, timeout_seconds)
 
 

--- a/integration-testing/test/test_network_topology.py
+++ b/integration-testing/test/test_network_topology.py
@@ -1,9 +1,6 @@
 import logging
 
-from casperlabs_local_net.wait import (
-    wait_for_block_contains,
-    wait_for_finished_adding_block,
-)
+from casperlabs_local_net.wait import wait_for_block_contains, wait_for_added_block
 from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT
 from casperlabs_local_net.common import Contract
 
@@ -43,4 +40,4 @@ def test_star_network(star_network):
 
     # validate all nodes get block
     for node in star_network.docker_nodes:
-        wait_for_finished_adding_block(node, block, node.timeout)
+        wait_for_added_block(node, block, node.timeout)

--- a/integration-testing/test/test_network_topology.py
+++ b/integration-testing/test/test_network_topology.py
@@ -2,7 +2,7 @@ import logging
 
 from casperlabs_local_net.wait import (
     wait_for_block_contains,
-    wait_for_new_fork_choice_tip_block,
+    wait_for_finished_adding_block,
 )
 from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT
 from casperlabs_local_net.common import Contract
@@ -43,4 +43,4 @@ def test_star_network(star_network):
 
     # validate all nodes get block
     for node in star_network.docker_nodes:
-        wait_for_new_fork_choice_tip_block(node, block, node.timeout)
+        wait_for_finished_adding_block(node, block, node.timeout)


### PR DESCRIPTION
### Overview
Requeue orphaned deploys before proposing a new block rather than after adding blocks from any other validator. Hopefully this way less time will be spent on doing it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-938

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
