### PR TITLE
NODE-935: Print deploy information in Scala CLI client

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -9,10 +9,20 @@ import scala.util.Either
 @typeclass trait DeployService[F[_]] {
   def deploy(d: consensus.Deploy): F[Either[Throwable, String]]
   def propose(): F[Either[Throwable, String]]
-  def showBlock(blockHash: String): F[Either[Throwable, BlockInfo]]
-  def showDeploys(blockHash: String): F[Either[Throwable, String]]
-  def showDeploy(blockHash: String): F[Either[Throwable, String]]
-  def showBlocks(depth: Int): F[Either[Throwable, String]]
+  def showBlock(
+      blockHash: String
+  ): F[Either[Throwable, BlockInfo]]
+  def showDeploys(
+      blockHash: String,
+      bytesStandard: Boolean,
+      json: Boolean
+  ): F[Either[Throwable, String]]
+  def showDeploy(
+      blockHash: String,
+      bytesStandard: Boolean,
+      json: Boolean
+  ): F[Either[Throwable, String]]
+  def showBlocks(depth: Int, bytesStandard: Boolean, json: Boolean): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]
   def queryState(
       blockHash: String,

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -136,7 +136,7 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
   def showDeploy(hash: String): Task[Either[Throwable, String]] =
     casperServiceStub
       .getDeployInfo(GetDeployInfoRequest(hash, DeployInfo.View.BASIC))
-      .map(Printer.printToUnicodeString(_))
+      .map(Printer.ProtoString.print(_, base16 = true))
       .attempt
 
   def showDeploys(hash: String): Task[Either[Throwable, String]] =
@@ -147,7 +147,7 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
         case (d, idx) =>
           s"""
          |------------- deploy # $hash / $idx ---------------
-         |${Printer.printToUnicodeString(d)}
+         |${Printer.ProtoString.print(d, base16 = true)}
          |---------------------------------------------------
          |""".stripMargin
       }
@@ -206,7 +206,7 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       .map { bi =>
         s"""
          |------------- block @ ${bi.getSummary.rank} ---------------
-         |${Printer.printToUnicodeString(bi)}
+         |${Printer.ProtoString.print(bi, base16 = true)}
          |-----------------------------------------------------
          |""".stripMargin
       }

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -133,23 +133,35 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       .getBlockInfo(GetBlockInfoRequest(hash, BlockInfo.View.FULL))
       .attempt
 
-  def showDeploy(hash: String): Task[Either[Throwable, String]] =
+  def showDeploy(
+      hash: String,
+      bytesStandard: Boolean,
+      json: Boolean
+  ): Task[Either[Throwable, String]] =
     casperServiceStub
       .getDeployInfo(GetDeployInfoRequest(hash, DeployInfo.View.BASIC))
-      .map(Printer.ProtoString.print(_, base16 = true))
+      .map(Printer.print(_, bytesStandard, json))
       .attempt
 
-  def showDeploys(hash: String): Task[Either[Throwable, String]] =
+  def showDeploys(
+      hash: String,
+      bytesStandard: Boolean,
+      json: Boolean
+  ): Task[Either[Throwable, String]] =
     casperServiceStub
       .streamBlockDeploys(StreamBlockDeploysRequest(hash, DeployInfo.View.BASIC))
       .zipWithIndex
       .map {
         case (d, idx) =>
-          s"""
-         |------------- deploy # $hash / $idx ---------------
-         |${Printer.ProtoString.print(d, base16 = true)}
-         |---------------------------------------------------
-         |""".stripMargin
+          if (json) {
+            Printer.print(d, bytesStandard, json = true)
+          } else {
+            s"""
+               |------------- deploy # $hash / $idx ---------------
+               |${Printer.print(d, bytesStandard, json = false)}
+               |---------------------------------------------------
+               |""".stripMargin
+          }
       }
       .toListL
       .map { xs =>
@@ -200,15 +212,23 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       }
       .attempt
 
-  def showBlocks(depth: Int): Task[Either[Throwable, String]] =
+  def showBlocks(
+      depth: Int,
+      bytesStandard: Boolean,
+      json: Boolean
+  ): Task[Either[Throwable, String]] =
     casperServiceStub
       .streamBlockInfos(StreamBlockInfosRequest(depth = depth, view = BlockInfo.View.BASIC))
       .map { bi =>
-        s"""
-         |------------- block @ ${bi.getSummary.rank} ---------------
-         |${Printer.ProtoString.print(bi, base16 = true)}
-         |-----------------------------------------------------
-         |""".stripMargin
+        if (json) {
+          Printer.print(bi, bytesStandard, json = true)
+        } else {
+          s"""
+           |------------- block @ ${bi.getSummary.rank} ---------------
+           |${Printer.print(bi, bytesStandard, json = false)}
+           |-----------------------------------------------------
+           |""".stripMargin
+        }
       }
       .toListL
       .map { xs =>

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -47,10 +47,14 @@ object Main {
       configuration: Configuration
   ): F[Unit] =
     configuration match {
-      case ShowBlock(hash)   => DeployRuntime.showBlock(hash)
-      case ShowDeploy(hash)  => DeployRuntime.showDeploy(hash)
-      case ShowDeploys(hash) => DeployRuntime.showDeploys(hash)
-      case ShowBlocks(depth) => DeployRuntime.showBlocks(depth)
+      case ShowBlock(hash, bytesStandard, json) =>
+        DeployRuntime.showBlock(hash, bytesStandard, json)
+      case ShowDeploy(hash, bytesStandard, json) =>
+        DeployRuntime.showDeploy(hash, bytesStandard, json)
+      case ShowDeploys(hash, bytesStandard, json) =>
+        DeployRuntime.showDeploys(hash, bytesStandard, json)
+      case ShowBlocks(depth, bytesStandard, json) =>
+        DeployRuntime.showBlocks(depth, bytesStandard, json)
       case Unbond(
           amount,
           contracts,
@@ -134,8 +138,8 @@ object Main {
       case SendDeploy(deploy) =>
         DeployRuntime.sendDeploy(deploy)
 
-      case PrintDeploy(deploy, base16, proto) =>
-        DeployRuntime.printDeploy(deploy, base16, proto)
+      case PrintDeploy(deploy, bytesStandard, json) =>
+        DeployRuntime.printDeploy(deploy, bytesStandard, json)
 
       case Sign(deploy, signedDeployOut, publicKey, privateKey) =>
         DeployRuntime.sign(deploy, signedDeployOut, publicKey, privateKey)
@@ -146,8 +150,8 @@ object Main {
       case VisualizeDag(depth, showJustificationLines, out, streaming) =>
         DeployRuntime.visualizeDag(depth, showJustificationLines, out, streaming)
 
-      case Query(hash, keyType, keyValue, path) =>
-        DeployRuntime.queryState(hash, keyType, keyValue, path)
+      case Query(hash, keyType, keyValue, path, bytesStandard, json) =>
+        DeployRuntime.queryState(hash, keyType, keyValue, path, bytesStandard, json)
 
       case Balance(address, blockHash) =>
         DeployRuntime.balance(address, blockHash)

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -134,6 +134,9 @@ object Main {
       case SendDeploy(deploy) =>
         DeployRuntime.sendDeploy(deploy)
 
+      case PrintDeploy(deploy, base16, proto) =>
+        DeployRuntime.printDeploy(deploy, base16, proto)
+
       case Sign(deploy, signedDeployOut, publicKey, privateKey) =>
         DeployRuntime.sign(deploy, signedDeployOut, publicKey, privateKey)
 

--- a/client/src/main/scala/io/casperlabs/client/Printer.scala
+++ b/client/src/main/scala/io/casperlabs/client/Printer.scala
@@ -1,95 +1,152 @@
 package io.casperlabs.client
 
-import io.casperlabs.crypto.codec.Base16
 import java.math.BigInteger
+
+import com.google.protobuf.ByteString
+import io.casperlabs.crypto.codec.Base16
+import io.circe.Json
 import scalapb.GeneratedMessage
-import scalapb.descriptors.{FieldDescriptor, PByteString, PEmpty, PMessage, PRepeated, PValue}
-import scalapb.textformat.{TextGenerator}
+import scalapb.descriptors._
+import scalapb.textformat.TextGenerator
 
-/** Based on what scalapb `toProtoString` does but using Base16 for bytes. */
+import scala.collection.mutable
+
+sealed trait Printer {
+  def print(m: GeneratedMessage, base16: Boolean): String
+}
+
 object Printer {
-  def printToUnicodeString(m: GeneratedMessage) = {
-    val out = new TextGenerator(singleLine = false, escapeNonAscii = false)
-    print(m.toPMessage, out)
-    out.result()
-  }
 
-  def print(p: PMessage, out: TextGenerator): Unit =
-    p.value.toSeq.sortBy(_._1.number).foreach {
-      case (fd, value) => printField(fd, value, out)
+  /** Based on what scalapb-circe `JsonFormat.toJsonString` does but allows to customize Base16/Base64 for bytes. */
+  object Json extends Printer {
+    private val base16Printer = new scalapb_circe.Printer() {
+      override def serializeSingleValue(
+          fd: FieldDescriptor,
+          value: PValue,
+          formattingLongAsNumber: Boolean
+      ): Json =
+        value match {
+          case PByteString(value) =>
+            io.circe.Json.fromString(Base16.encode(value.toByteArray))
+          case v => super.serializeSingleValue(fd, v, formattingLongAsNumber)
+        }
     }
+    private val base64Printer = new scalapb_circe.Printer()
+    private val indent        = ' '.toString * 2
 
-  def printField(fd: FieldDescriptor, value: PValue, out: TextGenerator): Unit = value match {
-    case PRepeated(values) =>
-      values.foreach(v => printSingleField(fd, v, out))
-    case PEmpty =>
-    case _ =>
-      printSingleField(fd, value, out)
-  }
-
-  def printSingleField(fd: FieldDescriptor, value: PValue, out: TextGenerator) = {
-    out.add(fd.name)
-    value match {
-      case PMessage(_) =>
-        out.addNewLine(" {").indent()
-        printFieldValue(fd, value, out)
-        out.outdent().addNewLine("}")
-      case _ =>
-        out.add(": ")
-        printFieldValue(fd, value, out)
-        out.addNewLine("")
+    override def print(m: GeneratedMessage, base16: Boolean): String = {
+      val json = if (base16) base16Printer.toJson(m) else base64Printer.toJson(m)
+      json.pretty(io.circe.Printer.indented(indent))
     }
   }
 
-  def printFieldValue(fd: FieldDescriptor, value: PValue, out: TextGenerator): Unit =
-    value match {
-      case scalapb.descriptors.PInt(v) =>
-        if (fd.protoType.isTypeUint32 || fd.protoType.isTypeFixed32)
-          out.add(unsignedToString(v))
-        else
+  /** Based on what scalapb `toProtoString` does but but allows to customize Base16/Base64 for bytes. */
+  object ProtoString extends Printer {
+    override def print(m: GeneratedMessage, base16: Boolean): String =
+      if (base16) {
+        this.printToUnicodeString(m)
+      } else {
+        scalapb.TextFormat.printToUnicodeString(m)
+      }
+
+    private def printToUnicodeString(m: GeneratedMessage) = {
+      val out = new TextGenerator(singleLine = false, escapeNonAscii = false)
+      print(m.toPMessage, out)
+      out.result()
+      out.result()
+    }
+
+    private def print(p: PMessage, out: TextGenerator): Unit =
+      p.value.toSeq.sortBy(_._1.number).foreach {
+        case (fd, value) => printField(fd, value, out)
+      }
+
+    private def printField(
+        fd: FieldDescriptor,
+        value: PValue,
+        out: TextGenerator
+    ): Unit =
+      value match {
+        case PRepeated(values) =>
+          values.foreach(v => printSingleField(fd, v, out))
+        case PEmpty =>
+        case _ =>
+          printSingleField(fd, value, out)
+      }
+
+    private def printSingleField(
+        fd: FieldDescriptor,
+        value: PValue,
+        out: TextGenerator
+    ) = {
+      out.add(fd.name)
+      value match {
+        case PMessage(_) =>
+          out.addNewLine(" {").indent()
+          printFieldValue(fd, value, out)
+          out.outdent().addNewLine("}")
+        case _ =>
+          out.add(": ")
+          printFieldValue(fd, value, out)
+          out.addNewLine("")
+      }
+    }
+
+    private def printFieldValue(
+        fd: FieldDescriptor,
+        value: PValue,
+        out: TextGenerator
+    ): Unit =
+      value match {
+        case scalapb.descriptors.PInt(v) =>
+          if (fd.protoType.isTypeUint32 || fd.protoType.isTypeFixed32)
+            out.add(unsignedToString(v))
+          else
+            out.add(v.toString)
+        case scalapb.descriptors.PLong(v) =>
+          if (fd.protoType.isTypeUint64 || fd.protoType.isTypeFixed64)
+            out.add(unsignedToString(v))
+          else
+            out.add(v.toString)
+        case scalapb.descriptors.PBoolean(v) =>
           out.add(v.toString)
-      case scalapb.descriptors.PLong(v) =>
-        if (fd.protoType.isTypeUint64 || fd.protoType.isTypeFixed64)
-          out.add(unsignedToString(v))
-        else
+        case scalapb.descriptors.PFloat(v) =>
           out.add(v.toString)
-      case scalapb.descriptors.PBoolean(v) =>
-        out.add(v.toString)
-      case scalapb.descriptors.PFloat(v) =>
-        out.add(v.toString)
-      case scalapb.descriptors.PDouble(v) =>
-        out.add(v.toString)
-      case scalapb.descriptors.PEnum(v) =>
-        if (!v.isUnrecognized)
-          out.add(v.name)
-        else
-          out.add(v.number.toString)
-      case e: scalapb.descriptors.PMessage =>
-        print(e, out)
-      case scalapb.descriptors.PString(v) =>
-        out
-          .add("\"")
-          .addMaybeEscape(v)
-          .add("\"")
-      case scalapb.descriptors.PByteString(v) =>
-        out
-          .add("\"")
-          //.add(textformat.TextFormatUtils.escapeBytes(v))
-          .add(Base16.encode(v.toByteArray))
-          .add("\"")
-      case scalapb.descriptors.PRepeated(_) =>
-        throw new RuntimeException("Should not happen.")
-      case scalapb.descriptors.PEmpty =>
-        throw new RuntimeException("Should not happen.")
-    }
+        case scalapb.descriptors.PDouble(v) =>
+          out.add(v.toString)
+        case scalapb.descriptors.PEnum(v) =>
+          if (!v.isUnrecognized)
+            out.add(v.name)
+          else
+            out.add(v.number.toString)
+        case e: scalapb.descriptors.PMessage =>
+          print(e, out)
+        case scalapb.descriptors.PString(v) =>
+          out
+            .add("\"")
+            .addMaybeEscape(v)
+            .add("\"")
+        case scalapb.descriptors.PByteString(v) =>
+          out
+            .add("\"")
+            //.add(textformat.TextFormatUtils.escapeBytes(v))
+            .add(Base16.encode(v.toByteArray))
+            .add("\"")
+        case scalapb.descriptors.PRepeated(_) =>
+          throw new RuntimeException("Should not happen.")
+        case scalapb.descriptors.PEmpty =>
+          throw new RuntimeException("Should not happen.")
+      }
 
-  /** Convert an unsigned 32-bit integer to a string. */
-  def unsignedToString(value: Int): String =
-    if (value >= 0) java.lang.Integer.toString(value)
-    else java.lang.Long.toString(value & 0X00000000FFFFFFFFL)
+    /** Convert an unsigned 32-bit integer to a string. */
+    private def unsignedToString(value: Int): String =
+      if (value >= 0) java.lang.Integer.toString(value)
+      else java.lang.Long.toString(value & 0X00000000FFFFFFFFL)
 
-  /** Convert an unsigned 64-bit integer to a string. */
-  def unsignedToString(value: Long): String =
-    if (value >= 0) java.lang.Long.toString(value)
-    else BigInteger.valueOf(value & 0X7FFFFFFFFFFFFFFFL).setBit(63).toString
+    /** Convert an unsigned 64-bit integer to a string. */
+    private def unsignedToString(value: Long): String =
+      if (value >= 0) java.lang.Long.toString(value)
+      else BigInteger.valueOf(value & 0X7FFFFFFFFFFFFFFFL).setBit(63).toString
+  }
+
 }

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -127,6 +127,10 @@ object DeployConfig {
 }
 
 sealed trait Configuration
+sealed trait Formatting {
+  def bytesStandard: Boolean
+  def json: Boolean
+}
 
 final case class MakeDeploy(
     from: Option[String],
@@ -141,9 +145,10 @@ final case class SendDeploy(
 
 final case class PrintDeploy(
     deploy: Array[Byte],
-    base16: Boolean,
-    proto: Boolean
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 
 final case class Deploy(
     from: Option[String],
@@ -163,10 +168,18 @@ final case class Sign(
 
 final case object Propose extends Configuration
 
-final case class ShowBlock(blockHash: String)   extends Configuration
-final case class ShowDeploys(blockHash: String) extends Configuration
-final case class ShowDeploy(deployHash: String) extends Configuration
-final case class ShowBlocks(depth: Int)         extends Configuration
+final case class ShowBlock(blockHash: String, bytesStandard: Boolean, json: Boolean)
+    extends Configuration
+    with Formatting
+final case class ShowDeploys(blockHash: String, bytesStandard: Boolean, json: Boolean)
+    extends Configuration
+    with Formatting
+final case class ShowDeploy(deployHash: String, bytesStandard: Boolean, json: Boolean)
+    extends Configuration
+    with Formatting
+final case class ShowBlocks(depth: Int, bytesStandard: Boolean, json: Boolean)
+    extends Configuration
+    with Formatting
 final case class Bond(
     amount: Long,
     deployConfig: DeployConfig,
@@ -201,8 +214,11 @@ final case class Query(
     blockHash: String,
     keyType: String,
     key: String,
-    path: String
+    path: String,
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 
 object Configuration {
 
@@ -236,8 +252,8 @@ object Configuration {
       case options.printDeploy =>
         PrintDeploy(
           options.printDeploy.deployPath(),
-          options.printDeploy.base16(),
-          options.printDeploy.proto()
+          options.printDeploy.bytesStandard(),
+          options.printDeploy.json()
         )
       case options.signDeploy =>
         Sign(
@@ -249,13 +265,29 @@ object Configuration {
       case options.propose =>
         Propose
       case options.showBlock =>
-        ShowBlock(options.showBlock.hash())
+        ShowBlock(
+          options.showBlock.hash(),
+          options.showBlock.bytesStandard(),
+          options.showBlock.json()
+        )
       case options.showDeploys =>
-        ShowDeploys(options.showDeploys.hash())
+        ShowDeploys(
+          options.showDeploys.hash(),
+          options.showDeploys.bytesStandard(),
+          options.showDeploys.json()
+        )
       case options.showDeploy =>
-        ShowDeploy(options.showDeploy.hash())
+        ShowDeploy(
+          options.showDeploy.hash(),
+          options.showDeploy.bytesStandard(),
+          options.showDeploy.json()
+        )
       case options.showBlocks =>
-        ShowBlocks(options.showBlocks.depth())
+        ShowBlocks(
+          options.showBlocks.depth(),
+          options.showBlocks.bytesStandard(),
+          options.showBlocks.json()
+        )
       case options.unbond =>
         Unbond(
           options.unbond.amount.toOption,
@@ -287,7 +319,9 @@ object Configuration {
           options.query.blockHash(),
           options.query.keyType(),
           options.query.key(),
-          options.query.path()
+          options.query.path(),
+          options.query.bytesStandard(),
+          options.query.json()
         )
       case options.balance =>
         Balance(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -139,6 +139,12 @@ final case class SendDeploy(
     deploy: Array[Byte]
 ) extends Configuration
 
+final case class PrintDeploy(
+    deploy: Array[Byte],
+    base16: Boolean,
+    proto: Boolean
+) extends Configuration
+
 final case class Deploy(
     from: Option[String],
     deployConfig: DeployConfig,
@@ -227,6 +233,12 @@ object Configuration {
         )
       case options.sendDeploy =>
         SendDeploy(options.sendDeploy.deployPath())
+      case options.printDeploy =>
+        PrintDeploy(
+          options.printDeploy.deployPath(),
+          options.printDeploy.base16(),
+          options.printDeploy.proto()
+        )
       case options.signDeploy =>
         Sign(
           options.signDeploy.deployPath(),

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -141,6 +141,23 @@ object Options {
     }
   }
 
+  trait FormattingOptions { self: Subcommand =>
+    val bytesStandard = opt[Boolean](
+      required = false,
+      descr =
+        "Use standard encoding for bytes instead of default Base16, for JSON standard is Base64, for Protobuf text - ASCII escaped",
+      default = false.some,
+      name = "bytes-standard"
+    )
+
+    val json = opt[Boolean](
+      required = false,
+      descr = "Output in JSON instead of default Protobuf text encoding",
+      default = false.some,
+      name = "json",
+      short = 'j'
+    )
+  }
 }
 
 final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) {
@@ -324,7 +341,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(propose)
 
-  val showBlock = new Subcommand("show-block") {
+  val showBlock = new Subcommand("show-block") with FormattingOptions {
     descr(
       "View properties of a block known by Casper on an existing running node."
     )
@@ -339,7 +356,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showBlock)
 
-  val showDeploys = new Subcommand("show-deploys") {
+  val showDeploys = new Subcommand("show-deploys") with FormattingOptions {
     descr(
       "View deploys included in a block."
     )
@@ -354,7 +371,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showDeploys)
 
-  val showDeploy = new Subcommand("show-deploy") {
+  val showDeploy = new Subcommand("show-deploy") with FormattingOptions {
     descr(
       "View properties of a deploy known by Casper on an existing running node."
     )
@@ -369,24 +386,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showDeploy)
 
-  val printDeploy = new Subcommand("print-deploy") {
-    descr("Print information of a deploy saved by 'make-deploy' command in JSON/proto format")
-
-    val base16 = opt[Boolean](
-      required = false,
-      descr =
-        "Use Base16 for bytes encoding instead of default Base64 for JSON or ASCII escaped for '--proto'",
-      default = false.some,
-      name = "base16",
-      short = 'b'
-    )
-
-    val proto = opt[Boolean](
-      required = false,
-      descr = "Use Protobuf text format instead of default JSON",
-      default = false.some,
-      name = "proto"
-    )
+  val printDeploy = new Subcommand("print-deploy") with FormattingOptions {
+    descr("Print information of a deploy saved by 'make-deploy' command")
 
     val deployPath =
       opt[File](
@@ -399,7 +400,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(printDeploy)
 
-  val showBlocks = new Subcommand("show-blocks") {
+  val showBlocks = new Subcommand("show-blocks") with FormattingOptions {
     descr(
       "View list of blocks in the current Casper view on an existing running node."
     )
@@ -519,7 +520,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(visualizeBlocks)
 
-  val query = new Subcommand("query-state") {
+  val query = new Subcommand("query-state") with FormattingOptions {
     descr(
       "Query a value in the global state."
     )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -369,6 +369,36 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showDeploy)
 
+  val printDeploy = new Subcommand("print-deploy") {
+    descr("Print information of a deploy saved by 'make-deploy' command in JSON/proto format")
+
+    val base16 = opt[Boolean](
+      required = false,
+      descr =
+        "Use Base16 for bytes encoding instead of default Base64 for JSON or ASCII escaped for '--proto'",
+      default = false.some,
+      name = "base16",
+      short = 'b'
+    )
+
+    val proto = opt[Boolean](
+      required = false,
+      descr = "Use Protobuf text format instead of default JSON",
+      default = false.some,
+      name = "proto"
+    )
+
+    val deployPath =
+      opt[File](
+        required = true,
+        descr = "Path to the deploy file.",
+        validate = fileCheck,
+        short = 'i'
+      ).map(file => Files.readAllBytes(file.toPath))
+        .orElse(Some(IOUtils.toByteArray(System.in)))
+  }
+  addSubcommand(printDeploy)
+
   val showBlocks = new Subcommand("show-blocks") {
     descr(
       "View list of blocks in the current Casper view on an existing running node."

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -83,9 +83,10 @@ Success!
 ###### Alternative way of creating, signing and deploying contracts
 
 Every account can associate multiple keys with it and give each a weight. Collective weight of signing keys decides whether an action of certain type can be made. In order to collect weight of different associated keys a deploy has to be signed by corresponding private keys. `deploy` command does it all (creates a deploy, signs it and deploys to the node) but doesn't allow for signing with multiple keys. Therefore we split `deploy` into three separate commands:
-* `make-deploy` - creates a deploy from input parameters
-* `sign-deploy` - signs a deploy with given private key
-* `send-deploy` - sends a deploy to CasperLabs node
+* `make-deploy`  - creates a deploy from input parameters
+* `sign-deploy`  - signs a deploy with given private key
+* `print-deploy` - prints information of a deploy
+* `send-deploy`  - sends a deploy to CasperLabs node
 
 Commands read input deploy from both a file (`-i` flag) and STDIN. They can also write to both file and STDOUT.
 
@@ -120,6 +121,15 @@ casperlabs-client \
     --private-key private-key.pem
 ```
 This will read a deploy to sign from STDIN and output signed deploy to STDOUT. There are `-i` and `-o` flags for, respectively, reading a deploy from a file and writing signed deploy to a file.
+
+**Printing a deploy**
+```
+casperlabs-client \
+    --host localhost \
+    print-deploy \
+    --base16
+```
+This will print information of a deploy into STDOUT. There are `--proto` and `--base16` flags for, respectively, using standard Protobuf text encoding or JSON and using custom Base16 encoding instead of default ASCII-escaped for `--proto` or Base64 for JSON.
 
 **Sending deploy to the node**
 ```

--- a/docs/CONTRACTS.md
+++ b/docs/CONTRACTS.md
@@ -126,10 +126,9 @@ This will read a deploy to sign from STDIN and output signed deploy to STDOUT. T
 ```
 casperlabs-client \
     --host localhost \
-    print-deploy \
-    --base16
+    print-deploy
 ```
-This will print information of a deploy into STDOUT. There are `--proto` and `--base16` flags for, respectively, using standard Protobuf text encoding or JSON and using custom Base16 encoding instead of default ASCII-escaped for `--proto` or Base64 for JSON.
+This will print information of a deploy into STDOUT. There are `--json` and `--bytes-standard` flags for, respectively, using standard JSON vs Protobuf text encoding and standard ASCII-escaped for Protobuf or Base64 for JSON bytes encoding vs custom Base16. The same set of flags also available for all `show-*` and `query-state` commands. 
 
 **Sending deploy to the node**
 ```


### PR DESCRIPTION
### Overview
Adds new command for the Scala CLI client `print-deploy` to print information of a deploy created by `make-deploy` and possibly modified by `sign-deploy`.

The command is configurable to:
* use either JSON or Protobuf text encoding 
* use base16 bytes encoding or default one which is base64 for JSON and ASCII-escaped for Protobuf text encoding

~Defaults are JSON and base64.~
**UPD**: Defaults are Protobuf text encoding + base16.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-935

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
~Though, I added JSON format, but I didn't change anything where the previous format was using. The PR's formats changes only affect the new `print-deploy` command and nothing else.~

**UPD**: All `show-*` and `query-state` now also have formatting options same as `print-deploy` but defaults are chosen to preserve the previous format.
