### PR TITLE
NO-TICKET: execution-engine: remove outdated and unnecessary README

### DIFF
--- a/execution-engine/engine-grpc-server/README.md
+++ b/execution-engine/engine-grpc-server/README.md
@@ -1,9 +1,0 @@
-# COMM #
-
-This module implements a communication layer for execution engine. It is using gRPC library. Definitions for objects and services come from the `ipc.proto` file that is shared between Scala and Rust subprojects. Rust implements the server part of the gRPC services while Scala implements a client.
-
-## How to run ##
-
-In the root directory of the `comm` project run `cargo run --bin casperlabs-engine-grpc-server <socket>` where `<socket>` is the path to the socket file used for communicating between client and the server.
-
-Building `comm` requires that the [Protocol Buffers compiler](https://github.com/protocolbuffers/protobuf) `protoc` is installed and in `$PATH`.


### PR DESCRIPTION
### Overview
This PR removes `engine-grpc-server/README.md` which was outdated and is now replaced by our main documentation.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
