### PR TITLE
NODE-1041: Python client: add installation instructions for Mac and Windows

### DIFF
--- a/integration-testing/client/CasperLabsClient/README.md
+++ b/integration-testing/client/CasperLabsClient/README.md
@@ -6,17 +6,48 @@ interact with a CasperLabs node via its gRPC API.
 ## Installation
 
 `casperlabs-client` is a Python 3.6+ module, it does not support Python 2.7.
+
+### Linux
 You can install it with
+
+```
+pip3 install casperlabs-client
+```
+
+or, if you have only Python 3 installed (Python 3 installed as `python`, rather than `python3`):
 
 ```
 pip install casperlabs-client
 ```
 
-or, if you have both Python 2 and Python 3 installed:
+
+### Mac OS X
+
+Install Python 3 with brew.
 
 ```
-pip3 install casperlabs-client
+brew update
+brew upgrade
+pip install casperlabs-client
 ```
+
+### Windows 10
+
+To install `casperlabs-client` on Windows 10 you need to install latest Python 3.7,
+it is curently not possible to install it on Python 3.8 due to
+https://github.com/grpc/grpc/issues/20831
+
+You also need to install free Microsoft Visual Studio C++ 14.0.
+Get it with "Microsoft Visual C++ Build Tools": https://visualstudio.microsoft.com/downloads/
+This is required by 'pyblake2' extension.
+
+After installing the above you install the casperlabs-client by
+typing the following on the command prompt:
+
+```
+C:\Users\alice>pip install casperlabs-client
+```
+
 
 ## Getting started
 
@@ -29,7 +60,7 @@ import casperlabs_client
 client = casperlabs_client.CasperLabsClient('deploy.casperlabs.io', 40401)
 blockInfo = next(client.showBlocks(1, full_view=False))
 for bond in blockInfo.summary.header.state.bonds:
-    print(f'{bond.validator_public_key.hex()}: {bond.stake}')
+    print(f'{bond.validator_public_key.hex()}: {bond.stake.value}')
 ```
 
 When executed the script should print a list of bonded validators' public keys

--- a/integration-testing/client/CasperLabsClient/README.md
+++ b/integration-testing/client/CasperLabsClient/README.md
@@ -1,14 +1,22 @@
 # CasperLabs Python Client API library and command line tool
 
-[CasperLabs](https://casperlabs.io/) Python client is a library that can be used to
-interact with a CasperLabs node via its gRPC API.
+`casperlabs-client` is a Python package consisting of
+- a client library `casperlabs_client` that can be used to interact with
+  a [CasperLabs](https://casperlabs.io/) node
+  via its gRPC API and
+- a command line interface (CLI) script with the same name: `casperlabs_client`.
+
+Note, the name of the package available on PyPi is `casperlabs-client` (with hyphen),
+but the name of the library as well as the CLI is written with underscore: `casperlabs_client`.
+The name of the CLI is written with underscore to make it different from the Scala client,
+which is written with hyphen.
 
 ## Installation
 
 `casperlabs-client` is a Python 3.6+ module, it does not support Python 2.7.
 
 ### Linux
-You can install it with
+You can install the `casperlabs_client` package with
 
 ```
 pip3 install casperlabs-client
@@ -23,7 +31,9 @@ pip install casperlabs-client
 
 ### Mac OS X
 
-Install Python 3 with brew.
+Install Python 3 with brew: https://docs.python-guide.org/starting/install3/osx/
+
+Next, type the following commands in the Terminal:
 
 ```
 brew update
@@ -38,11 +48,13 @@ it is curently not possible to install it on Python 3.8 due to
 https://github.com/grpc/grpc/issues/20831
 
 You also need to install free Microsoft Visual Studio C++ 14.0.
-Get it with "Microsoft Visual C++ Build Tools": https://visualstudio.microsoft.com/downloads/
-This is required by 'pyblake2' extension.
+Get it with "Build Tools for Visual Studio 2019":
+https://visualstudio.microsoft.com/downloads/
+(All downloads -> Tools for Visual Studio 2019 -> Build tools for Visual Studio 2019).
+This is required by the `pyblake2` extension module.
 
-After installing the above you install the casperlabs-client by
-typing the following on the command prompt:
+After installing the above prerequisites you can install the `casperlabs-client` package by
+typing the following on the command line:
 
 ```
 C:\Users\alice>pip install casperlabs-client

--- a/integration-testing/client/CasperLabsClient/README.md
+++ b/integration-testing/client/CasperLabsClient/README.md
@@ -54,7 +54,7 @@ https://www.python.org/downloads/windows/
 If you install Python from the Windows Store
 you will need to manually add the `Scripts` folder of your Python installation to your `Path`
 in order to have the `casperlabs_client` command line tool
-available on the commmand line without providing full path to it.
+available on the command line without providing full path to it.
 This will be located in a path similar to this:
 
 ```

--- a/integration-testing/client/CasperLabsClient/README.md
+++ b/integration-testing/client/CasperLabsClient/README.md
@@ -16,6 +16,7 @@ which is written with hyphen.
 `casperlabs-client` is a Python 3.6+ module, it does not support Python 2.7.
 
 ### Linux
+
 You can install the `casperlabs_client` package with
 
 ```
@@ -46,6 +47,20 @@ pip install casperlabs-client
 To install `casperlabs-client` on Windows 10 you need to install latest Python 3.7,
 it is curently not possible to install it on Python 3.8 due to
 https://github.com/grpc/grpc/issues/20831
+
+It is recommended to install Python from the python.org website:
+https://www.python.org/downloads/windows/
+
+If you install Python from the Windows Store
+you will need to manually add the `Scripts` folder of your Python installation to your `Path`
+in order to have the `casperlabs_client` command line tool
+available on the commmand line without providing full path to it.
+This will be located in a path similar to this:
+
+```
+C:\Users\[USERNAME]\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.x_qbz5n2kfra8p0\LocalCache\local-packages\Python37\Scripts>
+```
+
 
 You also need to install free Microsoft Visual Studio C++ 14.0.
 Get it with "Build Tools for Visual Studio 2019":
@@ -84,6 +99,19 @@ and their stake:
 569b41d574c46390212d698660b5326269ddb0a761d1294258897ac717b4958b: 4000000000
 d286526663ca3766c80781543a148c635f2388bfe128981c3e4ac69cea88dc35: 3000000000
 ```
+
+Note, you will also see a warning:
+
+```
+WARNING:root:Creating insecure connection to deploy.casperlabs.io:40401 (<class 'casperlabs_client.casper_pb2_grpc.CasperServiceStub'>)
+```
+
+Currently it is possible to connect from client to node without SSL encryption,
+which is what the above example code does.
+In the future encryption will become obligatory
+and you will have to pass a `certificate_path` to the `CasperLabsClient` constructor.
+The warning about insecure connection is meant to remind about this.
+
 
 ## Deploying smart contracts
 

--- a/integration-testing/client/CasperLabsClient/install.sh
+++ b/integration-testing/client/CasperLabsClient/install.sh
@@ -5,9 +5,6 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd ${DIR}
 
-python setup.py install
-# Since we have overridden 'install' command in setup.py and setuptools has
-# a bug which does not install deps once you override `install` command
-# So we are manually installing deps here.
-pip install -r requirements.txt
-#python ${DIR}/tests/test_casperlabs_client.py
+rm -rf dist/*
+python setup.py sdist
+pip install dist/casperlabs_client-*

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -168,8 +168,11 @@ def run_codegen():
 
 
 def prepare_sdist():
+    contracts_dir = (
+        os.environ.get("TAG_NAME") and "/root/bundled_contracts" or CONTRACTS_DIR
+    )
     bundled_contracts = [
-        f"{CONTRACTS_DIR}/{f}"
+        f"{contracts_dir}/{f}"
         for f in [
             "bonding.wasm",
             "standard_payment.wasm",

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -196,7 +196,6 @@ with open(path.join(THIS_DIRECTORY, "README.md"), encoding="utf-8") as fh:
 
 class CInstall(InstallCommand):
     def run(self):
-        run_codegen()
         super().run()
 
 

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -207,7 +207,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.5.2",
+    version="0.5.3",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -207,7 +207,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.5.4",
+    version="0.5.5",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -207,7 +207,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.5.3",
+    version="0.5.4",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",


### PR DESCRIPTION
### Overview
This PR provides installation on Mac and Windows instructions for Python client package `casperlabs-client`, available on https://pypi.org/project/casperlabs-client/.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1041

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
