### PR TITLE
NODE-1013: Raise default payment amount to 10M in Clarity.

### DIFF
--- a/explorer/Dockerfile
+++ b/explorer/Dockerfile
@@ -13,7 +13,7 @@ COPY ui/build /app/ui
 
 WORKDIR /app/server
 ENV STATIC_ROOT=/app/ui
-ENV PAYMENT_AMOUNT=1000000
+ENV PAYMENT_AMOUNT=10000000
 ENV PAYMENT_CONTRACT_PATH=/app/contracts/payment.wasm
 ENV FAUCET_CONTRACT_PATH=/app/contracts/faucet.wasm
 ENTRYPOINT node server.js

--- a/explorer/sdk/src/lib/Contracts.ts
+++ b/explorer/sdk/src/lib/Contracts.ts
@@ -79,7 +79,7 @@ export class BoundContract {
   constructor(
     private contract: Contract,
     private contractKeyPair: nacl.SignKeyPair
-  ) {}
+  ) { }
 
   public deploy(args: Deploy.Arg[], paymentAmount: bigint): Deploy {
     return this.contract.deploy(

--- a/explorer/server/.env
+++ b/explorer/server/.env
@@ -12,7 +12,7 @@ FAUCET_CONTRACT_PATH=../contracts/faucet.wasm
 PAYMENT_CONTRACT_PATH=../contracts/standard_payment.wasm
 
 # Got to send some payment for the faucet deploys
-PAYMENT_AMOUNT=1000000
+PAYMENT_AMOUNT=10000000
 
 # Location of a private key we can use for testing.
 FAUCET_ACCOUNT_PRIVATE_KEY_PATH=./test.private.key

--- a/hack/docker/docker-compose.yml
+++ b/hack/docker/docker-compose.yml
@@ -89,6 +89,7 @@ services:
     environment:
       FAUCET_ACCOUNT_PUBLIC_KEY_PATH: /app/keys/public.key
       FAUCET_ACCOUNT_PRIVATE_KEY_PATH: /app/keys/private.key
+      PAYMENT_AMOUNT: 10000000
       CASPER_SERVICE_URL: http://grpcwebproxy:8080
       SERVER_PORT: 8080
       # Not using TLS, Nginx does it.


### PR DESCRIPTION
### Overview
Clarity on DevNet and hack/docker cannot pay for the faucet deploys.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1013

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
There's no option to set the price at all, because it's hardcoded to 10 in the EE, but we'll have to add that too at some point no doubt.