### PR TITLE
EE-673: Remove Deploy from ipc.proto

### DIFF
--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -40,20 +40,6 @@ message Bond {
     io.casperlabs.casper.consensus.state.BigInt stake = 2;
 }
 
-message Deploy {
-    reserved 5; // motes in payment
-    reserved 7; // motes in payment
-    // Public key of the account which is the context of the execution.
-    bytes address = 1; // length 32 bytes
-    DeployCode session = 3;
-    DeployCode payment = 4;
-    uint64 gas_price = 6; // in units of Mote / Gas
-    // Public keys used to sign this deploy, to be checked against the keys
-    // associated with the account.
-    repeated bytes authorization_keys = 8;
-    bytes deploy_hash = 9;
-}
-
 message DeployItem {
     reserved 5; // motes in payment
     reserved 7; // nonce


### PR DESCRIPTION
### Overview
I noticed the `Deploy` message is still around, which is the original version of `DeployItem`. I guess it should have been removed in https://github.com/CasperLabs/CasperLabs/pull/1187

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-673

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
