### PR TITLE
EE-760: Remove Validated type

### DIFF
--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -281,6 +281,12 @@ from_try_from_impl!(Key, Key);
 from_try_from_impl!(Account, Account);
 from_try_from_impl!(Contract, Contract);
 
+impl From<(String, key::Key)> for Value {
+    fn from(named_key: (String, key::Key)) -> Value {
+        Value::NamedKey(named_key.0, named_key.1)
+    }
+}
+
 impl From<()> for Value {
     fn from(_: ()) -> Self {
         Value::Unit

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -281,9 +281,9 @@ from_try_from_impl!(Key, Key);
 from_try_from_impl!(Account, Account);
 from_try_from_impl!(Contract, Contract);
 
-impl From<(String, key::Key)> for Value {
-    fn from(named_key: (String, key::Key)) -> Value {
-        Value::NamedKey(named_key.0, named_key.1)
+impl From<(String, Key)> for Value {
+    fn from((name, key): (String, Key)) -> Value {
+        Value::NamedKey(name, key)
     }
 }
 

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -18,7 +18,7 @@ pub use self::uint::{U128, U256, U512};
 use crate::bytesrepr::{
     Error, FromBytes, ToBytes, U128_SIZE, U256_SIZE, U32_SIZE, U512_SIZE, U64_SIZE, U8_SIZE,
 };
-use crate::key::{self, Key, UREF_SIZE};
+use crate::key::{Key, UREF_SIZE};
 use crate::uref::URef;
 
 const INT32_ID: u8 = 0;
@@ -47,10 +47,10 @@ pub enum Value {
     ListInt32(Vec<i32>),
     String(String),
     ListString(Vec<String>),
-    NamedKey(String, key::Key),
-    Key(key::Key),
-    Account(account::Account),
-    Contract(contract::Contract),
+    NamedKey(String, Key),
+    Key(Key),
+    Account(Account),
+    Contract(Contract),
     Unit,
 }
 
@@ -195,20 +195,20 @@ impl FromBytes for Value {
                 Ok((Value::String(s), rem))
             }
             ACCT_ID => {
-                let (a, rem): (account::Account, &[u8]) = FromBytes::from_bytes(rest)?;
+                let (a, rem): (Account, &[u8]) = FromBytes::from_bytes(rest)?;
                 Ok((Value::Account(a), rem))
             }
             CONTRACT_ID => {
-                let (contract, rem): (contract::Contract, &[u8]) = FromBytes::from_bytes(rest)?;
+                let (contract, rem): (Contract, &[u8]) = FromBytes::from_bytes(rest)?;
                 Ok((Value::Contract(contract), rem))
             }
             NAMEDKEY_ID => {
                 let (name, rem1): (String, &[u8]) = FromBytes::from_bytes(rest)?;
-                let (key, rem2): (key::Key, &[u8]) = FromBytes::from_bytes(rem1)?;
+                let (key, rem2): (Key, &[u8]) = FromBytes::from_bytes(rem1)?;
                 Ok((Value::NamedKey(name, key), rem2))
             }
             KEY_ID => {
-                let (key, rem): (key::Key, &[u8]) = FromBytes::from_bytes(rest)?;
+                let (key, rem): (Key, &[u8]) = FromBytes::from_bytes(rest)?;
                 Ok((Value::Key(key), rem))
             }
             LISTSTRING_ID => {

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -29,7 +29,7 @@ use contract_ffi::value::{Account, ProtocolVersion, Value, U512};
 use engine_shared::additive_map::AdditiveMap;
 use engine_shared::gas::Gas;
 use engine_shared::motes::Motes;
-use engine_shared::newtypes::{Blake2bHash, CorrelationId, Validated};
+use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 use engine_shared::transform::Transform;
 use engine_storage::global_state::{CommitResult, StateProvider, StateReader};
 use engine_storage::protocol_data::ProtocolData;
@@ -141,14 +141,10 @@ where
 
         // Persist the "virtual system account".  It will get overwritten with the actual system
         // account below.
-        let key = {
-            let key = Key::Account(SYSTEM_ACCOUNT_ADDR);
-            Validated::new(key, Validated::valid).unwrap() // safe to unwrap
-        };
+        let key = Key::Account(SYSTEM_ACCOUNT_ADDR);
         let value = {
             let virtual_system_account = virtual_system_account.clone();
-            let value = Value::Account(virtual_system_account);
-            Validated::new(value, Validated::valid).unwrap() // safe to unwrap
+            Value::Account(virtual_system_account)
         };
 
         tracking_copy.borrow_mut().write(key, value);
@@ -378,19 +374,15 @@ where
                 )?;
 
                 // ...and write that account to global state...
-                let key = {
-                    let key = Key::Account(account_public_key.value());
-                    Validated::new(key, Validated::valid).unwrap() // safe to unwrap
-                };
+                let key = Key::Account(account_public_key.value());
                 let value = {
                     let account_main_purse = mint_result?;
                     let purse_id = PurseId::new(account_main_purse);
-                    let value = Value::Account(Account::create(
+                    Value::Account(Account::create(
                         account_public_key.value(),
                         named_keys,
                         purse_id,
-                    ));
-                    Validated::new(value, Validated::valid).unwrap() // safe to unwrap
+                    ))
                 };
 
                 tracking_copy_write.borrow_mut().write(key, value);
@@ -485,9 +477,7 @@ where
 
             // execute as system account
             let system_account = {
-                // safe to unwrap (Validated::valid is always true)
-                let key =
-                    Validated::new(Key::Account(SYSTEM_ACCOUNT_ADDR), Validated::valid).unwrap();
+                let key = Key::Account(SYSTEM_ACCOUNT_ADDR);
                 match tracking_copy.borrow_mut().read(correlation_id, &key) {
                     Ok(Some(Value::Account(account))) => account,
                     Ok(_) => panic!("system account must exist"),

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -310,7 +310,7 @@ where
     pub fn value_is_valid(&mut self, value_ptr: u32, value_size: u32) -> Result<bool, Trap> {
         let value = self.value_from_mem(value_ptr, value_size)?;
 
-        Ok(self.context.validate_keys(&value).is_ok())
+        Ok(self.context.validate_value(&value).is_ok())
     }
 
     /// Load the i-th argument invoked as part of a `sub_call` into

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -384,7 +384,7 @@ where
     pub fn write_gs(&mut self, key: Key, value: Value) -> Result<(), Error> {
         self.validate_writeable(&key)?;
         self.validate_key(&key)?;
-        self.validate_keys(&value)?;
+        self.validate_value(&value)?;
         self.state.borrow_mut().write(key, value);
         Ok(())
     }
@@ -413,7 +413,7 @@ where
     }
 
     pub fn store_function(&mut self, contract: Value) -> Result<[u8; 32], Error> {
-        self.validate_keys(&contract)?;
+        self.validate_value(&contract)?;
         if let Key::URef(contract_ref) = self.new_uref(contract)? {
             Ok(contract_ref.addr())
         } else {
@@ -424,7 +424,7 @@ where
 
     pub fn store_function_at_hash(&mut self, contract: Value) -> Result<[u8; 32], Error> {
         let new_hash = self.new_function_address()?;
-        self.validate_keys(&contract)?;
+        self.validate_value(&contract)?;
         let hash_key = Key::Hash(new_hash);
         self.state.borrow_mut().write(hash_key, contract);
         Ok(new_hash)
@@ -452,7 +452,7 @@ where
     }
 
     /// Validates whether keys used in the `value` are not forged.
-    pub fn validate_keys(&self, value: &Value) -> Result<(), Error> {
+    pub fn validate_value(&self, value: &Value) -> Result<(), Error> {
         match value {
             Value::Int32(_)
             | Value::UInt128(_)
@@ -606,7 +606,7 @@ where
     pub fn add_gs(&mut self, key: Key, value: Value) -> Result<(), Error> {
         self.validate_addable(&key)?;
         self.validate_key(&key)?;
-        self.validate_keys(&value)?;
+        self.validate_value(&value)?;
         self.add_gs_unsafe(key, value)
     }
 
@@ -804,7 +804,7 @@ where
     /// and then validates the keys it may contain.
     fn make_validated_value(&self, input: impl Into<Value>) -> Result<Value, Error> {
         let value = input.into();
-        self.validate_keys(&value)?;
+        self.validate_value(&value)?;
         Ok(value)
     }
 }

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -310,8 +310,7 @@ where
         // No need to perform actual validation on the base key because an account or
         // contract (i.e. the element stored under `base_key`) is allowed to add
         // new named keys to itself.
-        let named_key_value = Value::NamedKey(name.clone(), key);
-        self.validate_keys(&named_key_value)?;
+        let named_key_value = self.make_validated_value((name.clone(), key))?;
 
         self.add_gs_unsafe(self.base_key(), named_key_value)?;
         self.insert_key(name, key);

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -798,10 +798,9 @@ where
         attenuate_uref_for_account(&self.account(), uref)
     }
 
-    /// Creates validated instance of [Value].
+    /// Creates validated instance of [`Value`].
     ///
-    /// First, it is converting a value into [Value] type through [Into](std::convert::Into) trait,
-    /// and then validates the keys it may contain.
+    /// Converts its argument into a [`Value`] and validates any keys it may contain.
     fn make_validated_value(&self, input: impl Into<Value>) -> Result<Value, Error> {
         let value = input.into();
         self.validate_value(&value)?;

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -21,7 +21,7 @@ use engine_storage::global_state::in_memory::{InMemoryGlobalState, InMemoryGloba
 use engine_storage::global_state::{CommitResult, StateProvider};
 
 use super::attenuate_uref_for_account;
-use super::{Address, Error, RuntimeContext, Validated};
+use super::{Address, Error, RuntimeContext};
 use crate::engine_state::SYSTEM_ACCOUNT_ADDR;
 use crate::execution::extract_access_rights_from_keys;
 use crate::execution::AddressGenerator;
@@ -412,10 +412,7 @@ fn contract_key_addable_valid() {
         Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::V1_0_0).into();
     let tc = Rc::new(RefCell::new(mock_tc(account_key, account.clone())));
     // Store contract in the GlobalState so that we can mainpulate it later.
-    tc.borrow_mut().write(
-        Validated::new(contract_key, Validated::valid).unwrap(),
-        Validated::new(contract, Validated::valid).unwrap(),
-    );
+    tc.borrow_mut().write(contract_key, contract);
 
     let mut uref_map = BTreeMap::new();
     let uref = create_uref(&mut address_generator, AccessRights::WRITE);
@@ -475,10 +472,7 @@ fn contract_key_addable_invalid() {
         Contract::new(Vec::new(), BTreeMap::new(), ProtocolVersion::V1_0_0).into();
     let tc = Rc::new(RefCell::new(mock_tc(account_key, account.clone())));
     // Store contract in the GlobalState so that we can mainpulate it later.
-    tc.borrow_mut().write(
-        Validated::new(contract_key, Validated::valid).unwrap(),
-        Validated::new(contract, Validated::valid).unwrap(),
-    );
+    tc.borrow_mut().write(contract_key, contract);
 
     let mut uref_map = BTreeMap::new();
     let uref = create_uref(&mut address_generator, AccessRights::WRITE);

--- a/execution-engine/engine-core/src/tracking_copy/mod.rs
+++ b/execution-engine/engine-core/src/tracking_copy/mod.rs
@@ -11,7 +11,7 @@ use linked_hash_map::LinkedHashMap;
 use contract_ffi::key::Key;
 use contract_ffi::value::Value;
 use engine_shared::additive_map::AdditiveMap;
-use engine_shared::newtypes::{CorrelationId, Validated};
+use engine_shared::newtypes::CorrelationId;
 use engine_shared::transform::{self, Transform, TypeMismatch};
 use engine_storage::global_state::StateReader;
 
@@ -138,13 +138,13 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     pub fn get(
         &mut self,
         correlation_id: CorrelationId,
-        k: &Key,
+        key: &Key,
     ) -> Result<Option<Value>, R::Error> {
-        if let Some(value) = self.cache.get(k) {
+        if let Some(value) = self.cache.get(key) {
             return Ok(Some(value.to_owned()));
         }
-        if let Some(value) = self.reader.read(correlation_id, k)? {
-            self.cache.insert_read(*k, value.to_owned());
+        if let Some(value) = self.reader.read(correlation_id, key)? {
+            self.cache.insert_read(*key, value.to_owned());
             Ok(Some(value))
         } else {
             Ok(None)
@@ -154,7 +154,7 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     pub fn read(
         &mut self,
         correlation_id: CorrelationId,
-        k: &Validated<Key>,
+        k: &Key,
     ) -> Result<Option<Value>, R::Error> {
         let k = k.normalize();
         if let Some(value) = self.get(correlation_id, &k)? {
@@ -166,12 +166,11 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
         }
     }
 
-    pub fn write(&mut self, k: Validated<Key>, v: Validated<Value>) {
-        let v_local = v.into_raw();
+    pub fn write(&mut self, k: Key, v: Value) {
         let k = k.normalize();
-        self.cache.insert_write(k, v_local.clone());
+        self.cache.insert_write(k, v.clone());
         self.ops.insert_add(k, Op::Write);
-        self.fns.insert_add(k, Transform::Write(v_local));
+        self.fns.insert_add(k, Transform::Write(v));
     }
 
     /// Ok(None) represents missing key to which we want to "add" some value.
@@ -181,14 +180,14 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     pub fn add(
         &mut self,
         correlation_id: CorrelationId,
-        k: Validated<Key>,
-        v: Validated<Value>,
+        k: Key,
+        v: Value,
     ) -> Result<AddResult, R::Error> {
         let k = k.normalize();
         match self.get(correlation_id, &k)? {
             None => Ok(AddResult::KeyNotFound(k)),
             Some(current_value) => {
-                let t = match v.into_raw() {
+                let t = match v {
                     Value::Int32(i) => Transform::AddInt32(i),
                     Value::UInt128(i) => Transform::AddUInt128(i),
                     Value::UInt256(i) => Transform::AddUInt256(i),
@@ -230,8 +229,7 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
         base_key: Key,
         path: &[String],
     ) -> Result<QueryResult, R::Error> {
-        let validated_key = Validated::new(base_key, Validated::valid)?;
-        match self.read(correlation_id, &validated_key)? {
+        match self.read(correlation_id, &base_key)? {
             None => Ok(QueryResult::ValueNotFound(self.error_path_msg(
                 base_key,
                 path,
@@ -250,8 +248,7 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
                         match current_value {
                             Value::Account(account) => {
                                 if let Some(key) = account.named_keys().get(name) {
-                                    let validated_key = Validated::new(*key, Validated::valid)?;
-                                    self.read_key_or_stop(correlation_id, validated_key, i)
+                                    self.read_key_or_stop(correlation_id, *key, i)
                                 } else {
                                     Err(Ok((i, format!("Name {} not found in Account at path:", name))))
                                 }
@@ -259,8 +256,7 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
 
                             Value::Contract(contract) => {
                                 if let Some(key) = contract.named_keys().get(name) {
-                                    let validated_key = Validated::new(*key, Validated::valid)?;
-                                    self.read_key_or_stop(correlation_id, validated_key, i)
+                                    self.read_key_or_stop(correlation_id, *key, i)
                                 } else {
                                     Err(Ok((i, format!("Name {} not found in Contract at path:", name))))
                                 }
@@ -287,14 +283,14 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
     fn read_key_or_stop(
         &mut self,
         correlation_id: CorrelationId,
-        key: Validated<Key>,
+        key: Key,
         i: usize,
     ) -> Result<Value, Result<(usize, String), R::Error>> {
         match self.read(correlation_id, &key) {
             // continue recursion
             Ok(Some(value)) => Ok(value),
             // key not found in the global state; stop recursion
-            Ok(None) => Err(Ok((i, format!("Name {:?} not found: ", *key)))),
+            Ok(None) => Err(Ok((i, format!("Name {:?} not found: ", key)))),
             // global state access error; stop recursion
             Err(error) => Err(Err(error)),
         }

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -19,7 +19,7 @@ use engine_storage::global_state::{StateProvider, StateReader};
 use crate::engine_state::op::Op;
 
 use super::meter::count_meter::Count;
-use super::{AddResult, QueryResult, Validated};
+use super::{AddResult, QueryResult};
 use super::{TrackingCopy, TrackingCopyCache};
 
 struct CountingDb {
@@ -81,24 +81,12 @@ fn tracking_copy_caching() {
 
     let zero = Value::Int32(0);
     // first read
-    let value = tc
-        .read(
-            correlation_id,
-            &Validated::new(k, Validated::valid).unwrap(),
-        )
-        .unwrap()
-        .unwrap();
+    let value = tc.read(correlation_id, &k).unwrap().unwrap();
     assert_eq!(value, zero);
 
     // second read; should use cache instead
     // of going back to the DB
-    let value = tc
-        .read(
-            correlation_id,
-            &Validated::new(k, Validated::valid).unwrap(),
-        )
-        .unwrap()
-        .unwrap();
+    let value = tc.read(correlation_id, &k).unwrap().unwrap();
     let db_value = counter.get();
     assert_eq!(value, zero);
     assert_eq!(db_value, 1);
@@ -113,13 +101,7 @@ fn tracking_copy_read() {
     let k = Key::Hash([0u8; 32]);
 
     let zero = Value::Int32(0);
-    let value = tc
-        .read(
-            correlation_id,
-            &Validated::new(k, Validated::valid).unwrap(),
-        )
-        .unwrap()
-        .unwrap();
+    let value = tc.read(correlation_id, &k).unwrap().unwrap();
     // value read correctly
     assert_eq!(value, zero);
     // read produces an identity transform
@@ -141,10 +123,7 @@ fn tracking_copy_write() {
     let two = Value::Int32(2);
 
     // writing should work
-    tc.write(
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(one.clone(), Validated::valid).unwrap(),
-    );
+    tc.write(k, one.clone());
     // write does not need to query the DB
     let db_value = counter.get();
     assert_eq!(db_value, 0);
@@ -156,10 +135,7 @@ fn tracking_copy_write() {
     assert_eq!(tc.ops.get(&k), Some(&Op::Write));
 
     // writing again should update the values
-    tc.write(
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(two.clone(), Validated::valid).unwrap(),
-    );
+    tc.write(k, two.clone());
     let db_value = counter.get();
     assert_eq!(db_value, 0);
     assert_eq!(tc.fns.len(), 1);
@@ -179,11 +155,7 @@ fn tracking_copy_add_i32() {
     let three = Value::Int32(3);
 
     // adding should work
-    let add = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(three.clone(), Validated::valid).unwrap(),
-    );
+    let add = tc.add(correlation_id, k, three.clone());
     assert_matches!(add, Ok(_));
 
     // add creates a Transfrom
@@ -194,11 +166,7 @@ fn tracking_copy_add_i32() {
     assert_eq!(tc.ops.get(&k), Some(&Op::Add));
 
     // adding again should update the values
-    let add = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(three, Validated::valid).unwrap(),
-    );
+    let add = tc.add(correlation_id, k, three);
     assert_matches!(add, Ok(_));
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::AddInt32(6)));
@@ -234,21 +202,13 @@ fn tracking_copy_add_named_key() {
     }
 
     // adding the wrong type should fail
-    let failed_add = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(Value::Int32(3), Validated::valid).unwrap(),
-    );
+    let failed_add = tc.add(correlation_id, k, Value::Int32(3));
     assert_matches!(failed_add, Ok(AddResult::TypeMismatch(_)));
     assert_eq!(tc.ops.is_empty(), true);
     assert_eq!(tc.fns.is_empty(), true);
 
     // adding correct type works
-    let add = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(named_key, Validated::valid).unwrap(),
-    );
+    let add = tc.add(correlation_id, k, named_key);
     assert_matches!(add, Ok(_));
     // add creates a Transfrom
     assert_eq!(tc.fns.len(), 1);
@@ -261,11 +221,7 @@ fn tracking_copy_add_named_key() {
     if let Value::NamedKey(name, key) = other_named_key.clone() {
         map.insert(name, key);
     }
-    let add = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(other_named_key, Validated::valid).unwrap(),
-    );
+    let add = tc.add(correlation_id, k, other_named_key);
     assert_matches!(add, Ok(_));
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::AddKeys(map)));
@@ -283,14 +239,8 @@ fn tracking_copy_rw() {
 
     // reading then writing should update the op
     let value = Value::Int32(3);
-    let _ = tc.read(
-        correlation_id,
-        &Validated::new(k, Validated::valid).unwrap(),
-    );
-    tc.write(
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(value.clone(), Validated::valid).unwrap(),
-    );
+    let _ = tc.read(correlation_id, &k);
+    tc.write(k, value.clone());
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::Write(value)));
     assert_eq!(tc.ops.len(), 1);
@@ -307,15 +257,8 @@ fn tracking_copy_ra() {
 
     // reading then adding should update the op
     let value = Value::Int32(3);
-    let _ = tc.read(
-        correlation_id,
-        &Validated::new(k, Validated::valid).unwrap(),
-    );
-    let _ = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(value, Validated::valid).unwrap(),
-    );
+    let _ = tc.read(correlation_id, &k);
+    let _ = tc.add(correlation_id, k, value);
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::AddInt32(3)));
     assert_eq!(tc.ops.len(), 1);
@@ -334,15 +277,8 @@ fn tracking_copy_aw() {
     // adding then writing should update the op
     let value = Value::Int32(3);
     let write_value = Value::Int32(7);
-    let _ = tc.add(
-        correlation_id,
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(value, Validated::valid).unwrap(),
-    );
-    tc.write(
-        Validated::new(k, Validated::valid).unwrap(),
-        Validated::new(write_value.clone(), Validated::valid).unwrap(),
-    );
+    let _ = tc.add(correlation_id, k, value);
+    tc.write(k, write_value.clone());
     assert_eq!(tc.fns.len(), 1);
     assert_eq!(tc.fns.get(&k), Some(&Transform::Write(write_value)));
     assert_eq!(tc.ops.len(), 1);

--- a/execution-engine/engine-shared/src/newtypes.rs
+++ b/execution-engine/engine-shared/src/newtypes.rs
@@ -2,7 +2,6 @@
 use core::array::TryFromSliceError;
 use std::convert::TryFrom;
 use std::fmt;
-use std::ops::Deref;
 
 use blake2::digest::{Input, VariableOutput};
 use blake2::VarBlake2b;
@@ -97,42 +96,6 @@ impl ToBytes for Blake2bHash {
 impl FromBytes for Blake2bHash {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         FromBytes::from_bytes(bytes).map(|(arr, rem)| (Blake2bHash(arr), rem))
-    }
-}
-
-/// Represents a validated value.  Validation is user-specified.
-pub struct Validated<T>(T);
-
-impl<T> Validated<T> {
-    /// Creates a validated value from a given value and validation function.
-    pub fn new<E, F>(v: T, guard: F) -> Result<Validated<T>, E>
-    where
-        F: Fn(&T) -> Result<(), E>,
-    {
-        guard(&v).map(|_| Validated(v))
-    }
-
-    /// A validation function which always succeeds.
-    pub fn valid(_v: &T) -> Result<(), !> {
-        Ok(())
-    }
-
-    pub fn into_raw(self) -> T {
-        self.0
-    }
-}
-
-impl<T: Clone> Clone for Validated<T> {
-    fn clone(&self) -> Self {
-        Validated(self.0.clone())
-    }
-}
-
-impl<T: Clone> Deref for Validated<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        &self.0
     }
 }
 


### PR DESCRIPTION
### Overview

Removes `Validated` type from the codebase.

This type didn't really protect against misuse, it did spread across the code base and unfortunate consequence of it was that the most uses were just forcing a value into Validated without actual validation.

This PR changes the situation by removing, and introducing a helper `make_validated_value` which does the validation explicitly at a time of `Value` creation. Everything that comes to `runtime_context` from outside is validated at call site.

### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/browse/EE-760

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
