### PR TITLE
NO-TICKET Removing test and changing default to latest.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,10 +60,10 @@ docker-push-all: \
 	docker-push/key-generator \
 	docker-push/explorer
 
-docker-build/node: .make/docker-build/universal/node .make/docker-build/test/node
-docker-build/client: .make/docker-build/universal/client .make/docker-build/test/client
-docker-build/execution-engine: .make/docker-build/execution-engine .make/docker-build/test/execution-engine
-docker-build/integration-testing: .make/docker-build/integration-testing .make/docker-build/test/integration-testing
+docker-build/node: .make/docker-build/universal/node
+docker-build/client: .make/docker-build/universal/client
+docker-build/execution-engine: .make/docker-build/execution-engine
+docker-build/integration-testing: .make/docker-build/integration-testing
 docker-build/key-generator: .make/docker-build/key-generator
 docker-build/explorer: .make/docker-build/explorer
 docker-build/grpcwebproxy: .make/docker-build/grpcwebproxy
@@ -135,24 +135,6 @@ cargo-native-packager/%:
 	cp execution-engine/Dockerfile $(RELEASE)/Dockerfile
 	docker build -f $(RELEASE)/Dockerfile -t $(DOCKER_USERNAME)/execution-engine:$(DOCKER_LATEST_TAG) $(RELEASE)
 	rm -rf $(RELEASE)/Dockerfile
-	mkdir -p $(dir $@) && touch $@
-
-# Make a node that has some extras installed for testing.
-.make/docker-build/test/node: \
-		.make/docker-build/universal/node
-	docker tag $(DOCKER_USERNAME)/node:$(DOCKER_LATEST_TAG) $(DOCKER_USERNAME)/node:$(DOCKER_TEST_TAG)
-	mkdir -p $(dir $@) && touch $@
-
-# Make a test version for the execution engine as well just so we can swith version easily.
-.make/docker-build/test/execution-engine: \
-		.make/docker-build/execution-engine
-	docker tag $(DOCKER_USERNAME)/execution-engine:$(DOCKER_LATEST_TAG) $(DOCKER_USERNAME)/execution-engine:$(DOCKER_TEST_TAG)
-	mkdir -p $(dir $@) && touch $@
-
-# Make a test tagged version of client so all tags exist for integration-testing.
-.make/docker-build/test/client: \
-		.make/docker-build/universal/client
-	docker tag $(DOCKER_USERNAME)/client:$(DOCKER_LATEST_TAG) $(DOCKER_USERNAME)/client:$(DOCKER_TEST_TAG)
 	mkdir -p $(dir $@) && touch $@
 
 # Make an image to run Python tests under integration-testing.

--- a/integration-testing/casperlabs_local_net/docker_base.py
+++ b/integration-testing/casperlabs_local_net/docker_base.py
@@ -78,7 +78,7 @@ class DockerBase:
         elif self.config.custom_docker_tag is not None:
             return self.config.custom_docker_tag
         else:
-            return "test"
+            return "latest"
 
     @property
     def is_in_docker(self) -> bool:

--- a/integration-testing/docker_run_tests.sh
+++ b/integration-testing/docker_run_tests.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [[ -n $DRONE_BUILD_NUMBER ]]; then
-    export TAG_NAME=test-DRONE-${DRONE_BUILD_NUMBER}
+    export TAG_NAME=DRONE-${DRONE_BUILD_NUMBER}
 else
-    export TAG_NAME="test"
+    export TAG_NAME="latest"
 fi
 
 export TEST_RUN_ARGS=$@

--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -3,7 +3,7 @@
 PYTEST_ARGS="-vv -ra "
 
 # $TAG_NAME should have value of "DRONE-####" from docker_run_tests.sh in CI
-if [[ -n $TAG_NAME ]] && [[ "$TAG_NAME" != "test" ]]; then
+if [[ -n $TAG_NAME ]] && [[ "$TAG_NAME" != "latest" ]]; then
     # We only want to limit maxfail in CI
     PYTEST_ARGS="${PYTEST_ARGS} --maxfail=3 --tb=short"
 else


### PR DESCRIPTION
Removing building and using of test tags.  
Will use latest locally and non-test flagged DRONE-#### in CI

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
