### PR TITLE
NODE-959: Add commands bond and unbond to Python CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,8 @@ cargo-native-packager/%:
 		integration-testing/Dockerfile
 	$(eval IT_PATH = integration-testing)
 	cp -r protobuf $(IT_PATH)/
+	mkdir -p $(IT_PATH)/bundled_contracts
+	cp -r client/src/main/resources/*.wasm $(IT_PATH)/bundled_contracts/
 	docker build -f $(IT_PATH)/Dockerfile -t $(DOCKER_USERNAME)/integration-testing:$(DOCKER_LATEST_TAG) $(IT_PATH)/
 	rm -rf $(IT_PATH)/protobuf
 	mkdir -p $(dir $@) && touch $@

--- a/integration-testing/Dockerfile
+++ b/integration-testing/Dockerfile
@@ -15,3 +15,5 @@ COPY ./ /root/integration-testing/
 RUN python3 -m pipenv sync
 RUN mkdir -p /root/protobuf
 COPY ./protobuf/ /root/protobuf/
+RUN mkdir -p /root/bundled_contracts
+COPY ./bundled_contracts/ /root/bundled_contracts/

--- a/integration-testing/casperlabs_local_net/cli.py
+++ b/integration-testing/casperlabs_local_net/cli.py
@@ -92,8 +92,13 @@ class CLI:
 
     def __call__(self, *args):
         command_line = [str(self.cli_cmd)] + self.expand_args(args)
-        logging.info(f"EXECUTING []: {command_line}")
+        # logging.info(f"EXECUTING []: {command_line}")
         logging.info(f"EXECUTING: {' '.join(command_line)}")
+        if args[0] == "unbond":
+            # pass
+            import time
+
+            time.sleep(100000)
         cp = subprocess.run(
             command_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/integration-testing/casperlabs_local_net/cli.py
+++ b/integration-testing/casperlabs_local_net/cli.py
@@ -94,11 +94,6 @@ class CLI:
         command_line = [str(self.cli_cmd)] + self.expand_args(args)
         # logging.info(f"EXECUTING []: {command_line}")
         logging.info(f"EXECUTING: {' '.join(command_line)}")
-        if args[0] == "unbond":
-            # pass
-            import time
-
-            time.sleep(100000)
         cp = subprocess.run(
             command_line, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )

--- a/integration-testing/casperlabs_local_net/cli.py
+++ b/integration-testing/casperlabs_local_net/cli.py
@@ -36,7 +36,7 @@ class CLI:
             os.environ.get("TAG_NAME", None) and node.container_name or "localhost"
         )
         self.port = node.grpc_external_docker_port
-        self.internal_port = node.grpc_internal_docker_port
+        self.port_internal = node.grpc_internal_docker_port
         self.cli_cmd = cli_cmd
         self.tls_parameters = tls_parameters or {}
         self.default_deploy_args = []
@@ -55,8 +55,8 @@ class CLI:
             f"{self.host}",
             "--port",
             f"{self.port}",
-            "--internal-port",
-            f"{self.internal_port}",
+            "--port-internal",
+            f"{self.port_internal}",
         ]
         if self.tls_parameters:
             connection_details += reduce(

--- a/integration-testing/casperlabs_local_net/cli.py
+++ b/integration-testing/casperlabs_local_net/cli.py
@@ -50,7 +50,14 @@ class CLI:
         return self.resources_directory / file_name
 
     def expand_args(self, args):
-        connection_details = ["--host", f"{self.host}", "--port", f"{self.port}"]
+        connection_details = [
+            "--host",
+            f"{self.host}",
+            "--port",
+            f"{self.port}",
+            "--internal-port",
+            f"{self.internal_port}",
+        ]
         if self.tls_parameters:
             connection_details += reduce(
                 add,
@@ -71,7 +78,7 @@ class CLI:
 
         output = binary_output.decode("utf-8")
 
-        if command in ("deploy", "send-deploy"):
+        if command in ("deploy", "send-deploy", "bond", "unbond"):
             return output.split()[2]
             # "Success! Deploy 0d4036bebb95de793b28de452d594531a29f8dc3c5394526094d30723fa5ff65 deployed."
 

--- a/integration-testing/casperlabs_local_net/python_client.py
+++ b/integration-testing/casperlabs_local_net/python_client.py
@@ -24,7 +24,7 @@ class PythonClient(CasperLabsClientBase, LoggingMixin):
 
         self.client = CasperLabsClient(
             host=host,
-            internal_port=self.node.grpc_internal_docker_port,
+            port_internal=self.node.grpc_internal_docker_port,
             port=self.node.grpc_external_docker_port,
             node_id=node_id,
             certificate_file=certificate_file,
@@ -32,7 +32,7 @@ class PythonClient(CasperLabsClientBase, LoggingMixin):
         logging.info(
             f"PythonClient(host={self.client.host}, "
             f"port={self.node.grpc_external_docker_port}, "
-            f"internal_port={self.node.grpc_internal_docker_port})"
+            f"port_internal={self.node.grpc_internal_docker_port})"
         )
 
     def __getattr__(self, name):

--- a/integration-testing/client/CasperLabsClient/README.md
+++ b/integration-testing/client/CasperLabsClient/README.md
@@ -65,7 +65,7 @@ To deploy a compiled contract from your account address:
 ```python
 response = client.deploy(from_addr="f2cbd19d054bd2b2c06ea26714275271663a5e4503d5d059de159c3b60d81ab7",
                          gas_price=1,
-                         payment="helloname.wasm",
+                         payment_amount=1000000,
                          session="helloname.wasm")
 ```
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -818,8 +818,8 @@ def deploy_command(casperlabs_client, args):
             ABI.args([ABI.big_int("amount", int(args.payment_amount))])
         )
         # Unless one of payment* options supplied use bundled standard-payment
-        if not (
-            args.payment or args.payment_name or args.payment_hash or args.payment_uref
+        if not any(
+            (args.payment, args.payment_name, args.payment_hash, args.payment_uref)
         ):
             p = pkg_resources.resource_filename(__name__, "standard_payment.wasm")
             if not os.path.exists(p):

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -873,7 +873,6 @@ def deploy_command(casperlabs_client, args):
             p = pkg_resources.resource_filename(__name__, "standard_payment.wasm")
             if not os.path.exists(p):
                 raise Exception(f"No bundled contract {p}")
-            logging.info(f"DEPLOY: Using {p} as a payment contract.")
             args.payment = p
 
     kwargs = dict(
@@ -896,8 +895,6 @@ def deploy_command(casperlabs_client, args):
         session_name=args.session_name,
         session_uref=args.session_uref and bytes.fromhex(args.session_uref),
     )
-    logging.info(f"DEPLOY: {kwargs}")
-    print(f"DEPLOY: {kwargs}")
     _, deploy_hash = casperlabs_client.deploy(**kwargs)
     print(f"Success! Deploy {deploy_hash.hex()} deployed")
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -817,7 +817,7 @@ def deploy_command(casperlabs_client, args):
 
     if args.payment_amount is not None:
         args.payment_args = ABI.args_to_json(
-            ABI.args([ABI.int_value("amount", int(args.payment_amount))])
+            ABI.args([ABI.big_int("amount", int(args.payment_amount))])
         )
         # Unless one of payment* options supplied use bundled standard-payment
         if not (

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -12,6 +12,7 @@ parent, root = file.parent, file.parents[1]
 sys.path.append(str(root))
 
 # end of hack #
+import os
 import time
 import argparse
 import grpc
@@ -24,6 +25,7 @@ import base64
 import json
 import struct
 import logging
+import pkg_resources
 
 # Monkey patching of google.protobuf.text_encoding.CEscape
 # to get keys and signatures in hex when printed
@@ -965,6 +967,13 @@ def main():
                        [('-b', '--block-hash'), dict(required=True, type=str, help='Hash of the block to query the state of')]])
     # fmt:on
     sys.exit(parser.run())
+
+
+def check_bundled_contracts():
+    print(dir(pkg_resources))
+    p = pkg_resources.resource_filename(__name__, "bonding.wasm")
+    if not os.path.exists(p):
+        raise Exception(f"No bundled contract {p}")
 
 
 if __name__ == "__main__":

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -765,9 +765,7 @@ def _set_session(args, file_name):
     """
     Use bundled contract unless one of the session* args is set.
     """
-    if not (
-        args.session or args.session_hash or args.session_name or args.session_uref
-    ):
+    if not any((args.session, args.session_hash, args.session_name, args.session_uref)):
         args.session = bundled_contract(file_name)
 
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -757,7 +757,7 @@ def bundled_contract(file_name):
     """
     p = pkg_resources.resource_filename(__name__, file_name)
     if not os.path.exists(p):
-        raise Exception(f"Missing bundled contract {file_name}")
+        raise Exception(f"Missing bundled contract {file_name} ({p})")
     return p
 
 

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -182,7 +182,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.4.3",
+    version="0.5.0",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -149,7 +149,18 @@ def run_codegen():
         [(r"(import .*_pb2)", r"from . \1")],
         glob(f"{PACKAGE_DIR}/*pb2*py"),
     )
-    for filename in glob(os.path.join(CONTRACTS_DIR, "*.wasm")):
+
+    pattern = (
+        os.environ.get("TAG_NAME")
+        and "/root/bundled_contracts/*.wasm"
+        or os.path.join(CONTRACTS_DIR, "*.wasm")
+    )
+    bundled_contracts = list(glob(pattern))
+    if len(bundled_contracts) == 0:
+        raise Exception(
+            f"Could not find wasm files that should be bunndled with the client. {pattern}"
+        )
+    for filename in bundled_contracts:
         shutil.copy(filename, PACKAGE_DIR)
 
 

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -17,6 +17,7 @@ from setuptools.command.install import install as InstallCommand
 from distutils.spawn import find_executable
 
 THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+CONTRACTS_DIR = f"{THIS_DIRECTORY}/../../../client/src/main/resources"
 PROTOBUF_DIR = f"{THIS_DIRECTORY}/../../../protobuf"
 PROTO_DIR = f"{THIS_DIRECTORY}/casperlabs_client/proto"
 PACKAGE_DIR = f"{THIS_DIRECTORY}/casperlabs_client"
@@ -148,6 +149,8 @@ def run_codegen():
         [(r"(import .*_pb2)", r"from . \1")],
         glob(f"{PACKAGE_DIR}/*pb2*py"),
     )
+    for filename in glob(os.path.join(CONTRACTS_DIR, "*.wasm")):
+        shutil.copy(filename, PACKAGE_DIR)
 
 
 with open(path.join(THIS_DIRECTORY, "README.md"), encoding="utf-8") as fh:
@@ -187,6 +190,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     include_package_data=True,
+    package_data={NAME: [f"{THIS_DIRECTORY}/casperlabs_client/*.wasm"]},
     keywords="casperlabs blockchain ethereum smart-contracts",
     author="CasperLabs LLC",
     author_email="testing@casperlabs.io",

--- a/integration-testing/test/test_python_bonding.py
+++ b/integration-testing/test/test_python_bonding.py
@@ -47,32 +47,19 @@ def bond_to_the_network(network: OneNodeNetwork, bond_amount: int, account_numbe
         "--amount", bond_amount,
         '--public-key', account.public_key_path,
         '--private-key', account.private_key_path,
-        # '--payment-amount', EXECUTION_PAYMENT_AMOUNT,
-        "--payment", cli.resource(Contract.STANDARD_PAYMENT),
-        "--payment-args", cli.payment_json,
+        '--payment-amount', EXECUTION_PAYMENT_AMOUNT,
         '--from', account.public_key_hex)
     # fmt: on
     block_hash = cli("propose")
     return block_hash, account
 
 
-EXECUTION_PAYMENT_AMOUNT = 10 * 10 * 6
+EXECUTION_PAYMENT_AMOUNT = 100 * 10 ** 6
 
 
 def unbond_from_network(
     network: OneNodeNetwork, bonding_amount: int, account_number: int
 ):
-    """
-    node = network.docker_nodes[1]
-    account = Account(account_number)
-    r = node.d_client.unbond(bonding_amount, account.private_key_docker_path)
-    assert "Success!" in r
-    r = node.d_client.propose()
-    block_hash = extract_block_hash_from_propose_output(r)
-    assert block_hash is not None
-    return block_hash, account
-    """
-
     node = network.docker_nodes[1]
     account = Account(account_number)
     cli = CLI(node)
@@ -81,9 +68,7 @@ def unbond_from_network(
         "--amount", bonding_amount,
         '--public-key', account.public_key_path,
         "--private-key", account.private_key_path,
-        # "--payment-amount", EXECUTION_PAYMENT_AMOUNT,
-        "--payment", cli.resource(Contract.STANDARD_PAYMENT),
-        "--payment-args", cli.payment_json,
+        "--payment-amount", EXECUTION_PAYMENT_AMOUNT,
         "--from", account.public_key_hex)
     # fmt: on
     block_hash = cli("propose")

--- a/integration-testing/test/test_python_bonding.py
+++ b/integration-testing/test/test_python_bonding.py
@@ -13,7 +13,7 @@ from casperlabs_local_net.common import extract_block_hash_from_propose_output
 from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT
 
 
-BONDING_ACCT = 295
+BONDING_ACCT = 294
 
 
 def add_funded_account_to_network(network: OneNodeNetwork, account_number: int):

--- a/integration-testing/test/test_python_bonding.py
+++ b/integration-testing/test/test_python_bonding.py
@@ -62,6 +62,7 @@ EXECUTION_PAYMENT_AMOUNT = 10 * 10 * 6
 def unbond_from_network(
     network: OneNodeNetwork, bonding_amount: int, account_number: int
 ):
+    """
     node = network.docker_nodes[1]
     account = Account(account_number)
     r = node.d_client.unbond(bonding_amount, account.private_key_docker_path)
@@ -70,6 +71,7 @@ def unbond_from_network(
     block_hash = extract_block_hash_from_propose_output(r)
     assert block_hash is not None
     return block_hash, account
+    """
 
     node = network.docker_nodes[1]
     account = Account(account_number)

--- a/integration-testing/test/test_python_bonding.py
+++ b/integration-testing/test/test_python_bonding.py
@@ -1,0 +1,308 @@
+import pytest
+import logging
+
+from casperlabs_local_net.common import Contract
+from casperlabs_local_net.client_parser import parse_show_block
+from casperlabs_local_net.client_parser import parse_show_blocks
+from casperlabs_local_net.cli import CLI
+from casperlabs_local_net.casperlabs_network import OneNodeNetwork
+from casperlabs_local_net.casperlabs_accounts import Account
+from casperlabs_local_net.wait import wait_for_block_hash_propagated_to_all_nodes
+from casperlabs_client import InternalError
+from casperlabs_local_net.common import extract_block_hash_from_propose_output
+from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT
+
+
+BONDING_ACCT = 295
+
+
+def add_funded_account_to_network(network: OneNodeNetwork, account_number: int):
+    node0 = network.docker_nodes[0]
+    cli = CLI(node0)
+    prev_number = len(network.docker_nodes)
+    account = network.add_new_node_to_network(account=Account(account_number))
+    assert (
+        len(network.docker_nodes) == prev_number + 1
+    ), f"Total number of nodes should be {prev_number + 1}."
+    response = node0.d_client.transfer(
+        amount=1000000000,
+        private_key=GENESIS_ACCOUNT.private_key_docker_path,
+        target_account=account.public_key,
+    )
+    assert "Success!" in response
+    block_hash = cli("propose")
+    for deployInfo in node0.p_client.showDeploys(block_hash):
+        assert (
+            deployInfo.is_error is False
+        ), f"Transfer Failed: {deployInfo.error_message}"
+
+
+def bond_to_the_network(network: OneNodeNetwork, bond_amount: int, account_number: int):
+    # Using account that will not exist in bonds.txt from high number
+    account = Account(account_number)
+    node0, node1 = network.docker_nodes
+    cli = CLI(node0)
+    # fmt: off
+    cli("bond",
+        "--amount", bond_amount,
+        '--public-key', account.public_key_path,
+        '--private-key', account.private_key_path,
+        # '--payment-amount', EXECUTION_PAYMENT_AMOUNT,
+        "--payment", cli.resource(Contract.STANDARD_PAYMENT),
+        "--payment-args", cli.payment_json,
+        '--from', account.public_key_hex)
+    # fmt: on
+    block_hash = cli("propose")
+    return block_hash, account
+
+
+EXECUTION_PAYMENT_AMOUNT = 10 * 10 * 6
+
+
+def unbond_from_network(
+    network: OneNodeNetwork, bonding_amount: int, account_number: int
+):
+    node = network.docker_nodes[1]
+    account = Account(account_number)
+    r = node.d_client.unbond(bonding_amount, account.private_key_docker_path)
+    assert "Success!" in r
+    r = node.d_client.propose()
+    block_hash = extract_block_hash_from_propose_output(r)
+    assert block_hash is not None
+    return block_hash, account
+
+    node = network.docker_nodes[1]
+    account = Account(account_number)
+    cli = CLI(node)
+    # fmt: off
+    cli("unbond",
+        "--amount", bonding_amount,
+        '--public-key', account.public_key_path,
+        "--private-key", account.private_key_path,
+        # "--payment-amount", EXECUTION_PAYMENT_AMOUNT,
+        "--payment", cli.resource(Contract.STANDARD_PAYMENT),
+        "--payment-args", cli.payment_json,
+        "--from", account.public_key_hex)
+    # fmt: on
+    block_hash = cli("propose")
+    return block_hash, account
+
+
+def add_account_and_bond_to_network(
+    network: OneNodeNetwork, bond_amount: int, account_number: int
+):
+    add_funded_account_to_network(network, account_number)
+    return bond_to_the_network(network, bond_amount, account_number)
+
+
+def assert_pre_state_of_network(network: OneNodeNetwork):
+    node0 = network.docker_nodes[0]
+    blocks = parse_show_blocks(node0.client.show_blocks(1000))
+    assert len(blocks) == 1
+
+
+def check_no_errors_in_deploys(node, block_hash):
+    deploy_infos = list(node.p_client.show_deploys(block_hash))
+    assert len(deploy_infos) > 0
+    for deploy_info in deploy_infos:
+        if deploy_info.is_error:
+            raise Exception(deploy_info.error_message)
+
+
+def bonds_by_account_and_stake(
+    node, block_hash: str, bonding_amount: int, public_key: str
+):
+    block = node.d_client.show_block(block_hash)
+    block_ds = parse_show_block(block)
+    bonds = list(
+        filter(
+            lambda x: int(x.stake.value) == bonding_amount
+            and x.validator_public_key == public_key,
+            block_ds.summary.header.state.bonds,
+        )
+    )
+    return bonds
+
+
+def test_python_bonding_and_unbonding_with_deploys(one_node_network_fn):
+    """
+    Feature file: consensus.feature
+    Scenario: Bonding a validator node to an existing network.
+    """
+    # Bond
+    logging.info(f"Funding Account {BONDING_ACCT} and bonding to network.")
+    bonding_amount = 1
+    assert_pre_state_of_network(one_node_network_fn)
+    block_hash, account = add_account_and_bond_to_network(
+        one_node_network_fn, bonding_amount, BONDING_ACCT
+    )
+
+    node0, node1 = one_node_network_fn.docker_nodes
+    check_no_errors_in_deploys(node0, block_hash)
+
+    bonds = bonds_by_account_and_stake(
+        node1, block_hash, bonding_amount, account.public_key_hex
+    )
+    assert len(bonds) == 1
+
+    wait_for_block_hash_propagated_to_all_nodes(
+        one_node_network_fn.docker_nodes, block_hash
+    )
+
+    # Test deploy/propose bonded
+    logging.info(f"Deploy and propose on bonded node.")
+    block_hash = node1.d_client.deploy_and_propose(
+        from_address=account.public_key_hex,
+        session_contract=Contract.HELLO_NAME_DEFINE,
+        private_key=account.private_key_docker_path,
+        public_key=account.public_key_docker_path,
+    )
+    wait_for_block_hash_propagated_to_all_nodes(
+        one_node_network_fn.docker_nodes, block_hash
+    )
+    check_no_errors_in_deploys(node1, block_hash)
+
+    # Unbond
+    logging.info(f"Unbonding Account {BONDING_ACCT} from network.")
+    block_hash, account = unbond_from_network(
+        one_node_network_fn, bonding_amount, BONDING_ACCT
+    )
+    wait_for_block_hash_propagated_to_all_nodes(
+        one_node_network_fn.docker_nodes, block_hash
+    )
+    check_no_errors_in_deploys(node0, block_hash)
+
+    bonds = bonds_by_account_and_stake(
+        node0, block_hash, bonding_amount, account.public_key_hex
+    )
+    assert len(bonds) == 0
+
+    wait_for_block_hash_propagated_to_all_nodes(
+        one_node_network_fn.docker_nodes, block_hash
+    )
+
+    # Test deploy/propose unbonded
+    logging.info(f"Testing unbonded deploy and propose.")
+    node1.d_client.deploy(
+        from_address=account.public_key_hex,
+        session_contract=Contract.HELLO_NAME_DEFINE,
+        private_key=account.private_key_docker_path,
+        public_key=account.public_key_docker_path,
+    )
+    with pytest.raises(InternalError) as excinfo:
+        node1.p_client.propose().block_hash.hex()
+    assert "InvalidUnslashableBlock" in str(excinfo.value)
+
+
+def test_python_double_bonding(one_node_network_fn):
+    """
+    Feature file: consensus.feature
+    Scenario: Bonding a validator node twice to an existing network.
+    """
+
+    assert_pre_state_of_network(one_node_network_fn)
+    block_hash, account = add_account_and_bond_to_network(
+        one_node_network_fn, 1, BONDING_ACCT
+    )
+    node0, node1 = one_node_network_fn.docker_nodes
+    wait_for_block_hash_propagated_to_all_nodes(
+        one_node_network_fn.docker_nodes, block_hash
+    )
+    check_no_errors_in_deploys(node0, block_hash)
+
+    block_hash, account = bond_to_the_network(one_node_network_fn, 2, BONDING_ACCT)
+    wait_for_block_hash_propagated_to_all_nodes(
+        one_node_network_fn.docker_nodes, block_hash
+    )
+    check_no_errors_in_deploys(node1, block_hash)
+
+    bonds = bonds_by_account_and_stake(node1, block_hash, 1 + 2, account.public_key_hex)
+    assert len(bonds) == 1
+
+
+def test_python_partial_amount_unbonding(one_node_network_fn):
+    """
+    Feature file: consensus.feature
+    Scenario: unbonding a bonded validator node with partial bonding amount from an existing network.
+    """
+    bonding_amount = 11
+    unbond_amount = 4
+    remaining_amount = bonding_amount - unbond_amount
+    assert_pre_state_of_network(one_node_network_fn)
+    block_hash, account = add_account_and_bond_to_network(
+        one_node_network_fn, bonding_amount, BONDING_ACCT
+    )
+    node0, node1 = one_node_network_fn.docker_nodes
+    check_no_errors_in_deploys(node0, block_hash)
+
+    bonds = bonds_by_account_and_stake(
+        node1, block_hash, bonding_amount, account.public_key_hex
+    )
+    assert len(bonds) == 1
+
+    block_hash, account = unbond_from_network(
+        one_node_network_fn, unbond_amount, BONDING_ACCT
+    )
+    check_no_errors_in_deploys(node1, block_hash)
+
+    bonds = bonds_by_account_and_stake(
+        node1, block_hash, remaining_amount, account.public_key_hex
+    )
+    assert len(bonds) == 1
+
+
+def test_python_invalid_bonding_amount(one_node_network_fn):
+    """
+    Feature file: consensus.feature
+    Scenario: Bonding a validator node to an existing network.
+    """
+    # 190 is current total staked amount.
+    bonding_amount = (190 * 1000) + 1
+    block_hash, account = add_account_and_bond_to_network(
+        one_node_network_fn, bonding_amount, BONDING_ACCT
+    )
+    node1 = one_node_network_fn.docker_nodes[1]
+    bonds = bonds_by_account_and_stake(
+        node1, block_hash, bonding_amount, account.public_key_hex
+    )
+    assert len(bonds) == 0
+
+    r = node1.d_client.show_deploys(block_hash)[0]
+    assert r.is_error is True
+    assert r.error_message == "Exit code: 65286"
+
+
+def test_python_unbonding_without_bonding(one_node_network_fn):
+    """
+    Feature file: consensus.feature
+    Scenario: unbonding a validator node which was not bonded to an existing network.
+    """
+    bonding_amount = 1
+    account = Account(BONDING_ACCT)
+    assert_pre_state_of_network(one_node_network_fn)
+    add_funded_account_to_network(one_node_network_fn, BONDING_ACCT)
+    assert (
+        len(one_node_network_fn.docker_nodes) == 2
+    ), "Total number of nodes should be 2."
+
+    node0, node1 = one_node_network_fn.docker_nodes
+    r = node0.d_client.unbond(bonding_amount, account.private_key_docker_path)
+    assert "Success!" in r
+    r = node0.d_client.propose()
+    block_hash = extract_block_hash_from_propose_output(r)
+    assert block_hash is not None
+    # block_hash, account = unbond_from_network(one_node_network_fn, bonding_amount, BONDING_ACCT)
+
+    r = node0.client.show_deploys(block_hash)[0]
+    assert r.is_error is True
+    assert r.error_message == "Exit code: 65280"
+
+    block = node1.client.show_block(block_hash)
+    block_ds = parse_show_block(block)
+    bonds = list(
+        filter(
+            lambda x: x.validator_public_key == account.public_key_hex,
+            block_ds.summary.header.state.bonds,
+        )
+    )
+    assert len(bonds) == 0

--- a/integration-testing/test/test_python_client_bundled_contracts.py
+++ b/integration-testing/test/test_python_client_bundled_contracts.py
@@ -1,0 +1,5 @@
+import casperlabs_client
+
+
+def test_check_bundled_contracts():
+    casperlabs_client.check_bundled_contracts()


### PR DESCRIPTION
### Overview
This PR  adds bond and unbond commands to Python CLI.
Contracts that are bundled with Scala client are now also bundled with Python client.
Option `--payment-amount` has been added that implies usage of `standard_payment.wasm` (NODE-940).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-959
https://casperlabs.atlassian.net/browse/NODE-940

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
NA
