### PR TITLE
CON-557: J-past-cone of the message cannot merge its creator's swimlane.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
@@ -47,6 +47,7 @@ final case object InvalidDeployCount     extends InvalidBlock with Slashable
 final case object InvalidDeployHash      extends InvalidBlock with Slashable
 final case object InvalidDeploySignature extends InvalidBlock with Slashable
 final case object InvalidDeployHeader    extends InvalidBlock with Slashable
+final case object SwimlaneMerged         extends InvalidBlock with Slashable
 final case object DeployDependencyNotMet extends InvalidBlock with Slashable
 final case object DeployExpired          extends InvalidBlock with Slashable
 final case object DeployFromFuture       extends InvalidBlock with Slashable

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -737,7 +737,7 @@ object MultiParentCasperImpl {
             InvalidRepeatDeploy | InvalidChainName | InvalidBlockHash | InvalidDeployCount |
             InvalidDeployHash | InvalidDeploySignature | InvalidPreStateHash |
             InvalidPostStateHash | InvalidTargetHash | InvalidDeployHeader |
-            DeployDependencyNotMet | DeployExpired | DeployFromFuture =>
+            DeployDependencyNotMet | DeployExpired | DeployFromFuture | SwimlaneMerged =>
           handleInvalidBlockEffect(status, block) *> dag.pure[F]
 
         case Processing | Processed =>
@@ -857,7 +857,7 @@ object MultiParentCasperImpl {
               InvalidSequenceNumber | InvalidPrevBlockHash | NeglectedInvalidBlock |
               InvalidTransaction | InvalidBondsCache | InvalidRepeatDeploy | InvalidChainName |
               InvalidBlockHash | InvalidDeployCount | InvalidDeployHash | InvalidDeploySignature |
-              InvalidPreStateHash | InvalidPostStateHash | Processing | Processed |
+              InvalidPreStateHash | InvalidPostStateHash | Processing | Processed | SwimlaneMerged |
               InvalidTargetHash | InvalidDeployHeader | DeployDependencyNotMet | DeployExpired =>
             ().pure[F]
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -1,6 +1,6 @@
 package io.casperlabs.casper.validation
 
-import cats.Applicative
+import cats.{Applicative, Monad}
 import cats.implicits._
 import cats.mtl.FunctorRaise
 import com.google.protobuf.ByteString
@@ -128,6 +128,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
       _ <- blockRank(summary, dag)
       _ <- validatorPrevBlockHash(summary, dag)
       _ <- sequenceNumber(summary, dag)
+      _ <- swimlane(summary, dag)
       // Checks that need the body.
       _ <- blockHash(block)
       _ <- deployCount(block)
@@ -408,6 +409,46 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log
     FunctorRaise[F, InvalidBlock]
       .raise[Unit](InvalidTargetHash)
       .whenA(b.getHeader.messageType.isBallot && b.getHeader.parentHashes.size != 1)
+
+  // Check whether message merges its creator swimlane.
+  // A block cannot have more than one latest message in its j-past-cone from its creator.
+  // i.e. an equivocator cannot cite multiple of its latest messages.
+  def swimlane(b: BlockSummary, dag: DagRepresentation[F]): F[Unit] =
+    for {
+      equivocators <- dag.getEquivocators
+      message      <- MonadThrowable[F].fromTry(Message.fromBlockSummary(b))
+      _ <- Monad[F].whenA(equivocators.contains(message.validatorId)) {
+            for {
+              equivocations       <- dag.getEquivocations.map(_(message.validatorId))
+              equivocationsHashes = equivocations.map(_.messageHash)
+              minRank = EquivocationDetector
+                .findMinBaseRank(Map(message.validatorId -> equivocations))
+                .getOrElse(0L) // We know it has to be defined by this point.
+              seenEquivocations <- DagOperations
+                                    .swimlaneV[F](message.validatorId, message, dag)
+                                    .foldWhileLeft(Set.empty[BlockHash]) {
+                                      case (seenEquivocations, message) =>
+                                        if (message.rank <= minRank) {
+                                          Right(seenEquivocations)
+                                        } else {
+                                          if (equivocationsHashes.contains(message.messageHash)) {
+                                            if (seenEquivocations.nonEmpty) {
+                                              Right(seenEquivocations + message.messageHash)
+                                            } else Left(Set(message.messageHash))
+                                          } else Left(seenEquivocations)
+                                        }
+                                    }
+              _ <- Monad[F].whenA(seenEquivocations.size > 1) {
+                    val msg =
+                      s"${message.messageHash} cites multiple latest message by its creator ${message.validatorId}: ${seenEquivocations
+                        .map(PrettyPrinter.buildString)
+                        .mkString("[", ",", "]")}"
+                    Log[F].warn(ignore(b, msg)) *> FunctorRaise[F, InvalidBlock]
+                      .raise[Unit](SwimlaneMerged)
+                  }
+            } yield ()
+          }
+    } yield ()
 
   /**
     * Works with either efficient justifications or full explicit justifications.

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -644,7 +644,7 @@ class ValidationTest
       .groupBy(_._1)
       .mapValues(_.map(_._2).toSet)
 
-  def createValidatorBlock[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage: DeployStorage](
+  def createValidatorBlock[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage](
       parents: Seq[Block],
       bonds: Seq[Bond],
       justifications: Seq[Block],
@@ -662,7 +662,7 @@ class ValidationTest
     } yield block
 
   "Parent validation" should "return true for proper justifications and false otherwise" in withStorage {
-    implicit blockStorage => implicit dagStorage => implicit deployStorage =>
+    implicit blockStorage => implicit dagStorage => _ =>
       val v0 = generateValidator("V1")
       val v1 = generateValidator("V2")
       val v2 = generateValidator("V3")
@@ -750,7 +750,7 @@ class ValidationTest
 
   // See [[/resources/casper/localDetectedForeignDidnt.jpg]]
   it should "use only j-past-cone of the block when detecting equivocators" in withStorage {
-    implicit blockStorage => implicit dagStorage => implicit deployStorage =>
+    implicit blockStorage => implicit dagStorage => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
       val v2 = generateValidator("v2")
@@ -1239,6 +1239,54 @@ class ValidationTest
                          )
         Right(postStateHash) = validateResult
       } yield postStateHash should be(computedPostStateHash)
+  }
+
+  "j-past-cone of the block" should "not merge equivocator's swimlane" in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      val v0 = generateValidator("v0")
+      val v1 = generateValidator("v1")
+
+      val bondsMap = Map(
+        v0 -> 2,
+        v1 -> 3
+      )
+
+      val bonds = bondsMap.map(b => Bond(b._1, b._2)).toSeq
+
+      for {
+        genesis <- createAndStoreBlock[Task](Seq.empty, bonds = bonds)
+        a       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
+        b       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
+        c       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(a), v1)
+        d       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(b, c), v0)
+        dag     <- dagStorage.getRepresentation
+        _ <- ValidationImpl[Task].swimlane(d, dag).attempt shouldBeF Left(
+              ValidateErrorWrapper(SwimlaneMerged)
+            )
+      } yield ()
+  }
+
+  it should "not raise errors when j-past-cone does not merge a swmilane" in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      val v0 = generateValidator("v0")
+      val v1 = generateValidator("v1")
+
+      val bondsMap = Map(
+        v0 -> 2,
+        v1 -> 3
+      )
+
+      val bonds = bondsMap.map(b => Bond(b._1, b._2)).toSeq
+
+      for {
+        genesis <- createAndStoreBlock[Task](Seq.empty, bonds = bonds)
+        a       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
+        _       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
+        c       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(a), v1)
+        d       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(a, c), v0)
+        dag     <- dagStorage.getRepresentation
+        _       <- ValidationImpl[Task].swimlane(d, dag).attempt shouldBeF Right(())
+      } yield ()
   }
 
   // TODO: Bring back once there is an easy way to create a _valid_ block.

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -1258,7 +1258,7 @@ class ValidationTest
         a       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
         b       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
         c       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(a), v1)
-        d       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(b, c), v0)
+        d       <- createValidatorBlock[Task](Seq(b), bonds, Seq(c), v0)
         dag     <- dagStorage.getRepresentation
         _ <- ValidationImpl[Task].swimlane(d, dag).attempt shouldBeF Left(
               ValidateErrorWrapper(SwimlaneMerged)
@@ -1283,7 +1283,7 @@ class ValidationTest
         a       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
         _       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq.empty, v0)
         c       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(a), v1)
-        d       <- createValidatorBlock[Task](Seq(genesis), bonds, Seq(a, c), v0)
+        d       <- createValidatorBlock[Task](Seq(a), bonds, Seq(c), v0)
         dag     <- dagStorage.getRepresentation
         _       <- ValidationImpl[Task].swimlane(d, dag).attempt shouldBeF Right(())
       } yield ()


### PR DESCRIPTION
### Overview
Reject block as invalid if its j-past-cone cites more than one latest message by its creator.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-557

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
