### PR TITLE
NODE-1001: Denormalise deploy summary and body into buffered_deploys.

### DIFF
--- a/storage/src/main/resources/db/migration/V20191101_1001__Add_body_to_deploy_buffer.sql
+++ b/storage/src/main/resources/db/migration/V20191101_1001__Add_body_to_deploy_buffer.sql
@@ -1,0 +1,16 @@
+
+-- Add the deploy summary and body to the buffer so we don't have to join.
+-- NOTE: The table was created 'without rowid', so it might perform better
+-- if it was recreated as a regular table, now that it will hold data. At
+-- least it will never hold many rows. Would need to copy all index defs
+-- and track down all the alterations made to it.
+
+ALTER TABLE buffered_deploys
+    ADD COLUMN summary BLOB;
+
+ALTER TABLE buffered_deploys
+    ADD COLUMN body BLOB;
+
+UPDATE buffered_deploys
+SET    summary = (SELECT summary FROM deploys d WHERE d.hash = buffered_deploys.hash),
+       body    = (SELECT body    FROM deploys d WHERE d.hash = buffered_deploys.hash);


### PR DESCRIPTION
### Overview
Creating blocks take longer after like 300GB of data has accumulated. We only need deploys which are in the buffer, so by replicating the data we can get rid of joins with the full deploys table.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1001

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
