### PR TITLE
EE-752: Move query logic into core

### DIFF
--- a/execution-engine/engine-core/src/engine_state/query.rs
+++ b/execution-engine/engine-core/src/engine_state/query.rs
@@ -1,0 +1,49 @@
+use crate::tracking_copy::TrackingCopyQueryResult;
+use contract_ffi::{key::Key, value::Value};
+use engine_shared::newtypes::Blake2bHash;
+
+pub enum QueryResult {
+    RootNotFound,
+    ValueNotFound(String),
+    Success(Value),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueryRequest {
+    state_hash: Blake2bHash,
+    key: Key,
+    path: Vec<String>,
+}
+
+impl QueryRequest {
+    pub fn new(state_hash: Blake2bHash, key: Key, path: Vec<String>) -> Self {
+        QueryRequest {
+            state_hash,
+            key,
+            path,
+        }
+    }
+
+    pub fn state_hash(&self) -> Blake2bHash {
+        self.state_hash
+    }
+
+    pub fn key(&self) -> Key {
+        self.key
+    }
+
+    pub fn path(&self) -> &[String] {
+        &self.path
+    }
+}
+
+impl From<TrackingCopyQueryResult> for QueryResult {
+    fn from(tracking_copy_query_result: TrackingCopyQueryResult) -> Self {
+        match tracking_copy_query_result {
+            TrackingCopyQueryResult::ValueNotFound(full_path) => {
+                QueryResult::ValueNotFound(full_path)
+            }
+            TrackingCopyQueryResult::Success(value) => QueryResult::Success(value),
+        }
+    }
+}

--- a/execution-engine/engine-core/src/tracking_copy/ext.rs
+++ b/execution-engine/engine-core/src/tracking_copy/ext.rs
@@ -9,7 +9,7 @@ use engine_storage::global_state::StateReader;
 
 use crate::{
     execution,
-    tracking_copy::{QueryResult, TrackingCopy},
+    tracking_copy::{TrackingCopy, TrackingCopyQueryResult},
 };
 
 pub trait TrackingCopyExt<R> {
@@ -82,12 +82,11 @@ where
             .query(correlation_id, balance_mapping_key, &[])
             .map_err(Into::into)?
         {
-            QueryResult::Success(Value::Key(key)) => Ok(key),
-            QueryResult::Success(other) => Err(execution::Error::TypeMismatch(TypeMismatch::new(
-                "Value::Key".to_string(),
-                other.type_string(),
-            ))),
-            QueryResult::ValueNotFound(msg) => Err(execution::Error::URefNotFound(msg)),
+            TrackingCopyQueryResult::Success(Value::Key(key)) => Ok(key),
+            TrackingCopyQueryResult::Success(other) => Err(execution::Error::TypeMismatch(
+                TypeMismatch::new("Value::Key".to_string(), other.type_string()),
+            )),
+            TrackingCopyQueryResult::ValueNotFound(msg) => Err(execution::Error::URefNotFound(msg)),
         }
     }
 
@@ -101,12 +100,11 @@ where
             Err(_) => return Err(execution::Error::KeyNotFound(key)),
         };
         match query_result {
-            QueryResult::Success(Value::UInt512(balance)) => Ok(Motes::new(balance)),
-            QueryResult::Success(other) => Err(execution::Error::TypeMismatch(TypeMismatch::new(
-                "Value::UInt512".to_string(),
-                other.type_string(),
-            ))),
-            QueryResult::ValueNotFound(_) => Err(execution::Error::KeyNotFound(key)),
+            TrackingCopyQueryResult::Success(Value::UInt512(balance)) => Ok(Motes::new(balance)),
+            TrackingCopyQueryResult::Success(other) => Err(execution::Error::TypeMismatch(
+                TypeMismatch::new("Value::UInt512".to_string(), other.type_string()),
+            )),
+            TrackingCopyQueryResult::ValueNotFound(_) => Err(execution::Error::KeyNotFound(key)),
         }
     }
 

--- a/execution-engine/engine-core/src/tracking_copy/mod.rs
+++ b/execution-engine/engine-core/src/tracking_copy/mod.rs
@@ -22,7 +22,7 @@ pub use self::ext::TrackingCopyExt;
 use self::meter::{heap_meter::HeapSize, Meter};
 
 #[derive(Debug)]
-pub enum QueryResult {
+pub enum TrackingCopyQueryResult {
     Success(Value),
     ValueNotFound(String),
 }
@@ -227,9 +227,9 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
         correlation_id: CorrelationId,
         base_key: Key,
         path: &[String],
-    ) -> Result<QueryResult, R::Error> {
+    ) -> Result<TrackingCopyQueryResult, R::Error> {
         match self.read(correlation_id, &base_key)? {
-            None => Ok(QueryResult::ValueNotFound(self.error_path_msg(
+            None => Ok(TrackingCopyQueryResult::ValueNotFound(self.error_path_msg(
                 base_key,
                 path,
                 "".to_owned(),
@@ -269,8 +269,8 @@ impl<R: StateReader<Key, Value>> TrackingCopy<R> {
                 );
 
                 match result {
-                    Ok(value) => Ok(QueryResult::Success(value)),
-                    Err(Ok((i, s))) => Ok(QueryResult::ValueNotFound(
+                    Ok(value) => Ok(TrackingCopyQueryResult::Success(value)),
+                    Err(Ok((i, s))) => Ok(TrackingCopyQueryResult::ValueNotFound(
                         self.error_path_msg(base_key, path, s, i),
                     )),
                     Err(Err(err)) => Err(err),

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -15,7 +15,9 @@ use contract_ffi::{
 use engine_shared::{newtypes::CorrelationId, transform::Transform};
 use engine_storage::global_state::{in_memory::InMemoryGlobalState, StateProvider, StateReader};
 
-use super::{meter::count_meter::Count, AddResult, QueryResult, TrackingCopy, TrackingCopyCache};
+use super::{
+    meter::count_meter::Count, AddResult, TrackingCopy, TrackingCopyCache, TrackingCopyQueryResult,
+};
 use crate::engine_state::op::Op;
 
 struct CountingDb {
@@ -289,7 +291,7 @@ proptest! {
         let view = gs.checkout(root_hash).unwrap().unwrap();
         let mut tc = TrackingCopy::new(view);
         let empty_path = Vec::new();
-        if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, k, &empty_path) {
+        if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, k, &empty_path) {
             assert_eq!(v, result);
         } else {
             panic!("Query failed when it should not have!");
@@ -297,7 +299,7 @@ proptest! {
 
         if missing_key != k {
             let result = tc.query(correlation_id, missing_key, &empty_path);
-            assert_matches!(result, Ok(QueryResult::ValueNotFound(_)));
+            assert_matches!(result, Ok(TrackingCopyQueryResult::ValueNotFound(_)));
         }
     }
 
@@ -323,7 +325,7 @@ proptest! {
         let view = gs.checkout(root_hash).unwrap().unwrap();
         let mut tc = TrackingCopy::new(view);
         let path = vec!(name.clone());
-        if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, contract_key, &path) {
+        if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, contract_key, &path) {
             assert_eq!(v, result);
         } else {
             panic!("Query failed when it should not have!");
@@ -331,7 +333,7 @@ proptest! {
 
         if missing_name != name {
             let result = tc.query(correlation_id, contract_key, &[missing_name]);
-            assert_matches!(result, Ok(QueryResult::ValueNotFound(_)));
+            assert_matches!(result, Ok(TrackingCopyQueryResult::ValueNotFound(_)));
         }
     }
 
@@ -365,7 +367,7 @@ proptest! {
         let view = gs.checkout(root_hash).unwrap().unwrap();
         let mut tc = TrackingCopy::new(view);
         let path = vec!(name.clone());
-        if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
+        if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
             assert_eq!(v, result);
         } else {
             panic!("Query failed when it should not have!");
@@ -373,7 +375,7 @@ proptest! {
 
         if missing_name != name {
             let result = tc.query(correlation_id, account_key, &[missing_name]);
-            assert_matches!(result, Ok(QueryResult::ValueNotFound(_)));
+            assert_matches!(result, Ok(TrackingCopyQueryResult::ValueNotFound(_)));
         }
     }
 
@@ -417,7 +419,7 @@ proptest! {
         let view = gs.checkout(root_hash).unwrap().unwrap();
         let mut tc = TrackingCopy::new(view);
         let path = vec!(contract_name, state_name);
-        if let Ok(QueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
+        if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
             assert_eq!(v, result);
         } else {
             panic!("Query failed when it should not have!");

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -23,6 +23,7 @@ use engine_core::{
         execution_result::ExecutionResult,
         genesis::{GenesisAccount, GenesisConfig},
         op::Op,
+        query::QueryRequest,
         upgrade::UpgradeConfig,
         Error as EngineError, RootNotFound,
     },
@@ -32,6 +33,7 @@ use engine_core::{
 use engine_shared::{
     additive_map::AdditiveMap,
     motes::Motes,
+    newtypes::BLAKE2B_DIGEST_LENGTH,
     transform::{self, TypeMismatch},
 };
 use engine_wasm_prep::wasm_costs::WasmCosts;
@@ -47,12 +49,13 @@ fn transform_write(v: contract_ffi::value::Value) -> Result<transform::Transform
 
 #[derive(Debug)]
 pub enum MappingError {
-    InvalidHashLength { expected: usize, actual: usize },
+    InvalidStateHashLength { expected: usize, actual: usize },
     InvalidPublicKeyLength { expected: usize, actual: usize },
     InvalidDeployHashLength { expected: usize, actual: usize },
     ParsingError(ParsingError),
     InvalidStateHash(String),
     MissingPayload,
+    TryFromSliceError,
 }
 
 impl MappingError {
@@ -77,7 +80,7 @@ impl From<ParsingError> for MappingError {
 impl From<MappingError> for engine_state::Error {
     fn from(error: MappingError) -> Self {
         match error {
-            MappingError::InvalidHashLength { expected, actual } => {
+            MappingError::InvalidStateHashLength { expected, actual } => {
                 engine_state::Error::InvalidHashLength { expected, actual }
             }
             _ => engine_state::Error::DeployError,
@@ -88,7 +91,7 @@ impl From<MappingError> for engine_state::Error {
 impl Display for MappingError {
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
         match self {
-            MappingError::InvalidHashLength { expected, actual } => write!(
+            MappingError::InvalidStateHashLength { expected, actual } => write!(
                 f,
                 "Invalid hash length: expected {}, actual {}",
                 expected, actual
@@ -108,6 +111,7 @@ impl Display for MappingError {
             }
             MappingError::InvalidStateHash(message) => write!(f, "Invalid hash: {}", message),
             MappingError::MissingPayload => write!(f, "Missing payload"),
+            MappingError::TryFromSliceError => write!(f, "Unable to convert from slice"),
         }
     }
 }
@@ -1111,6 +1115,35 @@ impl TryFrom<ipc::UpgradeRequest> for UpgradeConfig {
             wasm_costs,
             activation_point,
         ))
+    }
+}
+
+impl TryFrom<ipc::QueryRequest> for engine_state::query::QueryRequest {
+    type Error = MappingError;
+
+    fn try_from(query_request: ipc::QueryRequest) -> Result<Self, Self::Error> {
+        let state_hash = {
+            let state_hash = query_request.get_state_hash();
+            let length = state_hash.len();
+            if length != BLAKE2B_DIGEST_LENGTH {
+                return Err(MappingError::InvalidStateHashLength {
+                    expected: BLAKE2B_DIGEST_LENGTH,
+                    actual: length,
+                });
+            }
+            state_hash
+                .try_into()
+                .map_err(|_| MappingError::TryFromSliceError)?
+        };
+
+        let key = query_request
+            .get_base_key()
+            .try_into()
+            .map_err(MappingError::ParsingError)?;
+
+        let path = query_request.get_path();
+
+        Ok(QueryRequest::new(state_hash, key, path.to_vec()))
     }
 }
 

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -718,7 +718,7 @@ where
             .engine_state
             .query(RequestOptions::new(), query_request)
             .wait_drop_metadata()
-            .expect("should query");
+            .expect("should get query response");
 
         if query_response.has_success() {
             query_response.get_success().try_into().ok()

--- a/execution-engine/engine-tests/src/test/metrics.rs
+++ b/execution-engine/engine-tests/src/test/metrics.rs
@@ -1,6 +1,5 @@
 use lazy_static::lazy_static;
 
-use contract_ffi::key::Key;
 use engine_core::engine_state::EngineConfig;
 use engine_shared::{
     logging::{
@@ -29,54 +28,6 @@ fn setup() {
 
 lazy_static! {
     static ref LOG_SETTINGS: LogSettings = get_log_settings(LogLevel::Debug);
-}
-
-#[test]
-fn should_query_with_metrics() {
-    setup();
-    let correlation_id = CorrelationId::new();
-    let mocked_account = test_utils::mocked_account(test_support::MOCKED_ACCOUNT_ADDRESS);
-    let (global_state, root_hash) =
-        InMemoryGlobalState::from_pairs(correlation_id, &mocked_account).unwrap();
-    let engine_config = EngineConfig::new();
-    let result =
-        InMemoryWasmTestBuilder::new(global_state, engine_config, root_hash.to_vec()).finish();
-
-    let _result = result
-        .builder()
-        .query(
-            None,
-            Key::Account(test_support::MOCKED_ACCOUNT_ADDRESS),
-            &[],
-        )
-        .expect("should query");
-
-    let log_items = BUFFERED_LOGGER
-        .extract_correlated(&correlation_id.to_string())
-        .expect("log items expected");
-
-    assert!(!log_items.is_empty());
-    for log_item in log_items {
-        assert!(
-            log_item
-                .properties
-                .contains_key(&"correlation_id".to_string()),
-            "should have correlation_id"
-        );
-
-        let matched_correlation_id = log_item
-            .properties
-            .get(&"correlation_id".to_string())
-            .expect("should have correlation id value");
-
-        assert_eq!(
-            matched_correlation_id,
-            &correlation_id.to_string(),
-            "correlation_id should match"
-        );
-
-        assert_eq!(log_item.log_level, "Metric", "expected Metric");
-    }
 }
 
 #[test]


### PR DESCRIPTION
This PR refactors the logic in the ipc_grpc::ExecutionEngineService `query` handler, pushing essential business logic and tracking_copy access into engine_core.

https://casperlabs.atlassian.net/browse/EE-752

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned for review.