### PR TITLE
EE-758: Enable merge_imports in rustfmt.toml

### DIFF
--- a/execution-engine/contract-ffi/benches/bytesrepr_bench.rs
+++ b/execution-engine/contract-ffi/benches/bytesrepr_bench.rs
@@ -2,21 +2,20 @@
 
 extern crate test;
 
-use std::collections::BTreeMap;
-use std::iter;
+use std::{collections::BTreeMap, iter};
 
-use test::black_box;
-use test::Bencher;
+use test::{black_box, Bencher};
 
-use casperlabs_contract_ffi::bytesrepr::{FromBytes, ToBytes};
-use casperlabs_contract_ffi::key::Key;
-use casperlabs_contract_ffi::uref::{AccessRights, URef};
-use casperlabs_contract_ffi::value::account::{AssociatedKeys, PublicKey, PurseId, Weight};
-use casperlabs_contract_ffi::value::{
-    account::Account,
-    contract::Contract,
-    uint::{U128, U256, U512},
-    ProtocolVersion, Value,
+use casperlabs_contract_ffi::{
+    bytesrepr::{FromBytes, ToBytes},
+    key::Key,
+    uref::{AccessRights, URef},
+    value::{
+        account::{Account, AssociatedKeys, PublicKey, PurseId, Weight},
+        contract::Contract,
+        uint::{U128, U256, U512},
+        ProtocolVersion, Value,
+    },
 };
 
 static KB: usize = 1024;

--- a/execution-engine/contract-ffi/src/args_parser.rs
+++ b/execution-engine/contract-ffi/src/args_parser.rs
@@ -1,3 +1,5 @@
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/execution-engine/contract-ffi/src/base16.rs
+++ b/execution-engine/contract-ffi/src/base16.rs
@@ -1,8 +1,5 @@
-use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
-use core::num::ParseIntError;
-use core::str;
+use alloc::{format, string::String, vec::Vec};
+use core::{num::ParseIntError, str};
 
 use failure::Fail;
 

--- a/execution-engine/contract-ffi/src/bytesrepr.rs
+++ b/execution-engine/contract-ffi/src/bytesrepr.rs
@@ -1,13 +1,13 @@
-use super::alloc::collections::BTreeMap;
-use super::alloc::collections::TryReserveError;
-use super::alloc::string::String;
-use super::alloc::vec::Vec;
+use super::alloc::{
+    collections::{BTreeMap, TryReserveError},
+    string::String,
+    vec::Vec,
+};
 
 use core::mem::{size_of, MaybeUninit};
 use failure::Fail;
 
-use crate::value::ProtocolVersion;
-use crate::value::SemVer;
+use crate::value::{ProtocolVersion, SemVer};
 
 pub const I32_SIZE: usize = size_of::<i32>();
 pub const U8_SIZE: usize = size_of::<u8>();
@@ -533,11 +533,9 @@ where
 #[allow(clippy::unnecessary_operation)]
 #[cfg(test)]
 mod proptests {
-    use proptest::collection::vec;
-    use proptest::prelude::*;
+    use proptest::{collection::vec, prelude::*};
 
-    use crate::bytesrepr;
-    use crate::gens::*;
+    use crate::{bytesrepr, gens::*};
 
     proptest! {
         #[test]

--- a/execution-engine/contract-ffi/src/contract_api/account.rs
+++ b/execution-engine/contract-ffi/src/contract_api/account.rs
@@ -2,14 +2,15 @@ use alloc::vec::Vec;
 use core::convert::TryFrom;
 
 use super::to_ptr;
-use crate::bytesrepr::deserialize;
-use crate::contract_api;
-use crate::ext_ffi;
-use crate::unwrap_or_revert::UnwrapOrRevert;
 pub use crate::value::account::PublicKey;
-use crate::value::account::{
-    ActionType, AddKeyFailure, PurseId, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
-    Weight, PURSE_ID_SIZE_SERIALIZED,
+use crate::{
+    bytesrepr::deserialize,
+    contract_api, ext_ffi,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{
+        ActionType, AddKeyFailure, PurseId, RemoveKeyFailure, SetThresholdFailure,
+        UpdateKeyFailure, Weight, PURSE_ID_SIZE_SERIALIZED,
+    },
 };
 
 pub fn get_main_purse() -> PurseId {

--- a/execution-engine/contract-ffi/src/contract_api/contract_ref.rs
+++ b/execution-engine/contract-ffi/src/contract_api/contract_ref.rs
@@ -1,6 +1,5 @@
 use super::TURef;
-use crate::key::Key;
-use crate::value::Contract;
+use crate::{key::Key, value::Contract};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContractRef {

--- a/execution-engine/contract-ffi/src/contract_api/error.rs
+++ b/execution-engine/contract-ffi/src/contract_api/error.rs
@@ -1,11 +1,13 @@
-use core::fmt::{self, Debug, Formatter};
-use core::{u16, u8};
+use core::{
+    fmt::{self, Debug, Formatter},
+    u16, u8,
+};
 
-use crate::bytesrepr;
-use crate::contract_api::turef::AccessRightsError;
-use crate::system_contracts::{mint, pos};
-use crate::value::account::{
-    AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
+use crate::{
+    bytesrepr,
+    contract_api::turef::AccessRightsError,
+    system_contracts::{mint, pos},
+    value::account::{AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure},
 };
 
 /// All `Error` variants defined in this library other than `Error::User` will convert to a `u32`

--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -6,11 +6,12 @@ pub mod storage;
 pub mod system;
 mod turef;
 
-use alloc::alloc::{Alloc, Global};
-use alloc::vec::Vec;
+use alloc::{
+    alloc::{Alloc, Global},
+    vec::Vec,
+};
 
-use crate::bytesrepr::ToBytes;
-use crate::unwrap_or_revert::UnwrapOrRevert;
+use crate::{bytesrepr::ToBytes, unwrap_or_revert::UnwrapOrRevert};
 pub use contract_ref::ContractRef;
 pub use error::{i32_from, result_from, Error};
 pub use turef::TURef;

--- a/execution-engine/contract-ffi/src/contract_api/runtime.rs
+++ b/execution-engine/contract-ffi/src/contract_api/runtime.rs
@@ -1,18 +1,23 @@
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use super::error::{result_from, Error};
-use super::{alloc_bytes, str_ref_to_ptr, to_ptr, ContractRef, TURef};
-use crate::args_parser::ArgsParser;
-use crate::bytesrepr::{self, deserialize, FromBytes, ToBytes};
-use crate::execution::{Phase, PHASE_SIZE};
-use crate::ext_ffi;
-use crate::key::Key;
-use crate::unwrap_or_revert::UnwrapOrRevert;
-use crate::uref::URef;
-use crate::value::account::{BlockTime, PublicKey, BLOCKTIME_SER_SIZE};
-use crate::value::{Contract, Value};
+use super::{
+    alloc_bytes,
+    error::{result_from, Error},
+    str_ref_to_ptr, to_ptr, ContractRef, TURef,
+};
+use crate::{
+    args_parser::ArgsParser,
+    bytesrepr::{self, deserialize, FromBytes, ToBytes},
+    execution::{Phase, PHASE_SIZE},
+    ext_ffi,
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+    value::{
+        account::{BlockTime, PublicKey, BLOCKTIME_SER_SIZE},
+        Contract, Value,
+    },
+};
 
 /// Return `t` to the host, terminating the currently running module.
 /// Note this function is only relevant to contracts stored on chain which

--- a/execution-engine/contract-ffi/src/contract_api/storage.rs
+++ b/execution-engine/contract-ffi/src/contract_api/storage.rs
@@ -1,17 +1,19 @@
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec::Vec;
-use core::convert::{From, TryFrom, TryInto};
-use core::u8;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use core::{
+    convert::{From, TryFrom, TryInto},
+    u8,
+};
 
 use super::{alloc_bytes, str_ref_to_ptr, to_ptr, ContractRef, TURef};
-use crate::bytesrepr::{self, deserialize, ToBytes};
-use crate::contract_api::{runtime, Error};
-use crate::ext_ffi;
-use crate::key::{Key, UREF_SIZE};
-use crate::unwrap_or_revert::UnwrapOrRevert;
-use crate::uref::AccessRights;
-use crate::value::{Contract, Value};
+use crate::{
+    bytesrepr::{self, deserialize, ToBytes},
+    contract_api::{runtime, Error},
+    ext_ffi,
+    key::{Key, UREF_SIZE},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::AccessRights,
+    value::{Contract, Value},
+};
 
 pub(crate) fn read_untyped(key: &Key) -> Result<Option<Value>, bytesrepr::Error> {
     // Note: _bytes is necessary to keep the Vec<u8> in scope. If _bytes is

--- a/execution-engine/contract-ffi/src/contract_api/system.rs
+++ b/execution-engine/contract-ffi/src/contract_api/system.rs
@@ -1,19 +1,19 @@
 use alloc::vec::Vec;
-use core::fmt::Debug;
-use core::u8;
+use core::{fmt::Debug, u8};
 
-use super::error::Error;
-use super::runtime::revert;
-use super::{alloc_bytes, to_ptr, ContractRef, TURef};
-use crate::bytesrepr::deserialize;
-use crate::contract_api::error::result_from;
-use crate::contract_api::runtime;
-use crate::ext_ffi;
-use crate::system_contracts::SystemContract;
-use crate::unwrap_or_revert::UnwrapOrRevert;
-use crate::uref::UREF_SIZE_SERIALIZED;
-use crate::value::account::{PublicKey, PurseId, PURSE_ID_SIZE_SERIALIZED};
-use crate::value::U512;
+use super::{alloc_bytes, error::Error, runtime::revert, to_ptr, ContractRef, TURef};
+use crate::{
+    bytesrepr::deserialize,
+    contract_api::{error::result_from, runtime},
+    ext_ffi,
+    system_contracts::SystemContract,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::UREF_SIZE_SERIALIZED,
+    value::{
+        account::{PublicKey, PurseId, PURSE_ID_SIZE_SERIALIZED},
+        U512,
+    },
+};
 
 pub type TransferResult = Result<TransferredTo, Error>;
 

--- a/execution-engine/contract-ffi/src/contract_api/turef.rs
+++ b/execution-engine/contract-ffi/src/contract_api/turef.rs
@@ -1,12 +1,11 @@
 use hex_fmt::HexFmt;
 
-use core::any::type_name;
-use core::fmt;
-use core::marker::PhantomData;
+use core::{any::type_name, fmt, marker::PhantomData};
 
-use crate::uref::AccessRights;
-use crate::uref::URef;
-use crate::value::Value;
+use crate::{
+    uref::{AccessRights, URef},
+    value::Value,
+};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum AccessRightsError {
@@ -87,9 +86,7 @@ impl<T> core::fmt::Display for TURef<T> {
 mod tests {
     use alloc::string::{String, ToString};
 
-    use crate::contract_api::TURef;
-    use crate::uref::AccessRights;
-    use crate::value::Value;
+    use crate::{contract_api::TURef, uref::AccessRights, value::Value};
 
     #[test]
     fn turef_as_string() {

--- a/execution-engine/contract-ffi/src/execution.rs
+++ b/execution-engine/contract-ffi/src/execution.rs
@@ -1,3 +1,5 @@
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/execution-engine/contract-ffi/src/gens.rs
+++ b/execution-engine/contract-ffi/src/gens.rs
@@ -1,18 +1,22 @@
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec;
+use alloc::{collections::BTreeMap, string::String, vec};
 
-use proptest::collection::{btree_map, vec};
-use proptest::prelude::*;
-use proptest::{array, bits, option, result};
-
-use crate::execution::Phase;
-use crate::key::*;
-use crate::uref::{AccessRights, URef};
-use crate::value::account::{
-    ActionThresholds, AssociatedKeys, PublicKey, PurseId, Weight, MAX_KEYS,
+use proptest::{
+    array, bits,
+    collection::{btree_map, vec},
+    option,
+    prelude::*,
+    result,
 };
-use crate::value::*;
+
+use crate::{
+    execution::Phase,
+    key::*,
+    uref::{AccessRights, URef},
+    value::{
+        account::{ActionThresholds, AssociatedKeys, PublicKey, PurseId, Weight, MAX_KEYS},
+        *,
+    },
+};
 
 pub fn u8_slice_32() -> impl Strategy<Value = [u8; 32]> {
     vec(any::<u8>(), 32).prop_map(|b| {

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -1,14 +1,17 @@
-use alloc::format;
-use alloc::vec::Vec;
+use alloc::{format, vec::Vec};
 
-use blake2::digest::{Input, VariableOutput};
-use blake2::VarBlake2b;
+use blake2::{
+    digest::{Input, VariableOutput},
+    VarBlake2b,
+};
 use hex_fmt::HexFmt;
 
-use crate::base16;
-use crate::bytesrepr::{Error, FromBytes, ToBytes, N32, U32_SIZE};
-use crate::contract_api::{ContractRef, TURef};
-use crate::uref::{AccessRights, URef, UREF_SIZE_SERIALIZED};
+use crate::{
+    base16,
+    bytesrepr::{Error, FromBytes, ToBytes, N32, U32_SIZE},
+    contract_api::{ContractRef, TURef},
+    uref::{AccessRights, URef, UREF_SIZE_SERIALIZED},
+};
 
 const ACCOUNT_ID: u8 = 0;
 const HASH_ID: u8 = 1;
@@ -276,14 +279,21 @@ impl ToBytes for Vec<Key> {
 #[allow(clippy::unnecessary_operation)]
 #[cfg(test)]
 mod tests {
-    use alloc::format;
-    use alloc::string::String;
+    // Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+    #[rustfmt::skip]
     use alloc::vec;
-    use alloc::vec::Vec;
+    use alloc::{format, string::String, vec::Vec};
 
-    use crate::bytesrepr::{Error, FromBytes};
-    use crate::key::Key;
-    use crate::uref::{AccessRights, URef};
+    use proptest::{
+        prelude::*,
+        string::{string_regex, RegexGeneratorStrategy},
+    };
+
+    use crate::{
+        bytesrepr::{Error, FromBytes},
+        key::Key,
+        uref::{AccessRights, URef},
+    };
 
     fn test_readable(right: AccessRights, is_true: bool) {
         assert_eq!(right.is_readable(), is_true)
@@ -378,9 +388,6 @@ mod tests {
         // verifies that the arbitrary key length doesn't get truncated
         assert_ne!(local1, local2);
     }
-
-    use proptest::prelude::*;
-    use proptest::string::{string_regex, RegexGeneratorStrategy};
 
     /// Create a base16 string of [[length]] size.
     fn base16_str_arb(length: usize) -> RegexGeneratorStrategy<String> {

--- a/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mint/error.rs
@@ -5,8 +5,10 @@ use core::convert::{TryFrom, TryInto};
 
 use failure::Fail;
 
-use crate::bytesrepr::{self, FromBytes, ToBytes};
-use crate::system_contracts::mint::purse_id::PurseIdError;
+use crate::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    system_contracts::mint::purse_id::PurseIdError,
+};
 
 /// An enum error that is capable of carrying a value across FFI-Host
 /// boundary.

--- a/execution-engine/contract-ffi/src/system_contracts/pos/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/pos/mod.rs
@@ -1,5 +1,3 @@
 mod error;
 
-pub use error::Error;
-pub use error::PurseLookupError;
-pub use error::Result;
+pub use error::{Error, PurseLookupError, Result};

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -1,14 +1,13 @@
-use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{format, string::String, vec::Vec};
 
 use bitflags::bitflags;
 use hex_fmt::HexFmt;
 
-use crate::base16;
-use crate::bytesrepr;
-use crate::bytesrepr::{OPTION_SIZE, U32_SIZE};
-use crate::contract_api::TURef;
+use crate::{
+    base16,
+    bytesrepr::{self, OPTION_SIZE, U32_SIZE},
+    contract_api::TURef,
+};
 
 pub const UREF_ADDR_SIZE: usize = 32;
 pub const ACCESS_RIGHTS_SIZE: usize = 1;

--- a/execution-engine/contract-ffi/src/value/account.rs
+++ b/execution-engine/contract-ffi/src/value/account.rs
@@ -1,18 +1,23 @@
-use alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
-use alloc::string::String;
-use alloc::vec::Vec;
-use core::convert::TryFrom;
-use core::fmt::{Debug, Display, Formatter};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+    vec::Vec,
+};
+use core::{
+    convert::TryFrom,
+    fmt::{Debug, Display, Formatter},
+};
 
 use failure::Fail;
 use hex_fmt::HexFmt;
 
-use crate::bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE, U8_SIZE};
-use crate::contract_api::runtime;
-use crate::contract_api::Error as ApiError;
-use crate::key::{Key, UREF_SIZE};
-use crate::unwrap_or_revert::UnwrapOrRevert;
-use crate::uref::{AccessRights, URef, UREF_SIZE_SERIALIZED};
+use crate::{
+    bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE, U8_SIZE},
+    contract_api::{runtime, Error as ApiError},
+    key::{Key, UREF_SIZE},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef, UREF_SIZE_SERIALIZED},
+};
 
 pub const PURSE_ID_SIZE_SERIALIZED: usize = UREF_SIZE_SERIALIZED;
 
@@ -859,16 +864,22 @@ impl FromBytes for Account {
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
+    // Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+    #[rustfmt::skip]
     use alloc::vec;
-    use alloc::vec::Vec;
-    use core::convert::TryFrom;
-    use core::iter::FromIterator;
+    use alloc::{
+        collections::{BTreeMap, BTreeSet},
+        vec::Vec,
+    };
+    use core::{convert::TryFrom, iter::FromIterator};
 
-    use crate::uref::{AccessRights, URef};
-    use crate::value::account::{
-        Account, ActionThresholds, ActionType, AddKeyFailure, AssociatedKeys, PublicKey, PurseId,
-        RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight, KEY_SIZE, MAX_KEYS,
+    use crate::{
+        uref::{AccessRights, URef},
+        value::account::{
+            Account, ActionThresholds, ActionType, AddKeyFailure, AssociatedKeys, PublicKey,
+            PurseId, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight, KEY_SIZE,
+            MAX_KEYS,
+        },
     };
 
     #[test]

--- a/execution-engine/contract-ffi/src/value/contract.rs
+++ b/execution-engine/contract-ffi/src/value/contract.rs
@@ -1,9 +1,10 @@
-use crate::bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE};
-use crate::key::{Key, UREF_SIZE};
-use crate::value::ProtocolVersion;
-use alloc::collections::btree_map::BTreeMap;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
+use crate::{
+    bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE},
+    key::{Key, UREF_SIZE},
+    value::ProtocolVersion,
+};
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Contract {

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -4,23 +4,26 @@ pub mod protocol_version;
 mod semver;
 pub mod uint;
 
-use alloc::string::String;
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
-use alloc::vec::Vec;
-use core::convert::TryFrom;
-use core::iter;
-use core::mem::size_of;
+use alloc::{string::String, vec::Vec};
+use core::{convert::TryFrom, iter, mem::size_of};
 
-pub use self::account::Account;
-pub use self::contract::Contract;
-pub use self::protocol_version::ProtocolVersion;
-pub use self::semver::SemVer;
-pub use self::uint::{U128, U256, U512};
-use crate::bytesrepr::{
-    Error, FromBytes, ToBytes, U128_SIZE, U256_SIZE, U32_SIZE, U512_SIZE, U64_SIZE, U8_SIZE,
+pub use self::{
+    account::Account,
+    contract::Contract,
+    protocol_version::ProtocolVersion,
+    semver::SemVer,
+    uint::{U128, U256, U512},
 };
-use crate::key::{self, Key, UREF_SIZE};
-use crate::uref::URef;
+use crate::{
+    bytesrepr::{
+        Error, FromBytes, ToBytes, U128_SIZE, U256_SIZE, U32_SIZE, U512_SIZE, U64_SIZE, U8_SIZE,
+    },
+    key::{self, Key, UREF_SIZE},
+    uref::URef,
+};
 
 const INT32_ID: u8 = 0;
 const BYTEARRAY_ID: u8 = 1;

--- a/execution-engine/contract-ffi/src/value/protocol_version.rs
+++ b/execution-engine/contract-ffi/src/value/protocol_version.rs
@@ -35,8 +35,7 @@ impl fmt::Display for ProtocolVersion {
 
 #[cfg(test)]
 mod tests {
-    use crate::value::semver::SemVer;
-    use crate::value::ProtocolVersion;
+    use crate::value::{semver::SemVer, ProtocolVersion};
 
     #[test]
     fn should_be_able_to_get_instance() {

--- a/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
@@ -2,11 +2,15 @@
 
 use binascii::ConvertError;
 
-use contract_ffi::contract_api::system::TransferredTo;
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::uint::U512;
+use contract_ffi::{
+    contract_api::{
+        runtime,
+        system::{self, TransferredTo},
+        Error,
+    },
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, uint::U512},
+};
 
 fn parse_public_key(hex: &[u8]) -> Result<PublicKey, ConvertError> {
     let mut buff = [0u8; 32];

--- a/execution-engine/contracts/bench/create-accounts/src/lib.rs
+++ b/execution-engine/contracts/bench/create-accounts/src/lib.rs
@@ -5,10 +5,11 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::convert::TryFrom;
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/bench/transfer-to-existing-account/src/lib.rs
+++ b/execution-engine/contracts/bench/transfer-to-existing-account/src/lib.rs
@@ -1,10 +1,14 @@
 #![no_std]
 
-use contract_ffi::contract_api::system::TransferredTo;
-use contract_ffi::contract_api::{runtime, system, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{
+        runtime,
+        system::{self, TransferredTo},
+        Error as ApiError,
+    },
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 enum Arg {
     PublicKey = 0,

--- a/execution-engine/contracts/client/bonding/src/lib.rs
+++ b/execution-engine/contracts/client/bonding/src/lib.rs
@@ -4,10 +4,12 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::uint::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::uint::U512,
+};
 
 const BOND_METHOD_NAME: &str = "bond";
 

--- a/execution-engine/contracts/client/named-purse-payment/src/lib.rs
+++ b/execution-engine/contracts/client/named-purse-payment/src/lib.rs
@@ -2,14 +2,14 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 const SET_REFUND_PURSE: &str = "set_refund_purse";

--- a/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment-stored/src/lib.rs
@@ -2,15 +2,14 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec;
+use alloc::{collections::BTreeMap, string::String, vec};
 
-use contract_ffi::contract_api::{account, runtime, storage, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, storage, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";

--- a/execution-engine/contracts/client/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 

--- a/execution-engine/contracts/client/transfer-to-account/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 /// Executes mote transfer to supplied public key.
 /// Transfers the requested amount.

--- a/execution-engine/contracts/client/unbonding/src/lib.rs
+++ b/execution-engine/contracts/client/unbonding/src/lib.rs
@@ -4,9 +4,11 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::uint::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::uint::U512,
+};
 
 const UNBOND_METHOD_NAME: &str = "unbond";
 

--- a/execution-engine/contracts/examples/bonding-call/src/lib.rs
+++ b/execution-engine/contracts/examples/bonding-call/src/lib.rs
@@ -4,10 +4,12 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::uint::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::uint::U512,
+};
 
 const BOND_METHOD_NAME: &str = "bond";
 

--- a/execution-engine/contracts/examples/counter-call/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-call/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const COUNTER_KEY: &str = "counter";
 const GET_METHOD: &str = "get";

--- a/execution-engine/contracts/examples/counter-define/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-define/src/lib.rs
@@ -2,14 +2,13 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use contract_ffi::contract_api::TURef;
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError, TURef},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const COUNT_KEY: &str = "count";
 const COUNTER_EXT: &str = "counter_ext";

--- a/execution-engine/contracts/examples/hello-name-call/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-call/src/lib.rs
@@ -2,12 +2,13 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::Value;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::Value,
+};
 
 const HELLO_NAME_KEY: &str = "hello_name";
 const HELLOWORLD_KEY: &str = "helloworld";

--- a/execution-engine/contracts/examples/hello-name-define/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-define/src/lib.rs
@@ -2,12 +2,12 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const HELLO_NAME_EXT: &str = "hello_name_ext";
 const HELLO_NAME_KEY: &str = "hello_name";

--- a/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
@@ -2,14 +2,14 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use core::convert::From;
 
-use contract_ffi::contract_api::TURef;
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError, TURef},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const MAIL_FEED_KEY: &str = "mail_feed";
 const MAILING_KEY: &str = "mailing";

--- a/execution-engine/contracts/examples/mailing-list-define/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-define/src/lib.rs
@@ -2,15 +2,17 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError, TURef};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError, TURef},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+};
 
 const LIST_KEY: &str = "list";
 const MAILING_KEY: &str = "mailing";

--- a/execution-engine/contracts/examples/unbonding-call/src/lib.rs
+++ b/execution-engine/contracts/examples/unbonding-call/src/lib.rs
@@ -4,9 +4,11 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::uint::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::uint::U512,
+};
 
 const UNBOND_METHOD_NAME: &str = "unbond";
 

--- a/execution-engine/contracts/explorer/faucet/src/lib.rs
+++ b/execution-engine/contracts/explorer/faucet/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, storage, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, storage, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 const TRANSFER_AMOUNT: u32 = 10_000_000;
 

--- a/execution-engine/contracts/integration/add-associated-key/src/lib.rs
+++ b/execution-engine/contracts/integration/add-associated-key/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{PublicKey, Weight},
+};
 
 enum Arg {
     Account = 0,

--- a/execution-engine/contracts/integration/args-multi/src/lib.rs
+++ b/execution-engine/contracts/integration/args-multi/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 enum Arg {
     AccountNumber = 0,

--- a/execution-engine/contracts/integration/args-u32/src/lib.rs
+++ b/execution-engine/contracts/integration/args-u32/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 enum Arg {
     Number = 0,

--- a/execution-engine/contracts/integration/args-u512/src/lib.rs
+++ b/execution-engine/contracts/integration/args-u512/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::U512,
+};
 
 enum Arg {
     Number = 0,

--- a/execution-engine/contracts/integration/create-named-purse/src/lib.rs
+++ b/execution-engine/contracts/integration/create-named-purse/src/lib.rs
@@ -4,11 +4,12 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 enum Arg {
     Amount = 0,

--- a/execution-engine/contracts/integration/get-caller-call/src/lib.rs
+++ b/execution-engine/contracts/integration/get-caller-call/src/lib.rs
@@ -4,9 +4,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{runtime, ContractRef, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, ContractRef, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const GET_CALLER_KEY: &str = "get_caller";
 

--- a/execution-engine/contracts/integration/get-caller-define/src/lib.rs
+++ b/execution-engine/contracts/integration/get-caller-define/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 
 use alloc::collections::BTreeMap;
 
-use contract_ffi::contract_api::{runtime, storage};
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{
+    contract_api::{runtime, storage},
+    value::account::PublicKey,
+};
 
 const GET_CALLER_EXT: &str = "get_caller_ext";
 const GET_CALLER_KEY: &str = "get_caller";

--- a/execution-engine/contracts/integration/list-known-urefs-call/src/lib.rs
+++ b/execution-engine/contracts/integration/list-known-urefs-call/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::ContractRef;
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, ContractRef, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const LIST_NAMED_KEYS_KEY: &str = "list_named_keys";
 

--- a/execution-engine/contracts/integration/list-known-urefs-define/src/lib.rs
+++ b/execution-engine/contracts/integration/list-known-urefs-define/src/lib.rs
@@ -2,15 +2,15 @@
 
 extern crate alloc;
 
-use alloc::borrow::ToOwned;
-use alloc::collections::BTreeMap;
-use alloc::string::String;
+use alloc::{borrow::ToOwned, collections::BTreeMap, string::String};
 use core::iter;
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::Value;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::Value,
+};
 
 const BAR_KEY: &str = "Bar";
 const FOO_KEY: &str = "Foo";

--- a/execution-engine/contracts/integration/payment-from-named-purse/src/lib.rs
+++ b/execution-engine/contracts/integration/payment-from-named-purse/src/lib.rs
@@ -2,14 +2,14 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 
-use contract_ffi::contract_api::{runtime, system, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error as ApiError},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 const SET_REFUND_PURSE: &str = "set_refund_purse";

--- a/execution-engine/contracts/integration/set-key-thresholds/src/lib.rs
+++ b/execution-engine/contracts/integration/set-key-thresholds/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{ActionType, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{ActionType, Weight},
+};
 
 enum Arg {
     KeyManagement = 0,

--- a/execution-engine/contracts/integration/subcall-revert-call/src/lib.rs
+++ b/execution-engine/contracts/integration/subcall-revert-call/src/lib.rs
@@ -4,9 +4,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{runtime, ContractRef, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, ContractRef, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const REVERT_TEST_KEY: &str = "revert_test";
 

--- a/execution-engine/contracts/integration/update-associated-key/src/lib.rs
+++ b/execution-engine/contracts/integration/update-associated-key/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{PublicKey, Weight},
+};
 
 enum Arg {
     Account = 0,

--- a/execution-engine/contracts/profiling/simple-transfer/src/lib.rs
+++ b/execution-engine/contracts/profiling/simple-transfer/src/lib.rs
@@ -1,10 +1,14 @@
 #![no_std]
 
-use contract_ffi::contract_api::system::TransferredTo;
-use contract_ffi::contract_api::{runtime, system, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{
+        runtime,
+        system::{self, TransferredTo},
+        Error as ApiError,
+    },
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 enum Arg {
     PublicKey = 0,

--- a/execution-engine/contracts/profiling/state-initializer/src/lib.rs
+++ b/execution-engine/contracts/profiling/state-initializer/src/lib.rs
@@ -2,11 +2,15 @@
 //! account.
 #![no_std]
 
-use contract_ffi::contract_api::system::TransferredTo;
-use contract_ffi::contract_api::{runtime, system, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{
+        runtime,
+        system::{self, TransferredTo},
+        Error as ApiError,
+    },
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 enum Arg {
     Account1PublicKey = 0,

--- a/execution-engine/contracts/system/mint-install/src/lib.rs
+++ b/execution-engine/contracts/system/mint-install/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const MINT_FUNCTION_NAME: &str = "mint_ext";
 

--- a/execution-engine/contracts/system/mint-token/src/capabilities.rs
+++ b/execution-engine/contracts/system/mint-token/src/capabilities.rs
@@ -1,12 +1,12 @@
-use core::convert::TryFrom;
-use core::marker::PhantomData;
+use core::{convert::TryFrom, marker::PhantomData};
 
 use contract_api::storage;
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::TURef;
-use contract_ffi::key::Key;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::Value;
+use contract_ffi::{
+    contract_api::{self, TURef},
+    key::Key,
+    uref::{AccessRights, URef},
+    value::Value,
+};
 
 /// Trait representing the ability to read a value. Use case: a key
 /// for the blockdag global state (`TURef`) is obviously Readable,

--- a/execution-engine/contracts/system/mint-token/src/internal_purse_id.rs
+++ b/execution-engine/contracts/system/mint-token/src/internal_purse_id.rs
@@ -1,7 +1,5 @@
 use contract_api::runtime;
-use contract_ffi::contract_api;
-use contract_ffi::system_contracts::mint::PurseIdError;
-use contract_ffi::uref::URef;
+use contract_ffi::{contract_api, system_contracts::mint::PurseIdError, uref::URef};
 
 pub struct WithdrawId([u8; 32]);
 

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -12,17 +12,17 @@ mod capabilities;
 pub mod internal_purse_id;
 pub mod mint;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 use core::convert::TryInto;
 
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts::mint::Error;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::KEY_SIZE;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError},
+    key::Key,
+    system_contracts::mint::Error,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+    value::{account::KEY_SIZE, U512},
+};
 
 use capabilities::{ARef, RAWRef};
 use internal_purse_id::{DepositId, WithdrawId};

--- a/execution-engine/contracts/system/mint-token/src/mint.rs
+++ b/execution-engine/contracts/system/mint-token/src/mint.rs
@@ -1,5 +1,4 @@
-use contract_ffi::system_contracts::mint::Error;
-use contract_ffi::value::U512;
+use contract_ffi::{system_contracts::mint::Error, value::U512};
 
 use crate::capabilities::{Addable, Readable, Writable};
 
@@ -41,15 +40,18 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::BTreeMap;
-    use alloc::rc::Rc;
-    use core::cell::{Cell, RefCell};
-    use core::ops::Add;
+    use alloc::{collections::BTreeMap, rc::Rc};
+    use core::{
+        cell::{Cell, RefCell},
+        ops::Add,
+    };
 
     use contract_ffi::value::U512;
 
-    use crate::capabilities::{Addable, Readable, Writable};
-    use crate::mint::{Error, Mint};
+    use crate::{
+        capabilities::{Addable, Readable, Writable},
+        mint::{Error, Mint},
+    };
 
     const GENESIS_PURSE_AMOUNT: u32 = 150;
     const GENESIS_PURSE: FullId = FullId(0);

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -2,18 +2,20 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec;
+use alloc::{collections::BTreeMap, string::String, vec};
 use core::fmt::Write;
 
-use contract_ffi::contract_api::{runtime, storage, ContractRef, Error, TURef};
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts::mint;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, storage, ContractRef, Error, TURef},
+    key::Key,
+    system_contracts::mint,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+    value::{
+        account::{PublicKey, PurseId},
+        U512,
+    },
+};
 
 const PLACEHOLDER_KEY: Key = Key::Hash([0u8; 32]);
 const POS_BONDING_PURSE: &str = "pos_bonding_purse";

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -5,21 +5,28 @@ extern crate alloc;
 mod queue;
 mod stakes;
 
-use alloc::string::String;
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
-use contract_ffi::contract_api::{runtime, system};
-use contract_ffi::execution::Phase;
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts::pos::{Error, PurseLookupError, Result};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{BlockTime, PublicKey, PurseId};
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system},
+    execution::Phase,
+    key::Key,
+    system_contracts::pos::{Error, PurseLookupError, Result},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+    value::{
+        account::{BlockTime, PublicKey, PurseId},
+        U512,
+    },
+};
 
-use crate::queue::{QueueEntry, QueueLocal, QueueProvider};
-use crate::stakes::{ContractStakes, StakesProvider};
+use crate::{
+    queue::{QueueEntry, QueueLocal, QueueProvider},
+    stakes::{ContractStakes, StakesProvider},
+};
 
 /// Account used to run system functions (in particular `finalize_payment`).
 const SYSTEM_ACCOUNT: [u8; 32] = [0u8; 32];
@@ -354,18 +361,22 @@ pub extern "C" fn call() {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::iter;
+    use std::{cell::RefCell, iter};
 
-    use contract_ffi::system_contracts::pos::Result;
-    use contract_ffi::value::{
-        account::{BlockTime, PublicKey},
-        U512,
+    use contract_ffi::{
+        system_contracts::pos::Result,
+        value::{
+            account::{BlockTime, PublicKey},
+            U512,
+        },
     };
 
-    use crate::queue::{Queue, QueueProvider};
-    use crate::stakes::{Stakes, StakesProvider};
-    use crate::{bond, step, unbond, BOND_DELAY, UNBOND_DELAY};
+    use crate::{
+        bond,
+        queue::{Queue, QueueProvider},
+        stakes::{Stakes, StakesProvider},
+        step, unbond, BOND_DELAY, UNBOND_DELAY,
+    };
 
     const KEY1: [u8; 32] = [1; 32];
     const KEY2: [u8; 32] = [2; 32];

--- a/execution-engine/contracts/system/pos/src/queue.rs
+++ b/execution-engine/contracts/system/pos/src/queue.rs
@@ -1,12 +1,15 @@
 use alloc::vec::Vec;
-use core::convert::TryFrom;
-use core::result;
+use core::{convert::TryFrom, result};
 
-use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
-use contract_ffi::contract_api::storage;
-use contract_ffi::system_contracts::pos::{Error, Result};
-use contract_ffi::value::account::{BlockTime, PublicKey};
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    contract_api::storage,
+    system_contracts::pos::{Error, Result},
+    value::{
+        account::{BlockTime, PublicKey},
+        Value, U512,
+    },
+};
 
 const BONDING_KEY: u8 = 1;
 const UNBONDING_KEY: u8 = 2;
@@ -181,9 +184,13 @@ impl ToBytes for Queue {
 
 #[cfg(test)]
 mod tests {
-    use contract_ffi::system_contracts::pos::Error;
-    use contract_ffi::value::account::{BlockTime, PublicKey};
-    use contract_ffi::value::U512;
+    use contract_ffi::{
+        system_contracts::pos::Error,
+        value::{
+            account::{BlockTime, PublicKey},
+            U512,
+        },
+    };
 
     use crate::queue::{Queue, QueueEntry};
 

--- a/execution-engine/contracts/system/pos/src/stakes.rs
+++ b/execution-engine/contracts/system/pos/src/stakes.rs
@@ -1,11 +1,15 @@
-use alloc::collections::{BTreeMap, BTreeSet};
-use alloc::string::String;
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::String,
+};
 use core::fmt::Write;
 
-use contract_ffi::contract_api::runtime;
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts::pos::{Error, Result};
-use contract_ffi::value::{account::PublicKey, U512};
+use contract_ffi::{
+    contract_api::runtime,
+    key::Key,
+    system_contracts::pos::{Error, Result},
+    value::{account::PublicKey, U512},
+};
 
 use super::{MAX_DECREASE, MAX_INCREASE, MAX_REL_DECREASE, MAX_REL_INCREASE, MAX_SPREAD};
 
@@ -194,8 +198,10 @@ impl Stakes {
 
 #[cfg(test)]
 mod tests {
-    use contract_ffi::system_contracts::pos::Error;
-    use contract_ffi::value::{account::PublicKey, U512};
+    use contract_ffi::{
+        system_contracts::pos::Error,
+        value::{account::PublicKey, U512},
+    };
 
     use crate::stakes::Stakes;
 

--- a/execution-engine/contracts/system/test-mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/test-mint-token/src/lib.rs
@@ -2,12 +2,9 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 
-use contract_ffi::contract_api::runtime;
-use contract_ffi::key::Key;
-use contract_ffi::value::U512;
+use contract_ffi::{contract_api::runtime, key::Key, value::U512};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/add-update-associated-key/src/lib.rs
+++ b/execution-engine/contracts/test/add-update-associated-key/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{PublicKey, Weight},
+};
 
 const INIT_WEIGHT: u8 = 1;
 const MOD_WEIGHT: u8 = 2;

--- a/execution-engine/contracts/test/authorized-keys/src/lib.rs
+++ b/execution-engine/contracts/test/authorized-keys/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{ActionType, AddKeyFailure, PublicKey, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{ActionType, AddKeyFailure, PublicKey, Weight},
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/check-system-contract-urefs-access-rights/src/lib.rs
+++ b/execution-engine/contracts/test/check-system-contract-urefs-access-rights/src/lib.rs
@@ -1,8 +1,6 @@
 #![no_std]
 
-use contract_ffi::contract_api::runtime;
-use contract_ffi::key::Key;
-use contract_ffi::uref::URef;
+use contract_ffi::{contract_api::runtime, key::Key, uref::URef};
 
 #[allow(clippy::redundant_closure)]
 #[no_mangle]

--- a/execution-engine/contracts/test/create-purse-01/src/lib.rs
+++ b/execution-engine/contracts/test/create-purse-01/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 #[repr(u32)]
 enum Args {

--- a/execution-engine/contracts/test/deserialize-error/src/lib.rs
+++ b/execution-engine/contracts/test/deserialize-error/src/lib.rs
@@ -2,15 +2,17 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
 
-use contract_ffi::args_parser::ArgsParser;
-use contract_ffi::bytesrepr::ToBytes;
-use contract_ffi::contract_api::storage;
-use contract_ffi::contract_api::ContractRef;
-use contract_ffi::key::Key;
+use contract_ffi::{
+    args_parser::ArgsParser,
+    bytesrepr::ToBytes,
+    contract_api::{storage, ContractRef},
+    key::Key,
+};
 
 #[no_mangle]
 pub extern "C" fn do_nothing() {

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -2,13 +2,13 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::contract_api::{ContractRef, TURef};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::{
+    contract_api::{runtime, ContractRef, Error, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+};
 
 #[repr(u16)]
 enum Args {

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error, TURef};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
-use contract_ffi::value::Contract;
+use contract_ffi::{
+    contract_api::{runtime, Error, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+    value::Contract,
+};
 
 const ENTRY_FUNCTION_NAME: &str = "delegate";
 

--- a/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 
 use alloc::collections::BTreeMap;
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const ENTRY_FUNCTION_NAME: &str = "delegate";
 const CONTRACT_NAME: &str = "do_nothing_stored";

--- a/execution-engine/contracts/test/ee-221-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-221-regression/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, storage};
-use contract_ffi::key::Key;
+use contract_ffi::{
+    contract_api::{runtime, storage},
+    key::Key,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
@@ -4,10 +4,12 @@ extern crate alloc;
 
 use alloc::string::ToString;
 
-use contract_ffi::contract_api::{runtime, storage, ContractRef, Error, TURef};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
+use contract_ffi::{
+    contract_api::{runtime, storage, ContractRef, Error, TURef},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-401-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression/src/lib.rs
@@ -2,8 +2,7 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::contract_api::{runtime, storage, ContractRef};
 

--- a/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
+++ b/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
@@ -2,15 +2,15 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec;
+use alloc::{collections::BTreeMap, string::String, vec};
 
-use contract_ffi::contract_api::{runtime, storage, ContractRef, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, storage, ContractRef, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+    value::U512,
+};
 
 #[no_mangle]
 pub extern "C" fn do_nothing() {

--- a/execution-engine/contracts/test/ee-460-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-460-regression/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-536-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-536-regression/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{
-    ActionType, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight,
+use contract_ffi::{
+    contract_api::{account, runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{
+        ActionType, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight,
+    },
 };
 
 #[no_mangle]

--- a/execution-engine/contracts/test/ee-539-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-539-regression/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{ActionType, PublicKey, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{ActionType, PublicKey, Weight},
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/ee-550-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-550-regression/src/lib.rs
@@ -4,9 +4,11 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{account, runtime, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{ActionType, PublicKey, Weight};
+use contract_ffi::{
+    contract_api::{account, runtime, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{ActionType, PublicKey, Weight},
+};
 
 enum Arg {
     Pass = 0,

--- a/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
@@ -2,14 +2,17 @@
 
 extern crate alloc;
 
-use alloc::string::{String, ToString};
-use alloc::vec;
-use core::clone::Clone;
-use core::convert::Into;
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
+use core::{clone::Clone, convert::Into};
 
-use contract_ffi::contract_api::{runtime, storage, TURef};
-use contract_ffi::key::Key;
-use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::{
+    contract_api::{runtime, storage, TURef},
+    key::Key,
+    uref::{AccessRights, URef},
+};
 
 const DATA: &str = "data";
 const CONTRACT_NAME: &str = "create";

--- a/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
@@ -2,14 +2,17 @@
 
 extern crate alloc;
 
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
 
-use contract_ffi::contract_api::TURef;
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError, TURef},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+};
 
 const CONTRACT_POINTER: u32 = 0;
 

--- a/execution-engine/contracts/test/ee-597-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-597-regression/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{account, runtime, system, ContractRef};
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, ContractRef},
+    key::Key,
+    value::{account::PurseId, U512},
+};
 
 fn purse_to_key(p: PurseId) -> Key {
     Key::URef(p.value())

--- a/execution-engine/contracts/test/ee-598-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-598-regression/src/lib.rs
@@ -4,12 +4,12 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::ContractRef;
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, ContractRef, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 fn purse_to_key(p: PurseId) -> Key {
     Key::URef(p.value())

--- a/execution-engine/contracts/test/ee-601-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-601-regression/src/lib.rs
@@ -2,13 +2,16 @@
 
 extern crate alloc;
 
-use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
-use contract_ffi::contract_api::{account, runtime, storage, system, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, storage, system, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 const NEW_UREF_RESULT_UREF_NAME: &str = "new_uref_result";

--- a/execution-engine/contracts/test/get-arg/src/lib.rs
+++ b/execution-engine/contracts/test/get-arg/src/lib.rs
@@ -4,9 +4,11 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{runtime, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::U512,
+};
 
 #[repr(u16)]
 enum Error {

--- a/execution-engine/contracts/test/get-blocktime/src/lib.rs
+++ b/execution-engine/contracts/test/get-blocktime/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::BlockTime;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::BlockTime,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
@@ -2,12 +2,13 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, vec::Vec};
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::PublicKey,
+};
 
 #[no_mangle]
 pub extern "C" fn check_caller_ext() {

--- a/execution-engine/contracts/test/get-caller/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::PublicKey,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/get-phase-payment/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase-payment/src/lib.rs
@@ -4,11 +4,12 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::execution::Phase;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error},
+    execution::Phase,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 

--- a/execution-engine/contracts/test/get-phase/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::execution::Phase;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    execution::Phase,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
+++ b/execution-engine/contracts/test/key-management-thresholds/src/lib.rs
@@ -4,11 +4,13 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{account, runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{
-    ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
-    Weight,
+use contract_ffi::{
+    contract_api::{account, runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::{
+        ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure,
+        UpdateKeyFailure, Weight,
+    },
 };
 
 #[no_mangle]

--- a/execution-engine/contracts/test/list-named-keys/src/lib.rs
+++ b/execution-engine/contracts/test/list-named-keys/src/lib.rs
@@ -2,13 +2,13 @@
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
-use alloc::string::String;
-use alloc::vec::Vec;
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 enum Arg {
     InitialNamedKeys = 0,

--- a/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{runtime, Error};
-use contract_ffi::contract_api::{ContractRef, TURef};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
+use contract_ffi::{
+    contract_api::{runtime, ContractRef, Error, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+};
 
 #[repr(u32)]
 enum Args {

--- a/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgraded/src/lib.rs
@@ -4,8 +4,10 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 pub const ENTRY_FUNCTION_NAME: &str = "delegate";
 pub const CONTRACT_NAME: &str = "local_state_stored";

--- a/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-upgrader/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, Error, TURef};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
+use contract_ffi::{
+    contract_api::{runtime, Error, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+};
 
 #[repr(u16)]
 enum Args {

--- a/execution-engine/contracts/test/local-state-stored/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const ENTRY_FUNCTION_NAME: &str = "delegate";
 const CONTRACT_NAME: &str = "local_state_stored";

--- a/execution-engine/contracts/test/local-state/src/lib.rs
+++ b/execution-engine/contracts/test/local-state/src/lib.rs
@@ -4,8 +4,7 @@ extern crate alloc;
 
 use alloc::string::{String, ToString};
 
-use contract_ffi::contract_api::storage;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{contract_api::storage, unwrap_or_revert::UnwrapOrRevert};
 
 pub const LOCAL_KEY: [u8; 32] = [66u8; 32];
 pub const HELLO_PREFIX: &str = " Hello, ";

--- a/execution-engine/contracts/test/main-purse/src/lib.rs
+++ b/execution-engine/contracts/test/main-purse/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
+use contract_ffi::{
+    contract_api::{account, runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::PurseId,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/mint-purse/src/lib.rs
+++ b/execution-engine/contracts/test/mint-purse/src/lib.rs
@@ -4,13 +4,14 @@ extern crate alloc;
 
 use alloc::vec;
 
-use contract_ffi::contract_api::{runtime, system, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts::mint;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error as ApiError},
+    key::Key,
+    system_contracts::mint,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+    value::{account::PurseId, U512},
+};
 
 #[repr(u16)]
 enum Error {

--- a/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
@@ -2,11 +2,12 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 
-use contract_ffi::contract_api::{runtime, storage, system};
-use contract_ffi::key::Key;
+use contract_ffi::{
+    contract_api::{runtime, storage, system},
+    key::Key,
+};
 
 const NEW_ENDPOINT_NAME: &str = "version";
 const RESULT_TUREF_NAME: &str = "output_version";

--- a/execution-engine/contracts/test/modified-mint/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint/src/lib.rs
@@ -2,17 +2,23 @@
 
 extern crate alloc;
 
-use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::system_contracts::mint::Error;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::U512;
-use mint_token::internal_purse_id::{DepositId, WithdrawId};
-use mint_token::mint::Mint;
-use mint_token::CLMint;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError},
+    system_contracts::mint::Error,
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+    value::U512,
+};
+use mint_token::{
+    internal_purse_id::{DepositId, WithdrawId},
+    mint::Mint,
+    CLMint,
+};
 
 const VERSION: &str = "1.1.0";
 

--- a/execution-engine/contracts/test/named-keys/src/lib.rs
+++ b/execution-engine/contracts/test/named-keys/src/lib.rs
@@ -4,10 +4,12 @@ extern crate alloc;
 
 use alloc::string::{String, ToString};
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::U512,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/overwrite-uref-content/src/lib.rs
+++ b/execution-engine/contracts/test/overwrite-uref-content/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::string::{String, ToString};
 
-use contract_ffi::contract_api::TURef;
-use contract_ffi::contract_api::{runtime, storage, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::{AccessRights, URef};
+use contract_ffi::{
+    contract_api::{runtime, storage, Error as ApiError, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::{AccessRights, URef},
+};
 
 const CONTRACT_UREF: u32 = 0;
 

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -2,15 +2,20 @@
 
 extern crate alloc;
 
-use alloc::string::String;
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 
-use contract_ffi::contract_api::{account, runtime, system, ContractRef, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, ContractRef, Error as ApiError},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{
+        account::{PublicKey, PurseId},
+        U512,
+    },
+};
 
 #[repr(u16)]
 enum Error {

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -2,15 +2,20 @@
 
 extern crate alloc;
 
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::ContractRef;
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, ContractRef, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{
+        account::{PublicKey, PurseId},
+        U512,
+    },
+};
 
 fn purse_to_key(p: &PurseId) -> Key {
     Key::URef(p.value())

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::{account, runtime, system, Error as ApiError};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::uint::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error as ApiError},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, uint::U512},
+};
 
 #[repr(u16)]
 enum Error {

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -2,15 +2,17 @@
 
 extern crate alloc;
 
+// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
+#[rustfmt::skip]
 use alloc::vec;
 use alloc::vec::Vec;
 
-use contract_ffi::contract_api::ContractRef;
-use contract_ffi::contract_api::{account, runtime, system, Error as ApiError};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, ContractRef, Error as ApiError},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 #[repr(u16)]
 enum Error {

--- a/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
@@ -2,13 +2,13 @@
 
 extern crate alloc;
 
-use alloc::string::String;
-use alloc::vec;
+use alloc::{string::String, vec};
 
-use contract_ffi::contract_api::{runtime, storage, Error};
-use contract_ffi::contract_api::{ContractRef, TURef};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
+use contract_ffi::{
+    contract_api::{runtime, storage, ContractRef, Error, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+};
 
 pub const METHOD_VERSION: &str = "version";
 

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -2,13 +2,16 @@
 
 extern crate alloc;
 
-use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
-use contract_ffi::contract_api::TURef;
-use contract_ffi::contract_api::{runtime, storage, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::uref::URef;
+use contract_ffi::{
+    contract_api::{runtime, storage, system, Error, TURef},
+    unwrap_or_revert::UnwrapOrRevert,
+    uref::URef,
+};
 
 const ENTRY_FUNCTION_NAME: &str = "apply_method";
 pub const METHOD_ADD: &str = "add";

--- a/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
@@ -4,11 +4,15 @@ extern crate alloc;
 
 #[cfg(not(feature = "lib"))]
 use alloc::collections::BTreeMap;
-use alloc::string::{String, ToString};
-use alloc::vec;
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
-use contract_ffi::contract_api::{runtime, storage, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+use contract_ffi::{
+    contract_api::{runtime, storage, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
 
 const ENTRY_FUNCTION_NAME: &str = "apply_method";
 const CONTRACT_NAME: &str = "purse_holder_stored";

--- a/execution-engine/contracts/test/remove-associated-key/src/lib.rs
+++ b/execution-engine/contracts/test/remove-associated-key/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{account, runtime, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{
+    contract_api::{account, runtime, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::account::PublicKey,
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/system-contracts-access/src/lib.rs
+++ b/execution-engine/contracts/test/system-contracts-access/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::ContractRef;
-use contract_ffi::contract_api::{runtime, system, Error as ApiError};
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{
+    contract_api::{runtime, system, ContractRef, Error as ApiError},
+    uref::{AccessRights, URef},
+    value::account::PublicKey,
+};
 
 #[repr(u16)]
 enum Error {

--- a/execution-engine/contracts/test/transfer-main-purse-to-new-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-main-purse-to-new-purse/src/lib.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 
 use alloc::string::String;
 
-use contract_ffi::contract_api::{account, runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/transfer-purse-to-account-stored/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account-stored/src/lib.rs
@@ -4,11 +4,15 @@ extern crate alloc;
 
 use alloc::format;
 
-use contract_ffi::contract_api::{account, runtime, storage, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, storage, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{
+        account::{PublicKey, PurseId},
+        U512,
+    },
+};
 
 const TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME: &str = "transfer_purse_to_account";
 const TRANSFER_FUNCTION_NAME: &str = "transfer";

--- a/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account/src/lib.rs
@@ -4,11 +4,15 @@ extern crate alloc;
 
 use alloc::format;
 
-use contract_ffi::contract_api::{account, runtime, storage, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, storage, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{
+        account::{PublicKey, PurseId},
+        U512,
+    },
+};
 
 const TRANSFER_RESULT_UREF_NAME: &str = "transfer_result";
 const MAIN_PURSE_FINAL_BALANCE_UREF_NAME: &str = "final_balance";

--- a/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-purse/src/lib.rs
@@ -2,14 +2,14 @@
 
 extern crate alloc;
 
-use alloc::format;
-use alloc::string::String;
+use alloc::{format, string::String};
 
-use contract_ffi::contract_api::{account, runtime, storage, system, Error};
-use contract_ffi::key::Key;
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{account, runtime, storage, system, Error},
+    key::Key,
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PurseId, U512},
+};
 
 #[no_mangle]
 pub extern "C" fn call() {

--- a/execution-engine/contracts/test/transfer-to-account-01/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-to-account-01/src/lib.rs
@@ -1,8 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::U512,
+};
 
 const TRANSFER_AMOUNT: u32 = 250_000_000 + 1000;
 

--- a/execution-engine/contracts/test/transfer-to-account-02/src/lib.rs
+++ b/execution-engine/contracts/test/transfer-to-account-02/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
 
-use contract_ffi::contract_api::{runtime, system, Error};
-use contract_ffi::unwrap_or_revert::UnwrapOrRevert;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::{runtime, system, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+    value::{account::PublicKey, U512},
+};
 
 const ACCOUNT_2_ADDR: [u8; 32] = [2u8; 32];
 

--- a/execution-engine/engine-core/src/engine_state/deploy_item.rs
+++ b/execution-engine/engine-core/src/engine_state/deploy_item.rs
@@ -2,8 +2,7 @@ use std::collections::BTreeSet;
 
 use contract_ffi::value::account::PublicKey;
 
-use crate::engine_state::executable_deploy_item::ExecutableDeployItem;
-use crate::DeployHash;
+use crate::{engine_state::executable_deploy_item::ExecutableDeployItem, DeployHash};
 
 type GasPrice = u64;
 

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -2,8 +2,7 @@ use failure::Fail;
 
 use engine_shared::newtypes::Blake2bHash;
 
-use contract_ffi::bytesrepr;
-use contract_ffi::system_contracts::mint;
+use contract_ffi::{bytesrepr, system_contracts::mint};
 
 use crate::execution;
 use contract_ffi::value::ProtocolVersion;

--- a/execution-engine/engine-core/src/engine_state/execution_effect.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_effect.rs
@@ -1,6 +1,5 @@
 use contract_ffi::key::Key;
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::transform::Transform;
+use engine_shared::{additive_map::AdditiveMap, transform::Transform};
 
 use super::op::Op;
 

--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -1,15 +1,11 @@
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::gas::Gas;
-use engine_shared::motes::Motes;
-use engine_shared::newtypes::CorrelationId;
-use engine_shared::transform::Transform;
+use contract_ffi::{key::Key, value::Value};
+use engine_shared::{
+    additive_map::AdditiveMap, gas::Gas, motes::Motes, newtypes::CorrelationId,
+    transform::Transform,
+};
 use engine_storage::global_state::StateReader;
 
-use super::execution_effect::ExecutionEffect;
-use super::op::Op;
-use super::{error, CONV_RATE};
+use super::{error, execution_effect::ExecutionEffect, op::Op, CONV_RATE};
 
 #[derive(Debug)]
 pub enum ExecutionResult {

--- a/execution-engine/engine-core/src/engine_state/genesis.rs
+++ b/execution-engine/engine-core/src/engine_state/genesis.rs
@@ -4,11 +4,8 @@ use num_traits::Zero;
 
 use contract_ffi::key::Key;
 
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::ProtocolVersion;
-use engine_shared::motes::Motes;
-use engine_shared::newtypes::Blake2bHash;
-use engine_shared::transform::TypeMismatch;
+use contract_ffi::value::{account::PublicKey, ProtocolVersion};
+use engine_shared::{motes::Motes, newtypes::Blake2bHash, transform::TypeMismatch};
 use engine_storage::global_state::CommitResult;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -10,47 +10,60 @@ pub mod system_contract_cache;
 pub mod upgrade;
 pub mod utils;
 
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashMap},
+    rc::Rc,
+};
 
 use num_traits::Zero;
 use parity_wasm::elements::Module;
 
-use contract_ffi::args_parser::ArgsParser;
-use contract_ffi::bytesrepr::ToBytes;
-use contract_ffi::execution::Phase;
-use contract_ffi::key::{Key, HASH_SIZE};
-use contract_ffi::system_contracts::mint;
-use contract_ffi::uref::URef;
-use contract_ffi::uref::{AccessRights, UREF_ADDR_SIZE};
-use contract_ffi::value::account::{BlockTime, PublicKey, PurseId};
-use contract_ffi::value::{Account, ProtocolVersion, Value, U512};
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::gas::Gas;
-use engine_shared::motes::Motes;
-use engine_shared::newtypes::{Blake2bHash, CorrelationId, Validated};
-use engine_shared::transform::Transform;
-use engine_storage::global_state::{CommitResult, StateProvider, StateReader};
-use engine_storage::protocol_data::ProtocolData;
-use engine_wasm_prep::wasm_costs::WasmCosts;
-use engine_wasm_prep::Preprocessor;
-
-use self::deploy_item::DeployItem;
-pub use self::engine_config::EngineConfig;
-pub use self::error::{Error, RootNotFound};
-use self::executable_deploy_item::ExecutableDeployItem;
-use self::execution_result::ExecutionResult;
-use self::genesis::{
-    GenesisAccount, GenesisConfig, GenesisResult, POS_PAYMENT_PURSE, POS_REWARDS_PURSE,
+use contract_ffi::{
+    args_parser::ArgsParser,
+    bytesrepr::ToBytes,
+    execution::Phase,
+    key::{Key, HASH_SIZE},
+    system_contracts::mint,
+    uref::{AccessRights, URef, UREF_ADDR_SIZE},
+    value::{
+        account::{BlockTime, PublicKey, PurseId},
+        Account, ProtocolVersion, Value, U512,
+    },
 };
-use self::system_contract_cache::SystemContractCache;
-use crate::engine_state::error::Error::MissingSystemContractError;
-use crate::engine_state::upgrade::{UpgradeConfig, UpgradeResult};
-use crate::execution::AddressGenerator;
-use crate::execution::{self, Executor, MINT_NAME, POS_NAME};
-use crate::tracking_copy::{TrackingCopy, TrackingCopyExt};
-use crate::KnownKeys;
+use engine_shared::{
+    additive_map::AdditiveMap,
+    gas::Gas,
+    motes::Motes,
+    newtypes::{Blake2bHash, CorrelationId, Validated},
+    transform::Transform,
+};
+use engine_storage::{
+    global_state::{CommitResult, StateProvider, StateReader},
+    protocol_data::ProtocolData,
+};
+use engine_wasm_prep::{wasm_costs::WasmCosts, Preprocessor};
+
+use self::{
+    deploy_item::DeployItem,
+    executable_deploy_item::ExecutableDeployItem,
+    execution_result::ExecutionResult,
+    genesis::{GenesisAccount, GenesisConfig, GenesisResult, POS_PAYMENT_PURSE, POS_REWARDS_PURSE},
+    system_contract_cache::SystemContractCache,
+};
+pub use self::{
+    engine_config::EngineConfig,
+    error::{Error, RootNotFound},
+};
+use crate::{
+    engine_state::{
+        error::Error::MissingSystemContractError,
+        upgrade::{UpgradeConfig, UpgradeResult},
+    },
+    execution::{self, AddressGenerator, Executor, MINT_NAME, POS_NAME},
+    tracking_copy::{TrackingCopy, TrackingCopyExt},
+    KnownKeys,
+};
 
 // TODO?: MAX_PAYMENT && CONV_RATE values are currently arbitrary w/ real values
 // TBD gas * CONV_RATE = motes

--- a/execution-engine/engine-core/src/engine_state/op.rs
+++ b/execution-engine/engine-core/src/engine_state/op.rs
@@ -1,6 +1,8 @@
-use std::default::Default;
-use std::fmt::{self, Display, Formatter};
-use std::ops::{Add, AddAssign};
+use std::{
+    default::Default,
+    fmt::{self, Display, Formatter},
+    ops::{Add, AddAssign},
+};
 
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum Op {

--- a/execution-engine/engine-core/src/engine_state/system_contract_cache.rs
+++ b/execution-engine/engine-core/src/engine_state/system_contract_cache.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
 
 use parity_wasm::elements::Module;
 
@@ -45,8 +47,10 @@ mod tests {
 
     use contract_ffi::uref::{AccessRights, URef};
 
-    use crate::engine_state::system_contract_cache::SystemContractCache;
-    use crate::execution::{AddressGenerator, AddressGeneratorBuilder};
+    use crate::{
+        engine_state::system_contract_cache::SystemContractCache,
+        execution::{AddressGenerator, AddressGeneratorBuilder},
+    };
 
     lazy_static! {
         static ref ADDRESS_GENERATOR: Mutex<AddressGenerator> = Mutex::new(

--- a/execution-engine/engine-core/src/engine_state/upgrade.rs
+++ b/execution-engine/engine-core/src/engine_state/upgrade.rs
@@ -1,9 +1,7 @@
 use std::fmt;
 
-use contract_ffi::key::Key;
-use contract_ffi::value::ProtocolVersion;
-use engine_shared::newtypes::Blake2bHash;
-use engine_shared::transform::TypeMismatch;
+use contract_ffi::{key::Key, value::ProtocolVersion};
+use engine_shared::{newtypes::Blake2bHash, transform::TypeMismatch};
 use engine_storage::global_state::CommitResult;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 

--- a/execution-engine/engine-core/src/engine_state/utils.rs
+++ b/execution-engine/engine-core/src/engine_state/utils.rs
@@ -1,5 +1,4 @@
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::value::{account::PublicKey, U512};
 
 /// In PoS, the validators are stored under named keys with names formatted as
 /// "v_<hex-formatted-PublicKey>_<bond-amount>".  This function attempts to parse such a string back
@@ -33,8 +32,7 @@ pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(PublicKey,
 mod tests {
     use hex_fmt::HexFmt;
 
-    use contract_ffi::value::account::PublicKey;
-    use contract_ffi::value::U512;
+    use contract_ffi::value::{account::PublicKey, U512};
 
     use super::pos_validator_key_name_to_tuple;
 

--- a/execution-engine/engine-core/src/execution/address_generator.rs
+++ b/execution-engine/engine-core/src/execution/address_generator.rs
@@ -1,5 +1,7 @@
-use blake2::digest::{Input, VariableOutput};
-use blake2::VarBlake2b;
+use blake2::{
+    digest::{Input, VariableOutput},
+    VarBlake2b,
+};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaChaRng;
 

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -3,12 +3,12 @@ use core::fmt;
 use parity_wasm::elements;
 use wasmi;
 
-use contract_ffi::bytesrepr;
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{
-    AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
+use contract_ffi::{
+    bytesrepr,
+    key::Key,
+    system_contracts,
+    uref::{AccessRights, URef},
+    value::account::{AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure},
 };
 use engine_shared::transform::TypeMismatch;
 

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -1,27 +1,30 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+    rc::Rc,
+};
 
 use parity_wasm::elements::Module;
 
-use contract_ffi::bytesrepr::{self, FromBytes};
-use contract_ffi::execution::Phase;
-use contract_ffi::key::Key;
-use contract_ffi::value::account::{BlockTime, PublicKey};
-use contract_ffi::value::{Account, ProtocolVersion, Value};
-use engine_shared::gas::Gas;
-use engine_shared::newtypes::CorrelationId;
-use engine_storage::global_state::StateReader;
-use engine_storage::protocol_data::ProtocolData;
+use contract_ffi::{
+    bytesrepr::{self, FromBytes},
+    execution::Phase,
+    key::Key,
+    value::{
+        account::{BlockTime, PublicKey},
+        Account, ProtocolVersion, Value,
+    },
+};
+use engine_shared::{gas::Gas, newtypes::CorrelationId};
+use engine_storage::{global_state::StateReader, protocol_data::ProtocolData};
 
-use super::Error;
-use super::{extract_access_rights_from_keys, instance_and_memory, Runtime};
-use crate::engine_state::execution_result::ExecutionResult;
-use crate::engine_state::system_contract_cache::SystemContractCache;
-use crate::execution::address_generator::AddressGenerator;
-use crate::execution::FN_STORE_ID_INITIAL;
-use crate::runtime_context::{self, RuntimeContext};
-use crate::tracking_copy::TrackingCopy;
+use super::{extract_access_rights_from_keys, instance_and_memory, Error, Runtime};
+use crate::{
+    engine_state::{execution_result::ExecutionResult, system_contract_cache::SystemContractCache},
+    execution::{address_generator::AddressGenerator, FN_STORE_ID_INITIAL},
+    runtime_context::{self, RuntimeContext},
+    tracking_copy::TrackingCopy,
+};
 
 macro_rules! on_fail_charge {
     ($fn:expr) => {

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -6,11 +6,14 @@ mod runtime;
 #[cfg(test)]
 mod tests;
 
-pub use self::address_generator::{AddressGenerator, AddressGeneratorBuilder};
-pub use self::error::Error;
-pub use self::executor::Executor;
-pub use self::runtime::{
-    extract_access_rights_from_keys, extract_access_rights_from_urefs, instance_and_memory, Runtime,
+pub use self::{
+    address_generator::{AddressGenerator, AddressGeneratorBuilder},
+    error::Error,
+    executor::Executor,
+    runtime::{
+        extract_access_rights_from_keys, extract_access_rights_from_urefs, instance_and_memory,
+        Runtime,
+    },
 };
 
 pub const MINT_NAME: &str = "mint";

--- a/execution-engine/engine-core/src/execution/runtime/externals.rs
+++ b/execution-engine/engine-core/src/execution/runtime/externals.rs
@@ -2,18 +2,20 @@ use std::convert::TryFrom;
 
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
-use contract_ffi::bytesrepr::{self, ToBytes};
-use contract_ffi::contract_api;
-use contract_ffi::contract_api::system::TransferredTo;
-use contract_ffi::key::Key;
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    bytesrepr::{self, ToBytes},
+    contract_api::{self, system::TransferredTo},
+    key::Key,
+    value::{
+        account::{PublicKey, PurseId},
+        Value, U512,
+    },
+};
 
 use engine_shared::gas::Gas;
 use engine_storage::global_state::StateReader;
 
-use super::args::Args;
-use super::{Error, Runtime};
+use super::{args::Args, Error, Runtime};
 use crate::resolvers::v1_function_index::FunctionIndex;
 
 impl<'a, R: StateReader<Key, Value>> Externals for Runtime<'a, R>

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -1,32 +1,41 @@
 mod args;
 mod externals;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::convert::TryFrom;
-use std::iter::IntoIterator;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    convert::TryFrom,
+    iter::IntoIterator,
+};
 
 use itertools::Itertools;
 use parity_wasm::elements::Module;
 use wasmi::{ImportsBuilder, MemoryRef, ModuleInstance, ModuleRef, Trap, TrapKind};
 
-use contract_ffi::args_parser::ArgsParser;
-use contract_ffi::bytesrepr::{deserialize, ToBytes, U32_SIZE};
-use contract_ffi::contract_api::system::{TransferResult, TransferredTo};
-use contract_ffi::contract_api::Error as ApiError;
-use contract_ffi::key::Key;
-use contract_ffi::system_contracts::{self, mint, SystemContract};
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{ActionType, PublicKey, PurseId, Weight, PUBLIC_KEY_SIZE};
-use contract_ffi::value::{Account, ProtocolVersion, Value, U512};
+use contract_ffi::{
+    args_parser::ArgsParser,
+    bytesrepr::{deserialize, ToBytes, U32_SIZE},
+    contract_api::{
+        system::{TransferResult, TransferredTo},
+        Error as ApiError,
+    },
+    key::Key,
+    system_contracts::{self, mint, SystemContract},
+    uref::{AccessRights, URef},
+    value::{
+        account::{ActionType, PublicKey, PurseId, Weight, PUBLIC_KEY_SIZE},
+        Account, ProtocolVersion, Value, U512,
+    },
+};
 use engine_shared::gas::Gas;
 use engine_storage::global_state::StateReader;
 
 use super::{Error, MINT_NAME, POS_NAME};
-use crate::engine_state::system_contract_cache::SystemContractCache;
-use crate::resolvers::create_module_resolver;
-use crate::resolvers::memory_resolver::MemoryResolver;
-use crate::runtime_context::RuntimeContext;
-use crate::Address;
+use crate::{
+    engine_state::system_contract_cache::SystemContractCache,
+    resolvers::{create_module_resolver, memory_resolver::MemoryResolver},
+    runtime_context::RuntimeContext,
+    Address,
+};
 
 pub struct Runtime<'a, R> {
     system_contract_cache: SystemContractCache,

--- a/execution-engine/engine-core/src/execution/tests.rs
+++ b/execution-engine/engine-core/src/execution/tests.rs
@@ -39,8 +39,7 @@ fn on_fail_charge_err_laziness_test() {
 }
 #[test]
 fn on_fail_charge_with_action() {
-    use crate::engine_state::execution_effect::ExecutionEffect;
-    use crate::engine_state::op::Op;
+    use crate::engine_state::{execution_effect::ExecutionEffect, op::Op};
     use contract_ffi::key::Key;
     use engine_shared::transform::Transform;
     let f = || {

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -1,14 +1,13 @@
 use std::cell::RefCell;
 
-use wasmi::memory_units::Pages;
 use wasmi::{
-    Error as InterpreterError, FuncRef, MemoryDescriptor, MemoryInstance, Signature, ValueType,
+    memory_units::Pages, Error as InterpreterError, FuncInstance, FuncRef, MemoryDescriptor,
+    MemoryInstance, MemoryRef, ModuleImportResolver, Signature, ValueType,
 };
-use wasmi::{FuncInstance, MemoryRef, ModuleImportResolver};
 
-use super::error::ResolverError;
-use super::memory_resolver::MemoryResolver;
-use super::v1_function_index::FunctionIndex;
+use super::{
+    error::ResolverError, memory_resolver::MemoryResolver, v1_function_index::FunctionIndex,
+};
 
 pub struct RuntimeModuleImportResolver {
     memory: RefCell<Option<MemoryRef>>,

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -1,31 +1,41 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::convert::{TryFrom, TryInto};
-use std::fmt::Display;
-use std::rc::Rc;
-
-use blake2::digest::{Input, VariableOutput};
-use blake2::VarBlake2b;
-
-use contract_ffi::bytesrepr::{deserialize, ToBytes};
-use contract_ffi::execution::Phase;
-use contract_ffi::key::{Key, LOCAL_SEED_SIZE};
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{
-    Account, ActionType, AddKeyFailure, BlockTime, PublicKey, RemoveKeyFailure,
-    SetThresholdFailure, UpdateKeyFailure, Weight,
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    convert::{TryFrom, TryInto},
+    fmt::Display,
+    rc::Rc,
 };
-use contract_ffi::value::{Contract, ProtocolVersion, Value};
-use engine_shared::gas::Gas;
-use engine_shared::newtypes::{CorrelationId, Validated};
-use engine_storage::global_state::StateReader;
-use engine_storage::protocol_data::ProtocolData;
 
-use crate::engine_state::execution_effect::ExecutionEffect;
-use crate::engine_state::SYSTEM_ACCOUNT_ADDR;
-use crate::execution::{AddressGenerator, Error};
-use crate::tracking_copy::{AddResult, TrackingCopy};
-use crate::Address;
+use blake2::{
+    digest::{Input, VariableOutput},
+    VarBlake2b,
+};
+
+use contract_ffi::{
+    bytesrepr::{deserialize, ToBytes},
+    execution::Phase,
+    key::{Key, LOCAL_SEED_SIZE},
+    uref::{AccessRights, URef},
+    value::{
+        account::{
+            Account, ActionType, AddKeyFailure, BlockTime, PublicKey, RemoveKeyFailure,
+            SetThresholdFailure, UpdateKeyFailure, Weight,
+        },
+        Contract, ProtocolVersion, Value,
+    },
+};
+use engine_shared::{
+    gas::Gas,
+    newtypes::{CorrelationId, Validated},
+};
+use engine_storage::{global_state::StateReader, protocol_data::ProtocolData};
+
+use crate::{
+    engine_state::{execution_effect::ExecutionEffect, SYSTEM_ACCOUNT_ADDR},
+    execution::{AddressGenerator, Error},
+    tracking_copy::{AddResult, TrackingCopy},
+    Address,
+};
 
 #[cfg(test)]
 mod tests;

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -1,31 +1,39 @@
-use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::iter::{self, FromIterator};
-use std::rc::Rc;
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    iter::{self, FromIterator},
+    rc::Rc,
+};
 
 use rand::RngCore;
 
-use contract_ffi::execution::Phase;
-use contract_ffi::key::{Key, LOCAL_SEED_SIZE};
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{
-    ActionType, AddKeyFailure, AssociatedKeys, BlockTime, PublicKey, PurseId, RemoveKeyFailure,
-    SetThresholdFailure, Weight,
+use contract_ffi::{
+    execution::Phase,
+    key::{Key, LOCAL_SEED_SIZE},
+    uref::{AccessRights, URef},
+    value::{
+        self,
+        account::{
+            ActionType, AddKeyFailure, AssociatedKeys, BlockTime, PublicKey, PurseId,
+            RemoveKeyFailure, SetThresholdFailure, Weight,
+        },
+        Account, Contract, ProtocolVersion, Value,
+    },
 };
-use contract_ffi::value::{self, Account, Contract, ProtocolVersion, Value};
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::gas::Gas;
-use engine_shared::newtypes::CorrelationId;
-use engine_shared::transform::Transform;
-use engine_storage::global_state::in_memory::{InMemoryGlobalState, InMemoryGlobalStateView};
-use engine_storage::global_state::{CommitResult, StateProvider};
+use engine_shared::{
+    additive_map::AdditiveMap, gas::Gas, newtypes::CorrelationId, transform::Transform,
+};
+use engine_storage::global_state::{
+    in_memory::{InMemoryGlobalState, InMemoryGlobalStateView},
+    CommitResult, StateProvider,
+};
 
-use super::attenuate_uref_for_account;
-use super::{Address, Error, RuntimeContext, Validated};
-use crate::engine_state::SYSTEM_ACCOUNT_ADDR;
-use crate::execution::extract_access_rights_from_keys;
-use crate::execution::AddressGenerator;
-use crate::tracking_copy::TrackingCopy;
+use super::{attenuate_uref_for_account, Address, Error, RuntimeContext, Validated};
+use crate::{
+    engine_state::SYSTEM_ACCOUNT_ADDR,
+    execution::{extract_access_rights_from_keys, AddressGenerator},
+    tracking_copy::TrackingCopy,
+};
 
 const DEPLOY_HASH: [u8; 32] = [1u8; 32];
 const PHASE: Phase = Phase::Session;

--- a/execution-engine/engine-core/src/tracking_copy/byte_size.rs
+++ b/execution-engine/engine-core/src/tracking_copy/byte_size.rs
@@ -1,8 +1,10 @@
-use std::collections::btree_map::BTreeMap;
+use std::collections::BTreeMap;
 
-use contract_ffi::bytesrepr::I32_SIZE;
-use contract_ffi::key::Key;
-use contract_ffi::value::{Account, Contract, Value};
+use contract_ffi::{
+    bytesrepr::I32_SIZE,
+    key::Key,
+    value::{Account, Contract, Value},
+};
 
 /// Returns byte size of the element - both heap size and stack size.
 pub trait ByteSize {
@@ -119,7 +121,7 @@ impl HeapSizeOf for String {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::btree_map::BTreeMap;
+    use std::collections::BTreeMap;
 
     use contract_ffi::key::Key;
 

--- a/execution-engine/engine-core/src/tracking_copy/ext.rs
+++ b/execution-engine/engine-core/src/tracking_copy/ext.rs
@@ -1,14 +1,16 @@
-use contract_ffi::bytesrepr::ToBytes;
-use contract_ffi::key::Key;
-use contract_ffi::uref::URef;
-use contract_ffi::value::{Account, Contract, Value};
-use engine_shared::motes::Motes;
-use engine_shared::newtypes::CorrelationId;
-use engine_shared::transform::TypeMismatch;
+use contract_ffi::{
+    bytesrepr::ToBytes,
+    key::Key,
+    uref::URef,
+    value::{Account, Contract, Value},
+};
+use engine_shared::{motes::Motes, newtypes::CorrelationId, transform::TypeMismatch};
 use engine_storage::global_state::StateReader;
 
-use crate::execution;
-use crate::tracking_copy::{QueryResult, TrackingCopy};
+use crate::{
+    execution,
+    tracking_copy::{QueryResult, TrackingCopy},
+};
 
 pub trait TrackingCopyExt<R> {
     type Error;

--- a/execution-engine/engine-core/src/tracking_copy/mod.rs
+++ b/execution-engine/engine-core/src/tracking_copy/mod.rs
@@ -8,19 +8,18 @@ use std::collections::{BTreeMap, HashMap};
 
 use linked_hash_map::LinkedHashMap;
 
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::newtypes::{CorrelationId, Validated};
-use engine_shared::transform::{self, Transform, TypeMismatch};
+use contract_ffi::{key::Key, value::Value};
+use engine_shared::{
+    additive_map::AdditiveMap,
+    newtypes::{CorrelationId, Validated},
+    transform::{self, Transform, TypeMismatch},
+};
 use engine_storage::global_state::StateReader;
 
-use crate::engine_state::execution_effect::ExecutionEffect;
-use crate::engine_state::op::Op;
+use crate::engine_state::{execution_effect::ExecutionEffect, op::Op};
 
 pub use self::ext::TrackingCopyExt;
-use self::meter::heap_meter::HeapSize;
-use self::meter::Meter;
+use self::meter::{heap_meter::HeapSize, Meter};
 
 #[derive(Debug)]
 pub enum QueryResult {

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -1,27 +1,25 @@
-use std::cell::Cell;
-use std::collections::BTreeMap;
-use std::iter;
-use std::rc::Rc;
+use std::{cell::Cell, collections::BTreeMap, iter, rc::Rc};
 
 use matches::assert_matches;
-use proptest::collection::vec;
-use proptest::prelude::*;
+use proptest::{collection::vec, prelude::*};
 
-use contract_ffi::gens::*;
-use contract_ffi::key::Key;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{AssociatedKeys, PublicKey, PurseId, Weight, KEY_SIZE};
-use contract_ffi::value::{Account, Contract, ProtocolVersion, Value};
-use engine_shared::newtypes::CorrelationId;
-use engine_shared::transform::Transform;
-use engine_storage::global_state::in_memory::InMemoryGlobalState;
-use engine_storage::global_state::{StateProvider, StateReader};
+use contract_ffi::{
+    gens::*,
+    key::Key,
+    uref::{AccessRights, URef},
+    value::{
+        account::{AssociatedKeys, PublicKey, PurseId, Weight, KEY_SIZE},
+        Account, Contract, ProtocolVersion, Value,
+    },
+};
+use engine_shared::{newtypes::CorrelationId, transform::Transform};
+use engine_storage::global_state::{in_memory::InMemoryGlobalState, StateProvider, StateReader};
 
 use crate::engine_state::op::Op;
 
-use super::meter::count_meter::Count;
-use super::{AddResult, QueryResult, Validated};
-use super::{TrackingCopy, TrackingCopyCache};
+use super::{
+    meter::count_meter::Count, AddResult, QueryResult, TrackingCopy, TrackingCopyCache, Validated,
+};
 
 struct CountingDb {
     count: Rc<Cell<i32>>,

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -1,28 +1,39 @@
-use std::collections::{BTreeMap, BTreeSet};
-use std::convert::{TryFrom, TryInto};
-use std::fmt::{self, Display, Formatter};
-use std::string::ToString;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::{TryFrom, TryInto},
+    fmt::{self, Display, Formatter},
+    string::ToString,
+};
 
 use protobuf::{ProtobufEnum, RepeatedField};
 
-use contract_ffi::uref::URef;
-use contract_ffi::value::account::{
-    ActionThresholds, AssociatedKeys, PublicKey, PurseId, Weight, KEY_SIZE,
+use contract_ffi::{
+    uref::URef,
+    value::{
+        account::{ActionThresholds, AssociatedKeys, PublicKey, PurseId, Weight, KEY_SIZE},
+        ProtocolVersion, U512,
+    },
 };
-use contract_ffi::value::{ProtocolVersion, U512};
-use engine_core::engine_state::deploy_item::DeployItem;
-use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
-use engine_core::engine_state::execution_effect::ExecutionEffect;
-use engine_core::engine_state::execution_result::ExecutionResult;
-use engine_core::engine_state::genesis::{GenesisAccount, GenesisConfig};
-use engine_core::engine_state::op::Op;
-use engine_core::engine_state::upgrade::UpgradeConfig;
-use engine_core::engine_state::{Error as EngineError, RootNotFound};
-use engine_core::execution::Error as ExecutionError;
-use engine_core::{engine_state, DEPLOY_HASH_LENGTH};
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::motes::Motes;
-use engine_shared::transform::{self, TypeMismatch};
+use engine_core::{
+    engine_state::{
+        self,
+        deploy_item::DeployItem,
+        executable_deploy_item::ExecutableDeployItem,
+        execution_effect::ExecutionEffect,
+        execution_result::ExecutionResult,
+        genesis::{GenesisAccount, GenesisConfig},
+        op::Op,
+        upgrade::UpgradeConfig,
+        Error as EngineError, RootNotFound,
+    },
+    execution::Error as ExecutionError,
+    DEPLOY_HASH_LENGTH,
+};
+use engine_shared::{
+    additive_map::AdditiveMap,
+    motes::Motes,
+    transform::{self, TypeMismatch},
+};
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
 use crate::engine_server::{ipc, state, transforms};
@@ -1231,25 +1242,28 @@ mod tests {
 
     use proptest::prelude::*;
 
-    use contract_ffi::gens::{account_arb, contract_arb, key_arb, named_keys_arb, value_arb};
-    use contract_ffi::key::Key;
-    use contract_ffi::uref::{AccessRights, URef};
-    use engine_core::engine_state::execution_effect::ExecutionEffect;
-    use engine_core::engine_state::execution_result::ExecutionResult;
-    use engine_core::engine_state::{Error as EngineError, RootNotFound};
-    use engine_core::execution::Error;
-    use engine_shared::additive_map::AdditiveMap;
-    use engine_shared::gas::Gas;
-    use engine_shared::newtypes::Blake2bHash;
-    use engine_shared::transform::gens::transform_arb;
-    use engine_shared::transform::Transform;
+    use contract_ffi::{
+        gens::{account_arb, contract_arb, key_arb, named_keys_arb, value_arb},
+        key::Key,
+        uref::{AccessRights, URef},
+    };
+    use engine_core::{
+        engine_state::{
+            execution_effect::ExecutionEffect, execution_result::ExecutionResult,
+            Error as EngineError, RootNotFound,
+        },
+        execution::Error,
+    };
+    use engine_shared::{
+        additive_map::AdditiveMap,
+        gas::Gas,
+        newtypes::Blake2bHash,
+        transform::{gens::transform_arb, Transform},
+    };
 
     use crate::engine_server::mappings::CommitTransforms;
 
-    use super::execution_error;
-    use super::ipc;
-    use super::state;
-    use super::transforms;
+    use super::{execution_error, ipc, state, transforms};
     use contract_ffi::value::U512;
 
     // Test that wasm_error function actually returns DeployResult with result set

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -4,34 +4,40 @@ pub mod mappings;
 pub mod state;
 pub mod transforms;
 
-use std::collections::BTreeMap;
-use std::convert::{TryFrom, TryInto};
-use std::fmt::Debug;
-use std::io::ErrorKind;
-use std::marker::{Send, Sync};
-use std::time::Instant;
+use std::{
+    collections::BTreeMap,
+    convert::{TryFrom, TryInto},
+    fmt::Debug,
+    io::ErrorKind,
+    marker::{Send, Sync},
+    time::Instant,
+};
 
 use grpc::SingleResponse;
 
-use contract_ffi::value::account::BlockTime;
-use contract_ffi::value::ProtocolVersion;
-use engine_core::engine_state::deploy_item::DeployItem;
-use engine_core::engine_state::execution_result::ExecutionResult;
-use engine_core::engine_state::genesis::{GenesisConfig, GenesisResult};
-use engine_core::engine_state::upgrade::{UpgradeConfig, UpgradeResult};
-use engine_core::engine_state::EngineState;
-use engine_core::engine_state::Error as EngineError;
-use engine_core::execution::Executor;
-use engine_core::tracking_copy::QueryResult;
-use engine_shared::logging;
-use engine_shared::logging::log_level::LogLevel;
-use engine_shared::logging::{log_duration, log_info};
-use engine_shared::newtypes::{Blake2bHash, CorrelationId, BLAKE2B_DIGEST_LENGTH};
+use contract_ffi::value::{account::BlockTime, ProtocolVersion};
+use engine_core::{
+    engine_state::{
+        deploy_item::DeployItem,
+        execution_result::ExecutionResult,
+        genesis::{GenesisConfig, GenesisResult},
+        upgrade::{UpgradeConfig, UpgradeResult},
+        EngineState, Error as EngineError,
+    },
+    execution::Executor,
+    tracking_copy::QueryResult,
+};
+use engine_shared::{
+    logging::{self, log_duration, log_info, log_level::LogLevel},
+    newtypes::{Blake2bHash, CorrelationId, BLAKE2B_DIGEST_LENGTH},
+};
 use engine_storage::global_state::{CommitResult, StateProvider};
 use engine_wasm_prep::Preprocessor;
 
-use self::ipc_grpc::ExecutionEngineService;
-use self::mappings::{CommitTransforms, MappingError, ParsingError};
+use self::{
+    ipc_grpc::ExecutionEngineService,
+    mappings::{CommitTransforms, MappingError, ParsingError},
+};
 
 const METRIC_DURATION_COMMIT: &str = "commit_duration";
 const METRIC_DURATION_EXEC: &str = "exec_duration";

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -1,10 +1,14 @@
-use std::collections::btree_map::BTreeMap;
-use std::fs;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::PathBuf,
+    str::FromStr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use clap::{App, Arg, ArgMatches};
 use dirs::home_dir;
@@ -12,13 +16,18 @@ use engine_core::engine_state::{EngineConfig, EngineState};
 use lazy_static::lazy_static;
 use lmdb::DatabaseFlags;
 
-use engine_shared::logging::log_settings::{LogLevelFilter, LogSettings};
-use engine_shared::logging::{log_level, log_settings};
-use engine_shared::os::get_page_size;
-use engine_shared::{logging, socket};
-use engine_storage::global_state::lmdb::LmdbGlobalState;
-use engine_storage::transaction_source::lmdb::LmdbEnvironment;
-use engine_storage::trie_store::lmdb::LmdbTrieStore;
+use engine_shared::{
+    logging::{
+        self, log_level,
+        log_settings::{self, LogLevelFilter, LogSettings},
+    },
+    os::get_page_size,
+    socket,
+};
+use engine_storage::{
+    global_state::lmdb::LmdbGlobalState, transaction_source::lmdb::LmdbEnvironment,
+    trie_store::lmdb::LmdbTrieStore,
+};
 
 use casperlabs_engine_grpc_server::engine_server;
 use engine_storage::protocol_data_store::lmdb::LmdbProtocolDataStore;

--- a/execution-engine/engine-metrics-scraper/src/accumulator.rs
+++ b/execution-engine/engine-metrics-scraper/src/accumulator.rs
@@ -1,7 +1,9 @@
-use std::collections::vec_deque::VecDeque;
-use std::fmt;
-use std::sync::{Arc, Mutex, PoisonError, RwLock};
-use std::time::{Duration, Instant};
+use std::{
+    collections::vec_deque::VecDeque,
+    fmt,
+    sync::{Arc, Mutex, PoisonError, RwLock},
+    time::{Duration, Instant},
+};
 
 pub trait Pusher<T> {
     type Error: fmt::Debug;

--- a/execution-engine/engine-metrics-scraper/src/drain.rs
+++ b/execution-engine/engine-metrics-scraper/src/drain.rs
@@ -1,9 +1,9 @@
-use std::net::SocketAddr;
-use std::thread;
-use std::thread::JoinHandle;
+use std::{
+    net::SocketAddr,
+    thread::{self, JoinHandle},
+};
 
-use hyper::rt::Future;
-use hyper::{service, Body, Method, Request, Response, Server, StatusCode};
+use hyper::{rt::Future, service, Body, Method, Request, Response, Server, StatusCode};
 
 use crate::accumulator::Drainer;
 
@@ -52,8 +52,7 @@ pub fn open_drain<D: Drainer<String> + 'static>(
 
 #[cfg(test)]
 mod tests {
-    use std::string::ToString;
-    use std::time::Duration;
+    use std::{string::ToString, time::Duration};
 
     use futures::stream::Stream;
     use hyper::Client;

--- a/execution-engine/engine-metrics-scraper/src/main.rs
+++ b/execution-engine/engine-metrics-scraper/src/main.rs
@@ -2,9 +2,7 @@ mod accumulator;
 mod drain;
 mod sink;
 
-use std::io;
-use std::net::SocketAddr;
-use std::time::Duration;
+use std::{io, net::SocketAddr, time::Duration};
 
 use clap::{App, Arg};
 

--- a/execution-engine/engine-metrics-scraper/src/sink.rs
+++ b/execution-engine/engine-metrics-scraper/src/sink.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::io::BufRead;
+use std::io::{self, BufRead};
 
 use engine_shared::logging::logger;
 

--- a/execution-engine/engine-shared/src/additive_map.rs
+++ b/execution-engine/engine-shared/src/additive_map.rs
@@ -1,10 +1,14 @@
-use std::borrow::Borrow;
-use std::collections::hash_map::{IntoIter, Iter, IterMut, Keys, RandomState, Values};
-use std::collections::HashMap;
-use std::fmt::{self, Debug, Formatter};
-use std::hash::{BuildHasher, Hash};
-use std::iter::{FromIterator, IntoIterator};
-use std::ops::{AddAssign, Index};
+use std::{
+    borrow::Borrow,
+    collections::{
+        hash_map::{IntoIter, Iter, IterMut, Keys, RandomState, Values},
+        HashMap,
+    },
+    fmt::{self, Debug, Formatter},
+    hash::{BuildHasher, Hash},
+    iter::{FromIterator, IntoIterator},
+    ops::{AddAssign, Index},
+};
 
 #[derive(Clone)]
 pub struct AdditiveMap<K, V, S = RandomState>(HashMap<K, V, S>);

--- a/execution-engine/engine-shared/src/gas.rs
+++ b/execution-engine/engine-shared/src/gas.rs
@@ -84,8 +84,7 @@ impl Zero for Gas {
 
 #[cfg(test)]
 mod tests {
-    use crate::gas::Gas;
-    use crate::motes::Motes;
+    use crate::{gas::Gas, motes::Motes};
     use contract_ffi::value::U512;
 
     #[test]

--- a/execution-engine/engine-shared/src/logging/log_message.rs
+++ b/execution-engine/engine-shared/src/logging/log_message.rs
@@ -1,14 +1,17 @@
-use std::collections::hash_map::DefaultHasher;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::{hash_map::DefaultHasher, BTreeMap},
+    fmt,
+    hash::{Hash, Hasher},
+};
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use contract_ffi::value::SemVer;
 use serde::{Serialize, Serializer};
 
-use crate::logging::log_level::{LogLevel, LogPriority};
-use crate::logging::log_settings::{HostName, LogSettingsProvider, ProcessId, ProcessName};
+use crate::logging::{
+    log_level::{LogLevel, LogPriority},
+    log_settings::{HostName, LogSettingsProvider, ProcessId, ProcessName},
+};
 
 const MESSAGE_TYPE: &str = "ee-structured";
 
@@ -267,8 +270,7 @@ impl MessageProperties {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::logging::log_settings;
-    use crate::logging::log_settings::LogLevelFilter;
+    use crate::logging::log_settings::{self, LogLevelFilter};
 
     #[test]
     fn should_format_message_template_default_use_case() {

--- a/execution-engine/engine-shared/src/logging/log_settings.rs
+++ b/execution-engine/engine-shared/src/logging/log_settings.rs
@@ -1,5 +1,7 @@
-use std::process;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{
+    process,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 use lazy_static::lazy_static;
 use serde::Serialize;

--- a/execution-engine/engine-shared/src/logging/logger.rs
+++ b/execution-engine/engine-shared/src/logging/logger.rs
@@ -1,10 +1,11 @@
-use std::collections::BTreeMap;
-use std::sync::{Mutex, Once};
+use std::{
+    collections::BTreeMap,
+    sync::{Mutex, Once},
+};
 
 use lazy_static::lazy_static;
 use log::{Metadata, Record};
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub(crate) static LOGGER_INIT: Once = Once::new();
 pub(crate) const LOG_MAX_LEVEL: log::LevelFilter = log::LevelFilter::Trace;
@@ -211,15 +212,17 @@ pub fn initialize_buffered_logger() {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::thread;
+    use std::{sync::Arc, thread};
 
-    use crate::logging::log_level;
-    use crate::logging::log_message;
-    use crate::logging::log_settings::{
-        get_log_settings_provider, set_log_settings_provider, LogLevelFilter, LogSettings,
+    use crate::{
+        logging::{
+            log_level, log_message,
+            log_settings::{
+                get_log_settings_provider, set_log_settings_provider, LogLevelFilter, LogSettings,
+            },
+        },
+        utils::jsonify,
     };
-    use crate::utils::jsonify;
 
     use super::*;
 

--- a/execution-engine/engine-shared/src/logging/mod.rs
+++ b/execution-engine/engine-shared/src/logging/mod.rs
@@ -1,11 +1,17 @@
-use std::collections::btree_map::BTreeMap;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    collections::BTreeMap,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
-use crate::logging::log_level::LogLevel;
-use crate::logging::log_message::{LogMessage, MessageId};
-use crate::logging::logger::initialize_terminal_logger;
-use crate::newtypes::CorrelationId;
-use crate::utils::jsonify;
+use crate::{
+    logging::{
+        log_level::LogLevel,
+        log_message::{LogMessage, MessageId},
+        logger::initialize_terminal_logger,
+    },
+    newtypes::CorrelationId,
+    utils::jsonify,
+};
 
 pub mod log_level;
 pub mod log_message;

--- a/execution-engine/engine-shared/src/logging/tests.rs
+++ b/execution-engine/engine-shared/src/logging/tests.rs
@@ -1,12 +1,16 @@
-use std::thread;
-use std::time::{Instant, SystemTime};
+use std::{
+    thread,
+    time::{Instant, SystemTime},
+};
 
 use lazy_static::lazy_static;
 
-use crate::logging::log_settings::{
-    get_log_settings_provider, set_log_settings_provider, LogLevelFilter, LogSettings,
+use crate::logging::{
+    log_settings::{
+        get_log_settings_provider, set_log_settings_provider, LogLevelFilter, LogSettings,
+    },
+    logger::{initialize_buffered_logger, LogBufferProvider},
 };
-use crate::logging::logger::{initialize_buffered_logger, LogBufferProvider};
 
 use super::*;
 

--- a/execution-engine/engine-shared/src/motes.rs
+++ b/execution-engine/engine-shared/src/motes.rs
@@ -83,8 +83,7 @@ impl Zero for Motes {
 
 #[cfg(test)]
 mod tests {
-    use crate::gas::Gas;
-    use crate::motes::Motes;
+    use crate::{gas::Gas, motes::Motes};
     use contract_ffi::value::U512;
 
     #[test]

--- a/execution-engine/engine-shared/src/newtypes.rs
+++ b/execution-engine/engine-shared/src/newtypes.rs
@@ -1,11 +1,11 @@
 //! Some newtypes.
 use core::array::TryFromSliceError;
-use std::convert::TryFrom;
-use std::fmt;
-use std::ops::Deref;
+use std::{convert::TryFrom, fmt, ops::Deref};
 
-use blake2::digest::{Input, VariableOutput};
-use blake2::VarBlake2b;
+use blake2::{
+    digest::{Input, VariableOutput},
+    VarBlake2b,
+};
 use serde::Serialize;
 use uuid::Uuid;
 
@@ -157,8 +157,10 @@ impl fmt::Display for CorrelationId {
 
 #[cfg(test)]
 mod tests {
-    use crate::newtypes::{Blake2bHash, CorrelationId};
-    use crate::utils;
+    use crate::{
+        newtypes::{Blake2bHash, CorrelationId},
+        utils,
+    };
     use std::hash::{Hash, Hasher};
 
     #[test]

--- a/execution-engine/engine-shared/src/socket.rs
+++ b/execution-engine/engine-shared/src/socket.rs
@@ -1,5 +1,4 @@
-use std::io;
-use std::path::Path;
+use std::{io, path::Path};
 
 pub struct Socket(String);
 

--- a/execution-engine/engine-shared/src/test_utils.rs
+++ b/execution-engine/engine-shared/src/test_utils.rs
@@ -1,13 +1,16 @@
 //! Some functions to use in tests.
-use std::collections::btree_map::BTreeMap;
+use std::collections::BTreeMap;
 
-use parity_wasm::builder::ModuleBuilder;
-use parity_wasm::elements::{MemorySection, MemoryType, Module, Section, Serialize};
+use parity_wasm::{
+    builder::ModuleBuilder,
+    elements::{MemorySection, MemoryType, Module, Section, Serialize},
+};
 
-use contract_ffi::key::Key;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::{Account, Value};
+use contract_ffi::{
+    key::Key,
+    uref::{AccessRights, URef},
+    value::{account::PurseId, Account, Value},
+};
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
 /// Returns the serialized form of an empty Wasm Module

--- a/execution-engine/engine-shared/src/transform.rs
+++ b/execution-engine/engine-shared/src/transform.rs
@@ -1,11 +1,15 @@
-use std::collections::BTreeMap;
-use std::convert::TryFrom;
-use std::default::Default;
-use std::fmt::{self, Display, Formatter};
-use std::ops::{Add, AddAssign};
+use std::{
+    collections::BTreeMap,
+    convert::TryFrom,
+    default::Default,
+    fmt::{self, Display, Formatter},
+    ops::{Add, AddAssign},
+};
 
-use contract_ffi::key::Key;
-use contract_ffi::value::{Value, U128, U256, U512};
+use contract_ffi::{
+    key::Key,
+    value::{Value, U128, U256, U512},
+};
 use num::traits::{ToPrimitive, WrappingAdd, WrappingSub};
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -303,8 +307,7 @@ impl Default for Transform {
 pub mod gens {
     use super::Transform;
     use contract_ffi::gens::value_arb;
-    use proptest::collection::vec;
-    use proptest::prelude::*;
+    use proptest::{collection::vec, prelude::*};
 
     pub fn transform_arb() -> impl Strategy<Value = Transform> {
         prop_oneof![

--- a/execution-engine/engine-storage/benches/trie_bench.rs
+++ b/execution-engine/engine-storage/benches/trie_bench.rs
@@ -2,13 +2,14 @@
 
 extern crate test;
 
-use test::black_box;
-use test::Bencher;
+use test::{black_box, Bencher};
 
 use casperlabs_engine_storage::trie::{Pointer, PointerBlock, Trie};
-use contract_ffi::bytesrepr::{FromBytes, ToBytes};
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
+use contract_ffi::{
+    bytesrepr::{FromBytes, ToBytes},
+    key::Key,
+    value::Value,
+};
 use engine_shared::newtypes::Blake2bHash;
 
 #[bench]

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -1,25 +1,31 @@
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
-use contract_ffi::key::Key;
-use contract_ffi::value::{ProtocolVersion, Value};
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::newtypes::{Blake2bHash, CorrelationId};
-use engine_shared::transform::Transform;
+use contract_ffi::{
+    key::Key,
+    value::{ProtocolVersion, Value},
+};
+use engine_shared::{
+    additive_map::AdditiveMap,
+    newtypes::{Blake2bHash, CorrelationId},
+    transform::Transform,
+};
 
-use crate::error::{self, in_memory};
-use crate::global_state::StateReader;
-use crate::global_state::{commit, CommitResult, StateProvider};
-use crate::protocol_data::ProtocolData;
-use crate::protocol_data_store::in_memory::InMemoryProtocolDataStore;
-use crate::store::Store;
-use crate::transaction_source::in_memory::{InMemoryEnvironment, InMemoryReadTransaction};
-use crate::transaction_source::{Transaction, TransactionSource};
-use crate::trie::operations::create_hashed_empty_trie;
-use crate::trie::Trie;
-use crate::trie_store::in_memory::InMemoryTrieStore;
-use crate::trie_store::operations;
-use crate::trie_store::operations::{read, ReadResult, WriteResult};
+use crate::{
+    error::{self, in_memory},
+    global_state::{commit, CommitResult, StateProvider, StateReader},
+    protocol_data::ProtocolData,
+    protocol_data_store::in_memory::InMemoryProtocolDataStore,
+    store::Store,
+    transaction_source::{
+        in_memory::{InMemoryEnvironment, InMemoryReadTransaction},
+        Transaction, TransactionSource,
+    },
+    trie::{operations::create_hashed_empty_trie, Trie},
+    trie_store::{
+        in_memory::InMemoryTrieStore,
+        operations::{self, read, ReadResult, WriteResult},
+    },
+};
 
 pub struct InMemoryGlobalState {
     pub environment: Arc<InMemoryEnvironment>,

--- a/execution-engine/engine-storage/src/global_state/lmdb.rs
+++ b/execution-engine/engine-storage/src/global_state/lmdb.rs
@@ -1,26 +1,30 @@
-use std::ops::Deref;
-use std::sync::Arc;
+use std::{ops::Deref, sync::Arc};
 
 use lmdb;
 
-use contract_ffi::key::Key;
-use contract_ffi::value::{ProtocolVersion, Value};
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::newtypes::{Blake2bHash, CorrelationId};
-use engine_shared::transform::Transform;
+use contract_ffi::{
+    key::Key,
+    value::{ProtocolVersion, Value},
+};
+use engine_shared::{
+    additive_map::AdditiveMap,
+    newtypes::{Blake2bHash, CorrelationId},
+    transform::Transform,
+};
 
-use crate::error;
-use crate::global_state::StateReader;
-use crate::global_state::{commit, CommitResult, StateProvider};
-use crate::protocol_data::ProtocolData;
-use crate::protocol_data_store::lmdb::LmdbProtocolDataStore;
-use crate::store::Store;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::transaction_source::{Transaction, TransactionSource};
-use crate::trie::operations::create_hashed_empty_trie;
-use crate::trie::Trie;
-use crate::trie_store::lmdb::LmdbTrieStore;
-use crate::trie_store::operations::{read, ReadResult};
+use crate::{
+    error,
+    global_state::{commit, CommitResult, StateProvider, StateReader},
+    protocol_data::ProtocolData,
+    protocol_data_store::lmdb::LmdbProtocolDataStore,
+    store::Store,
+    transaction_source::{lmdb::LmdbEnvironment, Transaction, TransactionSource},
+    trie::{operations::create_hashed_empty_trie, Trie},
+    trie_store::{
+        lmdb::LmdbTrieStore,
+        operations::{read, ReadResult},
+    },
+};
 
 pub struct LmdbGlobalState {
     pub environment: Arc<LmdbEnvironment>,
@@ -160,8 +164,10 @@ mod tests {
     use lmdb::DatabaseFlags;
     use tempfile::tempdir;
 
-    use crate::trie_store::operations::{write, WriteResult};
-    use crate::TEST_MAP_SIZE;
+    use crate::{
+        trie_store::operations::{write, WriteResult},
+        TEST_MAP_SIZE,
+    };
 
     use super::*;
 

--- a/execution-engine/engine-storage/src/global_state/mod.rs
+++ b/execution-engine/engine-storage/src/global_state/mod.rs
@@ -1,24 +1,28 @@
 pub mod in_memory;
 pub mod lmdb;
 
-use std::collections::HashMap;
-use std::fmt;
-use std::hash::BuildHasher;
-use std::time::Instant;
+use std::{collections::HashMap, fmt, hash::BuildHasher, time::Instant};
 
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::{ProtocolVersion, Value, U512};
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::logging::{log_duration, log_metric, GAUGE};
-use engine_shared::newtypes::{Blake2bHash, CorrelationId};
-use engine_shared::transform::{self, Transform, TypeMismatch};
+use contract_ffi::{
+    key::Key,
+    value::{account::PublicKey, ProtocolVersion, Value, U512},
+};
+use engine_shared::{
+    additive_map::AdditiveMap,
+    logging::{log_duration, log_metric, GAUGE},
+    newtypes::{Blake2bHash, CorrelationId},
+    transform::{self, Transform, TypeMismatch},
+};
 
-use crate::protocol_data::ProtocolData;
-use crate::transaction_source::{Transaction, TransactionSource};
-use crate::trie::Trie;
-use crate::trie_store::operations::{read, write, ReadResult, WriteResult};
-use crate::trie_store::TrieStore;
+use crate::{
+    protocol_data::ProtocolData,
+    transaction_source::{Transaction, TransactionSource},
+    trie::Trie,
+    trie_store::{
+        operations::{read, write, ReadResult, WriteResult},
+        TrieStore,
+    },
+};
 
 const GLOBAL_STATE_COMMIT_READS: &str = "global_state_commit_reads";
 const GLOBAL_STATE_COMMIT_WRITES: &str = "global_state_commit_writes";

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -1,6 +1,7 @@
-use contract_ffi::bytesrepr;
-use contract_ffi::bytesrepr::{FromBytes, ToBytes};
-use contract_ffi::uref::{AccessRights, URef, UREF_SIZE_SERIALIZED};
+use contract_ffi::{
+    bytesrepr::{self, FromBytes, ToBytes},
+    uref::{AccessRights, URef, UREF_SIZE_SERIALIZED},
+};
 use engine_wasm_prep::wasm_costs::{WasmCosts, WASM_COSTS_SIZE_SERIALIZED};
 
 const PROTOCOL_DATA_SIZE_SERIALIZED: usize =
@@ -118,8 +119,10 @@ pub(crate) mod gens {
 mod tests {
     use proptest::proptest;
 
-    use contract_ffi::bytesrepr;
-    use contract_ffi::uref::{AccessRights, URef};
+    use contract_ffi::{
+        bytesrepr,
+        uref::{AccessRights, URef},
+    };
     use engine_shared::test_utils;
 
     use super::{gens, ProtocolData};

--- a/execution-engine/engine-storage/src/protocol_data_store/in_memory.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/in_memory.rs
@@ -1,10 +1,12 @@
 use contract_ffi::value::ProtocolVersion;
 
-use crate::error::in_memory::Error;
-use crate::protocol_data::ProtocolData;
-use crate::protocol_data_store::{self, ProtocolDataStore};
-use crate::store::Store;
-use crate::transaction_source::in_memory::InMemoryEnvironment;
+use crate::{
+    error::in_memory::Error,
+    protocol_data::ProtocolData,
+    protocol_data_store::{self, ProtocolDataStore},
+    store::Store,
+    transaction_source::in_memory::InMemoryEnvironment,
+};
 
 /// An in-memory protocol data store
 pub struct InMemoryProtocolDataStore {

--- a/execution-engine/engine-storage/src/protocol_data_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/lmdb.rs
@@ -1,11 +1,13 @@
 use contract_ffi::value::ProtocolVersion;
 use lmdb::{Database, DatabaseFlags};
 
-use crate::protocol_data::ProtocolData;
-use crate::protocol_data_store::ProtocolDataStore;
-use crate::store::Store;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::{error, protocol_data_store};
+use crate::{
+    error,
+    protocol_data::ProtocolData,
+    protocol_data_store::{self, ProtocolDataStore},
+    store::Store,
+    transaction_source::lmdb::LmdbEnvironment,
+};
 
 /// An LMDB-backed protocol data store.
 ///

--- a/execution-engine/engine-storage/src/protocol_data_store/mod.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/mod.rs
@@ -6,8 +6,7 @@ pub mod lmdb;
 #[cfg(test)]
 mod tests;
 
-use crate::protocol_data::ProtocolData;
-use crate::store::Store;
+use crate::{protocol_data::ProtocolData, store::Store};
 
 const NAME: &str = "PROTOCOL_DATA_STORE";
 

--- a/execution-engine/engine-storage/src/protocol_data_store/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/tests/proptests.rs
@@ -1,20 +1,17 @@
-use std::collections::BTreeMap;
-use std::ops::RangeInclusive;
+use std::{collections::BTreeMap, ops::RangeInclusive};
 
-use contract_ffi::gens as gens_ext;
-use contract_ffi::value::ProtocolVersion;
+use contract_ffi::{gens as gens_ext, value::ProtocolVersion};
 use lmdb::DatabaseFlags;
-use proptest::collection;
-use proptest::prelude::proptest;
+use proptest::{collection, prelude::proptest};
 use tempfile;
 
-use crate::protocol_data::{gens, ProtocolData};
-use crate::protocol_data_store::in_memory::InMemoryProtocolDataStore;
-use crate::protocol_data_store::lmdb::LmdbProtocolDataStore;
-use crate::store::tests as store_tests;
-use crate::transaction_source::in_memory::InMemoryEnvironment;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::TEST_MAP_SIZE;
+use crate::{
+    protocol_data::{gens, ProtocolData},
+    protocol_data_store::{in_memory::InMemoryProtocolDataStore, lmdb::LmdbProtocolDataStore},
+    store::tests as store_tests,
+    transaction_source::{in_memory::InMemoryEnvironment, lmdb::LmdbEnvironment},
+    TEST_MAP_SIZE,
+};
 
 const DEFAULT_MIN_LENGTH: usize = 1;
 const DEFAULT_MAX_LENGTH: usize = 16;

--- a/execution-engine/engine-storage/src/store/store_ext.rs
+++ b/execution-engine/engine-storage/src/store/store_ext.rs
@@ -1,7 +1,9 @@
 use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 
-use crate::store::Store;
-use crate::transaction_source::{Readable, Writable};
+use crate::{
+    store::Store,
+    transaction_source::{Readable, Writable},
+};
 
 pub trait StoreExt<K, V>: Store<K, V> {
     fn get_many<'a, T>(

--- a/execution-engine/engine-storage/src/store/tests.rs
+++ b/execution-engine/engine-storage/src/store/tests.rs
@@ -2,8 +2,10 @@ use std::collections::BTreeMap;
 
 use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 
-use crate::store::{Store, StoreExt};
-use crate::transaction_source::{Transaction, TransactionSource};
+use crate::{
+    store::{Store, StoreExt},
+    transaction_source::{Transaction, TransactionSource},
+};
 
 // should be moved to the `store` module
 fn roundtrip<'a, K, V, X, S>(

--- a/execution-engine/engine-storage/src/transaction_source/in_memory.rs
+++ b/execution-engine/engine-storage/src/transaction_source/in_memory.rs
@@ -1,8 +1,12 @@
-use std::collections::HashMap;
-use std::sync::{self, Arc, Mutex, MutexGuard};
+use std::{
+    collections::HashMap,
+    sync::{self, Arc, Mutex, MutexGuard},
+};
 
-use crate::error::in_memory::Error;
-use crate::transaction_source::{Readable, Transaction, TransactionSource, Writable};
+use crate::{
+    error::in_memory::Error,
+    transaction_source::{Readable, Transaction, TransactionSource, Writable},
+};
 
 /// A marker for use in a mutex which represents the capability to perform a
 /// write transaction.

--- a/execution-engine/engine-storage/src/transaction_source/lmdb.rs
+++ b/execution-engine/engine-storage/src/transaction_source/lmdb.rs
@@ -2,8 +2,11 @@ use std::path::PathBuf;
 
 use lmdb::{self, Database, Environment, RoTransaction, RwTransaction, WriteFlags};
 
-use crate::transaction_source::{Readable, Transaction, TransactionSource, Writable};
-use crate::{error, MAX_DBS};
+use crate::{
+    error,
+    transaction_source::{Readable, Transaction, TransactionSource, Writable},
+    MAX_DBS,
+};
 
 impl<'a> Transaction for RoTransaction<'a> {
     type Error = lmdb::Error;

--- a/execution-engine/engine-storage/src/trie/gens.rs
+++ b/execution-engine/engine-storage/src/trie/gens.rs
@@ -1,10 +1,10 @@
-use proptest::collection::vec;
-use proptest::option;
-use proptest::prelude::*;
+use proptest::{collection::vec, option, prelude::*};
 
-use contract_ffi::gens::{key_arb, value_arb};
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
+use contract_ffi::{
+    gens::{key_arb, value_arb},
+    key::Key,
+    value::Value,
+};
 use engine_shared::newtypes::Blake2bHash;
 
 use super::{Pointer, PointerBlock, Trie};

--- a/execution-engine/engine-storage/src/trie/mod.rs
+++ b/execution-engine/engine-storage/src/trie/mod.rs
@@ -1,7 +1,6 @@
 //! Core types for a Merkle Trie
 
-use std::mem::size_of;
-use std::ops::Deref;
+use std::{mem::size_of, ops::Deref};
 
 use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
 use engine_shared::newtypes::Blake2bHash;

--- a/execution-engine/engine-storage/src/trie_store/in_memory.rs
+++ b/execution-engine/engine-storage/src/trie_store/in_memory.rs
@@ -101,9 +101,9 @@
 use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 
 use super::*;
-use crate::error::in_memory::Error;
-use crate::transaction_source::in_memory::InMemoryEnvironment;
-use crate::trie_store;
+use crate::{
+    error::in_memory::Error, transaction_source::in_memory::InMemoryEnvironment, trie_store,
+};
 
 /// An in-memory trie store.
 pub struct InMemoryTrieStore {

--- a/execution-engine/engine-storage/src/trie_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/trie_store/lmdb.rs
@@ -109,11 +109,13 @@ use lmdb::{Database, DatabaseFlags};
 use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 use engine_shared::newtypes::Blake2bHash;
 
-use crate::store::Store;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::trie::Trie;
-use crate::trie_store::TrieStore;
-use crate::{error, trie_store};
+use crate::{
+    error,
+    store::Store,
+    transaction_source::lmdb::LmdbEnvironment,
+    trie::Trie,
+    trie_store::{self, TrieStore},
+};
 
 /// An LMDB-backed trie store.
 ///

--- a/execution-engine/engine-storage/src/trie_store/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/mod.rs
@@ -10,8 +10,7 @@ mod tests;
 
 use engine_shared::newtypes::Blake2bHash;
 
-use crate::store::Store;
-use crate::trie::Trie;
+use crate::{store::Store, trie::Trie};
 
 const NAME: &str = "TRIE_STORE";
 

--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -4,12 +4,16 @@ mod tests;
 use std::time::Instant;
 
 use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
-use engine_shared::logging::{log_duration, log_metric, GAUGE};
-use engine_shared::newtypes::{Blake2bHash, CorrelationId};
+use engine_shared::{
+    logging::{log_duration, log_metric, GAUGE},
+    newtypes::{Blake2bHash, CorrelationId},
+};
 
-use crate::transaction_source::{Readable, Writable};
-use crate::trie::{self, Parents, Pointer, Trie};
-use crate::trie_store::TrieStore;
+use crate::{
+    transaction_source::{Readable, Writable},
+    trie::{self, Parents, Pointer, Trie},
+    trie_store::TrieStore,
+};
 
 const TRIE_STORE_READ_DURATION: &str = "trie_store_read_duration";
 const TRIE_STORE_READ_GETS: &str = "trie_store_read_gets";

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -12,16 +12,21 @@ use tempfile::{tempdir, TempDir};
 use contract_ffi::bytesrepr::{self, FromBytes, ToBytes};
 use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 
-use crate::error::{self, in_memory};
-use crate::transaction_source::in_memory::InMemoryEnvironment;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::transaction_source::{Readable, Transaction, TransactionSource};
-use crate::trie::{Pointer, Trie};
-use crate::trie_store::in_memory::InMemoryTrieStore;
-use crate::trie_store::lmdb::LmdbTrieStore;
-use crate::trie_store::operations::{read, write, ReadResult, WriteResult};
-use crate::trie_store::TrieStore;
-use crate::TEST_MAP_SIZE;
+use crate::{
+    error::{self, in_memory},
+    transaction_source::{
+        in_memory::InMemoryEnvironment, lmdb::LmdbEnvironment, Readable, Transaction,
+        TransactionSource,
+    },
+    trie::{Pointer, Trie},
+    trie_store::{
+        in_memory::InMemoryTrieStore,
+        lmdb::LmdbTrieStore,
+        operations::{read, write, ReadResult, WriteResult},
+        TrieStore,
+    },
+    TEST_MAP_SIZE,
+};
 
 const TEST_KEY_LENGTH: usize = 7;
 

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/proptests.rs
@@ -1,8 +1,10 @@
 use std::ops::RangeInclusive;
 
-use proptest::array;
-use proptest::collection::vec;
-use proptest::prelude::{any, proptest, Strategy};
+use proptest::{
+    array,
+    collection::vec,
+    prelude::{any, proptest, Strategy},
+};
 
 use super::*;
 

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/scan.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/scan.rs
@@ -1,8 +1,10 @@
 use engine_shared::newtypes::Blake2bHash;
 
 use super::*;
-use crate::error::{self, in_memory};
-use crate::trie_store::operations::{scan, TrieScan};
+use crate::{
+    error::{self, in_memory},
+    trie_store::operations::{scan, TrieScan},
+};
 
 fn check_scan<'a, R, S, E>(
     correlation_id: CorrelationId,

--- a/execution-engine/engine-storage/src/trie_store/tests/concurrent.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/concurrent.rs
@@ -1,17 +1,20 @@
-use std::sync::{Arc, Barrier};
-use std::thread;
+use std::{
+    sync::{Arc, Barrier},
+    thread,
+};
 
 use tempfile::tempdir;
 
 use super::TestData;
-use crate::store::Store;
-use crate::transaction_source::in_memory::InMemoryEnvironment;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::transaction_source::{Transaction, TransactionSource};
-use crate::trie::Trie;
-use crate::trie_store::in_memory::InMemoryTrieStore;
-use crate::trie_store::lmdb::LmdbTrieStore;
-use crate::TEST_MAP_SIZE;
+use crate::{
+    store::Store,
+    transaction_source::{
+        in_memory::InMemoryEnvironment, lmdb::LmdbEnvironment, Transaction, TransactionSource,
+    },
+    trie::Trie,
+    trie_store::{in_memory::InMemoryTrieStore, lmdb::LmdbTrieStore},
+    TEST_MAP_SIZE,
+};
 
 #[test]
 fn lmdb_writer_mutex_does_not_collide_with_readers() {

--- a/execution-engine/engine-storage/src/trie_store/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/mod.rs
@@ -5,8 +5,7 @@ mod simple;
 use contract_ffi::bytesrepr::ToBytes;
 use engine_shared::newtypes::Blake2bHash;
 
-use crate::trie::Trie;
-use crate::trie::{Pointer, PointerBlock};
+use crate::trie::{Pointer, PointerBlock, Trie};
 
 #[derive(Clone)]
 struct TestData<K, V>(Blake2bHash, Trie<K, V>);

--- a/execution-engine/engine-storage/src/trie_store/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/proptests.rs
@@ -1,19 +1,17 @@
 use std::ops::RangeInclusive;
 
 use lmdb::DatabaseFlags;
-use proptest::collection::vec;
-use proptest::prelude::proptest;
+use proptest::{collection::vec, prelude::proptest};
 use tempfile::tempdir;
 
-use contract_ffi::bytesrepr::ToBytes;
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
+use contract_ffi::{bytesrepr::ToBytes, key::Key, value::Value};
 use engine_shared::newtypes::Blake2bHash;
 
-use crate::store::tests as store_tests;
-use crate::trie::gens::trie_arb;
-use crate::trie::Trie;
-use crate::TEST_MAP_SIZE;
+use crate::{
+    store::tests as store_tests,
+    trie::{gens::trie_arb, Trie},
+    TEST_MAP_SIZE,
+};
 use std::collections::BTreeMap;
 
 const DEFAULT_MIN_LENGTH: usize = 1;
@@ -30,8 +28,10 @@ fn get_range() -> RangeInclusive<usize> {
 }
 
 fn in_memory_roundtrip_succeeds(inputs: Vec<Trie<Key, Value>>) -> bool {
-    use crate::transaction_source::in_memory::InMemoryEnvironment;
-    use crate::trie_store::in_memory::InMemoryTrieStore;
+    use crate::{
+        transaction_source::in_memory::InMemoryEnvironment,
+        trie_store::in_memory::InMemoryTrieStore,
+    };
 
     let env = InMemoryEnvironment::new();
     let store = InMemoryTrieStore::new(&env, None);
@@ -45,8 +45,7 @@ fn in_memory_roundtrip_succeeds(inputs: Vec<Trie<Key, Value>>) -> bool {
 }
 
 fn lmdb_roundtrip_succeeds(inputs: Vec<Trie<Key, Value>>) -> bool {
-    use crate::transaction_source::lmdb::LmdbEnvironment;
-    use crate::trie_store::lmdb::LmdbTrieStore;
+    use crate::{transaction_source::lmdb::LmdbEnvironment, trie_store::lmdb::LmdbTrieStore};
 
     let tmp_dir = tempdir().unwrap();
     let env = LmdbEnvironment::new(&tmp_dir.path().to_path_buf(), *TEST_MAP_SIZE).unwrap();

--- a/execution-engine/engine-storage/src/trie_store/tests/simple.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/simple.rs
@@ -4,16 +4,16 @@ use tempfile::tempdir;
 use contract_ffi::bytesrepr::{FromBytes, ToBytes};
 
 use super::TestData;
-use crate::error::{self, in_memory};
-use crate::store::StoreExt;
-use crate::transaction_source::in_memory::InMemoryEnvironment;
-use crate::transaction_source::lmdb::LmdbEnvironment;
-use crate::transaction_source::{Transaction, TransactionSource};
-use crate::trie::Trie;
-use crate::trie_store::in_memory::InMemoryTrieStore;
-use crate::trie_store::lmdb::LmdbTrieStore;
-use crate::trie_store::TrieStore;
-use crate::TEST_MAP_SIZE;
+use crate::{
+    error::{self, in_memory},
+    store::StoreExt,
+    transaction_source::{
+        in_memory::InMemoryEnvironment, lmdb::LmdbEnvironment, Transaction, TransactionSource,
+    },
+    trie::Trie,
+    trie_store::{in_memory::InMemoryTrieStore, lmdb::LmdbTrieStore, TrieStore},
+    TEST_MAP_SIZE,
+};
 
 fn put_succeeds<'a, K, V, S, X, E>(
     store: &S,

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -1,13 +1,14 @@
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use tempfile::TempDir;
 
-use casperlabs_engine_tests::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, WasmTestResult,
-    STANDARD_PAYMENT_CONTRACT,
+use casperlabs_engine_tests::{
+    support::test_support::{
+        DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, WasmTestResult,
+        STANDARD_PAYMENT_CONTRACT,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
 };
-use casperlabs_engine_tests::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::value::{account::PublicKey, U512};
 use engine_core::engine_state::EngineConfig;
 use engine_storage::global_state::lmdb::LmdbGlobalState;
 

--- a/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
+++ b/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
@@ -4,23 +4,23 @@
 //! For details of how to run this executable, see the README in this directory or at
 //! https://github.com/CasperLabs/CasperLabs/blob/dev/execution-engine/engine-tests/src/profiling/README.md#concurrent-executor
 
-use std::iter::Sum;
-use std::sync::Arc;
-use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
+use std::{
+    iter::Sum,
+    sync::Arc,
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
 
 use clap::{crate_version, App, Arg};
 use crossbeam_channel::{Iter, Receiver, Sender};
 use grpc::{ClientStubExt, RequestOptions};
 use log::info;
 
-use casperlabs_engine_tests::support::profiling_common;
-use casperlabs_engine_tests::support::test_support::ExecuteRequestBuilder;
-use contract_ffi::base16;
-use contract_ffi::value::U512;
-use engine_grpc_server::engine_server::ipc::ExecuteRequest;
-use engine_grpc_server::engine_server::ipc_grpc::{
-    ExecutionEngineService, ExecutionEngineServiceClient,
+use casperlabs_engine_tests::support::{profiling_common, test_support::ExecuteRequestBuilder};
+use contract_ffi::{base16, value::U512};
+use engine_grpc_server::engine_server::{
+    ipc::ExecuteRequest,
+    ipc_grpc::{ExecutionEngineService, ExecutionEngineServiceClient},
 };
 
 const APP_NAME: &str = "Concurrent Executor";

--- a/execution-engine/engine-tests/src/profiling/simple_transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple_transfer.rs
@@ -7,19 +7,18 @@
 //! By avoiding setting up global state as part of this executable, it will allow profiling to be
 //! done only on meaningful code, rather than including test setup effort in the profile results.
 
-use std::env;
-use std::io;
-use std::path::PathBuf;
+use std::{env, io, path::PathBuf};
 
 use clap::{crate_version, App, Arg};
 
-use casperlabs_engine_tests::support::profiling_common;
-use casperlabs_engine_tests::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder,
+use casperlabs_engine_tests::{
+    support::{
+        profiling_common,
+        test_support::{DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder},
+    },
+    test::DEFAULT_PAYMENT,
 };
-use casperlabs_engine_tests::test::DEFAULT_PAYMENT;
-use contract_ffi::base16;
-use contract_ffi::value::U512;
+use contract_ffi::{base16, value::U512};
 use engine_core::engine_state::EngineConfig;
 
 const ABOUT: &str =

--- a/execution-engine/engine-tests/src/profiling/state_initializer.rs
+++ b/execution-engine/engine-tests/src/profiling/state_initializer.rs
@@ -2,20 +2,18 @@
 //! standalone test executable(s).  This will allow profiling to be done on executables running only
 //! meaningful code, rather than including test setup effort in the profile results.
 
-use std::env;
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
 use clap::{crate_version, App};
 
-use casperlabs_engine_tests::support::profiling_common;
-use casperlabs_engine_tests::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder,
+use casperlabs_engine_tests::{
+    support::{
+        profiling_common,
+        test_support::{DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder},
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
 };
-use casperlabs_engine_tests::test::{
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
-};
-use contract_ffi::base16;
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{base16, value::account::PublicKey};
 
 const ABOUT: &str = "Initializes global state in preparation for profiling runs. Outputs the root \
                      hash from the commit response.";

--- a/execution-engine/engine-tests/src/support/exec_with_return.rs
+++ b/execution-engine/engine-tests/src/support/exec_with_return.rs
@@ -1,26 +1,24 @@
-use std::cell::RefCell;
-use std::collections::BTreeSet;
-use std::convert::TryInto;
-use std::rc::Rc;
+use std::{cell::RefCell, collections::BTreeSet, convert::TryInto, rc::Rc};
 
-use contract_ffi::args_parser::ArgsParser;
-use contract_ffi::bytesrepr::{self, FromBytes};
-use contract_ffi::execution::Phase;
-use contract_ffi::key::Key;
-use contract_ffi::uref::URef;
-use contract_ffi::value::account::BlockTime;
-use contract_ffi::value::{ProtocolVersion, U512};
-use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
-use engine_core::engine_state::execution_effect::ExecutionEffect;
-use engine_core::engine_state::EngineState;
-use engine_core::execution;
-use engine_core::execution::AddressGenerator;
-use engine_core::runtime_context::RuntimeContext;
+use contract_ffi::{
+    args_parser::ArgsParser,
+    bytesrepr::{self, FromBytes},
+    execution::Phase,
+    key::Key,
+    uref::URef,
+    value::{account::BlockTime, ProtocolVersion, U512},
+};
+use engine_core::{
+    engine_state::{
+        executable_deploy_item::ExecutableDeployItem, execution_effect::ExecutionEffect,
+        EngineState,
+    },
+    execution::{self, AddressGenerator},
+    runtime_context::RuntimeContext,
+};
 use engine_grpc_server::engine_server::ipc_grpc::ExecutionEngineService;
-use engine_shared::gas::Gas;
-use engine_shared::newtypes::CorrelationId;
-use engine_storage::global_state::StateProvider;
-use engine_storage::protocol_data::ProtocolData;
+use engine_shared::{gas::Gas, newtypes::CorrelationId};
+use engine_storage::{global_state::StateProvider, protocol_data::ProtocolData};
 use engine_wasm_prep::Preprocessor;
 
 use crate::support::test_support::{self, WasmTestBuilder};

--- a/execution-engine/engine-tests/src/support/profiling_common.rs
+++ b/execution-engine/engine-tests/src/support/profiling_common.rs
@@ -1,11 +1,8 @@
-use std::env;
-use std::path::PathBuf;
-use std::str::FromStr;
+use std::{env, path::PathBuf, str::FromStr};
 
 use clap::{Arg, ArgMatches};
 
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::value::{account::PublicKey, U512};
 
 const DATA_DIR_ARG_NAME: &str = "data-dir";
 const DATA_DIR_ARG_SHORT: &str = "d";

--- a/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
@@ -1,11 +1,17 @@
 use lazy_static::lazy_static;
 
-use contract_ffi::key::Key;
-use contract_ffi::value::account::{PublicKey, Weight};
-use contract_ffi::value::{Account, U512};
+use contract_ffi::{
+    key::Key,
+    value::{
+        account::{PublicKey, Weight},
+        Account, U512,
+    },
+};
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
 const CONTRACT_REMOVE_ASSOCIATED_KEY: &str = "remove_associated_key.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
@@ -1,10 +1,12 @@
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, STANDARD_PAYMENT_CONTRACT,
+use crate::{
+    support::test_support::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+        STANDARD_PAYMENT_CONTRACT,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 use contract_ffi::value::account::{PublicKey, Weight};
-use engine_core::engine_state;
-use engine_core::execution;
+use engine_core::{engine_state, execution};
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
 const CONTRACT_AUTHORIZED_KEYS: &str = "authorized_keys.wasm";
 

--- a/execution-engine/engine-tests/src/test/contract_api/account/key_management_thresholds.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/key_management_thresholds.rs
@@ -1,9 +1,12 @@
 use contract_ffi::value::account::PublicKey;
 
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, STANDARD_PAYMENT_CONTRACT,
+use crate::{
+    support::test_support::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+        STANDARD_PAYMENT_CONTRACT,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 
 const CONTRACT_KEY_MANAGEMENT_THRESHOLDS: &str = "key_management_thresholds.wasm";
 

--- a/execution-engine/engine-tests/src/test/contract_api/account/named_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/named_keys.rs
@@ -1,5 +1,7 @@
-use contract_ffi::key::Key;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    key::Key,
+    value::{Value, U512},
+};
 use engine_shared::transform::Transform;
 
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};

--- a/execution-engine/engine-tests/src/test/contract_api/create_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/create_purse.rs
@@ -1,13 +1,16 @@
 use lazy_static::lazy_static;
 
-use contract_ffi::base16;
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    base16,
+    key::Key,
+    value::{account::PurseId, U512},
+};
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{ExecuteRequestBuilder, WasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, WasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_CREATE_PURSE_01: &str = "create_purse_01.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/get_arg.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_arg.rs
@@ -1,7 +1,5 @@
 use crate::support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use contract_ffi::args_parser::ArgsParser;
-use contract_ffi::contract_api::Error;
-use contract_ffi::value::U512;
+use contract_ffi::{args_parser::ArgsParser, contract_api::Error, value::U512};
 
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
 

--- a/execution-engine/engine-tests/src/test/contract_api/get_blocktime.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_blocktime.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 const CONTRACT_GET_BLOCKTIME: &str = "get_blocktime.wasm";
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/contract_api/get_caller.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_caller.rs
@@ -1,7 +1,9 @@
 use contract_ffi::value::account::PublicKey;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_GET_CALLER: &str = "get_caller.wasm";
 const CONTRACT_GET_CALLER_SUBCALL: &str = "get_caller_subcall.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/get_phase.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_phase.rs
@@ -1,10 +1,9 @@
-use contract_ffi::execution::Phase;
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{execution::Phase, value::account::PublicKey};
 
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+use crate::{
+    support::test_support::{DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
@@ -1,8 +1,12 @@
-use contract_ffi::contract_api::system::{MINT_NAME, POS_NAME};
-use contract_ffi::key::Key;
+use contract_ffi::{
+    contract_api::system::{MINT_NAME, POS_NAME},
+    key::Key,
+};
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 use std::collections::BTreeMap;
 
 const CONTRACT_LIST_NAMED_KEYS: &str = "list_named_keys.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/local_state.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/local_state.rs
@@ -1,10 +1,10 @@
-use contract_ffi::bytesrepr::ToBytes;
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
+use contract_ffi::{bytesrepr::ToBytes, key::Key, value::Value};
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 const CONTRACT_LOCAL_STATE: &str = "local_state.wasm";
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/contract_api/main_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/main_purse.rs
@@ -1,6 +1,5 @@
 use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use contract_ffi::key::Key;
-use contract_ffi::value::Value;
+use contract_ffi::{key::Key, value::Value};
 
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 

--- a/execution-engine/engine-tests/src/test/contract_api/mint_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/mint_purse.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, WasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, WasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_MINT_PURSE: &str = "mint_purse.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT_01: &str = "transfer_to_account_01.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/revert.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/revert.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const REVERT_WASM: &str = "revert.wasm";
 

--- a/execution-engine/engine-tests/src/test/contract_api/transfer.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer.rs
@@ -4,9 +4,12 @@ use contract_ffi::value::U512;
 use engine_core::engine_state::CONV_RATE;
 use engine_shared::motes::Motes;
 
-use crate::support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
+use crate::{
+    support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{
+        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG,
+        DEFAULT_PAYMENT,
+    },
 };
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
@@ -1,15 +1,21 @@
 use lazy_static::lazy_static;
 
-use contract_ffi::contract_api::system::{TransferResult, TransferredTo};
-use contract_ffi::contract_api::Error;
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    contract_api::{
+        system::{TransferResult, TransferredTo},
+        Error,
+    },
+    key::Key,
+    value::{account::PublicKey, Value, U512},
+};
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{
+        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG,
+        DEFAULT_PAYMENT,
+    },
 };
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_purse.rs
@@ -1,11 +1,16 @@
-use contract_ffi::contract_api::Error;
-use contract_ffi::key::Key;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    contract_api::Error,
+    key::Key,
+    value::{Value, U512},
+};
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{
+        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_GENESIS_CONFIG,
+        DEFAULT_PAYMENT,
+    },
 };
 
 const CONTRACT_TRANSFER_PURSE_TO_PURSE: &str = "transfer_purse_to_purse.wasm";

--- a/execution-engine/engine-tests/src/test/deploy/payment_code.rs
+++ b/execution-engine/engine-tests/src/test/deploy/payment_code.rs
@@ -1,21 +1,24 @@
 use std::convert::TryInto;
 
-use contract_ffi::bytesrepr::ToBytes;
-use contract_ffi::key::Key;
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::{Value, U512};
-use engine_core::engine_state::genesis::POS_REWARDS_PURSE;
-use engine_core::engine_state::{CONV_RATE, MAX_PAYMENT};
-use engine_shared::gas::Gas;
-use engine_shared::motes::Motes;
-use engine_shared::transform::Transform;
-
-use crate::support::test_support::{
-    self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+use contract_ffi::{
+    bytesrepr::ToBytes,
+    key::Key,
+    value::{
+        account::{PublicKey, PurseId},
+        Value, U512,
+    },
 };
-use crate::test::{
-    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_KEY,
-    DEFAULT_GENESIS_CONFIG,
+use engine_core::engine_state::{genesis::POS_REWARDS_PURSE, CONV_RATE, MAX_PAYMENT};
+use engine_shared::{gas::Gas, motes::Motes, transform::Transform};
+
+use crate::{
+    support::test_support::{
+        self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+    },
+    test::{
+        DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_KEY,
+        DEFAULT_GENESIS_CONFIG,
+    },
 };
 
 const ACCOUNT_1_ADDR: [u8; 32] = [42u8; 32];

--- a/execution-engine/engine-tests/src/test/deploy/preconditions.rs
+++ b/execution-engine/engine-tests/src/test/deploy/preconditions.rs
@@ -1,10 +1,9 @@
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::value::{account::PublicKey, U512};
 
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+use crate::{
+    support::test_support::{DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{CONTRACT_STANDARD_PAYMENT, DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
 };
-use crate::test::{CONTRACT_STANDARD_PAYMENT, DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
 
 const ACCOUNT_1_ADDR: [u8; 32] = [42u8; 32];
 

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -1,21 +1,20 @@
-use std::collections::hash_map::RandomState;
-use std::collections::BTreeMap;
+use std::collections::{hash_map::RandomState, BTreeMap};
 
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    key::Key,
+    value::{account::PublicKey, Value, U512},
+};
 use engine_core::engine_state::CONV_RATE;
-use engine_shared::additive_map::AdditiveMap;
-use engine_shared::gas::Gas;
-use engine_shared::motes::Motes;
-use engine_shared::transform::Transform;
+use engine_shared::{additive_map::AdditiveMap, gas::Gas, motes::Motes, transform::Transform};
 use std::convert::TryInto;
 
-use crate::support::test_support::{
-    self, DeployItemBuilder, Diff, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
-    GENESIS_INITIAL_BALANCE,
+use crate::{
+    support::test_support::{
+        self, DeployItemBuilder, Diff, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+        GENESIS_INITIAL_BALANCE,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_KEY, DEFAULT_GENESIS_CONFIG},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_KEY, DEFAULT_GENESIS_CONFIG};
 
 const ACCOUNT_1_ADDR: [u8; 32] = [42u8; 32];
 const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -2,11 +2,15 @@ use lazy_static::lazy_static;
 
 use contract_ffi::key::Key;
 use engine_core::engine_state::EngineConfig;
-use engine_shared::logging::log_level::LogLevel;
-use engine_shared::logging::log_settings::{self, LogLevelFilter, LogSettings};
-use engine_shared::logging::logger::{self, LogBufferProvider, BUFFERED_LOGGER};
-use engine_shared::newtypes::CorrelationId;
-use engine_shared::test_utils;
+use engine_shared::{
+    logging::{
+        log_level::LogLevel,
+        log_settings::{self, LogLevelFilter, LogSettings},
+        logger::{self, LogBufferProvider, BUFFERED_LOGGER},
+    },
+    newtypes::CorrelationId,
+    test_utils,
+};
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
 
 use crate::support::test_support::{self, InMemoryWasmTestBuilder};

--- a/execution-engine/engine-tests/src/test/mod.rs
+++ b/execution-engine/engine-tests/src/test/mod.rs
@@ -15,11 +15,9 @@ pub mod system_contracts;
 use lazy_static::lazy_static;
 use num_traits::identities::Zero;
 
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::{ProtocolVersion, U512};
+use contract_ffi::value::{account::PublicKey, ProtocolVersion, U512};
 use engine_core::engine_state::genesis::{GenesisAccount, GenesisConfig};
-use engine_shared::motes::Motes;
-use engine_shared::test_utils;
+use engine_shared::{motes::Motes, test_utils};
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
 use crate::support::test_support;

--- a/execution-engine/engine-tests/src/test/regression/ee_221.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_221.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_EE_221_REGRESSION: &str = "ee_221_regression.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_441.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_441.rs
@@ -1,11 +1,13 @@
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, STANDARD_PAYMENT_CONTRACT,
-};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
-use contract_ffi::key::Key;
-use contract_ffi::uref::URef;
-use contract_ffi::value::account::PublicKey;
+use contract_ffi::{key::Key, uref::URef, value::account::PublicKey};
 use engine_shared::transform::Transform;
+
+use crate::{
+    support::test_support::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+        STANDARD_PAYMENT_CONTRACT,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 fn get_uref(key: Key) -> URef {
     match key {

--- a/execution-engine/engine-tests/src/test/regression/ee_460.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_460.rs
@@ -1,7 +1,10 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
 use contract_ffi::value::U512;
 use engine_shared::transform::Transform;
+
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_EE_460_REGRESSION: &str = "ee_460_regression.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_468.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_468.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_DESERIALIZE_ERROR: &str = "deserialize_error.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_470.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_470.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 use engine_storage::global_state::in_memory::InMemoryGlobalState;
 

--- a/execution-engine/engine-tests/src/test/regression/ee_532.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_532.rs
@@ -1,7 +1,9 @@
 use engine_core::engine_state::Error;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::DEFAULT_GENESIS_CONFIG;
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::DEFAULT_GENESIS_CONFIG,
+};
 
 const CONTRACT_EE_532_REGRESSION: &str = "ee_532_regression.wasm";
 const UNKNOWN_ADDR: [u8; 32] = [42u8; 32];

--- a/execution-engine/engine-tests/src/test/regression/ee_536.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_536.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_EE_536_REGRESSION: &str = "ee_536_regression.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_549.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_549.rs
@@ -1,5 +1,7 @@
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_EE_549_REGRESSION: &str = "ee_549_regression.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_550.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_550.rs
@@ -1,10 +1,10 @@
 use contract_ffi::value::account::PublicKey;
 
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
-};
-use crate::test::{
-    CONTRACT_STANDARD_PAYMENT, DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
+use crate::{
+    support::test_support::{DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{
+        CONTRACT_STANDARD_PAYMENT, DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
+    },
 };
 
 const PASS_INIT_REMOVE: &str = "init_remove";

--- a/execution-engine/engine-tests/src/test/regression/ee_572.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_572.rs
@@ -1,8 +1,12 @@
-use contract_ffi::key::Key;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    key::Key,
+    value::{Value, U512},
+};
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_CREATE: &str = "ee_572_regression_create.wasm";
 const CONTRACT_ESCALATE: &str = "ee_572_regression_escalate.wasm";

--- a/execution-engine/engine-tests/src/test/regression/ee_584.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_584.rs
@@ -1,8 +1,10 @@
 use contract_ffi::value::Value;
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_EE_584_REGRESSION: &str = "ee_584_regression.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_597.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_597.rs
@@ -1,7 +1,9 @@
 use contract_ffi::contract_api::Error;
 
-use crate::support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const CONTRACT_EE_597_REGRESSION: &str = "ee_597_regression.wasm";
 

--- a/execution-engine/engine-tests/src/test/regression/ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_598.rs
@@ -1,16 +1,19 @@
 use lazy_static::lazy_static;
 
-use contract_ffi::contract_api::Error;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::{
+    contract_api::Error,
+    value::{account::PublicKey, U512},
+};
 use engine_core::engine_state::genesis::GenesisAccount;
 use engine_shared::motes::Motes;
 
-use crate::support::test_support::{
-    self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
-    STANDARD_PAYMENT_CONTRACT,
+use crate::{
+    support::test_support::{
+        self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+        STANDARD_PAYMENT_CONTRACT,
+    },
+    test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT},
 };
-use crate::test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT};
 
 const CONTRACT_POS_BONDING: &str = "pos_bonding.wasm";
 const ACCOUNT_1_ADDR: [u8; 32] = [7u8; 32];

--- a/execution-engine/engine-tests/src/test/regression/ee_601.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_601.rs
@@ -1,12 +1,13 @@
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::Value;
+use contract_ffi::{
+    key::Key,
+    value::{account::PublicKey, Value},
+};
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+use crate::{
+    support::test_support::{DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -1,13 +1,17 @@
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::{ProtocolVersion, Value, U512};
-use engine_core::engine_state::genesis::{GenesisAccount, GenesisConfig};
-use engine_core::engine_state::SYSTEM_ACCOUNT_ADDR;
+use contract_ffi::{
+    key::Key,
+    value::{account::PublicKey, ProtocolVersion, Value, U512},
+};
+use engine_core::engine_state::{
+    genesis::{GenesisAccount, GenesisConfig},
+    SYSTEM_ACCOUNT_ADDR,
+};
 use engine_shared::motes::Motes;
 
-use crate::support::test_support;
-use crate::support::test_support::InMemoryWasmTestBuilder;
-use crate::test::DEFAULT_WASM_COSTS;
+use crate::{
+    support::test_support::{self, InMemoryWasmTestBuilder},
+    test::DEFAULT_WASM_COSTS,
+};
 
 const MINT_INSTALL: &str = "mint_install.wasm";
 const POS_INSTALL: &str = "pos_install.wasm";

--- a/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
@@ -1,11 +1,13 @@
-use contract_ffi::key::Key;
-use contract_ffi::uref::URef;
-use contract_ffi::value::Value;
+use contract_ffi::{key::Key, uref::URef, value::Value};
 use engine_shared::transform::Transform;
 
-use crate::support::exec_with_return;
-use crate::support::test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::{
+        exec_with_return,
+        test_support::{WasmTestBuilder, DEFAULT_BLOCK_TIME},
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const DEPLOY_HASH_1: [u8; 32] = [1u8; 32];
 

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -1,12 +1,17 @@
 use std::collections::BTreeMap;
 
-use crate::support::exec_with_return;
-use crate::support::test_support::{ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_BLOCK_TIME};
-use contract_ffi::key::Key;
-use contract_ffi::uref::{AccessRights, URef};
-use contract_ffi::value::account::{PublicKey, PurseId};
-use contract_ffi::value::Value;
-use contract_ffi::value::U512;
+use crate::support::{
+    exec_with_return,
+    test_support::{ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_BLOCK_TIME},
+};
+use contract_ffi::{
+    key::Key,
+    uref::{AccessRights, URef},
+    value::{
+        account::{PublicKey, PurseId},
+        Value, U512,
+    },
+};
 use engine_shared::transform::Transform;
 
 use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
@@ -1,17 +1,22 @@
-use contract_ffi::base16;
-use contract_ffi::contract_api::Error;
-use contract_ffi::key::Key;
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::account::PurseId;
-use contract_ffi::value::{Value, U512};
+use contract_ffi::{
+    base16,
+    contract_api::Error,
+    key::Key,
+    value::{
+        account::{PublicKey, PurseId},
+        Value, U512,
+    },
+};
+use engine_core::engine_state::{
+    genesis::{GenesisAccount, POS_BONDING_PURSE},
+    CONV_RATE,
+};
+use engine_shared::{motes::Motes, transform::Transform};
 
-use engine_core::engine_state::genesis::{GenesisAccount, POS_BONDING_PURSE};
-use engine_core::engine_state::CONV_RATE;
-use engine_shared::motes::Motes;
-use engine_shared::transform::Transform;
-
-use crate::support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_POS_BONDING: &str = "pos_bonding.wasm";
 const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/commit_validators.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/commit_validators.rs
@@ -1,13 +1,14 @@
 use num_traits::Zero;
 use std::collections::HashMap;
 
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::value::{account::PublicKey, U512};
 use engine_core::engine_state::genesis::GenesisAccount;
 use engine_shared::motes::Motes;
 
-use crate::support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR};
+use crate::{
+    support::test_support::{self, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNTS, DEFAULT_ACCOUNT_ADDR},
+};
 
 const CONTRACT_LOCAL_STATE: &str = "local_state.wasm";
 const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
@@ -1,18 +1,24 @@
 use std::convert::TryInto;
 
-use contract_ffi::key::Key;
-use contract_ffi::value::account::{Account, PublicKey, PurseId};
-use contract_ffi::value::U512;
-
-use engine_core::engine_state::genesis::{POS_PAYMENT_PURSE, POS_REWARDS_PURSE};
-use engine_core::engine_state::CONV_RATE;
-
-use crate::support::test_support::{
-    self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+use contract_ffi::{
+    key::Key,
+    value::{
+        account::{Account, PublicKey, PurseId},
+        U512,
+    },
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
-use engine_shared::gas::Gas;
-use engine_shared::motes::Motes;
+use engine_core::engine_state::{
+    genesis::{POS_PAYMENT_PURSE, POS_REWARDS_PURSE},
+    CONV_RATE,
+};
+use engine_shared::{gas::Gas, motes::Motes};
+
+use crate::{
+    support::test_support::{
+        self, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_FINALIZE_PAYMENT: &str = "pos_finalize_payment.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/get_payment_purse.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/get_payment_purse.rs
@@ -1,7 +1,9 @@
 use contract_ffi::value::U512;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_POS_GET_PAYMENT_PURSE: &str = "pos_get_payment_purse.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/refund_purse.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/refund_purse.rs
@@ -1,10 +1,9 @@
-use contract_ffi::value::account::PublicKey;
-use contract_ffi::value::U512;
+use contract_ffi::value::{account::PublicKey, U512};
 
-use crate::support::test_support::{
-    DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+use crate::{
+    support::test_support::{DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
 const ACCOUNT_1_ADDR: [u8; 32] = [1u8; 32];

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
@@ -2,8 +2,10 @@ use lazy_static::lazy_static;
 
 use contract_ffi::value::U512;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_CHECK_SYSTEM_CONTRACT_UREFS_ACCESS_RIGHTS: &str =
     "check_system_contract_urefs_access_rights.wasm";

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
@@ -1,13 +1,13 @@
 use lazy_static::lazy_static;
 
-use contract_ffi::uref::URef;
-use contract_ffi::value::U512;
-use engine_core::engine_state::Error;
-use engine_core::execution;
+use contract_ffi::{uref::URef, value::U512};
+use engine_core::{engine_state::Error, execution};
 use engine_shared::transform::TypeMismatch;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
+};
 
 const CONTRACT_SYSTEM_CONTRACTS_ACCESS: &str = "system_contracts_access.wasm";
 const CONTRACT_OVERWRITE_UREF_CONTENT: &str = "overwrite_uref_content.wasm";

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -1,14 +1,18 @@
-use contract_ffi::key::Key;
-use contract_ffi::value::{ProtocolVersion, Value, U512};
+use contract_ffi::{
+    key::Key,
+    value::{ProtocolVersion, Value, U512},
+};
 use engine_core::engine_state::upgrade::ActivationPoint;
 use engine_grpc_server::engine_server::ipc::DeployCode;
 use engine_shared::transform::Transform;
 use engine_wasm_prep::wasm_costs::WasmCosts;
 
-use crate::support::test_support::{
-    self, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
+use crate::{
+    support::test_support::{
+        self, ExecuteRequestBuilder, InMemoryWasmTestBuilder, UpgradeRequestBuilder,
+    },
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_WASM_COSTS},
 };
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_WASM_COSTS};
 
 const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
 const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;

--- a/execution-engine/engine-tests/src/test/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/upgrade.rs
@@ -1,8 +1,10 @@
 use contract_ffi::value::Value;
 use engine_shared::transform::Transform;
 
-use crate::support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder};
-use crate::test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG};
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
 
 const DO_NOTHING_STORED_CONTRACT_NAME: &str = "do_nothing_stored";
 const DO_NOTHING_STORED_CALLER_CONTRACT_NAME: &str = "do_nothing_stored_caller";

--- a/execution-engine/engine-wasm-prep/src/lib.rs
+++ b/execution-engine/engine-wasm-prep/src/lib.rs
@@ -1,7 +1,9 @@
 pub mod wasm_costs;
 
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
+use std::{
+    error::Error,
+    fmt::{self, Display, Formatter},
+};
 
 use parity_wasm::elements::{Error as ParityWasmError, Module};
 use pwasm_utils::{externalize_mem, inject_gas_counter, rules};

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -1,5 +1,4 @@
-use contract_ffi::bytesrepr;
-use contract_ffi::bytesrepr::{FromBytes, ToBytes, U32_SIZE};
+use contract_ffi::bytesrepr::{self, FromBytes, ToBytes, U32_SIZE};
 
 const NUM_FIELDS: usize = 10;
 pub const WASM_COSTS_SIZE_SERIALIZED: usize = NUM_FIELDS * U32_SIZE;
@@ -78,8 +77,7 @@ impl FromBytes for WasmCosts {
 }
 
 pub mod gens {
-    use proptest::num;
-    use proptest::prop_compose;
+    use proptest::{num, prop_compose};
 
     use crate::wasm_costs::WasmCosts;
 

--- a/execution-engine/rustfmt.toml
+++ b/execution-engine/rustfmt.toml
@@ -1,2 +1,3 @@
 wrap_comments = true
 comment_width = 100
+merge_imports = true


### PR DESCRIPTION
### Overview
Enables [`merge_imports`](https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#merge_imports) in rustfmt.toml.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-758

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
