### PR TITLE
NODE-995: Disable auto-commit on the reader pool as well.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -113,7 +113,7 @@ package object effects {
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
     val writeXaconfig = mkConfig(poolSize = 1)
 
-    // Useing a separate Transactor for read operations because
+    // Using a separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection
     // preventing acquiring a connection in other places if we use a connection pool with size of 1.
     val readXaconfig = mkConfig(poolSize = 10)

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -93,24 +93,31 @@ package object effects {
       transactEC: ExecutionContext,
       serverDataDir: Path
   ): Resource[Task, (Transactor[Task], Transactor[Task])] = {
-    val writeXaconfig = new HikariConfig()
-    writeXaconfig.setDriverClassName("org.sqlite.JDBC")
-    writeXaconfig.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
-    writeXaconfig.setMinimumIdle(1)
-    writeXaconfig.setMaximumPoolSize(1)
-    // `autoCommit=true` is a default for Hikari; doobie sets `autoCommit=false`.
-    // From doobie's docs:
-    // * - Auto-commit will be set to `false`;
-    // * - the transaction will `commit` on success and `rollback` on failure;
-    writeXaconfig.setAutoCommit(false)
+    def mkConfig(poolSize: Int) = {
+      val config = new HikariConfig()
+      config.setDriverClassName("org.sqlite.JDBC")
+      config.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
+      config.setMinimumIdle(1)
+      config.setMaximumPoolSize(poolSize)
+      // `autoCommit=true` is a default for Hikari; doobie sets `autoCommit=false`.
+      // From doobie's docs:
+      // * - Auto-commit will be set to `false`;
+      // * - the transaction will `commit` on success and `rollback` on failure;
+      // Setting it to false to avoid seeing resets in the log every time.
+      config.setAutoCommit(false)
+      config
+    }
+
     // Using a connection pool with maximum size of 1 for writers because with the default settings we got SQLITE_BUSY errors.
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
+    val writeXaconfig = mkConfig(poolSize = 1)
 
-    // UPDATE: Use separate Transactor for read operations because
+    // Useing a separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection
     // preventing acquiring a connection in other places if we use a connection pool with size of 1.
-    // TODO: If SQLITE_BUSY errors happen again then we need to find another solution.
+    val readXaconfig = mkConfig(poolSize = 10)
+
     // Hint: Use config.setLeakDetectionThreshold(10000) to detect connection leaking
     for {
       writeXa <- HikariTransactor
@@ -128,13 +135,10 @@ package object effects {
                         sql"PRAGMA foreign_keys = ON;".update.run.void >> Transactor.before.get(xa)
                       )
                   }
-      // Ignoring foreign keys pragma during reads, because it doesn't affect on logic
+      // Ignoring foreign keys pragma during reads, because it doesn't affect the logic.
       readXa <- HikariTransactor
-                 .newHikariTransactor[Task](
-                   "org.sqlite.JDBC",
-                   s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}",
-                   "",
-                   "",
+                 .fromHikariConfig[Task](
+                   readXaconfig,
                    connectEC,
                    Blocker.liftExecutionContext(transactEC)
                  )


### PR DESCRIPTION
### Overview
Hikari pool has auto-commit on, doobie set it off, then Hikari resets it, spamming the logs.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-995

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
