### PR TITLE
NODE-998: Fix race condition in Python client deploy args serialisation to JSON

### DIFF
--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -208,7 +208,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.5.1",
+    version="0.5.2",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",

--- a/integration-testing/test/test_args.py
+++ b/integration-testing/test/test_args.py
@@ -4,23 +4,61 @@ import json
 from casperlabs_client import ABI
 
 
-def test_args_from_json():
-    account = bytes(range(32))
-    long_value = 123456
-    big_int_value = 123456789012345678901234567890
-    args = [
-        {"name": "amount", "value": {"long_value": long_value}},
-        {"name": "account", "value": {"bytes_value": account.hex()}},
-        {"name": "purse_id", "value": {"optional_value": {}}},
-        {
-            "name": "number",
-            "value": {"big_int": {"value": f"{big_int_value}", "bit_width": 512}},
-        },
-    ]
+account = bytes(range(32))
+long_value = 123456
+big_int_value = 123456789012345678901234567890
 
-    json_str = json.dumps(args)
+
+ARGS = [
+    {"name": "amount", "value": {"long_value": str(long_value)}},
+    {"name": "account", "value": {"bytes_value": account.hex()}},
+    {"name": "purse_id", "value": {"optional_value": {}}},
+    {
+        "name": "number",
+        "value": {"big_int": {"value": f"{big_int_value}", "bit_width": 512}},
+    },
+    {"name": "my_bytes", "value": {"bytes_value": account.hex()}},
+    {"name": "my_hash", "value": {"key": {"hash": {"hash": account.hex()}}}},
+    {"name": "my_address", "value": {"key": {"address": {"account": account.hex()}}}},
+    {
+        "name": "my_uref",
+        "value": {
+            "key": {"uref": {"uref": account.hex(), "access_rights": "READ_ADD"}}
+        },
+    },
+    {"name": "my_local", "value": {"key": {"local": {"hash": account.hex()}}}},
+]
+
+
+def test_args_from_json():
+    json_str = json.dumps(ARGS)
     args = ABI.args_from_json(json_str)
     assert args[0] == ABI.long_value("amount", long_value)
     assert args[1] == ABI.account("account", account)
     assert args[2] == ABI.optional_value("purse_id", None)
     assert args[3] == ABI.big_int("number", big_int_value)
+    assert args[4] == ABI.bytes_value("my_bytes", account)
+
+    assert args[5] == ABI.key_hash("my_hash", account)
+    assert args[6] == ABI.key_address("my_address", account)
+    assert args[7] == ABI.key_uref("my_uref", account, access_rights=5)
+    assert args[8] == ABI.key_local("my_local", account)
+
+
+def test_args_to_json():
+    args = [
+        ABI.long_value("amount", long_value),
+        ABI.account("account", account),
+        ABI.optional_value("purse_id", None),
+        ABI.big_int("number", big_int_value),
+        ABI.bytes_value("my_bytes", account),
+        ABI.key_hash("my_hash", account),
+        ABI.key_address("my_address", account),
+        ABI.key_uref("my_uref", account, access_rights=5),
+        ABI.key_local("my_local", account),
+    ]
+    json_str1 = json.dumps(ARGS, ensure_ascii=True, sort_keys=True, indent=2)
+    json_str2 = ABI.args_to_json(
+        ABI.args(args), ensure_ascii=True, sort_keys=True, indent=2
+    )
+    assert json_str1 == json_str2


### PR DESCRIPTION
### Overview
This PR fixes a race condition in Python protobuf serialisation to JSON format. 

Customization to print base16 binary data was initiaially implemented by mocking functions in `base64` module, which introduced a potential race condition. This has been removed and replaced with a clean conversion code which is thread safe.

Also, added few missing functions for constructing deploy args (in ABI class).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-998

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
