### PR TITLE
NO-TICKET: execution-engine: allow arguments to criterion executables

### DIFF
--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -28,6 +28,9 @@ criterion = "0.3"
 lmdb = "0.8.0"
 protobuf = "2"
 
+[lib]
+bench = false
+
 [[bench]]
 name = "transfer_bench"
 harness = false


### PR DESCRIPTION
### Overview
This PR allows us to pass arguments to criterion-based executables.

For example:
```
cargo bench --package casperlabs-engine-tests -- --save-baseline dev
```

Args [here](https://bheisler.github.io/criterion.rs/book/user_guide/command_line_options.html).


Fix found [here](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options).

### Which JIRA ticket does this PR relate to?
This is unticketed work related to internal benchmarking.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
