### PR TITLE
NODE-1004: Add git commit hash to version info.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -186,7 +186,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     override val argType: ArgType.V = ArgType.SINGLE
   }
 
-  version(s"CasperLabs Client ${BuildInfo.version}")
+  version(
+    s"CasperLabs Client ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+  )
   printedName = "casperlabs"
 
   val port =

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -121,7 +121,9 @@ private[configuration] final case class Options private (
 
   val configFile = opt[Path](descr = "Path to the TOML configuration file.")
 
-  version(s"CasperLabs Node ${BuildInfo.version}")
+  version(
+    s"CasperLabs Node ${BuildInfo.version} (${BuildInfo.gitHeadCommit.getOrElse("commit # unknown")})"
+  )
   printedName = "casperlabs"
   banner(
     """


### PR DESCRIPTION
### Overview
@piotr-putit wants to get the git hash for setting up log libraries. Currently this is only available from the logs themselves. The PR adds them to the Scallop `--version` option:

```console
$ ./node/target/universal/stage/bin/casperlabs-node --version
CasperLabs Node 0.9.0 (2207024f342dcde62decd558dcce58c58bb7470d)
$ ./client/target/universal/stage/bin/casperlabs-client --version
CasperLabs Client 0.9.0 (2207024f342dcde62decd558dcce58c58bb7470d)
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1004

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
