### PR TITLE
CON-555: Do not use blocks from equivocators as secondary parents.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -30,8 +30,8 @@ object Estimator {
     def tipsOfLatestMessages(
         latestMessages: List[BlockHash],
         stopHash: BlockHash
-    ): F[List[BlockHash]] =
-      if (latestMessages.isEmpty) List(genesis).pure[F]
+    ): F[List[Message]] =
+      if (latestMessages.isEmpty) dag.lookup(genesis).map(_.toList)
       else {
         // Start from the highest latest messages and traverse backwards
         implicit val ord = DagOperations.blockTopoOrderingDesc
@@ -45,9 +45,9 @@ object Estimator {
                    // We start with the tips and remove any message
                    // that is reachable through the parent-child link from other tips.
                    // This should leave us only with the tips that cannot be reached from others.
-                   .foldLeft(latestMessagesMeta.map(_.messageHash).toSet) {
+                   .foldLeft(latestMessagesMeta.toSet) {
                      case (tips, message) =>
-                       tips -- message.parents
+                       tips.filterNot(msg => message.parents.toSet.contains(msg.messageHash))
                    }
         } yield tips.toList
       }
@@ -61,20 +61,19 @@ object Estimator {
       scores        <- lmdScoring(dag, lca, latestMessageHashes, equivocators)
       newMainParent <- forkChoiceTip(dag, lca, scores)
       parents       <- tipsOfLatestMessages(latestMessagesFlattened, lca)
-      secondaryParents = parents.filter(_ != newMainParent).filterNot { message =>
+      secondaryParents = parents.filter(_.messageHash != newMainParent).filterNot { message =>
         // Filter out blocks created by equivocators from the secondary parents.
         // Secondary parents are not subject to the fork choice rule, the only requirement
         // is that they don't conflict with the main chain. This opens up possibility for various
         // kinds of attacks. An example could be a block created in the past, that includes a deploy
         // that should have expired by now, if that block did not conflict with the main parent
         // fork-choice would include it in the p-dag.
-        val creator = latestMessageHashes.find(_._2.contains(message)).map(_._1).get
-        equivocators.contains(creator)
+        equivocators.contains(message.validatorId)
       }
       sortedSecParents = secondaryParents
-        .sortBy(b => scores.getOrElse(b, Zero) -> b.toStringUtf8)
+        .sortBy(b => scores.getOrElse(b.messageHash, Zero) -> b.messageHash.toStringUtf8)
         .reverse
-    } yield newMainParent +: sortedSecParents
+    } yield newMainParent +: sortedSecParents.map(_.messageHash)
   }
 
   /** Computes scores for LMD GHOST.

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -46,7 +46,6 @@ import io.casperlabs.storage.deploy.DeployStorage
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.Gen
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.scalatest.prop.GeneratorDrivenPropertyChecks.forAll
 
@@ -688,15 +687,8 @@ class ValidationTest
         b       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(genesis), v2)
         c       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(genesis), v2)
         d       <- createValidatorBlock[Task](Seq(c, a), bonds, Seq(a, c), v3)
-        e <- {
-          // `b` and `c` create an equivocation. Their scores will be 0 but secondary parents
-          // list is sorted. If two values are the same we sort by hash.
-          // We need to make sure that block we create here has the same order of secondary parents
-          // as will be computed in the validation step.
-          val secondarySorted = Seq(b, c).sortBy(_.blockHash.toStringUtf8).reverse
-          createValidatorBlock[Task](Seq(a) ++ secondarySorted, bonds, Seq(a, b, c), v3)
-        }
-        dag <- dagStorage.getRepresentation
+        e       <- createValidatorBlock[Task](Seq(a), bonds, Seq(a, b, c), v3)
+        dag     <- dagStorage.getRepresentation
         // v3 hasn't seen v2 equivocating (in contrast to what "local" node saw).
         // It will choose C as a main parent and A as a secondary one.
         _ <- Validation[Task]


### PR DESCRIPTION
### Overview
As in the title.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-555

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Secondary parents are not subject to the fork choice rule, the only requirement is that they don't conflict with the main chain. This opens up possibility for various kinds of attacks. An example could be a block created in the past, that includes a deploy that should have expired by now, if that block did not conflict with the main parent fork-choice would include it in the p-dag.
