### PR TITLE
NODE-910: Add ListDeployInfos equivalent to GraphQL

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
@@ -101,11 +101,16 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
             blocks.types.DeployInfosWithPageInfoType,
             arguments = blocks.arguments.AccountPublicKeyBase16 :: blocks.arguments.First :: blocks.arguments.After :: Nil,
             resolve = { c =>
-              val accountPublicKeyBase16 = c.arg(blocks.arguments.AccountPublicKeyBase16)
-              val first                  = c.arg(blocks.arguments.First)
-              val after                  = c.arg(blocks.arguments.After)
               val program =
                 for {
+                  first <- Utils
+                            .check[F, Int](
+                              c.arg(blocks.arguments.First),
+                              "First must be greater than 0",
+                              _ > 0
+                            )
+                  accountPublicKeyBase16 = c.arg(blocks.arguments.AccountPublicKeyBase16)
+                  after                  = c.arg(blocks.arguments.After)
                   accountPublicKeyBase16 <- validateAccountPublicKey[F](
                                              accountPublicKeyBase16
                                            )

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/arguments/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/arguments/package.scala
@@ -31,4 +31,21 @@ package object arguments {
       StringType,
       description = "Base-16 hash of a deploy, must be 64 characters long"
     )
+
+  val AccountPublicKeyBase16 =
+    Argument(
+      "accountPublicKeyBase16",
+      StringType,
+      description = "Base-16 public key of a account, must be 64 characters long"
+    )
+
+  val First = Argument("first", IntType, description = "The maximum number of items to return.")
+
+  val After =
+    Argument(
+      "after",
+      OptionInputType(StringType),
+      description = "The endCursor value returned from a previous request, if any.",
+      ""
+    )
 }

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
@@ -11,6 +11,11 @@ import io.casperlabs.crypto.codec.{Base16, Base64}
 import io.casperlabs.node.api.graphql.schema.utils.{DateType, ProtocolVersionType}
 import io.casperlabs.models.BlockImplicits._
 import sangria.schema._
+import sangria.macros.derive._
+
+case class PageInfo(endCursor: String, hasNextPage: Boolean)
+
+case class DeployInfosWithPageInfo(deployInfos: List[DeployInfo], pageInfo: PageInfo)
 
 package object types {
 
@@ -267,6 +272,34 @@ package object types {
         "Deploys in the block".some,
         resolve = c => c.value._2.get.map(_.asLeft[ProcessingResult])
       )
+    )
+  )
+
+  val PageInfoType = ObjectType(
+    "PageInfo",
+    "Cursor based pagination information",
+    fields[Unit, PageInfo](
+      Field(
+        "endCursor",
+        StringType,
+        "The cursor of the last item in result".some,
+        resolve = _.value.endCursor
+      ),
+      Field(
+        "hasNextPage",
+        BooleanType,
+        "Whether there is another page of data available".some,
+        resolve = _.value.hasNextPage
+      )
+    )
+  )
+
+  val DeployInfosWithPageInfoType = ObjectType(
+    "deploys",
+    "A list of deploys for the specified account",
+    fields[Unit, DeployInfosWithPageInfo](
+      Field("deployInfos", ListType(DeployInfoType), resolve = _.value.deployInfos),
+      Field("pageInfo", PageInfoType, resolve = _.value.pageInfo)
     )
   )
 }


### PR DESCRIPTION
### Overview
Supporting a query `deploys` which is equivalent with `ListDeployInfos`  in GraphQL.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-910

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
