### PR TITLE
EE-767: Convert Preprocessor::deserialize to a standalone fn, clean up

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -340,7 +340,7 @@ where
                     .borrow_mut()
                     .get_contract(correlation_id, Key::URef(mint_reference))?;
                 let (bytes, _, _) = contract.destructure();
-                preprocessor.deserialize(&bytes)?
+                engine_wasm_prep::deserialize(&bytes)?
             };
 
             // For each account...
@@ -605,7 +605,7 @@ where
                     .borrow_mut()
                     .get_contract(correlation_id, stored_contract_key)?;
                 let (ret, _, _) = contract.destructure();
-                let module = preprocessor.deserialize(&ret)?;
+                let module = engine_wasm_prep::deserialize(&ret)?;
                 Ok(module)
             }
             ExecutableDeployItem::StoredContractByName { name, .. } => {
@@ -623,7 +623,7 @@ where
                     .borrow_mut()
                     .get_contract(correlation_id, *stored_contract_key)?;
                 let (ret, _, _) = contract.destructure();
-                let module = preprocessor.deserialize(&ret)?;
+                let module = engine_wasm_prep::deserialize(&ret)?;
                 Ok(module)
             }
             ExecutableDeployItem::StoredContractByURef { uref, .. } => {
@@ -671,7 +671,7 @@ where
                     .borrow_mut()
                     .get_contract(correlation_id, stored_contract_key)?;
                 let (ret, _, _) = contract.destructure();
-                let module = preprocessor.deserialize(&ret)?;
+                let module = engine_wasm_prep::deserialize(&ret)?;
                 Ok(module)
             }
         }
@@ -794,7 +794,7 @@ where
             };
 
             if !self.system_contract_cache.has(&mint_reference) {
-                let module = match preprocessor.deserialize(mint_contract.bytes()) {
+                let module = match engine_wasm_prep::deserialize(mint_contract.bytes()) {
                     Ok(module) => module,
                     Err(error) => return Ok(ExecutionResult::precondition_failure(error.into())),
                 };
@@ -1037,7 +1037,7 @@ where
                     Some(module) => module,
                     None => {
                         let module =
-                            match preprocessor.deserialize(&proof_of_stake_contract.bytes()) {
+                            match engine_wasm_prep::deserialize(&proof_of_stake_contract.bytes()) {
                                 Ok(module) => module,
                                 Err(error) => {
                                     return Ok(ExecutionResult::precondition_failure(error.into()))

--- a/execution-engine/engine-wasm-prep/src/lib.rs
+++ b/execution-engine/engine-wasm-prep/src/lib.rs
@@ -5,29 +5,30 @@ use std::{
     fmt::{self, Display, Formatter},
 };
 
-use parity_wasm::elements::{Error as ParityWasmError, Module};
-use pwasm_utils::{externalize_mem, inject_gas_counter, rules};
-use wasm_costs::WasmCosts;
+use parity_wasm::elements::{self, Module};
+use pwasm_utils::{self, stack_height};
+
+use crate::wasm_costs::WasmCosts;
 
 //NOTE: size of Wasm memory page is 64 KiB
 pub const MEM_PAGES: u32 = 64;
 
 #[derive(Debug)]
 pub enum PreprocessingError {
-    InvalidImportsError(String),
-    NoExportSection,
-    NoImportSection,
     DeserializeError(String),
     OperationForbiddenByGasRules,
     StackLimiterError,
 }
 
+impl From<elements::Error> for PreprocessingError {
+    fn from(error: elements::Error) -> Self {
+        PreprocessingError::DeserializeError(error.description().to_string())
+    }
+}
+
 impl Display for PreprocessingError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            PreprocessingError::InvalidImportsError(error) => write!(f, "Invalid imports error: {}", error),
-            PreprocessingError::NoExportSection => write!(f, "No export section found"),
-            PreprocessingError::NoImportSection => write!(f, "No import section found"),
             PreprocessingError::DeserializeError(error) => write!(f, "Deserialization error: {}", error),
             PreprocessingError::OperationForbiddenByGasRules => write!(f, "Encountered operation forbidden by gas rules. Consult instruction -> metering config map"),
             PreprocessingError::StackLimiterError => write!(f, "Stack limiter error"),
@@ -50,54 +51,17 @@ impl Preprocessor {
     }
 
     pub fn preprocess(&self, module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
-        let deserialized_module = deserialize(module_bytes)?;
-        let ext_mod = externalize_mem(deserialized_module, None, self.mem_pages);
-        let gas_mod = inject_gas_counters(ext_mod, &self.wasm_costs)?;
-        let module =
-            pwasm_utils::stack_height::inject_limiter(gas_mod, self.wasm_costs.max_stack_height)
-                .map_err(|_| PreprocessingError::StackLimiterError)?;
+        let module = deserialize(module_bytes)?;
+        let module = pwasm_utils::externalize_mem(module, None, self.mem_pages);
+        let module = pwasm_utils::inject_gas_counter(module, &self.wasm_costs.as_set())
+            .map_err(|_| PreprocessingError::OperationForbiddenByGasRules)?;
+        let module = stack_height::inject_limiter(module, self.wasm_costs.max_stack_height)
+            .map_err(|_| PreprocessingError::StackLimiterError)?;
         Ok(module)
     }
 }
 
 // Returns a parity Module from bytes without making modifications or limits
 pub fn deserialize(module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
-    let from_parity_err =
-        |err: ParityWasmError| PreprocessingError::DeserializeError(err.description().to_owned());
-    let module =
-        parity_wasm::deserialize_buffer::<Module>(&module_bytes).map_err(from_parity_err)?;
-    Ok(module)
-}
-
-fn gas_rules(wasm_costs: &WasmCosts) -> rules::Set {
-    rules::Set::new(wasm_costs.regular, {
-        let mut vals = ::std::collections::BTreeMap::new();
-        vals.insert(
-            rules::InstructionType::Load,
-            rules::Metering::Fixed(wasm_costs.mem as u32),
-        );
-        vals.insert(
-            rules::InstructionType::Store,
-            rules::Metering::Fixed(wasm_costs.mem as u32),
-        );
-        vals.insert(
-            rules::InstructionType::Div,
-            rules::Metering::Fixed(wasm_costs.div as u32),
-        );
-        vals.insert(
-            rules::InstructionType::Mul,
-            rules::Metering::Fixed(wasm_costs.mul as u32),
-        );
-        vals
-    })
-    .with_grow_cost(wasm_costs.grow_mem)
-    .with_forbidden_floats()
-}
-
-fn inject_gas_counters(
-    module: Module,
-    wasm_costs: &WasmCosts,
-) -> Result<Module, PreprocessingError> {
-    inject_gas_counter(module, &gas_rules(wasm_costs))
-        .map_err(|_| PreprocessingError::OperationForbiddenByGasRules)
+    parity_wasm::deserialize_buffer::<Module>(&module_bytes).map_err(Into::into)
 }

--- a/execution-engine/engine-wasm-prep/src/lib.rs
+++ b/execution-engine/engine-wasm-prep/src/lib.rs
@@ -53,7 +53,7 @@ impl Preprocessor {
     pub fn preprocess(&self, module_bytes: &[u8]) -> Result<Module, PreprocessingError> {
         let module = deserialize(module_bytes)?;
         let module = pwasm_utils::externalize_mem(module, None, self.mem_pages);
-        let module = pwasm_utils::inject_gas_counter(module, &self.wasm_costs.as_set())
+        let module = pwasm_utils::inject_gas_counter(module, &self.wasm_costs.to_set())
             .map_err(|_| PreprocessingError::OperationForbiddenByGasRules)?;
         let module = stack_height::inject_limiter(module, self.wasm_costs.max_stack_height)
             .map_err(|_| PreprocessingError::StackLimiterError)?;

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -36,7 +36,7 @@ pub struct WasmCosts {
 }
 
 impl WasmCosts {
-    pub(crate) fn as_set(&self) -> Set {
+    pub(crate) fn to_set(&self) -> Set {
         let meterings = {
             let mut tmp = BTreeMap::new();
             tmp.insert(InstructionType::Load, Metering::Fixed(self.mem));

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -1,3 +1,7 @@
+use std::collections::BTreeMap;
+
+use pwasm_utils::rules::{InstructionType, Metering, Set};
+
 use contract_ffi::bytesrepr::{self, FromBytes, ToBytes, U32_SIZE};
 
 const NUM_FIELDS: usize = 10;
@@ -29,6 +33,22 @@ pub struct WasmCosts {
     /// Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` /
     /// `opcodes_div`
     pub opcodes_div: u32,
+}
+
+impl WasmCosts {
+    pub(crate) fn as_set(&self) -> Set {
+        let meterings = {
+            let mut tmp = BTreeMap::new();
+            tmp.insert(InstructionType::Load, Metering::Fixed(self.mem));
+            tmp.insert(InstructionType::Store, Metering::Fixed(self.mem));
+            tmp.insert(InstructionType::Div, Metering::Fixed(self.div));
+            tmp.insert(InstructionType::Mul, Metering::Fixed(self.mul));
+            tmp
+        };
+        Set::new(self.regular, meterings)
+            .with_grow_cost(self.grow_mem)
+            .with_forbidden_floats()
+    }
 }
 
 impl ToBytes for WasmCosts {


### PR DESCRIPTION
### Overview
This PR converts `Preprocess::deserialize` to a standalone function.  There is no need for it to be a method, and this helps pave the way for simpler module caching code.  It also does some other cleanup in the `engine_wasm_prep` module.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-767

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
