### PR TITLE
EE-756: change tracking_copy to pub(crate)

### DIFF
--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod engine_state;
 pub mod execution;
 pub mod resolvers;
 pub mod runtime_context;
-pub mod tracking_copy;
+pub(crate) mod tracking_copy;
 
 pub const ADDRESS_LENGTH: usize = 32;
 pub const DEPLOY_HASH_LENGTH: usize = 32;

--- a/execution-engine/engine-core/src/tracking_copy/mod.rs
+++ b/execution-engine/engine-core/src/tracking_copy/mod.rs
@@ -82,10 +82,6 @@ impl<M: Meter<Key, Value>> TrackingCopyCache<M> {
 
         self.reads_cached.get_refresh(key).map(|v| &*v)
     }
-
-    pub fn is_empty(&self) -> bool {
-        self.reads_cached.is_empty() && self.muts_cached.is_empty()
-    }
 }
 
 pub struct TrackingCopy<R> {

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -64,7 +64,6 @@ fn tracking_copy_new() {
     let db = CountingDb::new(counter);
     let tc = TrackingCopy::new(db);
 
-    assert_eq!(tc.cache.is_empty(), true);
     assert_eq!(tc.ops.is_empty(), true);
     assert_eq!(tc.fns.is_empty(), true);
 }


### PR DESCRIPTION
This PR changes tracking_copy from pub to pub(crate).

https://casperlabs.atlassian.net/browse/EE-756

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned for review.