### PR TITLE
EE-731 remove payment flag

### DIFF
--- a/execution-engine/engine-core/src/engine_state/engine_config.rs
+++ b/execution-engine/engine-core/src/engine_state/engine_config.rs
@@ -1,7 +1,7 @@
 /// The runtime configuration of the execution engine
 #[derive(Debug, Clone)]
 pub struct EngineConfig {
-    use_payment_code: bool,
+    // feature flags go here
 }
 
 impl EngineConfig {
@@ -9,22 +9,10 @@ impl EngineConfig {
     pub fn new() -> EngineConfig {
         Default::default()
     }
-
-    /// Sets the `use_payment_code` field to the given arg.
-    pub fn set_use_payment_code(mut self, arg: bool) -> EngineConfig {
-        self.use_payment_code = arg;
-        self
-    }
-
-    pub fn use_payment_code(&self) -> bool {
-        self.use_payment_code
-    }
 }
 
 impl Default for EngineConfig {
     fn default() -> Self {
-        EngineConfig {
-            use_payment_code: false,
-        }
+        EngineConfig {}
     }
 }

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -53,7 +53,6 @@ pub const CONV_RATE: u64 = 10;
 
 pub const SYSTEM_ACCOUNT_ADDR: [u8; 32] = [0u8; 32];
 
-const DEFAULT_SESSION_MOTES: u64 = 1_000_000_000;
 const GENESIS_INITIAL_BLOCKTIME: u64 = 0;
 const MINT_METHOD_NAME: &str = "mint";
 
@@ -750,37 +749,6 @@ where
                 )));
             }
         };
-
-        // --- REMOVE BELOW --- //
-        // If payment logic is turned off, execute only session code
-        if !(self.config.use_payment_code()) {
-            // DEPLOY WITH NO PAYMENT
-
-            let session_motes = Motes::new(U512::from(DEFAULT_SESSION_MOTES));
-
-            let gas_limit = Gas::from_motes(session_motes, CONV_RATE).unwrap_or_default();
-
-            // Session code execution
-            let session_result = executor.exec(
-                session_module,
-                session.args(),
-                address,
-                &account,
-                authorization_keys,
-                blocktime,
-                deploy_hash,
-                gas_limit,
-                protocol_version,
-                correlation_id,
-                Rc::clone(&tracking_copy),
-                Phase::Session,
-                protocol_data,
-            );
-
-            return Ok(session_result);
-        }
-
-        // --- REMOVE ABOVE --- //
 
         let max_payment_cost: Motes = Motes::new(U512::from(MAX_PAYMENT));
 

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -88,11 +88,6 @@ const ARG_THREAD_COUNT_VALUE: &str = "NUM";
 const ARG_THREAD_COUNT_HELP: &str = "Worker thread count";
 const ARG_THREAD_COUNT_EXPECT: &str = "expected valid thread count";
 
-// use-payment-code feature flag
-const ARG_USE_PAYMENT_CODE: &str = "use-payment-code";
-const ARG_USE_PAYMENT_CODE_SHORT: &str = "x";
-const ARG_USE_PAYMENT_CODE_HELP: &str = "Enables the use of payment code";
-
 // runnable
 const SIGINT_HANDLE_EXPECT: &str = "Error setting Ctrl-C handler";
 const RUNNABLE_CHECK_INTERVAL_SECONDS: u64 = 3;
@@ -204,12 +199,6 @@ fn get_args() -> ArgMatches<'static> {
                 .help(ARG_THREAD_COUNT_HELP),
         )
         .arg(
-            Arg::with_name(ARG_USE_PAYMENT_CODE)
-                .short(ARG_USE_PAYMENT_CODE_SHORT)
-                .long(ARG_USE_PAYMENT_CODE)
-                .help(ARG_USE_PAYMENT_CODE_HELP),
-        )
-        .arg(
             Arg::with_name(ARG_SOCKET)
                 .required(true)
                 .help(ARG_SOCKET_HELP)
@@ -269,10 +258,10 @@ fn get_thread_count(matches: &ArgMatches) -> usize {
         .expect(ARG_THREAD_COUNT_EXPECT)
 }
 
-/// Parses `use-payment-code` argument and returns an [`EngineConfig`].
-fn get_engine_config(matches: &ArgMatches) -> EngineConfig {
-    let use_payment_code = matches.is_present(ARG_USE_PAYMENT_CODE);
-    EngineConfig::new().set_use_payment_code(use_payment_code)
+/// Returns an [`EngineConfig`].
+fn get_engine_config(_matches: &ArgMatches) -> EngineConfig {
+    // feature flags go here
+    EngineConfig::new()
 }
 
 /// Builds and returns a gRPC server.

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -26,10 +26,6 @@ const TRANSFER_BATCH_SIZE: u64 = 3;
 const PER_RUN_FUNDING: u64 = 10_000_000;
 const TARGET_ADDR: [u8; 32] = [127; 32];
 
-fn engine_with_payments() -> EngineConfig {
-    EngineConfig::new().set_use_payment_code(true)
-}
-
 fn bootstrap(accounts: &[PublicKey]) -> (WasmTestResult<LmdbGlobalState>, TempDir) {
     let accounts_bytes: Vec<Vec<u8>> = accounts
         .iter()
@@ -46,7 +42,7 @@ fn bootstrap(accounts: &[PublicKey]) -> (WasmTestResult<LmdbGlobalState>, TempDi
     )
     .build();
 
-    let result = LmdbWasmTestBuilder::new_with_config(&data_dir.path(), engine_with_payments())
+    let result = LmdbWasmTestBuilder::new_with_config(&data_dir.path(), EngineConfig::new())
         .run_genesis(&DEFAULT_GENESIS_CONFIG)
         .exec(exec_request)
         .expect_success()

--- a/execution-engine/engine-tests/src/profiling/simple-transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple-transfer.rs
@@ -117,11 +117,8 @@ fn main() {
         ExecuteRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut test_builder = LmdbWasmTestBuilder::open(
-        &args.data_dir,
-        EngineConfig::new().set_use_payment_code(true),
-        root_hash,
-    );
+    let mut test_builder =
+        LmdbWasmTestBuilder::open(&args.data_dir, EngineConfig::new(), root_hash);
 
     test_builder.exec(exec_request).expect_success().commit();
 

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -445,7 +445,7 @@ pub struct WasmTestBuilder<S> {
 
 impl Default for InMemoryWasmTestBuilder {
     fn default() -> Self {
-        let engine_config = EngineConfig::new().set_use_payment_code(true);
+        let engine_config = EngineConfig::new();
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
         let engine_state = EngineState::new(global_state, engine_config);
 

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -34,7 +34,7 @@ fn should_query_with_metrics() {
     let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
     let (global_state, root_hash) =
         InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let engine_config = EngineConfig::new().set_use_payment_code(true);
+    let engine_config = EngineConfig::new();
     let result =
         InMemoryWasmTestBuilder::new(global_state, engine_config, root_hash.to_vec()).finish();
 
@@ -83,7 +83,7 @@ fn should_commit_with_metrics() {
     let (global_state, root_hash) =
         InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
 
-    let engine_config = EngineConfig::new().set_use_payment_code(true);
+    let engine_config = EngineConfig::new();
 
     let result =
         InMemoryWasmTestBuilder::new(global_state, engine_config, root_hash.to_vec()).finish();
@@ -127,7 +127,7 @@ fn should_validate_with_metrics() {
     let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
     let (global_state, root_hash) =
         InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let engine_config = EngineConfig::new().set_use_payment_code(true);
+    let engine_config = EngineConfig::new();
 
     let wasm_bytes = test_utils::create_empty_wasm_module_bytes();
 

--- a/integration-testing/casperlabs_local_net/docker_execution_engine.py
+++ b/integration-testing/casperlabs_local_net/docker_execution_engine.py
@@ -8,7 +8,7 @@ class DockerExecutionEngine(LoggingDockerBase):
 
     @property
     def command(self) -> str:
-        return f".casperlabs/sockets/.casper-node.sock -x"
+        return f".casperlabs/sockets/.casper-node.sock"
 
     @property
     def volumes(self) -> dict:


### PR DESCRIPTION
This PR removes the use-payment-code flag from EE, removing the previously default option to run an instance of EE that skips payment code execution. 

https://casperlabs.atlassian.net/browse/EE-731

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.

NOTE: Leaving the EngineConfig instrumentation in place per @henrytill for upcoming feature flag usage.

NOTE: Developers with local scripts or config tasks that run EE passing the `-x` aka `--use-payment-code` arg should no longer pass that arg to EE.
