### PR TITLE
CON-600: handle case where one parent is a common ancestor of all others

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -407,11 +407,13 @@ object ExecEngineUtil {
         // The effect we return is the one which would be applied onto the first parent's
         // post-state, so we do not include the first parent in the effect.
         (chosenParents, _, nonFirstEffect) = chosen
-        blocks = chosenParents
-          .map(i => candidates(i))
-          // we only keep blocks which are not related in any way to other candidates
-          .filter(block => uncommonAncestors(block).size == 1)
-      } yield MergeResult.result[T, A](blocks.head, nonFirstEffect, blocks.tail)
+        blocks                             = chosenParents.map(i => candidates(i))
+        // We only keep secondary parents which are not related in any way to other candidates.
+        // Note: a block is not found in `uncommonAncestors` if it is common to all
+        // candidates, so we cannot assume it is present.
+        nonFirstParents = blocks.tail
+          .filter(block => uncommonAncestors.get(block).fold(false)(_.size == 1))
+      } yield MergeResult.result[T, A](blocks.head, nonFirstEffect, nonFirstParents)
   }
 
   def merge[F[_]: MonadThrowable: BlockStorage](

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -437,7 +437,7 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
     result4 shouldBe result3
   }
 
-  it should "filter redundant parents from the output list" in {
+  it should "filter redundant secondary parents from the output list" in {
     /*
      * The DAG looks like:
      *       i     j
@@ -483,6 +483,24 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
     result1 shouldBe ((nonFirstEffect, Vector(j, i)))
     // output is the same as if the input had only included the DAG tips
     result2 shouldBe result1
+  }
+
+  it should "filter redundant secondary parents, but not main parent" in {
+    // Dag looks like:
+    // genesis <- a <- b
+    val ops     = Map(1 -> Op.Read)
+    val genesis = OpDagNode.genesis(ops)
+    val a       = OpDagNode.withParents(ops, List(genesis))
+    val b       = OpDagNode.withParents(ops, List(a))
+
+    implicit val order: Ordering[OpDagNode] = ExecEngineUtilTest.opDagNodeOrder
+    val redundantMainParentResult           = OpDagNode.merge(Vector(a, b))
+    val redundantSecondaryParentResult      = OpDagNode.merge(Vector(b, a))
+
+    // main parent is not filtered out even though it is redundant with b
+    redundantMainParentResult shouldBe (ops -> Vector(a, b))
+    // secondary parent is filtered out because it is redundant with the main
+    redundantSecondaryParentResult shouldBe (Map.empty -> Vector(b))
   }
 }
 


### PR DESCRIPTION
### Overview
This PR fixes a bug where if a candidate parent was a common ancestor of all other parents then an exception was thrown. Additionally, it prevents the main parent from being filtered out (if this were allowed it would lead to inconsistent results). The new unit test shows that the bug is fixed and that the main parent cannot be filtered out, even when it is redundant.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-600

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
