### PR TITLE
NODE-440: Deploy chain name

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/BlockStatus.scala
@@ -47,6 +47,7 @@ final case object InvalidDeployCount     extends InvalidBlock with Slashable
 final case object InvalidDeployHash      extends InvalidBlock with Slashable
 final case object InvalidDeploySignature extends InvalidBlock with Slashable
 final case object InvalidDeployHeader    extends InvalidBlock with Slashable
+final case object InvalidDeployChainName extends InvalidBlock with Slashable
 final case object SwimlaneMerged         extends InvalidBlock with Slashable
 final case object DeployDependencyNotMet extends InvalidBlock with Slashable
 final case object DeployExpired          extends InvalidBlock with Slashable

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -737,7 +737,8 @@ object MultiParentCasperImpl {
             InvalidRepeatDeploy | InvalidChainName | InvalidBlockHash | InvalidDeployCount |
             InvalidDeployHash | InvalidDeploySignature | InvalidPreStateHash |
             InvalidPostStateHash | InvalidTargetHash | InvalidDeployHeader |
-            DeployDependencyNotMet | DeployExpired | DeployFromFuture | SwimlaneMerged =>
+            InvalidDeployChainName | DeployDependencyNotMet | DeployExpired | DeployFromFuture |
+            SwimlaneMerged =>
           handleInvalidBlockEffect(status, block) *> dag.pure[F]
 
         case Processing | Processed =>
@@ -855,10 +856,14 @@ object MultiParentCasperImpl {
 
           case InvalidUnslashableBlock | InvalidBlockNumber | InvalidParents |
               InvalidSequenceNumber | InvalidPrevBlockHash | NeglectedInvalidBlock |
-              InvalidTransaction | InvalidBondsCache | InvalidRepeatDeploy | InvalidChainName |
-              InvalidBlockHash | InvalidDeployCount | InvalidDeployHash | InvalidDeploySignature |
-              InvalidPreStateHash | InvalidPostStateHash | Processing | Processed | SwimlaneMerged |
-              InvalidTargetHash | InvalidDeployHeader | DeployDependencyNotMet | DeployExpired =>
+              InvalidTransaction | InvalidBondsCache | InvalidChainName | InvalidBlockHash |
+              InvalidDeployCount | InvalidPreStateHash | InvalidPostStateHash | SwimlaneMerged |
+              InvalidTargetHash | Processing | Processed =>
+            ().pure[F]
+
+          case InvalidRepeatDeploy | InvalidChainName | InvalidDeployHash | InvalidDeploySignature |
+              InvalidDeployChainName | InvalidDeployHeader | DeployDependencyNotMet |
+              DeployExpired =>
             ().pure[F]
 
           case UnexpectedBlockException(_) | DeployFromFuture =>

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -269,24 +269,40 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: FinalityDetector: Bl
   /** Add a deploy to the buffer, if the code passes basic validation. */
   def deploy(deploy: Deploy): F[Either[Throwable, Unit]] = validatorId match {
     case Some(_) =>
-      (deploy.getBody.session, deploy.getBody.payment) match {
-        case (None, _) | (_, None) | (Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty)), _) |
-            (_, Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty))) =>
-          new IllegalArgumentException(s"Deploy was missing session and/or payment code.")
-            .asLeft[Unit]
-            .pure[F]
-            .widen
-
-        case _ =>
-          addDeploy(deploy)
-      }
+      addDeploy(deploy)
     case None =>
       new IllegalStateException(s"Node is in read-only mode.").asLeft[Unit].pure[F].widen
+  }
+
+  private def validateDeploy(deploy: Deploy): F[Unit] = {
+    def illegal(msg: String): F[Unit] =
+      MonadThrowable[F].raiseError(new IllegalArgumentException(msg))
+
+    def check(msg: String)(f: F[Boolean]): F[Unit] =
+      f flatMap { ok =>
+        illegal(msg).whenA(!ok)
+      }
+
+    for {
+      _ <- (deploy.getBody.session, deploy.getBody.payment) match {
+            case (None, _) | (_, None) | (Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty)), _) |
+                (_, Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty))) =>
+              illegal(s"Deploy was missing session and/or payment code.")
+            case _ => ().pure[F]
+          }
+      _ <- check("Invalid deploy hash.")(Validation[F].deployHash(deploy))
+      _ <- check("Invalid deploy signature.")(Validation[F].deploySignature(deploy))
+      _ <- Validation[F].deployHeader(deploy, chainName) >>= { headerErrors =>
+            illegal(headerErrors.map(_.errorMessage).mkString("\n"))
+              .whenA(headerErrors.nonEmpty)
+          }
+    } yield ()
   }
 
   /** Add a deploy to the buffer, to be executed later. */
   private def addDeploy(deploy: Deploy): F[Either[Throwable, Unit]] =
     (for {
+      _ <- validateDeploy(deploy)
       _ <- DeployStorageWriter[F].addAsPending(List(deploy))
       _ <- Log[F].info(s"Received ${PrettyPrinter.buildString(deploy)}")
     } yield ()).attempt

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -58,21 +58,8 @@ object BlockAPI {
   def deploy[F[_]: MonadThrowable: MultiParentCasperRef: BlockStorage: Validation: FinalityDetector: Log: Metrics](
       d: Deploy
   ): F[Unit] = unsafeWithCasper[F, Unit]("Could not deploy.") { implicit casper =>
-    def check(msg: String)(f: F[Boolean]): F[Unit] =
-      f flatMap { ok =>
-        MonadThrowable[F].raiseError(InvalidArgument(msg)).whenA(!ok)
-      }
-
     for {
       _ <- Metrics[F].incrementCounter("deploys")
-      _ <- check("Invalid deploy hash.")(Validation[F].deployHash(d))
-      _ <- check("Invalid deploy signature.")(Validation[F].deploySignature(d))
-      _ <- Validation[F].deployHeader(d) >>= { headerErrors =>
-            MonadThrowable[F]
-              .raiseError(InvalidArgument(headerErrors.map(_.errorMessage).mkString("\n")))
-              .whenA(headerErrors.nonEmpty)
-          }
-
       r <- MultiParentCasper[F].deploy(d)
       _ <- r match {
             case Right(_) =>

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
@@ -39,6 +39,13 @@ object Errors {
     def invalidDependency(deployHash: ByteString, dependency: ByteString): DeployHeaderError =
       InvalidDependency(deployHash, dependency)
 
+    def invalidChainName(
+        deployHash: ByteString,
+        deployChainName: String,
+        expectedChainName: String
+    ): DeployHeaderError =
+      InvalidChainName(deployHash, deployChainName, expectedChainName)
+
     final case class MissingHeader(deployHash: ByteString) extends DeployHeaderError {
       def errorMessage: String =
         s"Deploy ${PrettyPrinter.buildString(deployHash)} does not contain a header"
@@ -73,6 +80,15 @@ object Errors {
 
         s"Deploy $deploy with dependency $dep is invalid. Dependencies are expected to be 32 bytes."
       }
+    }
+
+    final case class InvalidChainName(
+        deployHash: ByteString,
+        deployChainName: String,
+        expectedChainName: String
+    ) extends DeployHeaderError {
+      def errorMessage: String =
+        s"Deploy ${PrettyPrinter.buildString(deployHash)} with chain name '$deployChainName' is invalid. Expected empty chain or '$expectedChainName'."
     }
   }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -37,7 +37,7 @@ trait Validation[F[_]] {
 
   def deployHash(d: consensus.Deploy): F[Boolean]
 
-  def deployHeader(d: consensus.Deploy): F[List[Errors.DeployHeaderError]]
+  def deployHeader(d: consensus.Deploy, chainName: String): F[List[Errors.DeployHeaderError]]
 
   def deploySignature(d: consensus.Deploy): F[Boolean]
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -871,7 +871,7 @@ abstract class HashSetCasperTest
     } yield ()
   }
 
-  it should "reject blocks that include a invalid block pointer" in effectTest {
+  it should "reject blocks that include an invalid block pointer" in effectTest {
     for {
       nodes           <- networkEff(validatorKeys.take(3), genesis, transforms)
       deploys         <- (1L to 6L).toList.traverse(_ => ProtoUtil.basicDeploy[Task]())
@@ -1112,28 +1112,6 @@ abstract class HashSetCasperTest
 
       _ <- nodes.map(_.tearDown()).toList.sequence
     } yield ()
-  }
-
-  it should "fail when deploying with insufficient gas" in effectTest {
-    val node = standaloneEff(genesis, transforms, validatorKeys.head)
-    import node._
-    implicit val timeEff = new LogicalTime[Task]
-
-    for {
-      deploy <- ProtoUtil.basicDeploy[Task]().map { d =>
-                 d.withBody(
-                   d.getBody.withPayment(
-                     Deploy.Code().withWasm(ByteString.copyFromUtf8("some payment code"))
-                   )
-                 )
-               }
-      _                 <- node.casperEff.deploy(deploy)
-      createBlockResult <- MultiParentCasper[Task].createBlock
-      Created(block)    = createBlockResult
-    } yield {
-      cancelUntilFixed("FIXME: Implement cost accounting!")
-      //assert(block.body.get.deploys.head.isError)
-    }
   }
 
   it should "succeed if given enough gas for deploy" in effectTest {

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -76,7 +76,8 @@ class ValidationTest
 
   implicit val consensusConfig = ConsensusConfig()
 
-  val ed25519 = "ed25519"
+  val ed25519   = "ed25519"
+  val chainName = "testnet"
 
   override def beforeEach(): Unit = {
     log.reset()
@@ -303,13 +304,13 @@ class ValidationTest
       ConsensusConfig(dagSize = 10, maxSessionCodeBytes = 5, maxPaymentCodeBytes = 5)
 
     forAll { (deploy: consensus.Deploy) =>
-      withoutStorage { Validation[Task].deployHeader(deploy) } shouldBe Nil
+      withoutStorage { Validation[Task].deployHeader(deploy, chainName) } shouldBe Nil
     }
   }
 
   it should "not accept too short time to live" in withoutStorage {
     val deploy = DeployOps.randomTooShortTTL()
-    Validation[Task].deployHeader(deploy) shouldBeF List(
+    Validation[Task].deployHeader(deploy, chainName) shouldBeF List(
       DeployHeaderError
         .timeToLiveTooShort(deploy.deployHash, deploy.getHeader.ttlMillis, ValidationImpl.MIN_TTL)
     )
@@ -317,7 +318,7 @@ class ValidationTest
 
   it should "not accept too long time to live" in withoutStorage {
     val deploy = DeployOps.randomTooLongTTL()
-    Validation[Task].deployHeader(deploy) shouldBeF List(
+    Validation[Task].deployHeader(deploy, chainName) shouldBeF List(
       DeployHeaderError
         .timeToLiveTooLong(deploy.deployHash, deploy.getHeader.ttlMillis, ValidationImpl.MAX_TTL)
     )
@@ -325,7 +326,7 @@ class ValidationTest
 
   it should "not accept too many dependencies" in withoutStorage {
     val deploy = DeployOps.randomTooManyDependencies()
-    Validation[Task].deployHeader(deploy) shouldBeF List(
+    Validation[Task].deployHeader(deploy, chainName) shouldBeF List(
       DeployHeaderError.tooManyDependencies(
         deploy.deployHash,
         deploy.getHeader.dependencies.size,
@@ -336,9 +337,18 @@ class ValidationTest
 
   it should "not accept invalid dependencies" in withoutStorage {
     val deploy = DeployOps.randomInvalidDependency()
-    Validation[Task].deployHeader(deploy) shouldBeF List(
+    Validation[Task].deployHeader(deploy, chainName) shouldBeF List(
       DeployHeaderError
         .invalidDependency(deploy.deployHash, deploy.getHeader.dependencies.head)
+    )
+  }
+
+  it should "not accept invalid chain names" in withoutStorage {
+    val deploy    = DeployOps.randomInvalidChainName()
+    val chainName = "nevernet"
+    Validation[Task].deployHeader(deploy, chainName) shouldBeF List(
+      DeployHeaderError
+        .invalidChainName(deploy.deployHash, deploy.getHeader.chainName, chainName)
     )
   }
 
@@ -957,7 +967,7 @@ class ValidationTest
   }
 
   it should "fail a block with a deploy having an foreign chain name" in withStorage {
-    _ => _ => _ =>
+    implicit blockStorage => implicit dagStorage => _ =>
       val block = sample {
         for {
           b <- arbitrary[consensus.Block]
@@ -975,27 +985,52 @@ class ValidationTest
         }
       }
       for {
-        result <- ValidationImpl[Task].deployChainNames(block, "no country for old men").attempt
-        _      = result shouldBe Left(ValidateErrorWrapper(InvalidDeployChainName))
-      } yield ()
+        dag <- dagStorage.getRepresentation
+        result <- ValidationImpl[Task]
+                   .deployHeaders(
+                     block,
+                     dag,
+                     chainName = "no country for old men"
+                   )
+                   .attempt
+      } yield {
+        result shouldBe Left(ValidateErrorWrapper(InvalidDeployHeader))
+      }
   }
 
-  it should "pass a block with a deploy having no chain name" in withStorage { _ => _ => _ =>
-    val block = sample {
-      for {
-        b <- arbitrary[consensus.Block]
-      } yield {
-        b.withBody(
-          b.getBody.withDeploys(
-            b.getBody.deploys
-              .map(
-                x => x.withDeploy(x.getDeploy.withHeader(x.getDeploy.getHeader.withChainName("")))
+  it should "pass a block with a deploy having no chain name" in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      val now = System.currentTimeMillis
+      val block = sample {
+        for {
+          b <- arbitrary[consensus.Block]
+        } yield {
+          b.withHeader(
+              b.getHeader.withTimestamp(now)
+            )
+            .withBody(
+              b.getBody.withDeploys(
+                b.getBody.deploys
+                  .map(
+                    x =>
+                      x.withDeploy(
+                        x.getDeploy
+                          .withHeader(
+                            x.getDeploy.getHeader
+                              .withChainName("")
+                              .withTimestamp(now)
+                              .clearDependencies
+                          )
+                      )
+                  )
               )
-          )
-        )
+            )
+        }
       }
-    }
-    ValidationImpl[Task].deployChainNames(block, "area 51")
+      for {
+        dag <- dagStorage.getRepresentation
+        _   <- ValidationImpl[Task].deployHeaders(block, dag, chainName = "area 51")
+      } yield ()
   }
 
   "Block hash format validation" should "fail on invalid hash" in withStorage { _ => _ => _ =>
@@ -1092,7 +1127,7 @@ class ValidationTest
       for {
         block  <- createBlock[Task](Seq.empty, deploys = deploysWithCost)
         dag    <- dagStorage.getRepresentation
-        result <- ValidationImpl[Task].deployHeaders(block, dag).attempt
+        result <- ValidationImpl[Task].deployHeaders(block, dag, chainName).attempt
       } yield result shouldBe Left(ValidateErrorWrapper(InvalidDeployHeader))
   }
 
@@ -1121,7 +1156,7 @@ class ValidationTest
                   .map(_.changeTimestamp(blockTimestamp))
         _      <- blockStorage.put(block.blockHash, block, Seq.empty)
         dag    <- dagStorage.getRepresentation
-        result <- ValidationImpl[Task].deployHeaders(block, dag).attempt
+        result <- ValidationImpl[Task].deployHeaders(block, dag, chainName).attempt
       } yield result shouldBe Left(ValidateErrorWrapper(DeployFromFuture))
   }
 
@@ -1134,7 +1169,7 @@ class ValidationTest
                   .map(_.changeTimestamp(blockTimestamp))
         _      <- blockStorage.put(block.blockHash, block, Seq.empty)
         dag    <- dagStorage.getRepresentation
-        result <- ValidationImpl[Task].deployHeaders(block, dag).attempt
+        result <- ValidationImpl[Task].deployHeaders(block, dag, chainName).attempt
       } yield result shouldBe Left(ValidateErrorWrapper(DeployExpired))
   }
 
@@ -1148,7 +1183,7 @@ class ValidationTest
                   .map(_.changeTimestamp(blockTimestamp))
         _      <- blockStorage.put(block.blockHash, block, Seq.empty)
         dag    <- dagStorage.getRepresentation
-        result <- ValidationImpl[Task].deployHeaders(block, dag).attempt
+        result <- ValidationImpl[Task].deployHeaders(block, dag, chainName).attempt
       } yield result shouldBe Left(ValidateErrorWrapper(DeployDependencyNotMet))
   }
 
@@ -1177,7 +1212,7 @@ class ValidationTest
                    .map(_.changeTimestamp(timeC))
         _      <- blockStorage.put(blockC.blockHash, blockC, Seq.empty)
         dag    <- dagStorage.getRepresentation
-        result <- ValidationImpl[Task].deployHeaders(blockC, dag).attempt
+        result <- ValidationImpl[Task].deployHeaders(blockC, dag, chainName).attempt
       } yield result shouldBe Right(())
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -344,8 +344,11 @@ class ValidationTest
   }
 
   it should "not accept invalid chain names" in withoutStorage {
-    val deploy    = DeployOps.randomInvalidChainName()
     val chainName = "nevernet"
+    val deploy    = sample {
+      arbitrary[consensus.Deploy].map(_.withChainName(s"never say $chainName"))
+    }
+
     Validation[Task].deployHeader(deploy, chainName) shouldBeF List(
       DeployHeaderError
         .invalidChainName(deploy.deployHash, deploy.getHeader.chainName, chainName)

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -345,7 +345,7 @@ class ValidationTest
 
   it should "not accept invalid chain names" in withoutStorage {
     val chainName = "nevernet"
-    val deploy    = sample {
+    val deploy = sample {
       arbitrary[consensus.Deploy].map(_.withChainName(s"never say $chainName"))
     }
 
@@ -972,19 +972,12 @@ class ValidationTest
   it should "fail a block with a deploy having an foreign chain name" in withStorage {
     implicit blockStorage => implicit dagStorage => _ =>
       val block = sample {
-        for {
-          b <- arbitrary[consensus.Block]
-        } yield {
-          b.withBody(
-            b.getBody.withDeploys(
-              b.getBody.deploys.map(
-                x =>
-                  x.withDeploy(
-                    x.getDeploy.withHeader(x.getDeploy.getHeader.withChainName("la la land"))
-                  )
-              )
-            )
-          )
+        arbitrary[consensus.Block] map { block =>
+          block.update {
+            _.body.deploys := block.getBody.deploys.map { pd =>
+              pd.withDeploy(pd.getDeploy.withChainName("la la land"))
+            }
+          }
         }
       }
       for {

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -996,31 +996,19 @@ class ValidationTest
 
   it should "pass a block with a deploy having no chain name" in withStorage {
     implicit blockStorage => implicit dagStorage => _ =>
-      val now = System.currentTimeMillis
       val block = sample {
-        for {
-          b <- arbitrary[consensus.Block]
-        } yield {
-          b.withHeader(
-              b.getHeader.withTimestamp(now)
-            )
-            .withBody(
-              b.getBody.withDeploys(
-                b.getBody.deploys
-                  .map(
-                    x =>
-                      x.withDeploy(
-                        x.getDeploy
-                          .withHeader(
-                            x.getDeploy.getHeader
-                              .withChainName("")
-                              .withTimestamp(now)
-                              .clearDependencies
-                          )
-                      )
-                  )
-              )
-            )
+        arbitrary[consensus.Block] map { b =>
+          b.update(
+            _.body.deploys :=
+              b.getBody.deploys.map { pd =>
+                pd.update(
+                  _.deploy.header :=
+                    pd.getDeploy.getHeader
+                      .withChainName("")
+                      .clearDependencies
+                )
+              }
+          )
         }
       }
       for {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
@@ -102,15 +102,4 @@ object DeployOps extends ArbitraryConsensus {
 
     sample(genDeploy)
   }
-
-  def randomInvalidChainName(): Deploy = {
-    implicit val c = ConsensusConfig()
-
-    val genDeploy = for {
-      d  <- arbitrary[Deploy]
-      cn <- arbitrary[String]
-    } yield d.withChainName(cn)
-
-    sample(genDeploy)
-  }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
@@ -32,6 +32,11 @@ object DeployOps extends ArbitraryConsensus {
         deploy.withHeader(deploy.getHeader.withDependencies(dependencies))
       )
 
+    def withChainName(chainName: String): Deploy =
+      rehash(
+        deploy.withHeader(deploy.getHeader.withChainName(chainName))
+      )
+
     def processed(cost: Long): ProcessedDeploy = ProcessedDeploy().withDeploy(deploy).withCost(cost)
   }
 
@@ -94,6 +99,17 @@ object DeployOps extends ArbitraryConsensus {
         d =>
           d.getHeader.ttlMillis > 0 && d.getHeader.timestamp < (Long.MaxValue - d.getHeader.ttlMillis)
       )
+
+    sample(genDeploy)
+  }
+
+  def randomInvalidChainName(): Deploy = {
+    implicit val c = ConsensusConfig()
+
+    val genDeploy = for {
+      d  <- arbitrary[Deploy]
+      cn <- arbitrary[String]
+    } yield d.withChainName(cn)
 
     sample(genDeploy)
   }

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -386,6 +386,7 @@ object DeployRuntime {
           .withGasPrice(deployConfig.gasPrice)
           .withTtlMillis(deployConfig.timeToLive.getOrElse(0))
           .withDependencies(deployConfig.dependencies)
+          .withChainName(deployConfig.chainName)
       )
       .withBody(
         consensus.Deploy

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -44,7 +44,8 @@ final case class DeployConfig(
     gasPrice: Long,
     paymentAmount: Option[BigInt],
     timeToLive: Option[Int],
-    dependencies: List[ByteString]
+    dependencies: List[ByteString],
+    chainName: String
 ) {
   def session(defaultArgs: Seq[Arg] = Nil) = DeployConfig.toCode(sessionOptions, defaultArgs)
   def payment(defaultArgs: Seq[Arg] = Nil) = DeployConfig.toCode(paymentOptions, defaultArgs)
@@ -77,10 +78,11 @@ object DeployConfig {
       timeToLive = args.ttl.toOption,
       dependencies = args.dependencies.toOption
         .getOrElse(List.empty)
-        .map(d => ByteString.copyFrom(Base16.decode(d)))
+        .map(d => ByteString.copyFrom(Base16.decode(d))),
+      chainName = args.chainName()
     )
 
-  val empty = DeployConfig(CodeConfig.empty, CodeConfig.empty, 0, None, None, List.empty)
+  val empty = DeployConfig(CodeConfig.empty, CodeConfig.empty, 0, None, None, List.empty, "")
 
   /** Produce a Deploy.Code DTO from the options.
     * 'defaultArgs' can be used by specialized commands such as `transfer` and `unbond`

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -120,6 +120,14 @@ object Options {
       noshort = true
     )
 
+    val chainName = opt[String](
+      descr =
+        "Name of the chain to optionally restrict the deploy from being accidentally included anywhere else.",
+      required = false,
+      noshort = true,
+      default = "".some
+    )
+
     addValidation {
       val sessionsProvided =
         List(session.isDefined, sessionHash.isDefined, sessionName.isDefined, sessionUref.isDefined)

--- a/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
+++ b/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
@@ -173,11 +173,12 @@ trait ArbitraryConsensus {
   implicit def arbDeploy(implicit c: ConsensusConfig): Arbitrary[Deploy] = Arbitrary {
     for {
       accountKeys     <- Gen.oneOf(randomAccounts)
-      timestamp       <- Gen.choose(0L, Long.MaxValue)
+      timeToLive      <- Gen.option(Gen.choose(1 * 60 * 60 * 1000, 24 * 60 * 60 * 1000))
+      age             <- Gen.choose(0, timeToLive getOrElse 24 * 60 * 60 * 1000)
+      timestamp       = System.currentTimeMillis - age
       gasPrice        <- arbitrary[Long]
       sessionCode     <- Gen.choose(0, c.maxSessionCodeBytes).flatMap(genBytes(_))
       paymentCode     <- Gen.choose(0, c.maxPaymentCodeBytes).flatMap(genBytes(_))
-      timeToLive      <- Gen.option(Gen.choose(1 * 60 * 60 * 1000, 24 * 60 * 60 * 1000))
       numDependencies <- Gen.chooseNum(0, 10)
       dependencies    <- Gen.listOfN(numDependencies, genHash)
       body = Deploy
@@ -229,11 +230,12 @@ trait ArbitraryConsensus {
   // It's backwards but then the DAG of summaries doesn't need to spend time generating bodies.
   private def genBlockFromSummary(summary: BlockSummary)(implicit c: ConsensusConfig): Gen[Block] =
     for {
-      deploys <- Gen.listOfN(summary.deployCount, arbitrary[Block.ProcessedDeploy])
+      deploys   <- Gen.listOfN(summary.deployCount, arbitrary[Block.ProcessedDeploy])
+      timestamp = deploys.map(_.getDeploy.getHeader.timestamp).maximumOption.getOrElse(0L)
     } yield {
       Block()
         .withBlockHash(summary.blockHash)
-        .withHeader(summary.getHeader)
+        .withHeader(summary.getHeader.withTimestamp(timestamp))
         .withBody(Block.Body(deploys))
         .withSignature(summary.getSignature)
     }

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -51,6 +51,10 @@ message Deploy {
         // List of `Deploy.deploy_hash`s  that must be executed in past blocks
         // before this deploy can be executed.
         repeated bytes dependencies = 7;
+        // If present, the deploy can only be included in a block on the right chain.
+        // This can be used to preotect against accidental or malicious cross chain
+        // deploys, in case the same account exists on multiple networks.
+        string chain_name = 8;
     }
 
     message Body {


### PR DESCRIPTION
### Overview
Adds an optional `Deploy.Header.chain_name` field that users can set through the `--chain-name` CLI option during deployment. If set, it has to match the chain name in the ChainSpec. This mechanism can be used to protect against accidentally sending a deploy to the wrong network, or to get it deployed there by somebody else. This would only affect people who share the same account key, e.g. the one they use for testnet would be present on mainnet as well, where it hurts.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-440

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
@piokuc this could be integration tested and/or added to the Python client.
