### PR TITLE
NODE-1020: Enable SQLite WAL journal mode.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -105,9 +105,10 @@ package object effects {
       // Foreign keys support must be enabled explicitly in SQLite; it doesn't affect read logic though.
       // https://www.sqlite.org/foreignkeys.html#fk_enable
       config.addDataSourceProperty("foreign_keys", foreignKeys.toString)
-      // NOTE: We still saw at least one SQLITE_BUSY error in testing, sepsite the 1 sized pool.
+      // NOTE: We still saw at least one SQLITE_BUSY error in testing, despite the 1 sized pool.
       // NODE-1019 will add logging, maybe we'll learn more.
       config.addDataSourceProperty("busy_timeout", "5000")
+      config.addDataSourceProperty("journal_mode", "WAL")
       config
     }
 


### PR DESCRIPTION
# Overview
Change SQLite mode from rollback journal to WAL mode. This enables concurrent reads and writes.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1020

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
By default, SQLite will automatically checkpoint whenever a COMMIT occurs that causes the WAL file to be 1000 pages or more in size, or when the last database connection on a database file closes. 1000 pages (each of size 4kB) is 4MB of _any_ data being written to the DB. Given the current size of deploys, blocks, metadata, relations, etc and writing on both block creation and block validation, checkpointing should happen fairly often (preventing checkpoint starvation).

> WAL mode permits simultaneous readers and writers. It can do this because changes do not overwrite the original database file, but rather go into the separate write-ahead log file. That means that readers can continue to read the old, original, unaltered content from the original database file at the same time that the writer is appending to the write-ahead log. In WAL mode, SQLite exhibits “snapshot isolation”. When a read transaction starts, that reader continues to see an unchanging “snapshot” of the database file as it existed at the moment in time when the read transaction started. Any write transactions that commit while the read transaction is active are still invisible to the read transaction because the reader is seeing a snapshot of database file from a prior moment in time.

#### Sources:
1. [https://www.sqlite.org/wal.html](https://www.sqlite.org/wal.html)
2. [https://activesphere.com/blog/2018/12/24/understanding-sqlite-busy](https://activesphere.com/blog/2018/12/24/understanding-sqlite-busy)
3. [https://wiki.postgresql.org/wiki/SSI](https://wiki.postgresql.org/wiki/SSI)
