### PR TITLE
EE-705: clean up ExecutionEngineService::execute

### DIFF
--- a/execution-engine/engine-core/src/engine_state/deploy_item.rs
+++ b/execution-engine/engine-core/src/engine_state/deploy_item.rs
@@ -1,0 +1,62 @@
+use std::collections::BTreeSet;
+
+use contract_ffi::value::account::PublicKey;
+
+use crate::engine_state::executable_deploy_item::ExecutableDeployItem;
+use crate::DeployHash;
+
+type GasPrice = u64;
+
+/// Represents a deploy to be executed.  Corresponds to the similarly-named ipc protobuf message.
+pub struct DeployItem {
+    address: PublicKey,
+    session: ExecutableDeployItem,
+    payment: ExecutableDeployItem,
+    gas_price: GasPrice,
+    authorization_keys: Vec<PublicKey>,
+    deploy_hash: DeployHash,
+}
+
+impl DeployItem {
+    /// Creates a [`DeployItem`].
+    pub fn new(
+        address: PublicKey,
+        session: ExecutableDeployItem,
+        payment: ExecutableDeployItem,
+        gas_price: GasPrice,
+        authorization_keys: Vec<PublicKey>,
+        deploy_hash: DeployHash,
+    ) -> Self {
+        DeployItem {
+            address,
+            session,
+            payment,
+            gas_price,
+            authorization_keys,
+            deploy_hash,
+        }
+    }
+    pub fn address(&self) -> PublicKey {
+        self.address
+    }
+
+    pub fn session(&self) -> &ExecutableDeployItem {
+        &self.session
+    }
+
+    pub fn payment(&self) -> &ExecutableDeployItem {
+        &self.payment
+    }
+
+    pub fn gas_price(&self) -> GasPrice {
+        self.gas_price
+    }
+
+    pub fn authorization_keys(&self) -> BTreeSet<PublicKey> {
+        self.authorization_keys.iter().cloned().collect()
+    }
+
+    pub fn deploy_hash(&self) -> DeployHash {
+        self.deploy_hash
+    }
+}

--- a/execution-engine/engine-core/src/engine_state/deploy_item.rs
+++ b/execution-engine/engine-core/src/engine_state/deploy_item.rs
@@ -13,7 +13,7 @@ pub struct DeployItem {
     session: ExecutableDeployItem,
     payment: ExecutableDeployItem,
     gas_price: GasPrice,
-    authorization_keys: Vec<PublicKey>,
+    authorization_keys: BTreeSet<PublicKey>,
     deploy_hash: DeployHash,
 }
 
@@ -24,7 +24,7 @@ impl DeployItem {
         session: ExecutableDeployItem,
         payment: ExecutableDeployItem,
         gas_price: GasPrice,
-        authorization_keys: Vec<PublicKey>,
+        authorization_keys: BTreeSet<PublicKey>,
         deploy_hash: DeployHash,
     ) -> Self {
         DeployItem {
@@ -52,8 +52,8 @@ impl DeployItem {
         self.gas_price
     }
 
-    pub fn authorization_keys(&self) -> BTreeSet<PublicKey> {
-        self.authorization_keys.iter().cloned().collect()
+    pub fn authorization_keys(&self) -> &BTreeSet<PublicKey> {
+        &self.authorization_keys
     }
 
     pub fn deploy_hash(&self) -> DeployHash {

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -711,7 +711,7 @@ where
 
         // Authorize using provided authorization keys
         // validation_spec_3: account validity
-        if authorization_keys.is_empty() || !account.can_authorize(&authorization_keys) {
+        if authorization_keys.is_empty() || !account.can_authorize(authorization_keys) {
             return Ok(ExecutionResult::precondition_failure(
                 crate::engine_state::error::Error::AuthorizationError,
             ));
@@ -719,7 +719,7 @@ where
 
         // Check total key weight against deploy threshold
         // validation_spec_4: deploy validity
-        if !account.can_deploy_with(&authorization_keys) {
+        if !account.can_deploy_with(authorization_keys) {
             return Ok(ExecutionResult::precondition_failure(
                 // TODO?:this doesn't happen in execution any longer, should error variant be moved
                 execution::Error::DeploymentAuthorizationFailure.into(),

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -1,3 +1,4 @@
+pub mod deploy_item;
 pub mod engine_config;
 mod error;
 pub mod executable_deploy_item;
@@ -33,6 +34,7 @@ use engine_storage::protocol_data::ProtocolData;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 use engine_wasm_prep::Preprocessor;
 
+use self::deploy_item::DeployItem;
 pub use self::engine_config::EngineConfig;
 pub use self::error::{Error, RootNotFound};
 use self::executable_deploy_item::ExecutableDeployItem;
@@ -658,19 +660,21 @@ where
     #[allow(clippy::too_many_arguments)]
     pub fn deploy(
         &self,
-        session: ExecutableDeployItem,
-        payment: ExecutableDeployItem,
-        address: Key,
-        authorization_keys: BTreeSet<PublicKey>,
-        blocktime: BlockTime,
-        deploy_hash: [u8; 32],
-        prestate_hash: Blake2bHash,
-        protocol_version: ProtocolVersion,
         correlation_id: CorrelationId,
         executor: &Executor,
         preprocessor: &Preprocessor,
+        protocol_version: ProtocolVersion,
+        prestate_hash: Blake2bHash,
+        blocktime: BlockTime,
+        deploy_item: DeployItem,
     ) -> Result<ExecutionResult, RootNotFound> {
         // spec: https://casperlabs.atlassian.net/wiki/spaces/EN/pages/123404576/Payment+code+execution+specification
+
+        let session = deploy_item.session();
+        let payment = deploy_item.payment();
+        let address = Key::Account(deploy_item.address().value());
+        let authorization_keys = deploy_item.authorization_keys();
+        let deploy_hash = deploy_item.deploy_hash();
 
         // Create tracking copy (which functions as a deploy context)
         // validation_spec_2: prestate_hash check

--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -43,7 +43,10 @@ pub mod runtime_context;
 pub mod tracking_copy;
 
 pub const ADDRESS_LENGTH: usize = 32;
+pub const DEPLOY_HASH_LENGTH: usize = 32;
 
-type Address = [u8; ADDRESS_LENGTH];
+pub type Address = [u8; ADDRESS_LENGTH];
+
+pub type DeployHash = [u8; DEPLOY_HASH_LENGTH];
 
 type KnownKeys = BTreeMap<String, Key>;

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -11,6 +11,7 @@ use contract_ffi::value::account::{
     KEY_SIZE,
 };
 use contract_ffi::value::{ProtocolVersion, U512};
+use engine_core::engine_state::deploy_item::DeployItem;
 use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
 use engine_core::engine_state::execution_effect::ExecutionEffect;
 use engine_core::engine_state::execution_result::ExecutionResult;
@@ -20,11 +21,11 @@ use engine_core::engine_state::upgrade::UpgradeConfig;
 use engine_core::engine_state::{Error as EngineError, RootNotFound};
 use engine_core::execution::Error as ExecutionError;
 use engine_core::tracking_copy::utils;
+use engine_core::{engine_state, DEPLOY_HASH_LENGTH};
 use engine_shared::motes::Motes;
 use engine_shared::transform::{self, TypeMismatch};
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
-use crate::engine_server::ipc::{ChainSpec_CostTable, ChainSpec_GenesisAccount};
 use crate::engine_server::{ipc, state, transforms};
 
 mod uint;
@@ -36,15 +37,23 @@ fn transform_write(v: contract_ffi::value::Value) -> Result<transform::Transform
 
 #[derive(Debug)]
 pub enum MappingError {
+    InvalidHashLength { expected: usize, actual: usize },
     InvalidPublicKeyLength { expected: usize, actual: usize },
+    InvalidDeployHashLength { expected: usize, actual: usize },
     ParsingError(ParsingError),
-    InvalidHash(String),
+    InvalidStateHash(String),
+    MissingPayload,
 }
 
 impl MappingError {
     pub fn invalid_public_key_length(actual: usize) -> Self {
         let expected = KEY_SIZE;
         MappingError::InvalidPublicKeyLength { expected, actual }
+    }
+
+    pub fn invalid_deploy_hash_length(actual: usize) -> Self {
+        let expected = DEPLOY_HASH_LENGTH;
+        MappingError::InvalidDeployHashLength { expected, actual }
     }
 }
 
@@ -54,18 +63,41 @@ impl From<ParsingError> for MappingError {
     }
 }
 
+// This is whackadoodle, we know
+impl From<MappingError> for engine_state::Error {
+    fn from(error: MappingError) -> Self {
+        match error {
+            MappingError::InvalidHashLength { expected, actual } => {
+                engine_state::Error::InvalidHashLength { expected, actual }
+            }
+            _ => engine_state::Error::DeployError,
+        }
+    }
+}
+
 impl Display for MappingError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         match self {
+            MappingError::InvalidHashLength { expected, actual } => write!(
+                f,
+                "Invalid hash length: expected {}, actual {}",
+                expected, actual
+            ),
             MappingError::InvalidPublicKeyLength { expected, actual } => write!(
                 f,
                 "Invalid public key length: expected {}, actual {}",
                 expected, actual
             ),
+            MappingError::InvalidDeployHashLength { expected, actual } => write!(
+                f,
+                "Invalid deploy hash length: expected {}, actual {}",
+                expected, actual
+            ),
             MappingError::ParsingError(ParsingError(message)) => {
                 write!(f, "Parsing error: {}", message)
             }
-            MappingError::InvalidHash(message) => write!(f, "Invalid hash: {}", message),
+            MappingError::InvalidStateHash(message) => write!(f, "Invalid hash: {}", message),
+            MappingError::MissingPayload => write!(f, "Missing payload"),
         }
     }
 }
@@ -1034,11 +1066,11 @@ impl From<GenesisConfig> for ipc::ChainSpec_GenesisConfig {
                 .iter()
                 .cloned()
                 .map(Into::into)
-                .collect::<Vec<ChainSpec_GenesisAccount>>();
+                .collect::<Vec<ipc::ChainSpec_GenesisAccount>>();
             ret.set_accounts(RepeatedField::from(accounts));
         }
         {
-            let mut cost_table = ChainSpec_CostTable::new();
+            let mut cost_table = ipc::ChainSpec_CostTable::new();
             cost_table.set_wasm(genesis_config.wasm_costs().into());
             ret.set_costs(cost_table);
         }
@@ -1053,7 +1085,7 @@ impl TryFrom<ipc::UpgradeRequest> for UpgradeConfig {
         let pre_state_hash = upgrade_request
             .get_parent_state_hash()
             .try_into()
-            .map_err(|_| MappingError::InvalidHash("pre_state_hash".to_string()))?;
+            .map_err(|_| MappingError::InvalidStateHash("pre_state_hash".to_string()))?;
 
         let current_protocol_version = upgrade_request.get_protocol_version().into();
 
@@ -1171,6 +1203,56 @@ impl TryFrom<&ipc::Bond> for (PublicKey, U512) {
         };
         let stake = bond.get_stake().try_into()?;
         Ok((public_key, stake))
+    }
+}
+
+impl TryFrom<&ipc::DeployItem> for DeployItem {
+    type Error = MappingError;
+
+    fn try_from(value: &ipc::DeployItem) -> Result<Self, Self::Error> {
+        let address = {
+            let tmp = value.get_address();
+            match tmp.try_into() {
+                Ok(public_key) => public_key,
+                Err(_) => return Err(MappingError::invalid_public_key_length(tmp.len())),
+            }
+        };
+        let session = match &(value.get_session()).payload {
+            Some(payload) => payload.to_owned().into(),
+            None => return Err(MappingError::MissingPayload),
+        };
+        let payment = match &(value.get_payment()).payload {
+            Some(payload) => payload.to_owned().into(),
+            None => return Err(MappingError::MissingPayload),
+        };
+        let gas_price = value.get_gas_price();
+        let authorization_keys = value
+            .get_authorization_keys()
+            .iter()
+            .map(|raw: &Vec<u8>| match raw.as_slice().try_into() {
+                Ok(public_key) => Ok(public_key),
+                Err(_) => Err(MappingError::invalid_public_key_length(raw.len())),
+            })
+            .collect::<Result<Vec<PublicKey>, Self::Error>>()?;
+        let deploy_hash = {
+            let source = value.get_deploy_hash();
+            let length = source.len();
+            if length != DEPLOY_HASH_LENGTH {
+                return Err(MappingError::invalid_deploy_hash_length(length));
+            }
+            let mut ret = [0u8; DEPLOY_HASH_LENGTH];
+            ret.copy_from_slice(source);
+            ret
+        };
+
+        Ok(DeployItem::new(
+            address,
+            session,
+            payment,
+            gas_price,
+            authorization_keys,
+            deploy_hash,
+        ))
     }
 }
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::{TryFrom, TryInto};
 use std::fmt::{self, Display, Formatter};
 use std::string::ToString;
@@ -1229,11 +1229,12 @@ impl TryFrom<&ipc::DeployItem> for DeployItem {
         let authorization_keys = value
             .get_authorization_keys()
             .iter()
-            .map(|raw: &Vec<u8>| match raw.as_slice().try_into() {
-                Ok(public_key) => Ok(public_key),
-                Err(_) => Err(MappingError::invalid_public_key_length(raw.len())),
+            .map(|raw: &Vec<u8>| {
+                raw.as_slice()
+                    .try_into()
+                    .map_err(|_| MappingError::invalid_public_key_length(raw.len()))
             })
-            .collect::<Result<Vec<PublicKey>, Self::Error>>()?;
+            .collect::<Result<BTreeSet<PublicKey>, Self::Error>>()?;
         let deploy_hash = {
             let source = value.get_deploy_hash();
             let length = source.len();

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -1,6 +1,11 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::TryFrom;
-use std::convert::TryInto;
+pub mod ipc;
+pub mod ipc_grpc;
+pub mod mappings;
+pub mod state;
+pub mod transforms;
+
+use std::collections::BTreeMap;
+use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::io::ErrorKind;
 use std::marker::{Send, Sync};
@@ -8,33 +13,25 @@ use std::time::Instant;
 
 use grpc::SingleResponse;
 
-use contract_ffi::key::Key;
-use contract_ffi::value::account::{BlockTime, PublicKey};
+use contract_ffi::value::account::BlockTime;
 use contract_ffi::value::ProtocolVersion;
+use engine_core::engine_state::deploy_item::DeployItem;
 use engine_core::engine_state::execution_result::ExecutionResult;
 use engine_core::engine_state::genesis::{GenesisConfig, GenesisResult};
+use engine_core::engine_state::upgrade::{UpgradeConfig, UpgradeResult};
 use engine_core::engine_state::EngineState;
 use engine_core::engine_state::Error as EngineError;
 use engine_core::execution::Executor;
 use engine_core::tracking_copy::QueryResult;
 use engine_shared::logging;
+use engine_shared::logging::log_level::LogLevel;
 use engine_shared::logging::{log_duration, log_info};
-use engine_shared::newtypes::{Blake2bHash, CorrelationId};
+use engine_shared::newtypes::{Blake2bHash, CorrelationId, BLAKE2B_DIGEST_LENGTH};
 use engine_storage::global_state::{CommitResult, StateProvider};
 use engine_wasm_prep::Preprocessor;
 
 use self::ipc_grpc::ExecutionEngineService;
-use self::mappings::*;
-use engine_core::engine_state::upgrade::{UpgradeConfig, UpgradeResult};
-use engine_shared::logging::log_level::LogLevel;
-
-pub mod ipc;
-pub mod ipc_grpc;
-pub mod mappings;
-pub mod state;
-pub mod transforms;
-
-const EXPECTED_PUBLIC_KEY_LENGTH: usize = 32;
+use self::mappings::{CommitTransforms, MappingError, ParsingError};
 
 const METRIC_DURATION_COMMIT: &str = "commit_duration";
 const METRIC_DURATION_EXEC: &str = "exec_duration";
@@ -161,55 +158,77 @@ where
         let start = Instant::now();
         let correlation_id = CorrelationId::new();
 
-        let protocol_version = exec_request.get_protocol_version().into();
-
-        // TODO: don't unwrap
-        let prestate_hash: Blake2bHash = exec_request.get_parent_state_hash().try_into().unwrap();
-
-        // TODO: don't unwrap
-        let wasm_costs = self.wasm_costs(protocol_version).unwrap().unwrap();
-        let blocktime = BlockTime::new(exec_request.get_block_time());
-
-        let deploys = exec_request.get_deploys();
-
-        let preprocessor = Preprocessor::new(wasm_costs);
-
-        let executor = Executor;
-
-        let deploys_result: Result<Vec<ipc::DeployResult>, ipc::RootNotFound> = execute_deploys(
-            &self,
-            &executor,
-            &preprocessor,
-            prestate_hash,
-            blocktime,
-            deploys,
-            protocol_version,
-            correlation_id,
-        );
-
-        let exec_response = match deploys_result {
-            Ok(deploy_results) => {
-                let mut exec_response = ipc::ExecuteResponse::new();
-                let mut exec_result = ipc::ExecResult::new();
-                exec_result.set_deploy_results(protobuf::RepeatedField::from_vec(deploy_results));
-                exec_response.set_success(exec_result);
-                exec_response
-            }
-            Err(error) => {
-                logging::log_error("deploy results error: RootNotFound");
-                let mut exec_response = ipc::ExecuteResponse::new();
-                exec_response.set_missing_parent(error);
-                exec_response
+        let parent_state_hash = {
+            let parent_state_hash = exec_request.get_parent_state_hash();
+            match Blake2bHash::try_from(parent_state_hash) {
+                Ok(hash) => hash,
+                Err(_) => {
+                    // TODO: do not panic
+                    let length = parent_state_hash.len();
+                    panic!(
+                        "Invalid hash. Expected length: {:?}, actual length: {:?}",
+                        BLAKE2B_DIGEST_LENGTH, length
+                    )
+                }
             }
         };
+        let block_time = BlockTime::new(exec_request.get_block_time());
+        let protocol_version = exec_request.get_protocol_version().into();
+        // TODO: do not unwrap
+        let wasm_costs = self.wasm_costs(protocol_version).unwrap().unwrap();
+        let executor = Executor;
+        let preprocessor = Preprocessor::new(wasm_costs);
 
+        let mut exec_response = ipc::ExecuteResponse::new();
+        let mut results: Vec<ExecutionResult> = Vec::new();
+
+        for result in exec_request
+            .get_deploys()
+            .iter()
+            .map::<Result<DeployItem, MappingError>, _>(TryInto::try_into)
+        {
+            match result {
+                Ok(deploy_item) => {
+                    let result = self.deploy(
+                        correlation_id,
+                        &executor,
+                        &preprocessor,
+                        protocol_version,
+                        parent_state_hash,
+                        block_time,
+                        deploy_item,
+                    );
+                    match result {
+                        Ok(result) => results.push(result),
+                        Err(error) => {
+                            logging::log_error("deploy results error: RootNotFound");
+                            exec_response.set_missing_parent(error.into());
+                            log_duration(
+                                correlation_id,
+                                METRIC_DURATION_EXEC,
+                                TAG_RESPONSE_EXEC,
+                                start.elapsed(),
+                            );
+                            return grpc::SingleResponse::completed(exec_response);
+                        }
+                    };
+                }
+                Err(mapping_error) => {
+                    results.push(ExecutionResult::precondition_failure(mapping_error.into()))
+                }
+            }
+        }
+
+        let results: Vec<ipc::DeployResult> = results.into_iter().map(Into::into).collect();
+        let mut exec_result = ipc::ExecResult::new();
+        exec_result.set_deploy_results(protobuf::RepeatedField::from_vec(results));
+        exec_response.set_success(exec_result);
         log_duration(
             correlation_id,
             METRIC_DURATION_EXEC,
             TAG_RESPONSE_EXEC,
             start.elapsed(),
         );
-
         grpc::SingleResponse::completed(exec_response)
     }
 
@@ -543,113 +562,6 @@ where
 
         grpc::SingleResponse::completed(upgrade_response)
     }
-}
-
-#[allow(clippy::too_many_arguments)]
-fn execute_deploys<S>(
-    engine_state: &EngineState<S>,
-    executor: &Executor,
-    preprocessor: &Preprocessor,
-    prestate_hash: Blake2bHash,
-    blocktime: BlockTime,
-    deploys: &[ipc::DeployItem],
-    protocol_version: ProtocolVersion,
-    correlation_id: CorrelationId,
-) -> Result<Vec<ipc::DeployResult>, ipc::RootNotFound>
-where
-    S: StateProvider,
-    EngineError: From<S::Error>,
-    S::Error: Into<engine_core::execution::Error>,
-{
-    // We want to treat RootNotFound error differently b/c it should short-circuit
-    // the execution of ALL deploys within the block. This is because all of them
-    // share the same prestate and all of them would fail.
-    // Iterator (Result<_, _> + collect()) will short circuit the execution
-    // when run_deploy returns Err.
-    deploys
-        .iter()
-        .map(|deploy| {
-            let session = match deploy.get_session().to_owned().payload {
-                Some(payload) => payload.into(),
-                None => {
-                    return Ok(
-                        ExecutionResult::precondition_failure(EngineError::DeployError).into(),
-                    )
-                }
-            };
-
-            let payment = match deploy.get_payment().to_owned().payload {
-                Some(payload) => payload.into(),
-                None => {
-                    return Ok(
-                        ExecutionResult::precondition_failure(EngineError::DeployError).into(),
-                    )
-                }
-            };
-
-            let address = {
-                let address_len = deploy.address.len();
-                if address_len != EXPECTED_PUBLIC_KEY_LENGTH {
-                    let err = EngineError::InvalidPublicKeyLength {
-                        expected: EXPECTED_PUBLIC_KEY_LENGTH,
-                        actual: address_len,
-                    };
-                    let failure = ExecutionResult::precondition_failure(err);
-                    return Ok(failure.into());
-                }
-                let mut dest = [0; EXPECTED_PUBLIC_KEY_LENGTH];
-                dest.copy_from_slice(&deploy.address);
-                Key::Account(dest)
-            };
-
-            // Parse all authorization keys from IPC into a vector
-            let authorization_keys: BTreeSet<PublicKey> = {
-                let maybe_keys: Result<BTreeSet<_>, EngineError> = deploy
-                    .authorization_keys
-                    .iter()
-                    .map(|key_bytes| {
-                        // Try to convert an element of bytes into a possibly
-                        // valid PublicKey with error handling
-                        PublicKey::try_from(key_bytes.as_slice()).map_err(|_| {
-                            EngineError::InvalidPublicKeyLength {
-                                expected: EXPECTED_PUBLIC_KEY_LENGTH,
-                                actual: key_bytes.len(),
-                            }
-                        })
-                    })
-                    .collect();
-
-                match maybe_keys {
-                    Ok(keys) => keys,
-                    Err(error) => return Ok(ExecutionResult::precondition_failure(error).into()),
-                }
-            };
-
-            let deploy_hash = {
-                let mut buff = [0u8; 32];
-                let hash_slice = deploy.get_deploy_hash();
-                buff.copy_from_slice(hash_slice);
-                buff
-            };
-
-            engine_state
-                .deploy(
-                    session,
-                    payment,
-                    address,
-                    authorization_keys,
-                    blocktime,
-                    deploy_hash,
-                    prestate_hash,
-                    protocol_version,
-                    correlation_id,
-                    executor,
-                    preprocessor,
-                )
-                .map(Into::into)
-                .map_err(Into::into)
-        })
-        .collect()
 }
 
 // Helper method which returns single DeployResult that is set to be a

--- a/execution-engine/engine-shared/src/newtypes.rs
+++ b/execution-engine/engine-shared/src/newtypes.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
 
-const BLAKE2B_DIGEST_LENGTH: usize = 32;
+pub const BLAKE2B_DIGEST_LENGTH: usize = 32;
 
 /// Represents a 32-byte BLAKE2b hash digest
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
This PR consolidates execute and introduces a domain object for `DeployItem`

https://casperlabs.atlassian.net/browse/EE-705

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR is assigned.