### PR TITLE
EE-730: add note about data directory to --help

### DIFF
--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -70,7 +70,8 @@ const DEFAULT_PAGES: usize = 196_608_000;
 
 // socket
 const ARG_SOCKET: &str = "socket";
-const ARG_SOCKET_HELP: &str = "socket file";
+const ARG_SOCKET_HELP: &str =
+    "Path to socket.  Note that this path is independent of the data directory.";
 const ARG_SOCKET_EXPECT: &str = "socket required";
 const REMOVING_SOCKET_FILE_MESSAGE: &str = "removing old socket file";
 const REMOVING_SOCKET_FILE_EXPECT: &str = "failed to remove old socket file";


### PR DESCRIPTION
### Overview
This PR updates the output of `--help` to clarify that the path to the socket is independent of the data directory.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-730

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
