### PR TITLE
NODE-935: --deploy-path in print-deploy is optional.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -399,7 +399,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val deployPath =
       opt[File](
-        required = true,
+        required = false,
         descr = "Path to the deploy file.",
         validate = fileCheck,
         short = 'i'


### PR DESCRIPTION
### Overview
Noticed that `casperlabs-client print-deploy` doesn't work without the `--deploy-path` option, so you can't pipe data to it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-935

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
