### PR TITLE
EE-382: Add Display impl for PreprocessingError

### DIFF
--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -16,7 +16,7 @@ pub enum Error {
     InvalidPublicKeyLength { expected: usize, actual: usize },
     #[fail(display = "Invalid protocol version: {}", _0)]
     InvalidProtocolVersion(ProtocolVersion),
-    #[fail(display = "Wasm preprocessing error: {:?}", _0)]
+    #[fail(display = "Wasm preprocessing error: {}", _0)]
     WasmPreprocessingError(engine_wasm_prep::PreprocessingError),
     #[fail(display = "Wasm serialization error: {:?}", _0)]
     WasmSerializationError(parity_wasm::SerializationError),

--- a/execution-engine/engine-wasm-prep/src/lib.rs
+++ b/execution-engine/engine-wasm-prep/src/lib.rs
@@ -7,9 +7,11 @@ extern crate engine_shared;
 
 pub mod wasm_costs;
 
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+
 use parity_wasm::elements::{Error as ParityWasmError, Module};
 use pwasm_utils::{externalize_mem, inject_gas_counter, rules};
-use std::error::Error;
 use wasm_costs::WasmCosts;
 
 //NOTE: size of Wasm memory page is 64 KiB
@@ -23,6 +25,19 @@ pub enum PreprocessingError {
     DeserializeError(String),
     OperationForbiddenByGasRules,
     StackLimiterError,
+}
+
+impl Display for PreprocessingError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            PreprocessingError::InvalidImportsError(error) => write!(f, "Invalid imports error: {}", error),
+            PreprocessingError::NoExportSection => write!(f, "No export section found"),
+            PreprocessingError::NoImportSection => write!(f, "No import section found"),
+            PreprocessingError::DeserializeError(error) => write!(f, "Deserialization error: {}", error),
+            PreprocessingError::OperationForbiddenByGasRules => write!(f, "Encountered operation forbidden by gas rules. Consult instruction -> metering config map"),
+            PreprocessingError::StackLimiterError => write!(f, "Stack limiter error"),
+        }
+    }
 }
 
 use PreprocessingError::*;


### PR DESCRIPTION
### Overview
Adds `Display` impl for `PreprocessingError`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-382

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
