### PR TITLE
NODE-1021: Fix local key validation in the client.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -412,7 +412,7 @@ lazy val client = (project in file("client"))
     javacOptions ++= Seq("-Dnashorn.args=\"--no-deprecation-warning\""),
     packageSummary := "CasperLabs Client",
     packageDescription := "CLI tool for interaction with the CasperLabs Node",
-    libraryDependencies ++= commonDependencies ++ Seq(
+    libraryDependencies ++= commonDependencies ++ slf4jAdapters ++ Seq(
       scallop,
       grpcNetty,
       graphvizJava,

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -556,7 +556,16 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         name = "key",
         descr = "Base16 encoding of the base key.",
         required = true,
-        validate = hexCheck
+        validate = (key: String) => {
+          keyType() match {
+            case "local" =>
+              key.split(":") match {
+                case arr @ Array(_, _) => arr.forall(hexCheck)
+                case _                 => false
+              }
+            case _ => hexCheck(key)
+          }
+        }
       )
 
     val path =


### PR DESCRIPTION
### Overview
Fixes the `casperlabs-client` validation of the `--key` parameter in the `query-state` command to accept the `{seed}:{rest}` format, as stated by the docs.

```console
$ ./client/target/universal/stage/bin/casperlabs-client --host localhost query-state --block-hash abc123 --key abc123 --type local
[casperlabs] Error: Validation failure for 'key' option parameters: abc123
$ ./client/target/universal/stage/bin/casperlabs-client --host localhost query-state --block-hash abc123 --key abc123:cde456 --type local
Connection refused: localhost/127.0.0.1:40401
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1021

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
