### PR TITLE
NODE-845: Alternative sources before exponential backoff

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.3


### PR DESCRIPTION
### Overview
Increases exponential backoff only after traversing all sources. Previously, it was sticking to a single source, switching to others only after exhausting all possible tryings and unoptimistically spending too much time.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-845

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I strongly suggest to start reviewing the PR by looking on the changed unit test first, I've tried to graphically show how the new algorithm looks like.
