### PR TITLE
NODE-995: Fix deploy dependencies deadlocking on database connection

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/helper/StorageFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/StorageFixture.scala
@@ -69,12 +69,12 @@ object StorageFixture {
         )
 
     for {
-      db                                     <- createDbFile
-      jdbcUrl                                = createJdbcUrl(db)
-      implicit0(xa: Transactor.Aux[F, Unit]) = createTransactor(jdbcUrl)
-      _                                      <- initTables(jdbcUrl)
-      storage                                <- SQLiteStorage.create[F]()
-      indexedDagStorage                      <- IndexedDagStorage.create[F](storage)
+      db                <- createDbFile
+      jdbcUrl           = createJdbcUrl(db)
+      xa                = createTransactor(jdbcUrl)
+      _                 <- initTables(jdbcUrl)
+      storage           <- SQLiteStorage.create[F](readXa = xa, writeXa = xa)
+      indexedDagStorage <- IndexedDagStorage.create[F](storage)
     } yield (storage, indexedDagStorage, storage)
   }
 }

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -804,11 +804,11 @@ def test_multiple_deploys_per_block(cli):
     assert set(d.deploy.deploy_hash for d in deploys) == set((deploy_hash1, deploy_hash2))
 
 
-def disabled_test_dependencies_ok_scala(scala_cli):
+def test_dependencies_ok_scala(scala_cli):
     check_dependencies_ok(scala_cli)
 
 
-def disabled_test_dependencies_ok_python(cli):
+def test_dependencies_ok_python(cli):
     check_dependencies_ok(cli)
 
 
@@ -826,11 +826,11 @@ def check_dependencies_ok(cli):
     propose_check_no_errors(cli)
 
 
-def disabled_test_dependencies_multiple_ok_scala(scala_cli):
+def test_dependencies_multiple_ok_scala(scala_cli):
     check_dependencies_multiple_ok(scala_cli)
 
 
-def disabled_test_dependencies_multiple_ok_python(cli):
+def test_dependencies_multiple_ok_python(cli):
     check_dependencies_multiple_ok(cli)
 
 
@@ -852,11 +852,11 @@ def check_dependencies_multiple_ok(cli):
     propose_check_no_errors(cli)
 
 
-def disabled_test_dependencies_not_met_scala(scala_cli):
+def test_dependencies_not_met_scala(scala_cli):
     check_dependencies_not_met(scala_cli)
 
 
-def disabled_test_dependencies_not_met_python(cli):
+def test_dependencies_not_met_python(cli):
     check_dependencies_not_met(cli)
 
 

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -82,42 +82,62 @@ package object effects {
       def ask: Task[List[Node]]          = state.get.map(_.bootstraps)
     }
 
-  // https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
-  def doobieTransactor(
-      connectEC: ExecutionContext,  // for waiting on connections, should be bounded
-      transactEC: ExecutionContext, // for JDBC, can be unbounded
+  /**
+    * @see https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
+    * @param connectEC for waiting on connections, should be bounded
+    * @param transactEC for JDBC, can be unbounded
+    * @return Write and read Transactors
+    */
+  def doobieTransactors(
+      connectEC: ExecutionContext,
+      transactEC: ExecutionContext,
       serverDataDir: Path
-  ): Resource[Task, Transactor[Task]] = {
-    val config = new HikariConfig()
-    config.setDriverClassName("org.sqlite.JDBC")
-    config.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
-    config.setMinimumIdle(2)
-    config.setMaximumPoolSize(2)
+  ): Resource[Task, (Transactor[Task], Transactor[Task])] = {
+    val writeXaconfig = new HikariConfig()
+    writeXaconfig.setDriverClassName("org.sqlite.JDBC")
+    writeXaconfig.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
+    writeXaconfig.setMinimumIdle(1)
+    writeXaconfig.setMaximumPoolSize(1)
     // `autoCommit=true` is a default for Hikari; doobie sets `autoCommit=false`.
     // From doobie's docs:
     // * - Auto-commit will be set to `false`;
     // * - the transaction will `commit` on success and `rollback` on failure;
-    config.setAutoCommit(false)
-    // Using a connection pool with maximum size of 1 becuase with the default settings we got SQLITE_BUSY errors.
+    writeXaconfig.setAutoCommit(false)
+    // Using a connection pool with maximum size of 1 for writers because with the default settings we got SQLITE_BUSY errors.
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
 
-    // UPDATE: Set connection pool size to 2 because
+    // UPDATE: Use separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection
-    // preventing acquiring a connection in other places.
-    // If SQLITE_BUSY errors happen again then we need to find another solution.
-    // Hint: Use config.setLeakDetectionThreshold(10000) to detect connection leaking.
-    HikariTransactor
-      .fromHikariConfig[Task](
-        config,
-        connectEC,
-        Blocker.liftExecutionContext(transactEC)
-      )
-      .map { xa =>
-        // Foreign keys support must be enabled explicitly in SQLite
-        // https://www.sqlite.org/foreignkeys.html#fk_enable
-        Transactor.before
-          .set(xa, sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before.get(xa))
-      }
+    // preventing acquiring a connection in other places if we use a connection pool with size of 1.
+    // TODO: If SQLITE_BUSY errors happen again then we need to find another solution.
+    // Hint: Use config.setLeakDetectionThreshold(10000) to detect connection leaking
+    for {
+      writeXa <- HikariTransactor
+                  .fromHikariConfig[Task](
+                    writeXaconfig,
+                    connectEC,
+                    Blocker.liftExecutionContext(transactEC)
+                  )
+                  .map { xa =>
+                    // Foreign keys support must be enabled explicitly in SQLite
+                    // https://www.sqlite.org/foreignkeys.html#fk_enable
+                    Transactor.before
+                      .set(
+                        xa,
+                        sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before.get(xa)
+                      )
+                  }
+      // Ignoring foreign keys pragma during reads, because it doesn't affect on logic
+      readXa <- HikariTransactor
+                 .newHikariTransactor[Task](
+                   "org.sqlite.JDBC",
+                   s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}",
+                   "",
+                   "",
+                   connectEC,
+                   Blocker.liftExecutionContext(transactEC)
+                 )
+    } yield (writeXa, readXa)
   }
 }

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -1,52 +1,53 @@
 package io.casperlabs.storage
 
-import cats.effect.Sync
-import cats.implicits._
-import com.google.protobuf.ByteString
-import doobie.util.transactor.Transactor
-import io.casperlabs.casper.consensus.{Block, BlockSummary, Deploy}
-import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
-import io.casperlabs.metrics.Metrics
-import io.casperlabs.models.Message
-import io.casperlabs.shared.Time
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
-import io.casperlabs.storage.block.{BlockStorage, SQLiteBlockStorage}
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
-import io.casperlabs.storage.dag.{DagRepresentation, DagStorage, SQLiteDagStorage}
-import io.casperlabs.crypto.Keys.PublicKeyBS
-import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.storage.deploy.{
   DeployStorage,
   DeployStorageReader,
   DeployStorageWriter,
   SQLiteDeployStorage
 }
+import cats.effect.Sync
+import cats.implicits._
+import com.google.protobuf.ByteString
+import doobie.util.transactor.Transactor
+import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
+import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.models.Message
+import io.casperlabs.shared.Time
+import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.block.{BlockStorage, SQLiteBlockStorage}
+import io.casperlabs.storage.dag.DagRepresentation.Validator
+import io.casperlabs.storage.dag.{DagRepresentation, DagStorage, SQLiteDagStorage}
 import fs2._
 
-import scala.concurrent.duration.FiniteDuration
-import _root_.io.casperlabs.storage.deploy.DeployStorageReader
-
 object SQLiteStorage {
-  def create[F[_]: Sync: Transactor: Metrics: Time](
-      deployStorageChunkSize: Int = 100
+  def create[F[_]: Sync: Metrics: Time](
+      deployStorageChunkSize: Int = 100,
+      readXa: Transactor[F],
+      writeXa: Transactor[F]
   ): F[BlockStorage[F] with DagStorage[F] with DeployStorage[F] with DagRepresentation[F]] =
     create[F](
       deployStorageChunkSize = deployStorageChunkSize,
+      readXa = readXa,
+      writeXa = writeXa,
       wrapBlockStorage = (_: BlockStorage[F]).pure[F],
       wrapDagStorage = (_: DagStorage[F] with DagRepresentation[F]).pure[F]
     )
 
-  def create[F[_]: Sync: Transactor: Metrics: Time](
+  def create[F[_]: Sync: Metrics: Time](
       deployStorageChunkSize: Int,
+      readXa: Transactor[F],
+      writeXa: Transactor[F],
       wrapBlockStorage: BlockStorage[F] => F[BlockStorage[F]],
       wrapDagStorage: DagStorage[F] with DagRepresentation[F] => F[
         DagStorage[F] with DagRepresentation[F]
       ]
   ): F[BlockStorage[F] with DagStorage[F] with DeployStorage[F] with DagRepresentation[F]] =
     for {
-      blockStorage  <- SQLiteBlockStorage.create[F] >>= wrapBlockStorage
-      dagStorage    <- SQLiteDagStorage.create[F] >>= wrapDagStorage
-      deployStorage <- SQLiteDeployStorage.create[F](deployStorageChunkSize)
+      blockStorage  <- SQLiteBlockStorage.create[F](readXa, writeXa) >>= wrapBlockStorage
+      dagStorage    <- SQLiteDagStorage.create[F](readXa, writeXa) >>= wrapDagStorage
+      deployStorage <- SQLiteDeployStorage.create[F](deployStorageChunkSize, readXa, writeXa)
     } yield new BlockStorage[F] with DagStorage[F] with DeployStorage[F] with DagRepresentation[F] {
 
       override def writer: DeployStorageWriter[F] =

--- a/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
@@ -2,15 +2,14 @@ package io.casperlabs.storage.block
 
 import cats._
 import cats.effect._
-import cats.effect.concurrent._
 import cats.implicits._
 import com.google.protobuf.ByteString
 import doobie._
 import doobie.implicits._
 import doobie.util.transactor.Transactor
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
-import io.casperlabs.casper.consensus.{Block, BlockSummary, Deploy}
 import io.casperlabs.casper.consensus.info.BlockInfo
+import io.casperlabs.casper.consensus.{Block, BlockSummary, Deploy}
 import io.casperlabs.catscontrib.Fs2Compiler
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.ipc.TransformEntry
@@ -21,7 +20,8 @@ import io.casperlabs.storage.util.DoobieCodecs
 import io.casperlabs.storage.{BlockMsgWithTransform, BlockStorageMetricsSource}
 
 class SQLiteBlockStorage[F[_]: Bracket[?[_], Throwable]: Fs2Compiler](
-    xa: Transactor[F]
+    readXa: Transactor[F],
+    writeXa: Transactor[F]
 ) extends BlockStorage[F]
     with DoobieCodecs {
 
@@ -68,7 +68,7 @@ class SQLiteBlockStorage[F[_]: Bracket[?[_], Throwable]: Fs2Compiler](
     val transaction = initial.flatMap(_.fold(none[BlockMsgWithTransform].pure[ConnectionIO]) {
       case (blockHash, blockSummary) => createTransaction(blockHash, blockSummary)
     })
-    transaction.transact(xa)
+    transaction.transact(readXa)
   }
 
   override def getByPrefix(blockHashPrefix: String): F[Option[BlockMsgWithTransform]] = {
@@ -97,7 +97,7 @@ class SQLiteBlockStorage[F[_]: Bracket[?[_], Throwable]: Fs2Compiler](
             |LIMIT 1""".stripMargin
         .query[BlockInfo]
         .option
-        .transact(xa)
+        .transact(readXa)
 
     getByPrefix[BlockInfo](
       blockHashPrefix,
@@ -132,14 +132,14 @@ class SQLiteBlockStorage[F[_]: Bracket[?[_], Throwable]: Fs2Compiler](
     }
 
   override def isEmpty: F[Boolean] =
-    sql"SELECT COUNT(*) FROM blocks".query[Long].unique.map(_ == 0L).transact(xa)
+    sql"SELECT COUNT(*) FROM blocks".query[Long].unique.map(_ == 0L).transact(readXa)
 
   override def put(blockHash: BlockHash, blockMsg: BlockMsgWithTransform): F[Unit] =
     Update[(BlockHash, TransformEntry)]("""|INSERT OR IGNORE INTO transforms
                                            |(block_hash, data)
                                            |VALUES (?, ?)""".stripMargin)
       .updateMany(blockMsg.transformEntry.map(t => (blockHash, t)).toList)
-      .transact(xa)
+      .transact(writeXa)
       .void
 
   override def getBlockSummary(blockHash: BlockHash): F[Option[BlockSummary]] =
@@ -151,35 +151,37 @@ class SQLiteBlockStorage[F[_]: Bracket[?[_], Throwable]: Fs2Compiler](
           |WHERE block_hash=$blockHash""".stripMargin
       .query[BlockInfo]
       .option
-      .transact(xa)
+      .transact(readXa)
 
   override def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]] =
     sql"""|SELECT block_hash
           |FROM deploy_process_results
           |WHERE deploy_hash=$deployHash
-          |ORDER BY create_time_millis""".stripMargin.query[BlockHash].to[Seq].transact(xa)
+          |ORDER BY create_time_millis""".stripMargin.query[BlockHash].to[Seq].transact(readXa)
 
   override def checkpoint(): F[Unit] = ().pure[F]
 
   override def clear(): F[Unit] =
-    sql"DELETE FROM transforms".update.run.void.transact(xa)
+    sql"DELETE FROM transforms".update.run.void.transact(writeXa)
 
   override def close(): F[Unit] = ().pure[F]
 }
 
 object SQLiteBlockStorage {
-  private[storage] def create[F[_]](
-      implicit xa: Transactor[F],
+  private[storage] def create[F[_]](readXa: Transactor[F], writeXa: Transactor[F])(
+      implicit
       metricsF: Metrics[F],
       syncF: Sync[F],
       fs2Compiler: Fs2Compiler[F]
   ): F[BlockStorage[F]] =
     for {
-      blockStorage <- Sync[F].delay(new SQLiteBlockStorage[F](xa) with MeteredBlockStorage[F] {
-                       override implicit val m: Metrics[F] = metricsF
-                       override implicit val ms: Source =
-                         Metrics.Source(BlockStorageMetricsSource, "sqlite")
-                       override implicit val a: Apply[F] = syncF
-                     })
+      blockStorage <- Sync[F].delay(
+                       new SQLiteBlockStorage[F](readXa, writeXa) with MeteredBlockStorage[F] {
+                         override implicit val m: Metrics[F] = metricsF
+                         override implicit val ms: Source =
+                           Metrics.Source(BlockStorageMetricsSource, "sqlite")
+                         override implicit val a: Apply[F] = syncF
+                       }
+                     )
     } yield blockStorage: BlockStorage[F]
 }

--- a/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
@@ -191,5 +191,5 @@ class SQLiteBlockStorageTest extends BlockStorageTest with SQLiteFixture[BlockSt
   override def db: String = "/tmp/block_storage.db"
 
   override def createTestResource: Task[BlockStorage[Task]] =
-    SQLiteStorage.create[Task]()
+    SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
 }

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -208,9 +208,9 @@ object CachingBlockStorageTest {
       xa: Transactor[Task]
   ): Task[BlockStorage[Task]] =
     for {
-      underlyingBlockStorage <- SQLiteBlockStorage.create[Task]
-      dagStorage             <- SQLiteDagStorage.create[Task]
-      deployStorage          <- SQLiteDeployStorage.create[Task](100)
+      underlyingBlockStorage <- SQLiteBlockStorage.create[Task](xa, xa)
+      dagStorage             <- SQLiteDagStorage.create[Task](xa, xa)
+      deployStorage          <- SQLiteDeployStorage.create[Task](100, xa, xa)
     } yield new BlockStorage[Task] {
       override def get(blockHash: BlockHash): Task[Option[BlockMsgWithTransform]] =
         underlyingBlockStorage.get(blockHash)

--- a/storage/src/test/scala/io/casperlabs/storage/dag/CachingDagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/CachingDagStorageTest.scala
@@ -45,7 +45,7 @@ class CachingDagStorageTest
   private def prepareTestEnvironment(cacheSize: Long, neighborhoodRange: Int) = {
     implicit val metrics: MockMetrics = new MockMetrics()
     for {
-      dagStorage <- SQLiteDagStorage.create[Task]
+      dagStorage <- SQLiteDagStorage.create[Task](xa, xa)
       cache <- CachingDagStorage[Task](
                 dagStorage,
                 cacheSize,

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -4,7 +4,6 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
-import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.models.BlockImplicits._
 import io.casperlabs.models.Message
 import io.casperlabs.storage.{
@@ -170,7 +169,7 @@ class SQLiteDagStorageTest extends DagStorageTest with SQLiteFixture[DagStorage[
   override def db: String = "/tmp/dag_storage.db"
 
   override def createTestResource: Task[DagStorage[Task]] =
-    SQLiteStorage.create[Task]()
+    SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
 
   "SQLite DAG Storage" should "override validator's latest block hash only if new messages quotes the previous one" in {
     forAll { (initial: Block, a: Block, c: Block) =>

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/SQLiteDeployStorageSpec.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/SQLiteDeployStorageSpec.scala
@@ -1,12 +1,13 @@
 package io.casperlabs.storage.deploy
 
-import io.casperlabs.casper.consensus.info.DeployInfo
-import io.casperlabs.storage.{SQLiteFixture, SQLiteStorage}
-import io.casperlabs.shared.Sorting.byteStringOrdering
-import io.casperlabs.crypto.Keys.PublicKey
 import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.info.DeployInfo
+import io.casperlabs.crypto.Keys.PublicKey
+import io.casperlabs.shared.Sorting.byteStringOrdering
+import io.casperlabs.storage.{SQLiteFixture, SQLiteStorage}
 import monix.eval.Task
 import org.scalacheck.Gen
+
 import scala.concurrent.duration._
 
 class SQLiteDeployStorageSpec
@@ -36,7 +37,7 @@ class SQLiteDeployStorageSpec
       deployView: DeployInfo.View
   ): Task[(DeployStorageReader[Task], DeployStorageWriter[Task])] =
     SQLiteStorage
-      .create[Task]()
+      .create[Task](readXa = xa, writeXa = xa)
       .map(s => (s.reader(deployView), s.writer))
 
   "SQLiteDeployStorage" should {


### PR DESCRIPTION
### Overview
**Problem:**
Deploy dependencies feature brought in #1156 and #1174 didn't work because:
1. We set Hikari connection pool size to 1 because of _SQLITE_BUSY_ error in the past.
2. After a while we started using `fs2.Stream` as a return type for some of `SQLite` storages.
3. `fs2.Stream` holds an opened connection during evaluation preventing acquiring of the next connection causing `HikariPool-1 - Connection is not available, request timed out after 30003ms.`

**Solution:** ~Temporarily set Hikari connection pool size to 2.~
If _SQLITE_BUSY_ error starts happen again then we'll need to find another solution, maybe tweaking `SQLite` compilation options trying different threading modes. This most probably will require from us to compile `SQLite` by ourselves, since I didn't find such prebuilt `SQLite` binaries previously when I worked on fixing _SQLITE_BUSY_ error.

**UPDATE1:** During the code review, we agreed that bumping the connection pool size to 2 is not a solution and decided to give it a try for using separate Doobie Transactors for writes (size 1) and reads (many  connections). If I understand correctly, SQLite should be able handle setup with a single writer and multiple readers: https://www.sqlite.org/lockingv3.html (5.1 Writer starvation).
**UPDATE2:** The above comment about possible appearing of _SQLITE_BUSY_ errors is still actual and we should not forget about it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-995

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature. (I've reenabled integration tests)
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Hikari has a nice `leakDetectionThreshold` option which helped me finding the root cause. It's not ideal because the shown stack trace doesn't contain much of useful information, but it's still good to know about _existence_ of leaking connections.

**Example output:**
```
20:24:22.251 [HikariPool-1 housekeeper] WARN  com.zaxxer.hikari.pool.ProxyLeakTask - Connection leak detection triggered for org.sqlite.jdbc4.JDBC4Connection@5176d279 on thread db-conn-20, stack trace follows
java.lang.Exception: Apparent connection leak detected
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:100)
	at doobie.util.transactor$Transactor$fromDataSource$FromDataSourceUnapplied.$anonfun$apply$14(transactor.scala:280)
	at monix.eval.internal.TaskRunLoop$.startFull(TaskRunLoop.scala:81)
	at monix.eval.internal.TaskRunLoop$.$anonfun$restartAsync$1(TaskRunLoop.scala:222)
	at monix.execution.internal.InterceptRunnable.run(InterceptRunnable.scala:27)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```