### PR TITLE
NODE-983: Add more fine grained timings to the node.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -8,9 +8,7 @@ import io.casperlabs.casper.util.DagOperations
 import io.casperlabs.casper.util.ProtoUtil.weightFromValidatorByDag
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.metrics.Metrics.{MetricsOps, Source}
-import io.casperlabs.models.Weight
-import io.casperlabs.shared.LogSource
+import io.casperlabs.metrics.implicits._
 import io.casperlabs.models.{Message, Weight}
 import io.casperlabs.storage.dag.DagRepresentation
 

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -27,7 +27,7 @@ import io.casperlabs.crypto.Keys
 import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.ipc
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.metrics.Metrics.{MetricsOps, MetricsStreamOps}
+import io.casperlabs.metrics.implicits._
 import io.casperlabs.models.{Message, SmartContractEngineError, Weight}
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -465,7 +465,6 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: BlockStorage: DagSto
                          rank,
                          upgrades
                        )
-                       .timer("computeDeploysCheckpoint")
       } yield {
         if (checkpoint.deploysForBlock.isEmpty) {
           CreateBlockStatus.noNewDeploys

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -19,6 +19,7 @@ import io.casperlabs.crypto.Keys.{PublicKey, Signature}
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.ipc
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Weight
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
@@ -42,7 +43,7 @@ object ValidationImpl {
   def apply[F[_]](implicit ev: ValidationImpl[F]) = ev
 }
 
-class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log: Time]
+class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log: Time: Metrics]
     extends Validation[F] {
   import ValidationImpl.DRIFT
   import ValidationImpl.MAX_TTL

--- a/casper/src/test/scala/io/casperlabs/casper/DeriveValidation.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeriveValidation.scala
@@ -4,7 +4,7 @@ import cats.MonadError
 import cats.mtl.FunctorRaise
 import io.casperlabs.casper.validation.ValidationImpl
 import io.casperlabs.shared.{Log, Time}
-import io.casperlabs.casper.util.CasperLabsProtocolVersions
+import io.casperlabs.metrics.Metrics
 
 object DeriveValidation {
   implicit def deriveValidationImpl[F[_]](
@@ -12,6 +12,7 @@ object DeriveValidation {
       fr: FunctorRaise[F, InvalidBlock],
       log: Log[F],
       mt: MonadError[F, Throwable],
-      time: Time[F]
+      time: Time[F],
+      metrics: Metrics[F]
   ) = new ValidationImpl[F]
 }

--- a/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ManyValidatorsTest.scala
@@ -17,6 +17,7 @@ import scala.util.Random
 
 @silent("deprecated")
 class ManyValidatorsTest extends FlatSpec with Matchers with BlockGenerator with StorageFixture {
+
   "Show blocks" should "be processed quickly for a node with 300 validators" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage =>
       val bonds = Seq

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -15,6 +15,7 @@ import io.casperlabs.casper.util.execengine.ExecEngineUtil.{computeDeploysCheckp
 import io.casperlabs.casper.util.execengine.{DeploysCheckpoint, ExecEngineUtil}
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.Keys
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.p2p.EffectsTestInstances.LogicalTime
 import io.casperlabs.shared.{Log, Time}
 import io.casperlabs.smartcontracts.ExecutionEngineService
@@ -29,7 +30,7 @@ import scala.language.higherKinds
 object BlockGenerator {
   implicit val timeEff = new LogicalTime[Task]()
 
-  def updateChainWithBlockStateUpdate[F[_]: Sync: BlockStorage: IndexedDagStorage: DeployStorage: ExecutionEngineService: Log](
+  def updateChainWithBlockStateUpdate[F[_]: Sync: BlockStorage: IndexedDagStorage: DeployStorage: ExecutionEngineService: Log: Metrics](
       id: Int,
       genesis: Block
   ): F[Block] =
@@ -66,7 +67,7 @@ object BlockGenerator {
       IndexedDagStorage[F].inject(id, updatedBlock)
   }
 
-  private[casper] def computeBlockCheckpointFromDeploys[F[_]: Sync: BlockStorage: DeployStorage: Log: ExecutionEngineService](
+  private[casper] def computeBlockCheckpointFromDeploys[F[_]: Sync: BlockStorage: DeployStorage: Log: ExecutionEngineService: Metrics](
       b: Block,
       genesis: Block,
       dag: DagRepresentation[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -316,7 +316,7 @@ object HashSetCasperTestNode {
     if (x.length < length) Array.fill(length - x.length)(0.toByte) ++ x
     else x
 
-  def makeValidation[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log: Time]
+  def makeValidation[F[_]: MonadThrowable: FunctorRaise[?[_], InvalidBlock]: Log: Time: Metrics]
       : Validation[F] =
     new ValidationImpl[F] {
       // Tests are not signing the deploys.

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecutionEngineServiceStub.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecutionEngineServiceStub.scala
@@ -5,6 +5,7 @@ import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper
+import io.casperlabs.casper.CasperMetricsSource
 import io.casperlabs.casper.consensus.state.{Unit => _, _}
 import io.casperlabs.casper.consensus.{Block, Bond}
 import io.casperlabs.casper.util.{CasperLabsProtocolVersions, ProtoUtil}
@@ -12,6 +13,7 @@ import io.casperlabs.casper.util.execengine.ExecEngineUtil.StateHash
 import io.casperlabs.casper.validation.{Validation, ValidationImpl}
 import io.casperlabs.crypto.Keys.PublicKey
 import io.casperlabs.ipc._
+import io.casperlabs.metrics.Metrics.MetricsNOP
 import io.casperlabs.models.SmartContractEngineError
 import io.casperlabs.shared.{Log, Time}
 import io.casperlabs.smartcontracts.ExecutionEngineService
@@ -36,6 +38,7 @@ object ExecutionEngineServiceStub {
       override def nanoTime: F[Long]                        = 0L.pure[F]
       override def sleep(duration: FiniteDuration): F[Unit] = Sync[F].unit
     }
+    implicit val metrics    = new MetricsNOP[F]
     implicit val validation = new ValidationImpl[F]
     (for {
       parents <- ProtoUtil.unsafeGetParents[F](b)

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -137,7 +137,7 @@ package object gossiping {
                         )
 
       implicit0(deploySelection: DeploySelection[F]) <- Resource.pure[F, DeploySelection[F]](
-                                                         DeploySelection.create[F](
+                                                         DeploySelection.createMetered[F](
                                                            conf.casper.maxBlockSizeBytes
                                                          )
                                                        )

--- a/shared/src/main/scala/io/casperlabs/metrics/Metrics.scala
+++ b/shared/src/main/scala/io/casperlabs/metrics/Metrics.scala
@@ -68,7 +68,21 @@ object Metrics {
   sealed trait SourceTag
   type Source = String @@ SourceTag
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
-  private def Source(name: String): Source         = name.asInstanceOf[Source]
+  private def Source(name: String): Source = name.asInstanceOf[Source]
+  implicit class SourceOps(base: Source) {
+    def /(path: String): Source = Source(base, path)
+  }
   def Source(prefix: Source, name: String): Source = Source(s"$prefix.$name")
   val BaseSource: Source                           = Source("casperlabs")
+
+  implicit class MetricsOps[F[_], A](fa: F[A])(implicit M: Metrics[F], ev: Metrics.Source) {
+    def timer(name: String): F[A] = M.timer(name)(fa)
+  }
+
+  implicit class MetricsStreamOps[F[_], A](fas: fs2.Stream[F, A])(
+      implicit M: Metrics[F],
+      ev: Metrics.Source
+  ) {
+    def timerS(name: String): fs2.Stream[F, A] = M.timerS(name)(fas)
+  }
 }

--- a/shared/src/main/scala/io/casperlabs/metrics/Metrics.scala
+++ b/shared/src/main/scala/io/casperlabs/metrics/Metrics.scala
@@ -74,15 +74,4 @@ object Metrics {
   }
   def Source(prefix: Source, name: String): Source = Source(s"$prefix.$name")
   val BaseSource: Source                           = Source("casperlabs")
-
-  implicit class MetricsOps[F[_], A](fa: F[A])(implicit M: Metrics[F], ev: Metrics.Source) {
-    def timer(name: String): F[A] = M.timer(name)(fa)
-  }
-
-  implicit class MetricsStreamOps[F[_], A](fas: fs2.Stream[F, A])(
-      implicit M: Metrics[F],
-      ev: Metrics.Source
-  ) {
-    def timerS(name: String): fs2.Stream[F, A] = M.timerS(name)(fas)
-  }
 }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -241,7 +241,7 @@ object ExecutionEngineService {
 }
 
 object GrpcExecutionEngineService {
-  private implicit val EngineMetricsSource: Metrics.Source =
+  implicit val EngineMetricsSource: Metrics.Source =
     Metrics.Source(Metrics.BaseSource, "engine")
 
   private def initializeMetrics[F[_]: Metrics] =


### PR DESCRIPTION
### Overview
Adds couple of new timers to the node/consensus code.
### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-983

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The tree/structure of metrics is:
```
    • createBlock
        ◦ estimator
            ▪ calculateLCA
            ▪ lmdScoring
            ▪ forkChoiceTip
            ▪ tipsOfLatestMessages
        ◦ mergeTipsEffects
        ◦ requeueOrphanedDeploys
            ▪ readProcessedHashes (metered as part of storage metrics)
            ▪ filterDeploysNotInPast
            ▪ markAsPending (metered as part of storage metrics)
        ◦ remainingDeploys
            ▪ readPendingHashesAndHeaders (metered as part of storage metrics)
            ▪ filterDeploysNotInPast
            ▪ markAsDiscarded (metered as part of storage metrics)
        ◦ createProposal
            ▪ computeDeploysCheckpoint
                • selectDeploys
                • commit

    • validateBlock
        ◦ addBlock
            ▪ validateAndAddBlock
            ▪ updateLastFinalizedBlock
            ▪ removeFinalizedDeploys
```
