### PR TITLE
NO-TICKET: fix example contract calls

### DIFF
--- a/execution-engine/contracts/examples/counter-call/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-call/src/lib.rs
@@ -5,18 +5,13 @@ extern crate contract_ffi;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::ContractRef;
 use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
 #[no_mangle]
 pub extern "C" fn call() {
     let counter_uref = runtime::get_key("counter").unwrap_or_revert_with(Error::GetKey);
-    let contract_ref = match counter_uref {
-        Key::Hash(hash) => ContractRef::Hash(hash),
-        _ => runtime::revert(Error::UnexpectedKeyVariant),
-    };
+    let contract_ref = counter_uref.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
 
     {
         let args = ("inc",);

--- a/execution-engine/contracts/examples/counter-call/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-call/src/lib.rs
@@ -11,7 +11,9 @@ use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 #[no_mangle]
 pub extern "C" fn call() {
     let counter_uref = runtime::get_key("counter").unwrap_or_revert_with(Error::GetKey);
-    let contract_ref = counter_uref.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
+    let contract_ref = counter_uref
+        .to_c_ptr()
+        .unwrap_or_revert_with(Error::UnexpectedKeyVariant);
 
     {
         let args = ("inc",);

--- a/execution-engine/contracts/examples/hello-name-call/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-call/src/lib.rs
@@ -13,7 +13,9 @@ use contract_ffi::value::Value;
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("hello_name").unwrap_or_revert_with(Error::GetKey);
-    let contract_ref = contract_key.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
+    let contract_ref = contract_key
+        .to_c_ptr()
+        .unwrap_or_revert_with(Error::UnexpectedKeyVariant);
 
     let args = ("World",);
     let result: String = runtime::call_contract(contract_ref, &args, &Vec::new());

--- a/execution-engine/contracts/examples/hello-name-call/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-call/src/lib.rs
@@ -6,19 +6,15 @@ extern crate contract_ffi;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::ContractRef;
 use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::Value;
 
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("hello_name").unwrap_or_revert_with(Error::GetKey);
-    let contract_ref = match contract_key {
-        Key::Hash(hash) => ContractRef::Hash(hash),
-        _ => runtime::revert(Error::UnexpectedKeyVariant),
-    };
+    let contract_ref = contract_key.to_c_ptr().unwrap_or_revert_with(Error::UnexpectedKeyVariant);
+
     let args = ("World",);
     let result: String = runtime::call_contract(contract_ref, &args, &Vec::new());
     assert_eq!("Hello, World", result);

--- a/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use core::convert::From;
 
 use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::contract_api::{ContractRef, TURef};
+use contract_ffi::contract_api::TURef;
 use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
@@ -31,10 +31,7 @@ impl From<Error> for ApiError {
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("mailing").unwrap_or_revert_with(ApiError::GetKey);
-    let contract_ref = match contract_key {
-        Key::Hash(hash) => ContractRef::Hash(hash),
-        _ => runtime::revert(ApiError::UnexpectedKeyVariant),
-    };
+    let contract_ref = contract_key.to_c_ptr().unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);
 
     let method = "sub";
     let name = "CasperLabs";

--- a/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
@@ -7,8 +7,8 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::convert::From;
 
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
 use contract_ffi::contract_api::TURef;
+use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
 use contract_ffi::key::Key;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 
@@ -31,7 +31,9 @@ impl From<Error> for ApiError {
 #[no_mangle]
 pub extern "C" fn call() {
     let contract_key = runtime::get_key("mailing").unwrap_or_revert_with(ApiError::GetKey);
-    let contract_ref = contract_key.to_c_ptr().unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);
+    let contract_ref = contract_key
+        .to_c_ptr()
+        .unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);
 
     let method = "sub";
     let name = "CasperLabs";


### PR DESCRIPTION
### Overview
The example contracts were broken after a recent change to contract-ffi where store_function now returns a URef instead of a Hash. This change caused the match on the key look up in the call to fail. This PR fixes this. See also https://github.com/CasperLabs/contract-examples/pull/45

### Which JIRA ticket does this PR relate to?
N/A

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
