### PR TITLE
EE-749: Replace addr_to_hex with HexFmt

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -243,6 +244,7 @@ dependencies = [
  "casperlabs-engine-storage 0.1.0",
  "casperlabs-engine-wasm-prep 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -996,6 +998,11 @@ version = "0.1.0"
 dependencies = [
  "casperlabs-contract-ffi 0.18.0",
 ]
+
+[[package]]
+name = "hex_fmt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hostname"
@@ -2865,6 +2872,7 @@ dependencies = [
 "checksum grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8e530ef7894a104a1c8525ce68787b3491efa2098ce5e5454e8324ea78893548"
 "checksum grpc-compiler 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f140d998d8940880e464f3fd291052618199432e91e59ae5c5075c0c8a40c"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+"checksum hex_fmt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"

--- a/execution-engine/contract-ffi/Cargo.toml
+++ b/execution-engine/contract-ffi/Cargo.toml
@@ -21,6 +21,7 @@ uint = { version = "0.7.1", default-features = false, features = [] }
 proptest = { version = "0.9.2", default-features = false, optional = true }
 bitflags = "1.0.4"
 binascii = "0.1.2"
+hex_fmt = "0.3.0"
 
 [dev-dependencies]
 proptest = { version = "0.9.2", default-features = false }

--- a/execution-engine/contract-ffi/src/contract_api/turef.rs
+++ b/execution-engine/contract-ffi/src/contract_api/turef.rs
@@ -1,8 +1,9 @@
+use hex_fmt::HexFmt;
+
 use core::any::type_name;
 use core::fmt;
 use core::marker::PhantomData;
 
-use crate::key::addr_to_hex;
 use crate::uref::AccessRights;
 use crate::uref::URef;
 use crate::value::Value;
@@ -75,7 +76,7 @@ impl<T> core::fmt::Display for TURef<T> {
         write!(
             f,
             "TURef({}, {}; {})",
-            addr_to_hex(&self.addr()),
+            HexFmt(&self.addr()),
             self.access_rights(),
             type_name::<T>()
         )

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -1,7 +1,6 @@
-use core::fmt::Write;
-
 use blake2::digest::{Input, VariableOutput};
 use blake2::VarBlake2b;
+use hex_fmt::HexFmt;
 
 use crate::alloc::vec::Vec;
 use crate::base16;
@@ -60,25 +59,14 @@ impl Key {
     }
 }
 
-// There is no impl LowerHex for neither [u8; 32] nor &[u8] in std.
-// I can't impl them b/c they're not living in current crate.
-/// Creates a hex string from [u8; 32] table.
-pub fn addr_to_hex(addr: &[u8; 32]) -> String {
-    let mut str = String::with_capacity(64);
-    for b in addr {
-        write!(&mut str, "{:02x}", b).unwrap();
-    }
-    str
-}
-
 impl core::fmt::Display for Key {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         match self {
-            Key::Account(addr) => write!(f, "Key::Account({})", addr_to_hex(addr)),
-            Key::Hash(addr) => write!(f, "Key::Hash({})", addr_to_hex(addr)),
+            Key::Account(addr) => write!(f, "Key::Account({})", HexFmt(addr)),
+            Key::Hash(addr) => write!(f, "Key::Hash({})", HexFmt(addr)),
             Key::URef(uref) => write!(f, "Key::{}", uref), /* Display impl for URef will append */
             // URef(…).
-            Key::Local(hash) => write!(f, "Key::Local({})", addr_to_hex(hash)),
+            Key::Local(hash) => write!(f, "Key::Local({})", HexFmt(hash)),
         }
     }
 }

--- a/execution-engine/contract-ffi/src/lib.rs
+++ b/execution-engine/contract-ffi/src/lib.rs
@@ -9,21 +9,19 @@
 
 #[macro_use]
 extern crate alloc;
-
 extern crate binascii;
-
-#[macro_use]
-extern crate uint;
-#[macro_use]
-extern crate failure;
-extern crate wee_alloc;
 #[macro_use]
 extern crate bitflags;
 #[macro_use]
+extern crate failure;
+extern crate hex_fmt;
+#[macro_use]
 extern crate num_derive;
-
 #[cfg(any(test, feature = "gens"))]
 extern crate proptest;
+#[macro_use]
+extern crate uint;
+extern crate wee_alloc;
 
 #[cfg(not(feature = "std"))]
 #[global_allocator]

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -1,4 +1,5 @@
 use bitflags;
+use hex_fmt::HexFmt;
 
 use crate::alloc::string::String;
 use crate::alloc::vec::Vec;
@@ -82,11 +83,11 @@ impl core::fmt::Display for URef {
             write!(
                 f,
                 "URef({}, {})",
-                super::key::addr_to_hex(&addr),
+                HexFmt(&addr),
                 access_rights
             )
         } else {
-            write!(f, "URef({}, None)", super::key::addr_to_hex(&addr))
+            write!(f, "URef({}, None)", HexFmt(&addr))
         }
     }
 }

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -80,12 +80,7 @@ impl core::fmt::Display for URef {
         let addr = self.addr();
         let access_rights_o = self.access_rights();
         if let Some(access_rights) = access_rights_o {
-            write!(
-                f,
-                "URef({}, {})",
-                HexFmt(&addr),
-                access_rights
-            )
+            write!(f, "URef({}, {})", HexFmt(&addr), access_rights)
         } else {
             write!(f, "URef({}, None)", HexFmt(&addr))
         }

--- a/execution-engine/contract-ffi/src/value/account.rs
+++ b/execution-engine/contract-ffi/src/value/account.rs
@@ -1,15 +1,18 @@
-use crate::bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE, U8_SIZE};
-use crate::contract_api::runtime;
-use crate::contract_api::Error as ApiError;
-use crate::key::{addr_to_hex, Key, UREF_SIZE};
-use crate::unwrap_or_revert::UnwrapOrRevert;
-use crate::uref::{AccessRights, URef, UREF_SIZE_SERIALIZED};
 use alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::fmt::{Debug, Display, Formatter};
+
 use failure::Fail;
+use hex_fmt::HexFmt;
+
+use crate::bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE, U8_SIZE};
+use crate::contract_api::runtime;
+use crate::contract_api::Error as ApiError;
+use crate::key::{Key, UREF_SIZE};
+use crate::unwrap_or_revert::UnwrapOrRevert;
+use crate::uref::{AccessRights, URef, UREF_SIZE_SERIALIZED};
 
 pub const PURSE_ID_SIZE_SERIALIZED: usize = UREF_SIZE_SERIALIZED;
 
@@ -316,7 +319,7 @@ pub struct PublicKey([u8; KEY_SIZE]);
 
 impl Display for PublicKey {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        write!(f, "PublicKey({})", addr_to_hex(&self.0))
+        write!(f, "PublicKey({})", HexFmt(&self.0))
     }
 }
 

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -11,6 +11,7 @@ engine-shared = { path = "../engine-shared", package = "casperlabs-engine-shared
 engine-storage = { path = "../engine-storage", package = "casperlabs-engine-storage" }
 engine-wasm-prep = { path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 failure = "0.1.5"
+hex_fmt = "0.3.0"
 itertools = "0.8.0"
 linked-hash-map = "0.5.2"
 num-derive = "0.2.5"

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -1128,7 +1128,7 @@ where
         let bonded_validators = contract
             .named_keys()
             .keys()
-            .filter_map(|entry| utils::pos_validator_to_tuple(entry))
+            .filter_map(|entry| utils::pos_validator_key_name_to_tuple(entry))
             .collect::<HashMap<PublicKey, U512>>();
 
         Ok(bonded_validators)

--- a/execution-engine/engine-core/src/engine_state/utils.rs
+++ b/execution-engine/engine-core/src/engine_state/utils.rs
@@ -1,17 +1,11 @@
-use contract_ffi::key::addr_to_hex;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
 
-/// Helper function to create validator labels as they are constructed in PoS.
-pub fn pos_validator_key(pk: PublicKey, stakes: U512) -> String {
-    let public_key_hex: String = addr_to_hex(&pk.value());
-    // This is how PoS contract stores validator keys in its named_keys map.
-    format!("v_{}_{}", public_key_hex, stakes)
-}
-
-/// Dual of `pos_validator_key`. Parses PoS bond format to PublicKey, U512 pair.
-pub fn pos_validator_to_tuple(pos_bond: &str) -> Option<(PublicKey, U512)> {
-    let mut split_bond = pos_bond.split('_'); // expected format is "v_{public_key}_{bond}".
+/// In PoS, the validators are stored under named keys with names formatted as
+/// "v_<hex-formatted-PublicKey>_<bond-amount>".  This function attempts to parse such a string back
+/// into the `PublicKey` and bond amount.
+pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(PublicKey, U512)> {
+    let mut split_bond = pos_key_name.split('_'); // expected format is "v_{public_key}_{bond}".
     if Some("v") != split_bond.next() {
         None
     } else {
@@ -24,45 +18,72 @@ pub fn pos_validator_to_tuple(pos_bond: &str) -> Option<(PublicKey, U512)> {
             key_bytes[i] = u8::from_str_radix(&hex_key[2 * i..2 * (i + 1)], 16).ok()?;
         }
         let pub_key = PublicKey::new(key_bytes);
-        let balance = split_bond.next().and_then(|b| U512::from_dec_str(b).ok())?;
+        let balance = split_bond.next().and_then(|b| {
+            if b.is_empty() {
+                None
+            } else {
+                U512::from_dec_str(b).ok()
+            }
+        })?;
         Some((pub_key, balance))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use contract_ffi::key::addr_to_hex;
+    use hex_fmt::HexFmt;
+
     use contract_ffi::value::account::PublicKey;
     use contract_ffi::value::U512;
 
-    use super::{pos_validator_key, pos_validator_to_tuple};
-
-    #[test]
-    fn should_to_string_pos_validator() {
-        let public_key = PublicKey::new([1u8; 32]);
-        let hex_public_key = addr_to_hex(&public_key.value());
-        let stake = U512::from(100);
-        let expected = format!("v_{}_{}", hex_public_key, stake);
-        assert_eq!(pos_validator_key(public_key, stake), expected);
-    }
+    use super::pos_validator_key_name_to_tuple;
 
     #[test]
     fn should_parse_string_to_validator_tuple() {
         let public_key = PublicKey::new([1u8; 32]);
-        let hex_public_key = addr_to_hex(&public_key.value());
         let stake = U512::from(100);
-        let strng = format!("v_{}_{}", hex_public_key, stake);
+        let named_key_name = format!("v_{}_{}", HexFmt(&public_key.value()), stake);
 
-        let parsed = pos_validator_to_tuple(&strng);
+        let parsed = pos_validator_key_name_to_tuple(&named_key_name);
         assert!(parsed.is_some());
-        let (parsed_pk, parsed_stake) = parsed.unwrap();
-        assert_eq!(parsed_pk, public_key);
+        let (parsed_public_key, parsed_stake) = parsed.unwrap();
+        assert_eq!(parsed_public_key, public_key);
         assert_eq!(parsed_stake, stake);
     }
 
     #[test]
     fn should_not_parse_string_to_validator_tuple() {
-        let not_validator_stake = "v_10_ab".to_string();
-        assert!(pos_validator_to_tuple(&not_validator_stake).is_none());
+        let public_key = PublicKey::new([1u8; 32]);
+        let stake = U512::from(100);
+
+        let bad_prefix = format!("a_{}_{}", HexFmt(&public_key.value()), stake);
+        assert!(pos_validator_key_name_to_tuple(&bad_prefix).is_none());
+
+        let no_prefix = format!("_{}_{}", HexFmt(&public_key.value()), stake);
+        assert!(pos_validator_key_name_to_tuple(&no_prefix).is_none());
+
+        let short_key = format!("v_{}_{}", HexFmt(&[1u8; 31]), stake);
+        assert!(pos_validator_key_name_to_tuple(&short_key).is_none());
+
+        let long_key = format!("v_{}00_{}", HexFmt(&public_key.value()), stake);
+        assert!(pos_validator_key_name_to_tuple(&long_key).is_none());
+
+        let bad_key = format!("v_{}0g_{}", HexFmt(&[1u8; 31]), stake);
+        assert!(pos_validator_key_name_to_tuple(&bad_key).is_none());
+
+        let no_key = format!("v__{}", stake);
+        assert!(pos_validator_key_name_to_tuple(&no_key).is_none());
+
+        let no_key = format!("v_{}", stake);
+        assert!(pos_validator_key_name_to_tuple(&no_key).is_none());
+
+        let bad_stake = format!("v_{}_a", HexFmt(&public_key.value()));
+        assert!(pos_validator_key_name_to_tuple(&bad_stake).is_none());
+
+        let no_stake = format!("v_{}_", HexFmt(&public_key.value()));
+        assert!(pos_validator_key_name_to_tuple(&no_stake).is_none());
+
+        let no_stake = format!("v_{}", HexFmt(&public_key.value()));
+        assert!(pos_validator_key_name_to_tuple(&no_stake).is_none());
     }
 }

--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -7,6 +7,7 @@ extern crate core;
 // third-party dependencies
 extern crate blake2;
 extern crate failure;
+extern crate hex_fmt;
 extern crate itertools;
 extern crate linked_hash_map;
 extern crate parity_wasm;


### PR DESCRIPTION
### Overview
Replaces `addr_to_hex` with `HexFmt`.

This PR also removes the redundant `pos_validator_key()` function, and updates the `pos_validator_to_tuple()` function to not support strings of the form `v_<key>_` which were being parsed equivalently to `v_<key>_0`.  This function was also renamed and the test expanded to cover more failure cases.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-749

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
