### PR TITLE
NODE-995: Add busy timeout to transactors.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -93,7 +93,7 @@ package object effects {
       transactEC: ExecutionContext,
       serverDataDir: Path
   ): Resource[Task, (Transactor[Task], Transactor[Task])] = {
-    def mkConfig(poolSize: Int) = {
+    def mkConfig(poolSize: Int, foreignKeys: Boolean) = {
       val config = new HikariConfig()
       config.setDriverClassName("org.sqlite.JDBC")
       config.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
@@ -105,29 +105,24 @@ package object effects {
       // * - the transaction will `commit` on success and `rollback` on failure;
       // Setting it to false to avoid seeing resets in the log every time.
       config.setAutoCommit(false)
+      // Foreign keys support must be enabled explicitly in SQLite; it doesn't affect read logic though.
+      // https://www.sqlite.org/foreignkeys.html#fk_enable
+      config.addDataSourceProperty("foreign_keys", foreignKeys.toString)
+      // NOTE: We still saw at least one SQLITE_BUSY error in testing, sepsite the 1 sized pool.
+      // NODE-1019 will add logging, maybe we'll learn more.
+      config.addDataSourceProperty("busy_timeout", "5000")
       config
     }
-
-    def addPragma(pragma: doobie.util.fragment.Fragment)(xa: Transactor[Task]) =
-      Transactor.before.set(xa, pragma.update.run.void >> Transactor.before.get(xa))
 
     // Using a connection pool with maximum size of 1 for writers because with the default settings we got SQLITE_BUSY errors.
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
-    val writeXaconfig = mkConfig(poolSize = 1)
+    val writeXaconfig = mkConfig(poolSize = 1, foreignKeys = true)
 
     // Using a separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection
     // preventing acquiring a connection in other places if we use a connection pool with size of 1.
-    val readXaconfig = mkConfig(poolSize = 10)
-
-    // NOTE: We still saw at least one SQLITE_BUSY error in testing, sepsite the 1 sized pool.
-    // NODE-1019 will add logging, maybe we'll learn more.
-    val pragmaBusyTimeout = fr"PRAGMA busy_timeout = 5000;"
-
-    // Foreign keys support must be enabled explicitly in SQLite; it doesn't affect read logic though.
-    // https://www.sqlite.org/foreignkeys.html#fk_enable
-    val pragmaForeignKeys = fr"PRAGMA foreign_keys = ON;"
+    val readXaconfig = mkConfig(poolSize = 10, foreignKeys = false)
 
     // Hint: Use config.setLeakDetectionThreshold(10000) to detect connection leaking
     for {
@@ -137,14 +132,12 @@ package object effects {
                     connectEC,
                     Blocker.liftExecutionContext(transactEC)
                   )
-                  .map(addPragma(pragmaForeignKeys ++ pragmaBusyTimeout))
       readXa <- HikariTransactor
                  .fromHikariConfig[Task](
                    readXaconfig,
                    connectEC,
                    Blocker.liftExecutionContext(transactEC)
                  )
-                 .map(addPragma(pragmaBusyTimeout))
     } yield (writeXa, readXa)
   }
 }


### PR DESCRIPTION
### Overview
At least one integration test failed even with the 1 writer 10 reader pool configuration with SQLITE_BUSY. The busy error should only affect writes, of which we have 1 connection which is exclusively handed out by the pool, so it's quite baffling what other connection there might be, except the readers. The PR adds a 5 second busy timeout to both reads and writes.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-995

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
