### PR TITLE
NODE-990: Handle payment_amount in Python Client API in addition to CLI.

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -443,6 +443,7 @@ class CasperLabsClient:
         public_key: str = None,
         session_args: bytes = None,
         payment_args: bytes = None,
+        payment_amount: int = None,
         payment_hash: bytes = None,
         payment_name: str = None,
         payment_uref: bytes = None,
@@ -461,6 +462,12 @@ class CasperLabsClient:
 
         if from_addr and len(from_addr) != 32:
             raise Exception(f"from_addr must be 32 bytes")
+
+        if payment_amount:
+            payment_args = ABI.args([ABI.big_int("amount", int(payment_amount))])
+            # Unless one of payment* options supplied use bundled standard-payment
+            if not any((payment, payment_name, payment_hash, payment_uref)):
+                payment = bundled_contract("standard_payment.wasm")
 
         session_options = (session, session_hash, session_name, session_uref)
         payment_options = (payment, payment_hash, payment_name, payment_uref)
@@ -526,6 +533,7 @@ class CasperLabsClient:
         private_key: str = None,
         session_args: bytes = None,
         payment_args: bytes = None,
+        payment_amount: int = None,
         payment_hash: bytes = None,
         payment_name: str = None,
         payment_uref: bytes = None,
@@ -576,6 +584,7 @@ class CasperLabsClient:
             public_key=public_key,
             session_args=session_args,
             payment_args=payment_args,
+            payment_amount=payment_amount,
             payment_hash=payment_hash,
             payment_name=payment_name,
             payment_uref=payment_uref,
@@ -595,7 +604,7 @@ class CasperLabsClient:
 
     @api
     def send_deploy(self, deploy):
-        # TODO: Deploy returns Empty, error handing via exceptions, apparently,
+        # TODO: Deploy returns Empty, error handling via exceptions, apparently,
         # so no point in returning it.
         return self.casperService.Deploy(casper.DeployRequest(deploy=deploy))
 

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import pytest
 import time
@@ -485,6 +486,26 @@ def test_deploy_with_args(one_node_network, genesis_public_signing_key):
 
     for blockInfo in client.showBlocks(10):
         assert blockInfo.status.stats.block_size_bytes > 0
+
+
+def test_python_api_payment_amount(one_node_network):
+    """
+    Test Python Client API deploy handles payment_amount parameter.
+    """
+    node = one_node_network.docker_nodes[0]
+    client = node.p_client.client
+    account = node.test_account
+    client.deploy(
+        from_addr=account.public_key_hex,
+        public_key=account.public_key_path,
+        private_key=account.private_key_path,
+        session=os.path.join("resources", Contract.HELLO_NAME_DEFINE),
+        payment_amount=10000000,
+    )
+    block_hash = client.propose().block_hash.hex()
+    for deployInfo in client.showDeploys(block_hash):
+        if deployInfo.is_error:
+            raise Exception(f"Deploy failed: {deployInfo.error_message}")
 
 
 # Python CLI #


### PR DESCRIPTION
### Overview
This PR adds parameters `payment_amount` to Python API functions `deploy` and `make-deploy`.
This is a convenience parameter that allows user to pass payment amount in motes as an integer rather than ABI args object (with `session_args`). If `payment_amount` is present but no payment contract then `standard_payment.wasm` bundled with the client will be used.

Python CLI `deploy` command has been handling parameter `---payment-amount` for some time but equivalent API function did not till now.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-990

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
