### PR TITLE
Added test to verify both Node and EE are outputting logs.

### DIFF
--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -75,6 +75,19 @@ def test_account_state(node):
     assert "counter" in names
 
 
+def test_logging_enabled_for_node_and_execution_engine(one_node_network):
+    """
+    Verify both Node and EE are outputting logs.
+    """
+    assert (
+        "Listening for traffic on casperlabs://"
+        in one_node_network.docker_nodes[0].logs()
+    )
+    assert (
+        '"host_name":"execution-engine-' in one_node_network.execution_engines[0].logs()
+    )
+
+
 def test_transfer_with_overdraft(node):
     # Notated uses of account ids in common.py
     a_id = 297


### PR DESCRIPTION
Adding a simple test to verify the both Node and EE are outputting logs to prevent a previous condition we saw with missing logs in EE.

https://casperlabs.atlassian.net/browse/NODE-868

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
