### PR TITLE
NODE-979: Drop the last character if input string has uneven length

### DIFF
--- a/crypto/src/main/scala/io/casperlabs/crypto/codec/Base16.scala
+++ b/crypto/src/main/scala/io/casperlabs/crypto/codec/Base16.scala
@@ -14,14 +14,6 @@ object Base16 {
     hex2bytes(paddedInput)
   }
 
-  /* Returns None if can't decode */
-  def tryDecode(input: String): Option[Array[Byte]] = {
-    val paddedInput =
-      if (input.length % 2 == 0) input
-      else "0" + input
-    Try(paddedInput.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)).toOption
-  }
-
   private def bytes2hex(bytes: Array[Byte], sep: Option[String]): String =
     bytes.map("%02x".format(_)).mkString(sep.getOrElse(""))
 

--- a/crypto/src/main/scala/io/casperlabs/crypto/codec/Base16.scala
+++ b/crypto/src/main/scala/io/casperlabs/crypto/codec/Base16.scala
@@ -15,12 +15,12 @@ object Base16 {
   }
 
   /* Returns None if can't decode */
-  def tryDecode(input: String): Option[Array[Byte]] =
-    if (input.length % 2 == 0) {
-      Try(input.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)).toOption
-    } else {
-      None
-    }
+  def tryDecode(input: String): Option[Array[Byte]] = {
+    val paddedInput =
+      if (input.length % 2 == 0) input
+      else "0" + input
+    Try(paddedInput.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)).toOption
+  }
 
   private def bytes2hex(bytes: Array[Byte], sep: Option[String]): String =
     bytes.map("%02x".format(_)).mkString(sep.getOrElse(""))

--- a/crypto/src/test/scala/io/casperlabs/crypto/codec/Base16Spec.scala
+++ b/crypto/src/test/scala/io/casperlabs/crypto/codec/Base16Spec.scala
@@ -11,12 +11,4 @@ class Base16Spec extends PropSpec with GeneratorDrivenPropertyChecks with Matche
       decoded should equal(input)
     }
   }
-
-  property("tryDecode after encode returns the original input") {
-    forAll { (input: Array[Byte]) =>
-      val encoded = Base16.encode(input)
-      val decoded = Base16.tryDecode(encoded)
-      decoded.get should equal(input)
-    }
-  }
 }

--- a/node/src/main/scala/io/casperlabs/node/api/Utils.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Utils.scala
@@ -22,8 +22,8 @@ object Utils {
     Utils
       .checkString[F](
         p,
-        "BlockHash prefix must be at least 4 characters (2 bytes) long",
-        s => Base16.tryDecode(s).exists(_.length >= 2)
+        "BlockHash prefix must be >= 4 and <= 64 base16 characters (2 to 32 bytes) long",
+        _.matches("[a-f0-9]{4,64}")
       )
       .adaptErr(adaptError)
 
@@ -34,8 +34,8 @@ object Utils {
     Utils
       .checkString[F](
         p,
-        "DeployHash must be 64 characters (32 bytes) long",
-        Base16.tryDecode(_).exists(_.length == 32)
+        "DeployHash must be 64 base16 characters (32 bytes) long",
+        _.matches("[a-f0-9]{64}")
       )
       .adaptError(adaptError)
 


### PR DESCRIPTION
### Overview
Drops the last character if an input string has an uneven length during base16 decoding.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-979

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
