### PR TITLE
NODE-914 Custom tagged docker images to test framework.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,11 +137,8 @@ cargo-native-packager/%:
 
 # Make a node that has some extras installed for testing.
 .make/docker-build/test/node: \
-		.make/docker-build/universal/node \
-		hack/docker/test-node.Dockerfile
-	# Add system contracts so we can use them in integration testing.
-	# For live tests we should mount them from a real source.
-	docker build -f hack/docker/test-node.Dockerfile -t $(DOCKER_USERNAME)/node:$(DOCKER_TEST_TAG) hack/docker
+		.make/docker-build/universal/node
+	docker tag $(DOCKER_USERNAME)/node:$(DOCKER_LATEST_TAG) $(DOCKER_USERNAME)/node:$(DOCKER_TEST_TAG)
 	mkdir -p $(dir $@) && touch $@
 
 # Make a test version for the execution engine as well just so we can swith version easily.

--- a/hack/docker/test-node.Dockerfile
+++ b/hack/docker/test-node.Dockerfile
@@ -1,6 +1,0 @@
-FROM casperlabs/node:latest
-
-# Using iproute2 for network simulation with `tc`.
-# iptables can also be used to block individual ports.
-# Double update due to: Could not open file /var/lib/apt/lists/deb.debian.org_debian_dists_stretch-backports_main_binary-amd64_Packages.diff_Index - open (2: No such file or directory)
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* && (apt-get update || apt-get update) && apt-get install -yq iproute2 iptables curl sed nmap

--- a/integration-testing/casperlabs_local_net/casperlabs_network.py
+++ b/integration-testing/casperlabs_local_net/casperlabs_network.py
@@ -515,6 +515,30 @@ class CustomConnectionNetwork(CasperLabsNetwork):
             del self.network_names[tuple(connection)]
 
 
+class NetworkWithTaggedDev(CasperLabsNetwork):
+    def create_cl_network(self, node_count=2):
+        kp = self.get_key()
+        config = DockerConfig(
+            self.docker_client,
+            node_private_key=kp.private_key,
+            node_public_key=kp.public_key,
+            network=self.create_docker_network(),
+            node_account=kp,
+            grpc_encryption=self.grpc_encryption,
+        )
+        self.add_bootstrap(config)
+        config = DockerConfig(
+            self.docker_client,
+            node_private_key=kp.private_key,
+            node_public_key=kp.public_key,
+            network=self.create_docker_network(),
+            node_account=kp,
+            grpc_encryption=self.grpc_encryption,
+            custom_docker_tag="dev",
+        )
+        self.add_cl_node(config)
+
+
 if __name__ == "__main__":
     # For testing adding new networks.
     import sys

--- a/integration-testing/casperlabs_local_net/docker_base.py
+++ b/integration-testing/casperlabs_local_net/docker_base.py
@@ -69,10 +69,16 @@ class DockerBase:
         self.config = config
         self.connected_networks = []
 
-        self.docker_tag: str = "test"
-        if self.is_in_docker:
-            self.docker_tag = os.environ.get("TAG_NAME")
         self.container = self._get_container()
+
+    @property
+    def docker_tag(self) -> str:
+        if self.is_in_docker:
+            return os.environ.get("TAG_NAME")
+        elif self.config.custom_docker_tag is not None:
+            return self.config.custom_docker_tag
+        else:
+            return "test"
 
     @property
     def is_in_docker(self) -> bool:

--- a/integration-testing/casperlabs_local_net/docker_config.py
+++ b/integration-testing/casperlabs_local_net/docker_config.py
@@ -50,6 +50,7 @@ class DockerConfig:
     behind_proxy: bool = False
     # Function that returns bonds amount for each account to be placed in accounts.csv.
     bond_amount: Callable = default_bond_amount
+    custom_docker_tag: Optional[str] = None
 
     def __post_init__(self):
         if self.rand_str is None:

--- a/integration-testing/casperlabs_local_net/docker_node.py
+++ b/integration-testing/casperlabs_local_net/docker_node.py
@@ -327,11 +327,19 @@ class DockerNode(LoggingDockerBase):
         return f"run {bootstrap_flag} {' '.join(options)}"
 
     def get_metrics(self) -> Tuple[int, str]:
+        if self.config.custom_docker_tag is not None:
+            raise NotImplementedError(
+                "get_metrics not functional on nodes with custom_docker_tags."
+            )
         cmd = "curl -s http://localhost:40403/metrics"
         output = self.exec_run(cmd=cmd)
         return output
 
     def get_metrics_strict(self):
+        if self.config.custom_docker_tag is not None:
+            raise NotImplementedError(
+                "get_metrics not functional on nodes with custom_docker_tags."
+            )
         output = self.shell_out("curl", "-s", "http://localhost:40403/metrics")
         return output
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -18,6 +18,7 @@ from casperlabs_local_net.casperlabs_network import (
     ReadOnlyNodeNetwork,
     InterceptedTwoNodeNetwork,
     TwoNodeWithDifferentAccountsCSVNetwork,
+    NetworkWithTaggedDev,
 )
 from docker.client import DockerClient
 
@@ -130,6 +131,13 @@ def nodes(three_node_network):
 @pytest.fixture(scope="module")
 def node(one_node_network):
     return one_node_network.docker_nodes[0]
+
+
+@pytest.fixture(scope="module")
+def network_with_dev(docker_client_fixture):
+    with NetworkWithTaggedDev(docker_client_fixture) as nwtd:
+        nwtd.create_cl_network()
+        yield nwtd
 
 
 @pytest.fixture()


### PR DESCRIPTION
Added ability to specify custom docker image tags for adding older nodes into a network.

https://casperlabs.atlassian.net/browse/NODE-914

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
