### PR TITLE
EE-757: Remove most instances of 'extern crate'

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "siphasher 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wee_alloc 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2246,6 +2246,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,12 +2709,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uint"
-version = "0.7.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3092,6 +3098,7 @@ dependencies = [
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cefaa50e76a6f10b86f36e640eb1739eafbd4084865067778463913e43a77ff3"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum static_assertions 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
@@ -3127,7 +3134,7 @@ dependencies = [
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
-"checksum uint 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2143cded94692b156c356508d92888acc824db5bffc0b4089732264c6fcf86d4"
+"checksum uint 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e75a4cdd7b87b28840dba13c483b9a88ee6bbf16ba5c951ee1ecfcf723078e0d"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/execution-engine/contract-ffi/Cargo.toml
+++ b/execution-engine/contract-ffi/Cargo.toml
@@ -17,7 +17,7 @@ failure = { version = "0.1.5", default-features = false, features = ["failure_de
 num-traits = { version = "0.2.8", default-features = false }
 num-derive = { version = "0.2.5", default-features = false }
 wee_alloc = "0.4.3"
-uint = { version = "0.7.1", default-features = false, features = [] }
+uint = { version = "0.8.2", default-features = false, features = [] }
 proptest = { version = "0.9.2", default-features = false, optional = true }
 bitflags = "1.0.4"
 binascii = "0.1.2"

--- a/execution-engine/contract-ffi/benches/bytesrepr_bench.rs
+++ b/execution-engine/contract-ffi/benches/bytesrepr_bench.rs
@@ -1,11 +1,10 @@
 #![feature(test)]
 
-extern crate casperlabs_contract_ffi;
+extern crate test;
 
 use std::collections::BTreeMap;
 use std::iter;
 
-extern crate test;
 use test::black_box;
 use test::Bencher;
 

--- a/execution-engine/contract-ffi/src/args_parser.rs
+++ b/execution-engine/contract-ffi/src/args_parser.rs
@@ -1,3 +1,4 @@
+use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::bytesrepr::{Error, ToBytes};

--- a/execution-engine/contract-ffi/src/base16.rs
+++ b/execution-engine/contract-ffi/src/base16.rs
@@ -1,7 +1,10 @@
+use alloc::format;
 use alloc::string::String;
 use alloc::vec::Vec;
 use core::num::ParseIntError;
 use core::str;
+
+use failure::Fail;
 
 /// Encodes a slice of bytes in base16 form in lower case
 pub fn encode_lower(input: &[u8]) -> String {
@@ -37,22 +40,29 @@ pub fn decode_lower(input: &str) -> Result<Vec<u8>, Error> {
     }
 }
 
-#[test]
-fn test_encode_lower() {
-    assert_eq!(encode_lower(&[1, 2, 3, 254, 255]), "010203feff");
-    assert_eq!(encode_lower(&[]), "");
-}
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
 
-#[test]
-fn test_decode_lower() {
-    assert!(decode_lower("Hello world!").is_err());
-    assert_eq!(
-        decode_lower("010203feff").expect("should decode"),
-        &[0x01, 0x02, 0x03, 0xfe, 0xff]
-    );
-    // invalid length
-    assert!(decode_lower("010").is_err());
-    assert_eq!(decode_lower("").expect("should decode empty"), vec![]);
-    // invalid characters
-    assert!(decode_lower("\u{012345}deadbeef").is_err());
+    use super::*;
+
+    #[test]
+    fn test_encode_lower() {
+        assert_eq!(encode_lower(&[1, 2, 3, 254, 255]), "010203feff");
+        assert_eq!(encode_lower(&[]), "");
+    }
+
+    #[test]
+    fn test_decode_lower() {
+        assert!(decode_lower("Hello world!").is_err());
+        assert_eq!(
+            decode_lower("010203feff").expect("should decode"),
+            &[0x01, 0x02, 0x03, 0xfe, 0xff]
+        );
+        // invalid length
+        assert!(decode_lower("010").is_err());
+        assert_eq!(decode_lower("").expect("should decode empty"), vec![]);
+        // invalid characters
+        assert!(decode_lower("\u{012345}deadbeef").is_err());
+    }
 }

--- a/execution-engine/contract-ffi/src/contract_api/error.rs
+++ b/execution-engine/contract-ffi/src/contract_api/error.rs
@@ -344,8 +344,10 @@ pub fn result_from(value: i32) -> Result<(), Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use alloc::format;
     use core::{i32, u16, u8};
+
+    use super::*;
 
     fn round_trip(result: Result<(), Error>) {
         let code = i32_from(result);

--- a/execution-engine/contract-ffi/src/execution.rs
+++ b/execution-engine/contract-ffi/src/execution.rs
@@ -1,6 +1,10 @@
-use crate::bytesrepr::{Error, FromBytes, ToBytes};
+use alloc::vec;
 use alloc::vec::Vec;
+
+use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
+
+use crate::bytesrepr::{Error, FromBytes, ToBytes};
 
 pub const PHASE_SIZE: usize = 1;
 

--- a/execution-engine/contract-ffi/src/gens.rs
+++ b/execution-engine/contract-ffi/src/gens.rs
@@ -1,3 +1,11 @@
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec;
+
+use proptest::collection::{btree_map, vec};
+use proptest::prelude::*;
+use proptest::{array, bits, option, result};
+
 use crate::execution::Phase;
 use crate::key::*;
 use crate::uref::{AccessRights, URef};
@@ -5,11 +13,6 @@ use crate::value::account::{
     ActionThresholds, AssociatedKeys, PublicKey, PurseId, Weight, MAX_KEYS,
 };
 use crate::value::*;
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use proptest::collection::{btree_map, vec};
-use proptest::prelude::*;
-use proptest::{array, bits, option, result};
 
 pub fn u8_slice_32() -> impl Strategy<Value = [u8; 32]> {
     vec(any::<u8>(), 32).prop_map(|b| {

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -1,8 +1,10 @@
+use alloc::format;
+use alloc::vec::Vec;
+
 use blake2::digest::{Input, VariableOutput};
 use blake2::VarBlake2b;
 use hex_fmt::HexFmt;
 
-use crate::alloc::vec::Vec;
 use crate::base16;
 use crate::bytesrepr::{Error, FromBytes, ToBytes, N32, U32_SIZE};
 use crate::contract_api::{ContractRef, TURef};
@@ -274,11 +276,14 @@ impl ToBytes for Vec<Key> {
 #[allow(clippy::unnecessary_operation)]
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
     use crate::bytesrepr::{Error, FromBytes};
     use crate::key::Key;
     use crate::uref::{AccessRights, URef};
-    use alloc::string::String;
-    use alloc::vec::Vec;
 
     fn test_readable(right: AccessRights, is_true: bool) {
         assert_eq!(right.is_readable(), is_true)

--- a/execution-engine/contract-ffi/src/lib.rs
+++ b/execution-engine/contract-ffi/src/lib.rs
@@ -7,21 +7,7 @@
     try_reserve
 )]
 
-#[macro_use]
 extern crate alloc;
-extern crate binascii;
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate failure;
-extern crate hex_fmt;
-#[macro_use]
-extern crate num_derive;
-#[cfg(any(test, feature = "gens"))]
-extern crate proptest;
-#[macro_use]
-extern crate uint;
-extern crate wee_alloc;
 
 #[cfg(not(feature = "std"))]
 #[global_allocator]

--- a/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
@@ -3,6 +3,8 @@
 use alloc::vec::Vec;
 use core::convert::{TryFrom, TryInto};
 
+use failure::Fail;
+
 use crate::bytesrepr::{self, FromBytes, ToBytes};
 use crate::system_contracts::mint::purse_id::PurseIdError;
 

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -1,8 +1,10 @@
-use bitflags;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use bitflags::bitflags;
 use hex_fmt::HexFmt;
 
-use crate::alloc::string::String;
-use crate::alloc::vec::Vec;
 use crate::base16;
 use crate::bytesrepr;
 use crate::bytesrepr::{OPTION_SIZE, U32_SIZE};

--- a/execution-engine/contract-ffi/src/value/account.rs
+++ b/execution-engine/contract-ffi/src/value/account.rs
@@ -859,15 +859,17 @@ impl FromBytes for Account {
 
 #[cfg(test)]
 mod tests {
+    use alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::convert::TryFrom;
+    use core::iter::FromIterator;
+
     use crate::uref::{AccessRights, URef};
     use crate::value::account::{
         Account, ActionThresholds, ActionType, AddKeyFailure, AssociatedKeys, PublicKey, PurseId,
         RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight, KEY_SIZE, MAX_KEYS,
     };
-    use alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
-    use alloc::vec::Vec;
-    use core::convert::TryFrom;
-    use core::iter::FromIterator;
 
     #[test]
     fn associated_keys_add() {

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -5,6 +5,7 @@ mod semver;
 pub mod uint;
 
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 use core::iter;

--- a/execution-engine/contract-ffi/src/value/uint.rs
+++ b/execution-engine/contract-ffi/src/value/uint.rs
@@ -1,13 +1,18 @@
-use crate::bytesrepr::{self, Error, FromBytes, ToBytes};
 use alloc::vec::Vec;
+
 use num_traits::{Bounded, Num, One, Unsigned, WrappingAdd, WrappingSub, Zero};
 
-// Clippy generates a ton of warnings/errors for the code the macro generates.
-// As of uint v0.8.1 and using nightly-2019-08-25, this also generates the
-// following warning: "use of deprecated item 'core::mem::uninitialized': use
-// `mem::MaybeUninit` instead"
-#[allow(deprecated, clippy::all)]
+use crate::bytesrepr::{self, Error, FromBytes, ToBytes};
+
+#[allow(
+    clippy::assign_op_pattern,
+    clippy::ptr_offset_with_cast,
+    clippy::range_plus_one,
+    clippy::transmute_ptr_to_ptr
+)]
 mod macro_code {
+    use uint::construct_uint;
+
     construct_uint! {
         pub struct U512(8);
     }

--- a/execution-engine/contracts/SRE/create-test-node-01/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-01/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate create_test_node_shared;
-
 const NODE_01_ADDR: &[u8; 64] = b"d853ee569a6cf4315a26cf1190f9b55003aae433bd732453b967742b883da0b2";
 const INITIAL_AMOUNT: u64 = 1_000_000;
 

--- a/execution-engine/contracts/SRE/create-test-node-02/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-02/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate create_test_node_shared;
-
 const NODE_02_ADDR: &[u8; 64] = b"4ee7ad9b21fd625481d0a94c618a15ab92503a7457e428a4dcd9dd6f100e979b";
 const INITIAL_AMOUNT: u64 = 1_000_000;
 

--- a/execution-engine/contracts/SRE/create-test-node-03/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-03/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate create_test_node_shared;
-
 const NODE_03_ADDR: &[u8; 64] = b"a3b2fd2971f2de5145d2342df38555ce97070a27ef7e74b63e08c482697308dd";
 const INITIAL_AMOUNT: u64 = 1_000_000;
 

--- a/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate binascii;
-extern crate contract_ffi;
-
 use binascii::ConvertError;
 
 use contract_ffi::contract_api::system::TransferredTo;

--- a/execution-engine/contracts/bench/create-accounts/src/lib.rs
+++ b/execution-engine/contracts/bench/create-accounts/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::vec::Vec;
 use core::convert::TryFrom;

--- a/execution-engine/contracts/bench/transfer-to-existing-account/src/lib.rs
+++ b/execution-engine/contracts/bench/transfer-to-existing-account/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::system::TransferredTo;
 use contract_ffi::contract_api::{runtime, system, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/client/bonding/src/lib.rs
+++ b/execution-engine/contracts/client/bonding/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, system, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/client/named-purse-payment/src/lib.rs
+++ b/execution-engine/contracts/client/named-purse-payment/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/client/revert/src/lib.rs
+++ b/execution-engine/contracts/client/revert/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 
 #[no_mangle]

--- a/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
@@ -1,11 +1,10 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, storage, system, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/client/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/client/transfer-to-account/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/contracts/client/unbonding/src/lib.rs
+++ b/execution-engine/contracts/client/unbonding/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/examples/bonding-call/src/lib.rs
+++ b/execution-engine/contracts/examples/bonding-call/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
 
-extern crate contract_ffi;
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, system, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/examples/counter-call/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-call/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::vec::Vec;
 

--- a/execution-engine/contracts/examples/counter-define/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-define/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/execution-engine/contracts/examples/hello-name-call/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-call/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/execution-engine/contracts/examples/hello-name-define/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-define/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;

--- a/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 use alloc::vec::Vec;

--- a/execution-engine/contracts/examples/mailing-list-define/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-define/src/lib.rs
@@ -1,12 +1,10 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-
-extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api::{runtime, storage, Error as ApiError, TURef};

--- a/execution-engine/contracts/examples/unbonding-call/src/lib.rs
+++ b/execution-engine/contracts/examples/unbonding-call/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/explorer/faucet/src/lib.rs
+++ b/execution-engine/contracts/explorer/faucet/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, storage, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/contracts/integration/add-associated-key/src/lib.rs
+++ b/execution-engine/contracts/integration/add-associated-key/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{PublicKey, Weight};

--- a/execution-engine/contracts/integration/args-multi/src/lib.rs
+++ b/execution-engine/contracts/integration/args-multi/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 

--- a/execution-engine/contracts/integration/args-u32/src/lib.rs
+++ b/execution-engine/contracts/integration/args-u32/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 

--- a/execution-engine/contracts/integration/args-u512/src/lib.rs
+++ b/execution-engine/contracts/integration/args-u512/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::U512;

--- a/execution-engine/contracts/integration/create-named-purse/src/lib.rs
+++ b/execution-engine/contracts/integration/create-named-purse/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/integration/direct-revert/src/lib.rs
+++ b/execution-engine/contracts/integration/direct-revert/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 
 #[no_mangle]

--- a/execution-engine/contracts/integration/get-caller-call/src/lib.rs
+++ b/execution-engine/contracts/integration/get-caller-call/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api::{runtime, ContractRef, Error};

--- a/execution-engine/contracts/integration/get-caller-define/src/lib.rs
+++ b/execution-engine/contracts/integration/get-caller-define/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
-use alloc::collections::btree_map::BTreeMap;
+use alloc::collections::BTreeMap;
 
 use contract_ffi::contract_api::{runtime, storage};
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/contracts/integration/list-known-urefs-call/src/lib.rs
+++ b/execution-engine/contracts/integration/list-known-urefs-call/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api::ContractRef;

--- a/execution-engine/contracts/integration/list-known-urefs-define/src/lib.rs
+++ b/execution-engine/contracts/integration/list-known-urefs-define/src/lib.rs
@@ -2,10 +2,8 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::borrow::ToOwned;
-use alloc::collections::btree_map::BTreeMap;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use core::iter;
 

--- a/execution-engine/contracts/integration/payment-from-named-purse/src/lib.rs
+++ b/execution-engine/contracts/integration/payment-from-named-purse/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, system, Error as ApiError};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/integration/set-key-thresholds/src/lib.rs
+++ b/execution-engine/contracts/integration/set-key-thresholds/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{ActionType, Weight};

--- a/execution-engine/contracts/integration/subcall-revert-call/src/lib.rs
+++ b/execution-engine/contracts/integration/subcall-revert-call/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::vec::Vec;
 

--- a/execution-engine/contracts/integration/subcall-revert-define/src/lib.rs
+++ b/execution-engine/contracts/integration/subcall-revert-define/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 

--- a/execution-engine/contracts/integration/update-associated-key/src/lib.rs
+++ b/execution-engine/contracts/integration/update-associated-key/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{PublicKey, Weight};

--- a/execution-engine/contracts/profiling/simple-transfer/src/lib.rs
+++ b/execution-engine/contracts/profiling/simple-transfer/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::system::TransferredTo;
 use contract_ffi::contract_api::{runtime, system, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/profiling/state-initializer/src/lib.rs
+++ b/execution-engine/contracts/profiling/state-initializer/src/lib.rs
@@ -2,8 +2,6 @@
 //! account.
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::system::TransferredTo;
 use contract_ffi::contract_api::{runtime, system, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/system/mint-install/src/lib.rs
+++ b/execution-engine/contracts/system/mint-install/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
-extern crate mint_token;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, storage, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -1,9 +1,7 @@
 #![no_std]
 #![feature(cell_update)]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 mod capabilities;
 
@@ -15,6 +13,7 @@ pub mod internal_purse_id;
 pub mod mint;
 
 use alloc::string::String;
+use alloc::vec;
 use core::convert::TryInto;
 
 use contract_ffi::contract_api::{runtime, storage, Error as ApiError};

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -1,13 +1,10 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-
-extern crate contract_ffi;
-extern crate pos;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
+use alloc::vec;
 use core::fmt::Write;
 
 use contract_ffi::contract_api::{runtime, storage, ContractRef, Error, TURef};

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -1,13 +1,12 @@
 #![cfg_attr(not(test), no_std)]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 mod queue;
 mod stakes;
 
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api::{runtime, system};

--- a/execution-engine/contracts/system/test-mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/test-mint-token/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::runtime;
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/add-update-associated-key/src/lib.rs
+++ b/execution-engine/contracts/test/add-update-associated-key/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{PublicKey, Weight};

--- a/execution-engine/contracts/test/authorized-keys/src/lib.rs
+++ b/execution-engine/contracts/test/authorized-keys/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{ActionType, AddKeyFailure, PublicKey, Weight};

--- a/execution-engine/contracts/test/check-system-contract-urefs-access-rights/src/lib.rs
+++ b/execution-engine/contracts/test/check-system-contract-urefs-access-rights/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::runtime;
 use contract_ffi::key::Key;
 use contract_ffi::uref::URef;

--- a/execution-engine/contracts/test/create-purse-01/src/lib.rs
+++ b/execution-engine/contracts/test/create-purse-01/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
+
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/test/deserialize-error/src/lib.rs
+++ b/execution-engine/contracts/test/deserialize-error/src/lib.rs
@@ -1,12 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate core;
 
-extern crate contract_ffi;
-
-use alloc::collections::btree_map::BTreeMap;
+use alloc::collections::BTreeMap;
+use alloc::vec;
 use alloc::vec::Vec;
 
 use contract_ffi::args_parser::ArgsParser;

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::contract_api::{ContractRef, TURef};

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-extern crate create_purse_01;
-
 use contract_ffi::contract_api::{runtime, Error, TURef};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::uref::URef;

--- a/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 

--- a/execution-engine/contracts/test/do-nothing/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-extern crate contract_ffi;
+// Required to bring `#[panic_handler]` from `contract_ffi::handlers` into scope.
+#[allow(unused_imports)]
+use contract_ffi;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-221-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-221-regression/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, storage};
 use contract_ffi::key::Key;
 

--- a/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::ToString;
 

--- a/execution-engine/contracts/test/ee-401-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
-use alloc::collections::btree_map::BTreeMap;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 
 use contract_ffi::contract_api::{runtime, storage, ContractRef};

--- a/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
+++ b/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
@@ -1,12 +1,10 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
 
-extern crate contract_ffi;
-
-use alloc::collections::btree_map::BTreeMap;
+use alloc::collections::BTreeMap;
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, storage, ContractRef, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/ee-460-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-460-regression/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/contracts/test/ee-532-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-532-regression/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
-extern crate contract_ffi;
+// Required to bring `#[panic_handler]` from `contract_ffi::handlers` into scope.
+#[allow(unused_imports)]
+use contract_ffi;
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-536-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-536-regression/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{

--- a/execution-engine/contracts/test/ee-539-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-539-regression/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::{ActionType, PublicKey, Weight};

--- a/execution-engine/contracts/test/ee-549-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-549-regression/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, system};
 

--- a/execution-engine/contracts/test/ee-550-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-550-regression/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::string::{String, ToString};
+use alloc::vec;
 use core::clone::Clone;
 use core::convert::Into;
 

--- a/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 

--- a/execution-engine/contracts/test/ee-584-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-584-regression/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/test/ee-597-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-597-regression/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, system, ContractRef};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/ee-598-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-598-regression/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::ContractRef;
 use contract_ffi::contract_api::{account, runtime, system, Error};

--- a/execution-engine/contracts/test/ee-601-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-601-regression/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, storage, system, Error as ApiError};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/test/endless-loop/src/lib.rs
+++ b/execution-engine/contracts/test/endless-loop/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::account;
 
 #[no_mangle]

--- a/execution-engine/contracts/test/get-arg/src/lib.rs
+++ b/execution-engine/contracts/test/get-arg/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/test/get-blocktime/src/lib.rs
+++ b/execution-engine/contracts/test/get-blocktime/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::BlockTime;

--- a/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
-use alloc::collections::btree_map::BTreeMap;
-use alloc::prelude::v1::Vec;
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
 
 use contract_ffi::contract_api::{runtime, storage, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/test/get-caller/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/contracts/test/get-phase-payment/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase-payment/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{account, runtime, system, Error};
 use contract_ffi::execution::Phase;

--- a/execution-engine/contracts/test/get-phase/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::execution::Phase;
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
+++ b/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::string::String;
 
 use contract_ffi::contract_api::{account, runtime, Error};

--- a/execution-engine/contracts/test/list-named-keys/src/lib.rs
+++ b/execution-engine/contracts/test/list-named-keys/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;

--- a/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, Error};
 use contract_ffi::contract_api::{ContractRef, TURef};

--- a/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
@@ -2,9 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-extern crate local_state;
-
 use alloc::string::String;
 
 use contract_ffi::contract_api::{storage, Error};

--- a/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-extern crate local_state_stored_upgraded;
-
 use contract_ffi::contract_api::{runtime, Error, TURef};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::uref::URef;

--- a/execution-engine/contracts/test/local-state-stored/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-extern crate local_state;
-
 use contract_ffi::contract_api::{runtime, storage, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 

--- a/execution-engine/contracts/test/local-state/src/lib.rs
+++ b/execution-engine/contracts/test/local-state/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::string::{String, ToString};
 
 use contract_ffi::contract_api::storage;

--- a/execution-engine/contracts/test/main-purse/src/lib.rs
+++ b/execution-engine/contracts/test/main-purse/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PurseId;

--- a/execution-engine/contracts/test/mint-purse/src/lib.rs
+++ b/execution-engine/contracts/test/mint-purse/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, system, Error as ApiError};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, storage, system};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/modified-mint-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-upgrader/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-extern crate modified_mint;
-
 use contract_ffi::contract_api::{runtime, system, ContractRef, Error};
 
 #[repr(u16)]

--- a/execution-engine/contracts/test/modified-mint/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint/src/lib.rs
@@ -1,12 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
 
-extern crate contract_ffi;
-extern crate mint_token;
-
 use alloc::string::{String, ToString};
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
 use contract_ffi::system_contracts::mint::Error;

--- a/execution-engine/contracts/test/named-keys/src/lib.rs
+++ b/execution-engine/contracts/test/named-keys/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
 

--- a/execution-engine/contracts/test/overwrite-uref-content/src/lib.rs
+++ b/execution-engine/contracts/test/overwrite-uref-content/src/lib.rs
@@ -2,8 +2,6 @@
 
 extern crate alloc;
 
-extern crate contract_ffi;
-
 use alloc::string::{String, ToString};
 
 use contract_ffi::contract_api::TURef;

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -1,10 +1,10 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
-use alloc::prelude::v1::{String, Vec};
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 use contract_ffi::contract_api::{account, runtime, system, ContractRef, Error as ApiError};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
+use alloc::vec;
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api::ContractRef;

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::vec::Vec;
 

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
+use alloc::vec;
 use alloc::vec::Vec;
 
 use contract_ffi::contract_api::ContractRef;

--- a/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, storage, Error};
 use contract_ffi::contract_api::{ContractRef, TURef};

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -1,10 +1,9 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::{String, ToString};
+use alloc::vec;
 
 use contract_ffi::contract_api::TURef;
 use contract_ffi::contract_api::{runtime, storage, system, Error};

--- a/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
@@ -1,12 +1,11 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
 #[cfg(not(feature = "lib"))]
 use alloc::collections::BTreeMap;
 use alloc::string::{String, ToString};
+use alloc::vec;
 
 use contract_ffi::contract_api::{runtime, storage, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;

--- a/execution-engine/contracts/test/remove-associated-key/src/lib.rs
+++ b/execution-engine/contracts/test/remove-associated-key/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{account, runtime, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/contracts/test/system-contracts-access/src/lib.rs
+++ b/execution-engine/contracts/test/system-contracts-access/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::ContractRef;
 use contract_ffi::contract_api::{runtime, system, Error as ApiError};
 use contract_ffi::uref::{AccessRights, URef};

--- a/execution-engine/contracts/test/transfer-main-purse-to-new-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-main-purse-to-new-purse/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
 use alloc::string::String;
 

--- a/execution-engine/contracts/test/transfer-purse-to-account-stored/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account-stored/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::format;
 
 use contract_ffi::contract_api::{account, runtime, storage, system, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
@@ -1,8 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
+
+use alloc::format;
 
 use contract_ffi::contract_api::{account, runtime, storage, system, Error};
 use contract_ffi::key::Key;

--- a/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
-#[macro_use]
 extern crate alloc;
-extern crate contract_ffi;
 
+use alloc::format;
 use alloc::string::String;
 
 use contract_ffi::contract_api::{account, runtime, storage, system, Error};

--- a/execution-engine/contracts/test/transfer-to-account-01/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-to-account-01/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::U512;

--- a/execution-engine/contracts/test/transfer-to-account-02/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-to-account-02/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
 
-extern crate contract_ffi;
-
 use contract_ffi::contract_api::{runtime, system, Error};
 use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
 use contract_ffi::value::account::PublicKey;

--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -1,38 +1,6 @@
 #![feature(result_map_or_else)]
 #![feature(never_type)]
 
-// core dependencies
-extern crate core;
-
-// third-party dependencies
-extern crate blake2;
-extern crate failure;
-extern crate hex_fmt;
-extern crate itertools;
-extern crate linked_hash_map;
-extern crate parity_wasm;
-extern crate pwasm_utils;
-extern crate rand;
-extern crate rand_chacha;
-extern crate wasmi;
-
-// internal dependencies
-extern crate contract_ffi;
-extern crate engine_shared;
-extern crate engine_storage;
-extern crate engine_wasm_prep;
-
-// third-party dev-dependencies
-#[cfg(test)]
-#[macro_use]
-extern crate matches;
-#[cfg(test)]
-extern crate proptest;
-
-#[macro_use]
-extern crate num_derive;
-extern crate num_traits;
-
 use contract_ffi::key::Key;
 use std::collections::BTreeMap;
 

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -1,5 +1,7 @@
-use num_traits::{FromPrimitive, ToPrimitive};
 use std::convert::TryFrom;
+
+use num_derive::{FromPrimitive, ToPrimitive};
+use num_traits::{FromPrimitive, ToPrimitive};
 
 #[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
 #[repr(usize)]

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use std::iter;
 use std::rc::Rc;
 
+use matches::assert_matches;
 use proptest::collection::vec;
 use proptest::prelude::*;
 

--- a/execution-engine/engine-grpc-server/build.rs
+++ b/execution-engine/engine-grpc-server/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_rust_grpc;
-
 fn main() {
     println!("cargo:rerun-if-changed=../../protobuf/io/casperlabs/casper/consensus/state.proto");
     println!("cargo:rerun-if-changed=../../protobuf/io/casperlabs/ipc/ipc.proto");

--- a/execution-engine/engine-grpc-server/src/lib.rs
+++ b/execution-engine/engine-grpc-server/src/lib.rs
@@ -1,15 +1,1 @@
-extern crate contract_ffi;
-extern crate engine_core;
-extern crate engine_shared;
-extern crate engine_storage;
-extern crate engine_wasm_prep;
-extern crate grpc;
-extern crate lmdb;
-extern crate proptest;
-extern crate protobuf;
-extern crate wabt;
-
-#[cfg(test)]
-extern crate parity_wasm;
-
 pub mod engine_server;

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -1,16 +1,3 @@
-extern crate clap;
-extern crate ctrlc;
-extern crate dirs;
-extern crate grpc;
-#[macro_use]
-extern crate lazy_static;
-extern crate lmdb;
-
-extern crate casperlabs_engine_grpc_server;
-extern crate engine_core;
-extern crate engine_shared;
-extern crate engine_storage;
-
 use std::collections::btree_map::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
@@ -22,6 +9,7 @@ use std::time::Duration;
 use clap::{App, Arg, ArgMatches};
 use dirs::home_dir;
 use engine_core::engine_state::{EngineConfig, EngineState};
+use lazy_static::lazy_static;
 use lmdb::DatabaseFlags;
 
 use engine_shared::logging::log_settings::{LogLevelFilter, LogSettings};

--- a/execution-engine/engine-shared/src/lib.rs
+++ b/execution-engine/engine-shared/src/lib.rs
@@ -1,16 +1,5 @@
 #![feature(result_map_or_else, never_type)]
 
-extern crate blake2;
-extern crate chrono;
-extern crate contract_ffi;
-#[macro_use]
-extern crate lazy_static;
-extern crate base16;
-extern crate libc;
-extern crate log;
-extern crate num;
-extern crate parity_wasm;
-
 pub mod additive_map;
 #[macro_use]
 pub mod gas;

--- a/execution-engine/engine-shared/src/logging/log_settings.rs
+++ b/execution-engine/engine-shared/src/logging/log_settings.rs
@@ -1,6 +1,7 @@
 use std::process;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use lazy_static::lazy_static;
 use serde::Serialize;
 
 use crate::logging::log_level::*;

--- a/execution-engine/engine-shared/src/logging/logger.rs
+++ b/execution-engine/engine-shared/src/logging/logger.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Mutex, Once};
 
+use lazy_static::lazy_static;
 use log::{Metadata, Record};
 use serde::Deserialize;
 use serde::Serialize;

--- a/execution-engine/engine-shared/src/logging/tests.rs
+++ b/execution-engine/engine-shared/src/logging/tests.rs
@@ -1,6 +1,8 @@
 use std::thread;
 use std::time::{Instant, SystemTime};
 
+use lazy_static::lazy_static;
+
 use crate::logging::log_settings::{
     get_log_settings_provider, set_log_settings_provider, LogLevelFilter, LogSettings,
 };

--- a/execution-engine/engine-storage/benches/trie_bench.rs
+++ b/execution-engine/engine-storage/benches/trie_bench.rs
@@ -1,7 +1,5 @@
 #![feature(test)]
-extern crate casperlabs_engine_storage;
-extern crate contract_ffi;
-extern crate engine_shared;
+
 extern crate test;
 
 use test::black_box;

--- a/execution-engine/engine-storage/src/trie_store/in_memory.rs
+++ b/execution-engine/engine-storage/src/trie_store/in_memory.rs
@@ -3,9 +3,6 @@
 //! # Usage
 //!
 //! ```
-//! # extern crate casperlabs_engine_storage;
-//! # extern crate contract_ffi;
-//! # extern crate engine_shared;
 //! use casperlabs_engine_storage::store::Store;
 //! use casperlabs_engine_storage::transaction_source::{Transaction, TransactionSource};
 //! use casperlabs_engine_storage::transaction_source::in_memory::InMemoryEnvironment;

--- a/execution-engine/engine-storage/src/trie_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/trie_store/lmdb.rs
@@ -3,11 +3,6 @@
 //! # Usage
 //!
 //! ```
-//! # extern crate casperlabs_engine_storage;
-//! # extern crate contract_ffi;
-//! # extern crate lmdb;
-//! # extern crate engine_shared;
-//! # extern crate tempfile;
 //! use casperlabs_engine_storage::store::Store;
 //! use casperlabs_engine_storage::transaction_source::{Transaction, TransactionSource};
 //! use casperlabs_engine_storage::transaction_source::lmdb::LmdbEnvironment;

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -1,11 +1,4 @@
-#[macro_use]
-extern crate criterion;
-extern crate contract_ffi;
-extern crate engine_core;
-extern crate engine_shared;
-extern crate engine_storage;
-
-use criterion::{Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use tempfile::TempDir;
 
 use casperlabs_engine_tests::support::test_support::{

--- a/execution-engine/engine-tests/src/lib.rs
+++ b/execution-engine/engine-tests/src/lib.rs
@@ -1,17 +1,2 @@
-extern crate grpc;
-
-#[cfg(test)]
-#[macro_use]
-extern crate lazy_static;
-extern crate lmdb;
-extern crate protobuf;
-
-extern crate contract_ffi;
-extern crate engine_core;
-extern crate engine_grpc_server;
-extern crate engine_shared;
-extern crate engine_storage;
-extern crate engine_wasm_prep;
-
 pub mod support;
 pub mod test;

--- a/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
+++ b/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
@@ -4,23 +4,15 @@
 //! For details of how to run this executable, see the README in this directory or at
 //! https://github.com/CasperLabs/CasperLabs/blob/dev/execution-engine/engine-tests/src/profiling/README.md#concurrent-executor
 
-#[macro_use]
-extern crate clap;
-extern crate crossbeam_channel;
-extern crate env_logger;
-extern crate grpc;
-#[macro_use]
-extern crate log;
-
-use std::env;
 use std::iter::Sum;
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 use crossbeam_channel::{Iter, Receiver, Sender};
 use grpc::{ClientStubExt, RequestOptions};
+use log::info;
 
 use casperlabs_engine_tests::support::profiling_common;
 use casperlabs_engine_tests::support::test_support::ExecuteRequestBuilder;

--- a/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
@@ -1,9 +1,10 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
+use lazy_static::lazy_static;
 
 use contract_ffi::key::Key;
 use contract_ffi::value::account::{PublicKey, Weight};
 use contract_ffi::value::{Account, U512};
 
+use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/create_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/create_purse.rs
@@ -1,4 +1,4 @@
-use crate::support::test_support::{ExecuteRequestBuilder, WasmTestBuilder};
+use lazy_static::lazy_static;
 
 use contract_ffi::base16;
 use contract_ffi::key::Key;
@@ -6,6 +6,7 @@ use contract_ffi::value::account::PurseId;
 use contract_ffi::value::U512;
 use engine_shared::transform::Transform;
 
+use crate::support::test_support::{ExecuteRequestBuilder, WasmTestBuilder};
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 
 const CONTRACT_CREATE_PURSE_01: &str = "create_purse_01.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/transfer.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer.rs
@@ -1,10 +1,13 @@
+use lazy_static::lazy_static;
+
+use contract_ffi::value::U512;
+use engine_core::engine_state::CONV_RATE;
+use engine_shared::motes::Motes;
+
 use crate::support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder};
 use crate::test::{
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
 };
-use contract_ffi::value::U512;
-use engine_core::engine_state::CONV_RATE;
-use engine_shared::motes::Motes;
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT_01: &str = "transfer_to_account_01.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 use contract_ffi::contract_api::system::{TransferResult, TransferredTo};
 use contract_ffi::contract_api::Error;
 use contract_ffi::key::Key;

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -1,4 +1,4 @@
-use lazy_static;
+use lazy_static::lazy_static;
 
 use contract_ffi::key::Key;
 use engine_core::engine_state::EngineConfig;

--- a/execution-engine/engine-tests/src/test/regression/ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_598.rs
@@ -1,14 +1,16 @@
+use lazy_static::lazy_static;
+
 use contract_ffi::contract_api::Error;
 use contract_ffi::value::account::PublicKey;
 use contract_ffi::value::U512;
+use engine_core::engine_state::genesis::GenesisAccount;
+use engine_shared::motes::Motes;
 
 use crate::support::test_support::{
     self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
     STANDARD_PAYMENT_CONTRACT,
 };
 use crate::test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT};
-use engine_core::engine_state::genesis::GenesisAccount;
-use engine_shared::motes::Motes;
 
 const CONTRACT_POS_BONDING: &str = "pos_bonding.wasm";
 const ACCOUNT_1_ADDR: [u8; 32] = [7u8; 32];

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
@@ -1,3 +1,5 @@
+use lazy_static::lazy_static;
+
 use contract_ffi::value::U512;
 
 use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
@@ -1,11 +1,13 @@
-use contract_ffi::value::U512;
+use lazy_static::lazy_static;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 use contract_ffi::uref::URef;
+use contract_ffi::value::U512;
 use engine_core::engine_state::Error;
 use engine_core::execution;
 use engine_shared::transform::TypeMismatch;
+
+use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
+use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 
 const CONTRACT_SYSTEM_CONTRACTS_ACCESS: &str = "system_contracts_access.wasm";
 const CONTRACT_OVERWRITE_UREF_CONTENT: &str = "overwrite_uref_content.wasm";

--- a/execution-engine/engine-wasm-prep/src/lib.rs
+++ b/execution-engine/engine-wasm-prep/src/lib.rs
@@ -1,10 +1,3 @@
-extern crate parity_wasm;
-extern crate pwasm_utils;
-
-extern crate contract_ffi;
-#[cfg(test)]
-extern crate engine_shared;
-
 pub mod wasm_costs;
 
 use std::error::Error;


### PR DESCRIPTION
### Overview
Removes most instances of `extern crate`

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-757

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
In order to make use of the new style for importing third-party macros, I upgraded the `uint` crate version from 0.7.1 to 0.8.2.

I also moved the unit tests in contract-ffi/src/base16.rs to the usual `tests` module.
