### PR TITLE
NODE-902: Concurrent block processing

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -88,8 +88,10 @@ sealed abstract class MultiParentCasperInstances {
                                                        genesisPreState,
                                                        genesisEffects
                                                      )
+      semaphoreMap      <- SemaphoreMap[F, ByteString](1)
       statelessExecutor <- MultiParentCasperImpl.StatelessExecutor.create[F](chainName, upgrades)
       casper <- MultiParentCasperImpl.create[F](
+                 semaphoreMap,
                  statelessExecutor,
                  MultiParentCasperImpl.Broadcaster.fromGossipServices(validatorId, relaying),
                  validatorId,

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -412,11 +412,11 @@ abstract class HashSetCasperTest
     for {
       nodes <- networkEff(validatorKeys.take(4), genesis, transforms)
       // Create three independent blocks in parallel.
-      blocks <- List.range(0, 3).traverse(i => createBlock(nodes(i)))
-      // Add them all concurrently to the 4th node. it shouldn't run into validation problems.
+      blocks <- Task.sequence(nodes.map(createBlock))
+      // Add them all concurrently to the one of the nodes; it shouldn't run into validation problems.
       // NOTE: GossipServiceCasperTestNode would feed notifications one by one.
       results <- Task.gatherUnordered {
-                  blocks.map(nodes(3).casperEff.addBlock(_))
+                  blocks.map(nodes.head.casperEff.addBlock(_))
                 }
     } yield {
       forAll(results) {

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -72,7 +72,7 @@ abstract class HashSetCasperTest extends FlatSpec with Matchers with HashSetCasp
   // Casper used to process just 1 block at a time, and this test made sure
   // of that, but it doesn't make sense any more because the download manager
   // feeds them in a topological order. This test adds the *same* block on
-  // two threads, which will not happen under normal cirucmstances. We could
+  // two threads, which will not happen under normal circumstances. We could
   // protect against it but it should be an idempotent operation really.
   it should "not mind multiple threads to process the same block" in {
     val scheduler = Scheduler.fixedPool("three-threads", 3)

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -411,10 +411,10 @@ abstract class HashSetCasperTest
       } yield block
     for {
       nodes <- networkEff(validatorKeys.take(4), genesis, transforms)
-      // Create three independent blocks in parallel.
+      // Create blocks on different nodes that can add in parallel.
+      // NOTE: GossipServiceCasperTestNode would feed notifications one by one.
       blocks <- Task.sequence(nodes.map(createBlock))
       // Add them all concurrently to the one of the nodes; it shouldn't run into validation problems.
-      // NOTE: GossipServiceCasperTestNode would feed notifications one by one.
       results <- Task.gatherUnordered {
                   blocks.map(nodes.head.casperEff.addBlock(_))
                 }

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -16,6 +16,7 @@ import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
 import io.casperlabs.casper.helper.{GossipServiceCasperTestNodeFactory, HashSetCasperTestNode}
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.util._
+import io.casperlabs.casper.validation.Validation
 import io.casperlabs.catscontrib.TaskContrib._
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
@@ -41,7 +42,7 @@ class CreateBlockAPITest extends FlatSpec with Matchers with GossipServiceCasper
     casper.validation.raiseValidateErrorThroughApplicativeError[Task]
   implicit val logEff = new LogStub[Task]
 
-  implicit val validation = HashSetCasperTestNode.makeValidation[Task]
+  implicit val validation: Validation[Task] = HashSetCasperTestNode.makeValidation[Task]
 
   private val (validatorKeys, validators)                      = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
   private val bonds                                            = createBonds(validators)
@@ -97,6 +98,60 @@ class CreateBlockAPITest extends FlatSpec with Matchers with GossipServiceCasper
       response1.isRight shouldBe true
       response2.isRight shouldBe false
       response2.left.get.getMessage should include("ABORTED")
+    } finally {
+      node.tearDown()
+    }
+  }
+
+  "propose" should "handle concurrent calls and not create equivocations" in {
+    val threadCount        = 3
+    implicit val scheduler = Scheduler.fixedPool("propose-threads", threadCount)
+    // Similarly to integration tests, start multiple concurrent processes that
+    // try to deploy and immediately propose. The proposals should be rejected
+    // when another one is already running, but eventually all deploys should be
+    // taken and put into blocks. In the blocks we created should form a simple
+    // chain, there shouldn't be any forks in it, which we should see from the
+    // fact that each rank is occupied by a single block.
+    val node = standaloneEff(genesis, transforms, validatorKeys.head)
+
+    implicit val bs = node.blockStorage
+    implicit val fd = node.safetyOracleEff
+
+    def deployAndPropose(
+        blockApiLock: Semaphore[Task]
+    )(implicit casperRef: MultiParentCasperRef[Task]) =
+      for {
+        d <- ProtoUtil.basicDeploy[Task]()
+        _ <- BlockAPI.deploy[Task](d)
+        _ <- BlockAPI.propose[Task](blockApiLock)
+      } yield ()
+
+    val test: Task[Unit] = for {
+      casperRef    <- MultiParentCasperRef.of[Task]
+      _            <- casperRef.set(node.casperEff)
+      blockApiLock <- Semaphore[Task](1)
+      // Create blocks in waves.
+      results <- Task.sequence {
+                  List.fill(5) {
+                    Task.gatherUnordered {
+                      List.fill(threadCount) {
+                        deployAndPropose(blockApiLock)(casperRef).attempt
+                      }
+                    }
+                  }
+                }
+      // See how many blocks were created.
+      dag    <- node.dagStorage.getRepresentation
+      blocks <- dag.topoSortTail(Int.MaxValue).compile.toList.map(_.flatten)
+    } yield {
+      val successCount  = results.flatten.count(_.isRight)
+      val blocksPerRank = blocks.groupBy(_.getHeader.rank)
+      blocks should have size (1L + successCount.toLong)
+      blocksPerRank should have size (blocks.size.toLong)
+    }
+
+    try {
+      test.unsafeRunSync
     } finally {
       node.tearDown()
     }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -22,7 +22,7 @@ import io.casperlabs.crypto.Keys.PrivateKey
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.p2p.EffectsTestInstances._
-import io.casperlabs.shared.{Cell, Log, Time}
+import io.casperlabs.shared.{Cell, Log, SemaphoreMap, Time}
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.dag._
 import io.casperlabs.storage.deploy.DeployStorage
@@ -34,6 +34,7 @@ class GossipServiceCasperTestNode[F[_]](
     local: Node,
     genesis: consensus.Block,
     sk: PrivateKey,
+    semaphoresMap: SemaphoreMap[F, ByteString],
     faultToleranceThreshold: Float = 0f,
     maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None,
     chainName: String = "casperlabs",
@@ -57,10 +58,6 @@ class GossipServiceCasperTestNode[F[_]](
     ) (concurrentF, blockStorage, dagStorage, deployStorage, metricEff, casperState) {
   implicit val safetyOracleEff: FinalityDetector[F] = new FinalityDetectorBySingleSweepImpl[F]
 
-  val ownValidatorKey = validatorId match {
-    case ValidatorIdentity(key, _, _) => ByteString.copyFrom(key)
-  }
-
   implicit val raiseInvalidBlock = casper.validation.raiseValidateErrorThroughApplicativeError[F]
   implicit val validation        = HashSetCasperTestNode.makeValidation[F]
 
@@ -72,6 +69,7 @@ class GossipServiceCasperTestNode[F[_]](
   // - the download manager tries to validate a block
   implicit val casperEff: MultiParentCasperImpl[F] =
     new MultiParentCasperImpl[F](
+      semaphoresMap,
       new MultiParentCasperImpl.StatelessExecutor[F](chainName, upgrades = Nil),
       MultiParentCasperImpl.Broadcaster.fromGossipServices(Some(validatorId), relaying),
       Some(validatorId),
@@ -132,11 +130,13 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
     initStorage() flatMap {
       case (blockStorage, dagStorage, deployStorage) =>
         for {
-          casperState <- Cell.mvarCell[F, CasperState](CasperState())
+          casperState  <- Cell.mvarCell[F, CasperState](CasperState())
+          semaphoreMap <- SemaphoreMap[F, ByteString](1)
           node = new GossipServiceCasperTestNode[F](
             identity,
             genesis,
             sk,
+            semaphoreMap,
             faultToleranceThreshold,
             relaying = relaying,
             gossipService = new TestGossipService[F]()
@@ -214,10 +214,12 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                 casperState <- Cell.mvarCell[F, CasperState](
                                 CasperState()
                               )
+                semaphoreMap <- SemaphoreMap[F, ByteString](1)
                 node = new GossipServiceCasperTestNode[F](
                   peer,
                   genesis,
                   sk,
+                  semaphoreMap,
                   faultToleranceThreshold,
                   relaying = relaying,
                   gossipService = gossipService,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -34,7 +34,6 @@ class GossipServiceCasperTestNode[F[_]](
     local: Node,
     genesis: consensus.Block,
     sk: PrivateKey,
-    blockProcessingLock: Semaphore[F],
     faultToleranceThreshold: Float = 0f,
     maybeMakeEE: Option[HashSetCasperTestNode.MakeExecutionEngineService[F]] = None,
     chainName: String = "casperlabs",
@@ -79,7 +78,6 @@ class GossipServiceCasperTestNode[F[_]](
       genesis,
       chainName,
       upgrades = Nil,
-      blockProcessingLock,
       faultToleranceThreshold = faultToleranceThreshold
     )
 
@@ -134,13 +132,11 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
     initStorage() flatMap {
       case (blockStorage, dagStorage, deployStorage) =>
         for {
-          blockProcessingLock <- Semaphore[F](1)
-          casperState         <- Cell.mvarCell[F, CasperState](CasperState())
+          casperState <- Cell.mvarCell[F, CasperState](CasperState())
           node = new GossipServiceCasperTestNode[F](
             identity,
             genesis,
             sk,
-            blockProcessingLock,
             faultToleranceThreshold,
             relaying = relaying,
             gossipService = new TestGossipService[F]()
@@ -215,7 +211,6 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
           initStorage() flatMap {
             case (blockStorage, dagStorage, deployStorage) =>
               for {
-                semaphore <- Semaphore[F](1)
                 casperState <- Cell.mvarCell[F, CasperState](
                                 CasperState()
                               )
@@ -223,7 +218,6 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                   peer,
                   genesis,
                   sk,
-                  semaphore,
                   faultToleranceThreshold,
                   relaying = relaying,
                   gossipService = gossipService,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -64,6 +64,10 @@ abstract class HashSetCasperTestNode[F[_]](
 
   val validatorId = ValidatorIdentity(Ed25519.tryToPublic(sk).get, sk, Ed25519)
 
+  val ownValidatorKey = validatorId match {
+    case ValidatorIdentity(key, _, _) => ByteString.copyFrom(key)
+  }
+
   val bonds = genesis.getHeader.getState.bonds
     .map(b => PublicKey(b.validatorPublicKey.toByteArray) -> Weight(b.stake))
     .toMap

--- a/shared/src/main/scala/io/casperlabs/shared/SemaphoreMap.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/SemaphoreMap.scala
@@ -1,0 +1,40 @@
+package io.casperlabs.shared
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent._
+
+/** Keep track of semaphores when we want to limit to one operation per key. */
+class SemaphoreMap[F[_]: Concurrent, K](capacity: Int, ref: Ref[F, Map[K, Semaphore[F]]]) {
+  def getOrAdd(key: K): F[Semaphore[F]] =
+    ref.get.map(_.get(key)).flatMap {
+      case Some(semaphore) =>
+        semaphore.pure[F]
+      case None =>
+        for {
+          s0 <- Semaphore[F](capacity.toLong)
+          s1 <- ref.modify { ss =>
+                 ss.get(key) map { s1 =>
+                   ss -> s1
+                 } getOrElse {
+                   ss.updated(key, s0) -> s0
+                 }
+               }
+        } yield s1
+    }
+
+  def withPermit[T](key: K)(thunk: => F[T]) =
+    getOrAdd(key).flatMap { semaphore =>
+      semaphore.withPermit {
+        thunk
+      }
+    }
+}
+
+object SemaphoreMap {
+  def apply[F[_]: Concurrent, K](capacity: Int) =
+    for {
+      ref <- Ref[F].of(Map.empty[K, Semaphore[F]])
+    } yield new SemaphoreMap[F, K](capacity, ref)
+}

--- a/shared/src/test/scala/io/casperlabs/shared/SemaphoreMapSpec.scala
+++ b/shared/src/test/scala/io/casperlabs/shared/SemaphoreMapSpec.scala
@@ -1,0 +1,53 @@
+package io.casperlabs.shared
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.IntBinaryOperator
+import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+
+class SemaphoreMapSpec extends FlatSpec with Matchers with Inspectors {
+
+  "SemaphoreMap" should "only allow concurrency up to the capacity per key" in {
+    class Counter() {
+      val current = new AtomicInteger(0)
+      val max     = new AtomicInteger(0)
+    }
+
+    val counterMap = TrieMap.empty[Int, Counter]
+    val capacity   = 2
+
+    val test = for {
+      semaphoreMap <- SemaphoreMap[Task, Int](capacity)
+      tasks = List.range(0, 99).map { i =>
+        val k = i % 10
+        semaphoreMap.withPermit(k) {
+          for {
+            counter <- Task.delay {
+                        val counter = counterMap.getOrElseUpdate(k, new Counter())
+                        val curr    = counter.current.incrementAndGet()
+                        counter.max.accumulateAndGet(curr, new IntBinaryOperator {
+                          def applyAsInt(left: Int, right: Int) = math.max(left, right)
+                        })
+                        counter
+                      }
+            _ <- Task.sleep(50.millis)
+            _ <- Task.delay {
+                  counter.current.decrementAndGet()
+                }
+          } yield ()
+        }
+      }
+      _ <- Task.gatherUnordered(tasks)
+    } yield {
+      forAll(counterMap.values) { c =>
+        c.current.get shouldBe 0
+        c.max.get should be > 0
+        c.max.get should be <= capacity
+      }
+    }
+
+    test.runSyncUnsafe(10.seconds)
+  }
+}


### PR DESCRIPTION
### Overview
The PR removes the `blockProcessingLock` from `MultiParentCasper` that only allowed the node to process 1 block at a time. We can do this knowing that:
* The `BlockAPI` will take out a proposal lock, so a validator will not propose 2 blocks at the same time.
* The `DownloadManager` will feed the blocks in topological order to `addBlock`, so as long as there are no race conditions (like the one we saw with the `DagRepresentation` happening because `createBlock` happened concurrently with `addBlock`) we should be fine.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-902

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
