### PR TITLE
NODE-1034: abstractMerge filters out redundant parents from output list

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -405,7 +405,10 @@ object ExecEngineUtil {
         // The effect we return is the one which would be applied onto the first parent's
         // post-state, so we do not include the first parent in the effect.
         (chosenParents, _, nonFirstEffect) = chosen
-        blocks                             = chosenParents.map(i => candidates(i))
+        blocks = chosenParents
+          .map(i => candidates(i))
+          // we only keep blocks which are not related in any way to other candidates
+          .filter(block => uncommonAncestors(block).size == 1)
       } yield MergeResult.result[T, A](blocks.head, nonFirstEffect, blocks.tail)
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -474,12 +474,14 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
 
     implicit val order: Ordering[OpDagNode] = ExecEngineUtilTest.opDagNodeOrder
     val allBlocks                           = Vector(j, i, h, g, f, e, d, c, b, a)
-    val result1                             = OpDagNode.merge(allBlocks)
-    val result2                             = OpDagNode.merge(Vector(j, i))
+    val result1                             = OpDagNode.merge(allBlocks) // includes many redundant parents in input
+    val result2                             = OpDagNode.merge(Vector(j, i)) // includes only DAG tips
 
     val nonFirstEffect = Vector('a', 'c', 'd', 'f', 'g', 'i').map(ops.apply).reduce(_ + _)
 
+    // output does not include any redundant parents
     result1 shouldBe ((nonFirstEffect, Vector(j, i)))
+    // output is the same as if the input had only included the DAG tips
     result2 shouldBe result1
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -436,6 +436,52 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
     result3 shouldBe ((nonFirstEffect3, Vector(k, j)))
     result4 shouldBe result3
   }
+
+  it should "filter redundant parents from the output list" in {
+    /*
+     * The DAG looks like:
+     *       i     j
+     *     /  \    |
+     *     f   g   h
+     *    /\    \ /
+     *    c d    e
+     *     \/    |
+     *     a     b
+     *      \    /
+     *      genesis
+     */
+
+    val genesis = OpDagNode.genesis(Map(1 -> Op.Read))
+    val ops: Map[Char, OpMap[Int]] = ('a' to 'j').zipWithIndex
+      .map {
+        case (char, index) => char -> Map(index -> Op.Write)
+      }
+      .toMap
+      .updated('a', Map(100 -> Op.Write)) // a, d, f all update the same key, but are sequential
+      .updated('d', Map(100 -> Op.Write))
+      .updated('f', Map(100 -> Op.Write))
+
+    val a = OpDagNode.withParents(ops('a'), List(genesis))
+    val b = OpDagNode.withParents(ops('b'), List(genesis))
+    val c = OpDagNode.withParents(ops('c'), List(a))
+    val d = OpDagNode.withParents(ops('d'), List(a))
+    val e = OpDagNode.withParents(ops('e'), List(b))
+    val f = OpDagNode.withParents(ops('f'), List(c, d))
+    val g = OpDagNode.withParents(ops('g'), List(e))
+    val h = OpDagNode.withParents(ops('h'), List(e))
+    val i = OpDagNode.withParents(ops('i'), List(f, g))
+    val j = OpDagNode.withParents(ops('j'), List(h))
+
+    implicit val order: Ordering[OpDagNode] = ExecEngineUtilTest.opDagNodeOrder
+    val allBlocks                           = Vector(j, i, h, g, f, e, d, c, b, a)
+    val result1                             = OpDagNode.merge(allBlocks)
+    val result2                             = OpDagNode.merge(Vector(j, i))
+
+    val nonFirstEffect = Vector('a', 'c', 'd', 'f', 'g', 'i').map(ops.apply).reduce(_ + _)
+
+    result1 shouldBe ((nonFirstEffect, Vector(j, i)))
+    result2 shouldBe result1
+  }
 }
 
 object ExecEngineUtilTest {


### PR DESCRIPTION
### Overview
Optimization to the merge logic where it filters out redundant parents. This is important because the planned new fork-choice rule only considers the main tree, but the final parents list does not need to include parents which are related to each other via secondary links.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1034
https://casperlabs.atlassian.net/browse/NODE-1032

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
