### PR TITLE
NOTICK Removing old ApprovedBlockReceivedHandlerStateEntered message

### DIFF
--- a/integration-testing/casperlabs_local_net/wait.py
+++ b/integration-testing/casperlabs_local_net/wait.py
@@ -56,15 +56,9 @@ class NodeStarted(LogsContainMessage):
         super().__init__(node, "Listening for traffic on peer=casperlabs://", times)
 
 
-class ApprovedBlockReceivedHandlerStateEntered(LogsContainOneOf):
+class ApprovedBlockReceivedHandlerStateEntered(LogsContainMessage):
     def __init__(self, node: DockerNode) -> None:
-        super().__init__(
-            node,
-            [
-                "Making a transition to ApprovedBlockRecievedHandler state.",
-                "Making the transition to block processing.",
-            ],
-        )
+        super().__init__(node, "Making the transition to block processing.")
 
 
 class NewForkChoiceTipBlock(LogsContainMessage):


### PR DESCRIPTION
Removing old ApprovedBlockReceivedHandlerStateEntered message that was previously needed because of Node log typo.

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
