### PR TITLE
NODE-956: Integration test that checks nodes with equivocating blocks in their DAG carry on working correctly

### DIFF
--- a/integration-testing/test/test_equivocating_node_shutdown.py
+++ b/integration-testing/test/test_equivocating_node_shutdown.py
@@ -74,7 +74,7 @@ def test_equivocating_node_shutdown(three_node_network):
     expected_counter_result = count(1)
     for i in range(2):
         for node in nodes:
-            block_hash = nodes[0].p_client.deploy_and_propose(
+            block_hash = node.p_client.deploy_and_propose(
                 from_address=account.public_key_hex,
                 public_key=account.public_key_path,
                 private_key=account.private_key_path,

--- a/integration-testing/test/test_equivocating_node_shutdown.py
+++ b/integration-testing/test/test_equivocating_node_shutdown.py
@@ -6,7 +6,7 @@ from casperlabs_local_net.common import Contract
 from casperlabs_local_net.wait import wait_for_block_hash_propagated_to_all_nodes
 
 
-def test_equivocating_node_shutdown(three_node_network):
+def test_equivocating_node_shutdown_and_other_nodes_are_working_ok(three_node_network):
     network = three_node_network
     nodes = network.docker_nodes
     account = GENESIS_ACCOUNT

--- a/integration-testing/test/test_equivocating_node_shutdown.py
+++ b/integration-testing/test/test_equivocating_node_shutdown.py
@@ -59,28 +59,28 @@ def test_equivocating_node_shutdown(three_node_network):
     # Regardless, the remaining nodes should carry on working correctly.
     # They all should be able to deploy contracts and propose new blocks with them.
 
-    nodes = nodes[1:]
+    working_nodes = nodes[1:]
 
-    block_hash = nodes[0].p_client.deploy_and_propose(
+    block_hash = working_nodes[0].p_client.deploy_and_propose(
         from_address=account.public_key_hex,
         public_key=account.public_key_path,
         private_key=account.private_key_path,
         session_contract=Contract.COUNTER_DEFINE,
     )
-    wait_for_block_hash_propagated_to_all_nodes(nodes, block_hash)
+    wait_for_block_hash_propagated_to_all_nodes(working_nodes, block_hash)
 
     # Deploy counter_call.wasm on each node a couple of times,
     # check the value of the counter is correct.
     expected_counter_result = count(1)
     for i in range(2):
-        for node in nodes:
+        for node in working_nodes:
             block_hash = node.p_client.deploy_and_propose(
                 from_address=account.public_key_hex,
                 public_key=account.public_key_path,
                 private_key=account.private_key_path,
                 session_contract=Contract.COUNTER_CALL,
             )
-            wait_for_block_hash_propagated_to_all_nodes(nodes, block_hash)
+            wait_for_block_hash_propagated_to_all_nodes(working_nodes, block_hash)
 
             state = node.p_client.query_state(
                 block_hash=block_hash,

--- a/integration-testing/test/test_equivocating_node_shutdown.py
+++ b/integration-testing/test/test_equivocating_node_shutdown.py
@@ -1,12 +1,13 @@
 import logging
 import pytest
+from itertools import count
 from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT
 from casperlabs_local_net.common import Contract
 from casperlabs_local_net.wait import wait_for_block_hash_propagated_to_all_nodes
 
 
-def test_equivocating_node_shutdown(two_node_network):
-    network = two_node_network
+def test_equivocating_node_shutdown(three_node_network):
+    network = three_node_network
     nodes = network.docker_nodes
     account = GENESIS_ACCOUNT
 
@@ -26,8 +27,10 @@ def test_equivocating_node_shutdown(two_node_network):
     rc, output = nodes[0].exec_run(cmd)
     logging.info(f"============================ {cmd} => {rc}")
 
-    network.stop_cl_node(0)
-    network.stop_cl_node(1)
+    # Stop node-0. Also, stop all other nodes so when node-0 restarts it cannot sync old
+    # blocks from them.
+    for i in range(len(nodes)):
+        network.stop_cl_node(i)
 
     network.start_cl_node(0)
     # After node-0 restarted it should only have the genesis block.
@@ -35,8 +38,8 @@ def test_equivocating_node_shutdown(two_node_network):
 
     # Create the equivocating block.
     block_hash = nodes[0].p_client.deploy_and_propose(**deploy_options)
-
-    network.start_cl_node(1)
+    for i in range(1, len(nodes)):
+        network.start_cl_node(i)
     wait_for_block_hash_propagated_to_all_nodes(nodes, block_hash)
 
     assert len(list(nodes[1].p_client.show_blocks(1000))) == 3
@@ -51,3 +54,38 @@ def test_equivocating_node_shutdown(two_node_network):
     assert "Unable to resolve host node-0" in str(excinfo.value.output)
 
     assert "Node has detected it's own equivocation with block" in nodes[0].logs()
+
+    # node-0 is out of action. The rest of the nodes have equivocated blocks in their DAGs.
+    # Regardless, the remaining nodes should carry on working correctly.
+    # They all should be able to deploy contracts and propose new blocks with them.
+
+    nodes = nodes[1:]
+
+    block_hash = nodes[0].p_client.deploy_and_propose(
+        from_address=account.public_key_hex,
+        public_key=account.public_key_path,
+        private_key=account.private_key_path,
+        session_contract=Contract.COUNTER_DEFINE,
+    )
+    wait_for_block_hash_propagated_to_all_nodes(nodes, block_hash)
+
+    # Deploy counter_call.wasm on each node a couple of times,
+    # check the value of the counter is correct.
+    expected_counter_result = count(1)
+    for i in range(2):
+        for node in nodes:
+            block_hash = nodes[0].p_client.deploy_and_propose(
+                from_address=account.public_key_hex,
+                public_key=account.public_key_path,
+                private_key=account.private_key_path,
+                session_contract=Contract.COUNTER_CALL,
+            )
+            wait_for_block_hash_propagated_to_all_nodes(nodes, block_hash)
+
+            state = node.p_client.query_state(
+                block_hash=block_hash,
+                key=account.public_key_hex,
+                key_type="address",
+                path="counter/count",
+            )
+            assert state.int_value == next(expected_counter_result)


### PR DESCRIPTION
### Overview
This PR adds integration test checking that after an equivocating block is included in nodes' DAG they still carry on working correctly.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-956

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
