### PR TITLE
EE-732: monomorphize {Executor,Preprocessor}

### DIFF
--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -22,74 +22,6 @@ use crate::execution::FN_STORE_ID_INITIAL;
 use crate::runtime_context::{self, RuntimeContext};
 use crate::tracking_copy::TrackingCopy;
 
-pub trait Executor<A> {
-    #[allow(clippy::too_many_arguments)]
-    fn exec<R: StateReader<Key, Value>>(
-        &self,
-        parity_module: A,
-        args: &[u8],
-        base_key: Key,
-        account: &Account,
-        authorized_keys: BTreeSet<PublicKey>,
-        blocktime: BlockTime,
-        deploy_hash: [u8; 32],
-        gas_limit: Gas,
-        protocol_version: ProtocolVersion,
-        correlation_id: CorrelationId,
-        tc: Rc<RefCell<TrackingCopy<R>>>,
-        phase: Phase,
-        protocol_data: ProtocolData,
-    ) -> ExecutionResult
-    where
-        R::Error: Into<Error>;
-
-    #[allow(clippy::too_many_arguments)]
-    fn exec_direct<R: StateReader<Key, Value>>(
-        &self,
-        parity_module: A,
-        args: &[u8],
-        keys: &mut BTreeMap<String, Key>,
-        base_key: Key,
-        account: &Account,
-        authorization_keys: BTreeSet<PublicKey>,
-        blocktime: BlockTime,
-        deploy_hash: [u8; 32],
-        gas_limit: Gas,
-        protocol_version: ProtocolVersion,
-        correlation_id: CorrelationId,
-        state: Rc<RefCell<TrackingCopy<R>>>,
-        phase: Phase,
-        protocol_data: ProtocolData,
-    ) -> ExecutionResult
-    where
-        R::Error: Into<Error>;
-
-    #[allow(clippy::too_many_arguments)]
-    fn better_exec<R: StateReader<Key, Value>, T>(
-        &self,
-        module: A,
-        args: &[u8],
-        keys: &mut BTreeMap<String, Key>,
-        base_key: Key,
-        account: &Account,
-        authorization_keys: BTreeSet<PublicKey>,
-        blocktime: BlockTime,
-        deploy_hash: [u8; 32],
-        gas_limit: Gas,
-        address_generator: Rc<RefCell<AddressGenerator>>,
-        protocol_version: ProtocolVersion,
-        correlation_id: CorrelationId,
-        state: Rc<RefCell<TrackingCopy<R>>>,
-        phase: Phase,
-        protocol_data: ProtocolData,
-    ) -> Result<T, Error>
-    where
-        R::Error: Into<Error>,
-        T: FromBytes;
-}
-
-pub struct WasmiExecutor;
-
 macro_rules! on_fail_charge {
     ($fn:expr) => {
         match $fn {
@@ -128,8 +60,11 @@ macro_rules! on_fail_charge {
     };
 }
 
-impl Executor<Module> for WasmiExecutor {
-    fn exec<R: StateReader<Key, Value>>(
+pub struct Executor;
+
+#[allow(clippy::too_many_arguments)]
+impl Executor {
+    pub fn exec<R: StateReader<Key, Value>>(
         &self,
         parity_module: Module,
         args: &[u8],
@@ -214,7 +149,7 @@ impl Executor<Module> for WasmiExecutor {
         }
     }
 
-    fn exec_direct<R: StateReader<Key, Value>>(
+    pub fn exec_direct<R: StateReader<Key, Value>>(
         &self,
         parity_module: Module,
         args: &[u8],
@@ -333,7 +268,7 @@ impl Executor<Module> for WasmiExecutor {
         }
     }
 
-    fn better_exec<R: StateReader<Key, Value>, T>(
+    pub fn better_exec<R: StateReader<Key, Value>, T>(
         &self,
         module: Module,
         args: &[u8],

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -8,7 +8,7 @@ mod tests;
 
 pub use self::address_generator::AddressGenerator;
 pub use self::error::Error;
-pub use self::executor::{Executor, WasmiExecutor};
+pub use self::executor::Executor;
 pub use self::runtime::{
     extract_access_rights_from_keys, extract_access_rights_from_urefs, instance_and_memory, Runtime,
 };

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -15,13 +15,13 @@ use engine_core::engine_state::error::Error as EngineError;
 use engine_core::engine_state::execution_result::ExecutionResult;
 use engine_core::engine_state::genesis::{GenesisConfig, GenesisResult};
 use engine_core::engine_state::EngineState;
-use engine_core::execution::{Executor, WasmiExecutor};
+use engine_core::execution::Executor;
 use engine_core::tracking_copy::QueryResult;
 use engine_shared::logging;
 use engine_shared::logging::{log_duration, log_info};
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 use engine_storage::global_state::{CommitResult, StateProvider};
-use engine_wasm_prep::{Preprocessor, WasmiPreprocessor};
+use engine_wasm_prep::Preprocessor;
 
 use self::ipc_grpc::ExecutionEngineService;
 use self::mappings::*;
@@ -173,9 +173,9 @@ where
 
         let deploys = exec_request.get_deploys();
 
-        let preprocessor: WasmiPreprocessor = WasmiPreprocessor::new(wasm_costs);
+        let preprocessor = Preprocessor::new(wasm_costs);
 
-        let executor = WasmiExecutor;
+        let executor = Executor;
 
         let deploys_result: Result<Vec<ipc::DeployResult>, ipc::RootNotFound> = execute_deploys(
             &self,
@@ -547,10 +547,10 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn execute_deploys<A, S, E, P>(
+fn execute_deploys<S>(
     engine_state: &EngineState<S>,
-    executor: &E,
-    preprocessor: &P,
+    executor: &Executor,
+    preprocessor: &Preprocessor,
     prestate_hash: Blake2bHash,
     blocktime: BlockTime,
     deploys: &[ipc::DeployItem],
@@ -559,8 +559,6 @@ fn execute_deploys<A, S, E, P>(
 ) -> Result<Vec<ipc::DeployResult>, ipc::RootNotFound>
 where
     S: StateProvider,
-    E: Executor<A>,
-    P: Preprocessor<A>,
     EngineError: From<S::Error>,
     S::Error: Into<engine_core::execution::Error>,
 {

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -21,7 +21,7 @@ use engine_shared::gas::Gas;
 use engine_shared::newtypes::CorrelationId;
 use engine_storage::global_state::StateProvider;
 use engine_storage::protocol_data::ProtocolData;
-use engine_wasm_prep::WasmiPreprocessor;
+use engine_wasm_prep::Preprocessor;
 
 use crate::support::test_support::{self, WasmTestBuilder};
 
@@ -113,7 +113,7 @@ where
 
     let wasm_costs = *DEFAULT_WASM_COSTS;
 
-    let preprocessor = WasmiPreprocessor::new(wasm_costs);
+    let preprocessor = Preprocessor::new(wasm_costs);
     let parity_module = builder
         .get_engine_state()
         .get_module(

--- a/execution-engine/engine-wasm-prep/src/lib.rs
+++ b/execution-engine/engine-wasm-prep/src/lib.rs
@@ -27,28 +27,21 @@ pub enum PreprocessingError {
 
 use PreprocessingError::*;
 
-pub trait Preprocessor<A> {
-    fn preprocess(&self, module_bytes: &[u8]) -> Result<A, PreprocessingError>;
-    fn deserialize(&self, module_bytes: &[u8]) -> Result<A, PreprocessingError>;
-}
-
-pub struct WasmiPreprocessor {
+pub struct Preprocessor {
     wasm_costs: WasmCosts,
     // Number of memory pages.
     mem_pages: u32,
 }
 
-impl WasmiPreprocessor {
-    pub fn new(wasm_costs: WasmCosts) -> WasmiPreprocessor {
-        WasmiPreprocessor {
+impl Preprocessor {
+    pub fn new(wasm_costs: WasmCosts) -> Self {
+        Self {
             wasm_costs,
             mem_pages: MEM_PAGES,
         }
     }
-}
 
-impl Preprocessor<Module> for WasmiPreprocessor {
-    fn preprocess(&self, module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
+    pub fn preprocess(&self, module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
         let deserialized_module = self.deserialize(module_bytes)?;
         let ext_mod = externalize_mem(deserialized_module, None, self.mem_pages);
         let gas_mod = inject_gas_counters(ext_mod, &self.wasm_costs)?;
@@ -59,7 +52,7 @@ impl Preprocessor<Module> for WasmiPreprocessor {
     }
 
     // returns a parity Module from bytes without making modifications or limits
-    fn deserialize(&self, module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
+    pub fn deserialize(&self, module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
         let from_parity_err = |err: ParityWasmError| DeserializeError(err.description().to_owned());
         let module =
             parity_wasm::deserialize_buffer::<Module>(&module_bytes).map_err(from_parity_err)?;


### PR DESCRIPTION
### Overview
This PR monomorphizes the concept of an `Executor` and a `Preprocessor`.  In practice, we were achieving very little benefit from their generic definitions, and it was complicating our ability to write what was otherwise a reasonably straightforward module cache code.  

We wrote these generic abstractions assuming that we would be able to write other impls for other Wasm runtimes.  These assumptions are undercut by how closely coupled the EE is to `wasmi` in other areas.  It's simply hard to imagine another Wasm runtime plugging cleanly into our system only by virtue of these two traits.  As we have done elsewhere, we should strive to be generic when there is a clear benefit to doing so, like with our `TrieStore` trait, where we actually have two real implementations and there is a clear benefit to having them both.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-732

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
