### PR TITLE
EE-420: Rewrite purse to purse client side.

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/system.rs
+++ b/execution-engine/contract-ffi/src/contract_api/system.rs
@@ -9,11 +9,9 @@ use crate::bytesrepr::deserialize;
 use crate::contract_api::error::result_from;
 use crate::ext_ffi;
 use crate::key::Key;
-use crate::system_contracts::mint;
-use crate::system_contracts::SystemContract;
+use crate::system_contracts::{mint, SystemContract};
 use crate::unwrap_or_revert::UnwrapOrRevert;
-use crate::uref::URef;
-use crate::uref::UREF_SIZE_SERIALIZED;
+use crate::uref::{URef, UREF_SIZE_SERIALIZED};
 use crate::value::account::{PublicKey, PurseId, PURSE_ID_SIZE_SERIALIZED};
 use crate::value::U512;
 
@@ -168,9 +166,5 @@ pub fn transfer_from_purse_to_purse(
     let mint_result: Result<(), mint::Error> =
         runtime::call_contract(mint_contract_ref, &args, &extra_urefs);
 
-    if mint_result.is_ok() {
-        Ok(())
-    } else {
-        Err(Error::Transfer)
-    }
+    mint_result.map_err(|_| Error::Transfer)
 }

--- a/execution-engine/contract-ffi/src/ext_ffi.rs
+++ b/execution-engine/contract-ffi/src/ext_ffi.rs
@@ -74,14 +74,6 @@ extern "C" {
         amount_ptr: *const u8,
         amount_size: usize,
     ) -> i32;
-    pub fn transfer_from_purse_to_purse(
-        source_ptr: *const u8,
-        source_size: usize,
-        target_ptr: *const u8,
-        target_size: usize,
-        amount_ptr: *const u8,
-        amount_size: usize,
-    ) -> i32;
     pub fn get_balance(purse_id_ptr: *const u8, purse_id_size: usize) -> i32;
     pub fn get_phase(dest_ptr: *mut u8);
     pub fn upgrade_contract_at_uref(

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -380,26 +380,6 @@ where
                 Ok(Some(RuntimeValue::I32(TransferredTo::i32_from(ret))))
             }
 
-            FunctionIndex::TransferFromPurseToPurseIndex => {
-                // args(0) = pointer to array of bytes in Wasm memory of a source purse
-                // args(1) = length of array of bytes in Wasm memory of a source purse
-                // args(2) = pointer to array of bytes in Wasm memory of a target purse
-                // args(3) = length of array of bytes in Wasm memory of a target purse
-                // args(4) = pointer to array of bytes in Wasm memory of an amount
-                // args(5) = length of array of bytes in Wasm memory of an amount
-                let (source_ptr, source_size, target_ptr, target_size, amount_ptr, amount_size) =
-                    Args::parse(args)?;
-                let ret = self.transfer_from_purse_to_purse(
-                    source_ptr,
-                    source_size,
-                    target_ptr,
-                    target_size,
-                    amount_ptr,
-                    amount_size,
-                )?;
-                Ok(Some(RuntimeValue::I32(contract_api::i32_from(ret))))
-            }
-
             FunctionIndex::GetBalanceIndex => {
                 // args(0) = pointer to purse_id input
                 // args(1) = length of purse_id

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -894,43 +894,6 @@ where
         }
     }
 
-    /// Transfers `amount` of motes from `source` purse to `target` purse.
-    fn transfer_from_purse_to_purse(
-        &mut self,
-        source_ptr: u32,
-        source_size: u32,
-        target_ptr: u32,
-        target_size: u32,
-        amount_ptr: u32,
-        amount_size: u32,
-    ) -> Result<Result<(), ApiError>, Error> {
-        let source: PurseId = {
-            let bytes = self.bytes_from_mem(source_ptr, source_size as usize)?;
-            deserialize(&bytes).map_err(Error::BytesRepr)?
-        };
-
-        let target: PurseId = {
-            let bytes = self.bytes_from_mem(target_ptr, target_size as usize)?;
-            deserialize(&bytes).map_err(Error::BytesRepr)?
-        };
-
-        let amount: U512 = {
-            let bytes = self.bytes_from_mem(amount_ptr, amount_size as usize)?;
-            deserialize(&bytes).map_err(Error::BytesRepr)?
-        };
-
-        let mint_contract_key = self.get_mint_contract_uref().into();
-
-        if self
-            .mint_transfer(mint_contract_key, source, target, amount)
-            .is_ok()
-        {
-            Ok(Ok(()))
-        } else {
-            Ok(Err(ApiError::Transfer))
-        }
-    }
-
     fn get_balance(&mut self, purse_id: PurseId) -> Result<Option<U512>, Error> {
         let seed = self.get_mint_contract_uref().addr();
 

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -37,12 +37,11 @@ pub enum FunctionIndex {
     CreatePurseIndex = 30,
     TransferToAccountIndex = 31,
     TransferFromPurseToAccountIndex = 32,
-    TransferFromPurseToPurseIndex = 33,
-    GetBalanceIndex = 34,
-    GetPhaseIndex = 35,
-    UpgradeContractAtURefIndex = 36,
-    GetSystemContractIndex = 37,
-    GetMainPurseIndex = 38,
+    GetBalanceIndex = 33,
+    GetPhaseIndex = 34,
+    UpgradeContractAtURefIndex = 35,
+    GetSystemContractIndex = 36,
+    GetMainPurseIndex = 37,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -173,10 +173,6 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
                 FunctionIndex::TransferFromPurseToAccountIndex.into(),
             ),
-            "transfer_from_purse_to_purse" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 6][..], Some(ValueType::I32)),
-                FunctionIndex::TransferFromPurseToPurseIndex.into(),
-            ),
             "get_balance" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], Some(ValueType::I32)),
                 FunctionIndex::GetBalanceIndex.into(),


### PR DESCRIPTION
### Overview
_Provide a brief description of what this PR does, and why it's needed._

Rewrites `transfer_from_purse_to_purse` with client-side logic by execution `"transfer"` on mint contract.

Blocked by #1301 which implements the benchmarks.

After applying this change on top of #1301 and re-running only purse-related benchmarks the results on my machine suggests no performance regression (changes within noise threshold)

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

https://casperlabs.atlassian.net/browse/EE-420

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
