### PR TITLE
OP-830: bump crate 0.18.0 -> 0.19.0

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -4,14 +4,14 @@
 name = "add-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "add-update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -34,21 +34,21 @@ dependencies = [
 name = "args-multi"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "args-u32"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "args-u512"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -77,7 +77,7 @@ dependencies = [
 name = "authorized-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -175,14 +175,14 @@ dependencies = [
 name = "bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "bonding-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "casperlabs-contract-ffi"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -246,7 +246,7 @@ name = "casperlabs-engine-core"
 version = "0.1.0"
 dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
  "casperlabs-engine-wasm-prep 0.1.0",
@@ -271,7 +271,7 @@ dependencies = [
 name = "casperlabs-engine-grpc-server"
 version = "0.9.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-storage 0.1.0",
@@ -308,7 +308,7 @@ version = "0.2.0"
 dependencies = [
  "base16 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "casperlabs-engine-wasm-prep 0.1.0",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -327,7 +327,7 @@ dependencies = [
 name = "casperlabs-engine-storage"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "casperlabs-engine-shared 0.2.0",
  "casperlabs-engine-wasm-prep 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -343,7 +343,7 @@ dependencies = [
 name = "casperlabs-engine-tests"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "casperlabs-engine-core 0.1.0",
  "casperlabs-engine-grpc-server 0.9.0",
  "casperlabs-engine-shared 0.2.0",
@@ -367,7 +367,7 @@ dependencies = [
 name = "casperlabs-engine-wasm-prep"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "casperlabs-engine-shared 0.2.0",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -393,7 +393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "check-system-contract-urefs-access-rights"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -446,35 +446,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "counter-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "counter-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "create-accounts"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "create-named-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "create-purse-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ name = "create-test-node-shared"
 version = "0.1.0"
 dependencies = [
  "binascii 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ dependencies = [
 name = "deserialize-error"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ dependencies = [
 name = "direct-revert"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -665,28 +665,28 @@ dependencies = [
 name = "do-nothing"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "do-nothing-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "do-nothing-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "do-nothing-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "create-purse-01 0.1.0",
 ]
 
@@ -694,112 +694,112 @@ dependencies = [
 name = "ee-221-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-401-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-401-regression-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-441-rng-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-460-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-532-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-536-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-539-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-549-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-550-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-572-regression-create"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-572-regression-escalate"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-584-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-597-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-598-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "ee-601-regression"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -811,7 +811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "endless-loop"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -850,7 +850,7 @@ dependencies = [
 name = "faucet"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -903,56 +903,56 @@ dependencies = [
 name = "get-arg"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-blocktime"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-caller-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-caller-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-caller-subcall"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-phase"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "get-phase-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1019,14 +1019,14 @@ dependencies = [
 name = "hello-name-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "hello-name-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1169,7 +1169,7 @@ dependencies = [
 name = "key-management-thresholds"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1191,21 +1191,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "list-known-urefs-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "list-known-urefs-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "list-named-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1232,14 +1232,14 @@ dependencies = [
 name = "local-state"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "local-state-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "local-state 0.1.0",
 ]
 
@@ -1247,14 +1247,14 @@ dependencies = [
 name = "local-state-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "local-state-stored-upgraded"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "local-state 0.1.0",
 ]
 
@@ -1262,7 +1262,7 @@ dependencies = [
 name = "local-state-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "local-state-stored-upgraded 0.1.0",
 ]
 
@@ -1303,21 +1303,21 @@ dependencies = [
 name = "mailing-list-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "mailing-list-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "main-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1355,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mint-install"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "mint-token 0.1.0",
 ]
 
@@ -1363,14 +1363,14 @@ dependencies = [
 name = "mint-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1415,7 +1415,7 @@ dependencies = [
 name = "modified-mint"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "mint-token 0.1.0",
 ]
 
@@ -1423,14 +1423,14 @@ dependencies = [
 name = "modified-mint-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "modified-mint-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "modified-mint 0.1.0",
 ]
 
@@ -1438,14 +1438,14 @@ dependencies = [
 name = "named-keys"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "named-purse-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1560,7 +1560,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "overwrite-uref-content"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1628,7 +1628,7 @@ dependencies = [
 name = "payment-from-named-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1640,35 +1640,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "pos"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "pos-bonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "pos-finalize-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "pos-get-payment-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "pos-install"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
  "pos 0.1.0",
 ]
 
@@ -1676,7 +1676,7 @@ dependencies = [
 name = "pos-refund-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -1770,21 +1770,21 @@ dependencies = [
 name = "purse-holder-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "purse-holder-stored-caller"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "purse-holder-stored-upgrader"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2054,7 +2054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "remove-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2069,7 +2069,7 @@ dependencies = [
 name = "revert"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2189,14 +2189,14 @@ dependencies = [
 name = "set-key-thresholds"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "simple-transfer"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2228,21 +2228,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "standard-payment"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "standard-payment-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "state-initializer"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2262,14 +2262,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "subcall-revert-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "subcall-revert-define"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2312,7 +2312,7 @@ dependencies = [
 name = "system-contracts-access"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2349,7 +2349,7 @@ dependencies = [
 name = "test-mint-token"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2640,56 +2640,56 @@ dependencies = [
 name = "transfer-main-purse-to-new-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-account-stored"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-purse-to-purse"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-to-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-to-account-01"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-to-account-02"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "transfer-to-existing-account"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2716,14 +2716,14 @@ dependencies = [
 name = "unbonding"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
 name = "unbonding-call"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]
@@ -2754,7 +2754,7 @@ dependencies = [
 name = "update-associated-key"
 version = "0.1.0"
 dependencies = [
- "casperlabs-contract-ffi 0.18.0",
+ "casperlabs-contract-ffi 0.19.0",
 ]
 
 [[package]]

--- a/execution-engine/contract-ffi/Cargo.toml
+++ b/execution-engine/contract-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-contract-ffi"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."


### PR DESCRIPTION
### Overview
Bumps ffi to 0.18.0 -> 0.19.0 in prep for release. Will publish to crates.io after merging.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-830

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
