### PR TITLE
NODE-1035: Modify kamon time-buckets.

### DIFF
--- a/node/src/main/resources/application.conf
+++ b/node/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+kamon.prometheus.buckets.time-buckets = [0.1,0.25,0.5,1,2.5,5,10,20,30,60]


### PR DESCRIPTION
### Overview
Modifies default Kamon time buckets to have more resolution on the "slow side".

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1035

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Sample metrics:
```
# TYPE casperlabs_block_storage_cache_get_time_seconds histogram
casperlabs_block_storage_cache_get_time_seconds_bucket{le="0.1"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="0.25"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="0.5"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="1.0"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="2.5"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="5.0"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="10.0"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="20.0"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="30.0"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="60.0"} 2.0
casperlabs_block_storage_cache_get_time_seconds_bucket{le="+Inf"} 2.0
```