### PR TITLE
ECO-152: Showing bonded validators list on Clarity

### DIFF
--- a/explorer/grpc/package.json
+++ b/explorer/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-grpc",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Generated gRPC JavaScript code and TypeScript declarations to interact with the CasperLabs blockchain",
   "scripts": {},
   "keywords": [

--- a/explorer/sdk/package.json
+++ b/explorer/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "SDK to interact with the CasperLabs blockchain using gRPC",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/explorer/sdk/src/services/CasperService.ts
+++ b/explorer/sdk/src/services/CasperService.ts
@@ -12,6 +12,7 @@ import {
   GetBlockInfoRequest,
   GetBlockStateRequest,
   GetDeployInfoRequest,
+  GetLastFinalizedBlockInfoRequest,
   ListDeployInfosRequest,
   ListDeployInfosResponse,
   StateQuery,
@@ -255,6 +256,24 @@ export default class CasperService {
       res => res.getBigInt()!
     );
     return Number(balance.getValue());
+  }
+
+  getLastFinalizedBlockInfo(): Promise<BlockInfo> {
+    return new Promise<BlockInfo>((resolve, reject) => {
+      const request = new GetLastFinalizedBlockInfoRequest();
+
+      grpc.unary(GrpcCasperService.GetLastFinalizedBlockInfo, {
+        host: this.url,
+        request,
+        onEnd: res => {
+          if (res.status === grpc.Code.OK) {
+            resolve(res.message as BlockInfo);
+          } else {
+            reject(new GrpcError(res.status, res.statusMessage));
+          }
+        }
+      })
+    })
   }
 }
 

--- a/explorer/ui/src/components/BondedValidatorsTable.tsx
+++ b/explorer/ui/src/components/BondedValidatorsTable.tsx
@@ -18,17 +18,17 @@ export const BondedValidatorsTable = observer(
         finalizedBonds.map(bond => bond.getValidatorPublicKey_asB64())
       );
     }
+    let bondsList = props.block
+      .getSummary()!
+      .getHeader()!
+      .getState()!
+      .getBondsList();
     return (
       <DataTable
-        title="Bonded Validators List"
+        title={`Bonded Validators List (${bondsList.length})`}
         headers={['Validator', 'Stake', 'Finalized']}
         rows={
-          props.block &&
-          props.block
-            .getSummary()!
-            .getHeader()!
-            .getState()!
-            .getBondsList()
+          bondsList
         }
         renderRow={(bond, i) => {
           return (
@@ -43,15 +43,16 @@ export const BondedValidatorsTable = observer(
                 {finalizedBondedValidators.has(
                   bond.getValidatorPublicKey_asB64()
                 ) ? (
-                  <Icon name="check-circle" color="green" />
+                  <Icon name="check-circle" color="green"/>
                 ) : (
-                  <Icon name="clock" />
+                  <Icon name="clock"/>
                 )}
               </td>
             </tr>
           );
         }}
       />
-    );
+    )
+      ;
   }
 );

--- a/explorer/ui/src/components/BondedValidatorsTable.tsx
+++ b/explorer/ui/src/components/BondedValidatorsTable.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { observer } from 'mobx-react';
+import DataTable from './DataTable';
+import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
+import { encodeBase16 } from 'casperlabs-sdk';
+import { Icon } from './Utils';
+
+export const BondedValidatorsTable = observer(
+  (props: { block: BlockInfo; lastFinalizedBlock: BlockInfo | undefined }) => {
+    let finalizedBondedValidators = new Set();
+    if (props.lastFinalizedBlock) {
+      let finalizedBonds = props.lastFinalizedBlock
+        .getSummary()!
+        .getHeader()!
+        .getState()!
+        .getBondsList();
+      finalizedBondedValidators = new Set(
+        finalizedBonds.map(bond => bond.getValidatorPublicKey_asB64())
+      );
+    }
+    return (
+      <DataTable
+        title="Bonded Validators List"
+        headers={['Validator', 'Stake', 'Finalized']}
+        rows={
+          props.block &&
+          props.block
+            .getSummary()!
+            .getHeader()!
+            .getState()!
+            .getBondsList()
+        }
+        renderRow={(bond, i) => {
+          return (
+            <tr key={i}>
+              <td className="text-left">
+                {encodeBase16(bond.getValidatorPublicKey_asU8())}
+              </td>
+              <td className="text-right">
+                {Number(bond.getStake()!.getValue()).toLocaleString()}
+              </td>
+              <td className="text-center">
+                {finalizedBondedValidators.has(
+                  bond.getValidatorPublicKey_asB64()
+                ) ? (
+                  <Icon name="check-circle" color="green" />
+                ) : (
+                  <Icon name="clock" />
+                )}
+              </td>
+            </tr>
+          );
+        }}
+      />
+    );
+  }
+);

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -2,19 +2,22 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import DagContainer from '../containers/DagContainer';
 import {
-  RefreshableComponent,
   LinkButton,
   ListInline,
-  shortHash
+  RefreshableComponent,
+  shortHash,
+  ToggleButton
 } from './Utils';
 import { BlockDAG } from './BlockDAG';
 import DataTable from './DataTable';
-import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
+import {BlockInfo} from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
 import $ from 'jquery';
 import { DagStepButtons } from './BlockList';
 import { Link } from 'react-router-dom';
 import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
+import Timestamp from './TimeStamp';
+import { BondedValidatorsTable } from './BondedValidatorsTable';
 
 interface Props {
   dag: DagContainer;
@@ -46,6 +49,14 @@ export default class Explorer extends RefreshableComponent<Props, {}> {
                   <DagStepButtons step={dag.step} />
                   {dag.hasBlocks && (
                     <span>Select a block to see its details.</span>
+                  )}
+                  {dag.selectedBlock && (
+                    <ToggleButton
+                      title={'Show bonded validators'}
+                      onClick={() => dag.toggleShowValidators()}
+                      pressed={dag.toggleValidatorsList}
+                      size="sm"
+                    />
                   )}
                 </ListInline>
               }
@@ -83,6 +94,14 @@ export default class Explorer extends RefreshableComponent<Props, {}> {
                       blockHashBase16
                   );
                 }}
+              />
+            </div>
+          )}
+          {dag.selectedBlock && dag.toggleValidatorsList && (
+            <div className="col-sm-12">
+              <BondedValidatorsTable
+                block={dag.selectedBlock}
+                lastFinalizedBlock={dag.lastFinalizedBlock}
               />
             </div>
           )}

--- a/explorer/ui/src/components/Utils.tsx
+++ b/explorer/ui/src/components/Utils.tsx
@@ -54,6 +54,24 @@ export const Button = (props: {
   </button>
 );
 
+export const ToggleButton = (props: {
+  title?: string;
+  onClick: () => void;
+  pressed: boolean;
+  size: 'lg' | 'sm' | 'xs';
+}) => (
+  <button
+    type="button"
+    className={`btn btn-${props.size} btn-toggle`}
+    data-toggle="button"
+    aria-pressed={props.pressed}
+    onClick={_ => props.onClick()}
+    title={props.title}
+  >
+    <div className="handle" />
+  </button>
+);
+
 export const LinkButton = (props: { onClick: () => void; title: string }) => (
   <button className="link" onClick={() => props.onClick()}>
     {props.title}

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -55,6 +55,8 @@ export class DagContainer {
   @observable selectedBlock: BlockInfo | undefined = undefined;
   @observable depth = 10;
   @observable maxRank = 0;
+  @observable toggleValidatorsList: boolean = false;
+  @observable lastFinalizedBlock: BlockInfo | undefined = undefined;
 
   constructor(
     private errors: ErrorContainer,
@@ -63,6 +65,10 @@ export class DagContainer {
 
   get minRank() {
     return Math.max(0, this.maxRank - this.depth + 1);
+  }
+
+  toggleShowValidators() {
+    this.toggleValidatorsList = !this.toggleValidatorsList;
   }
 
   get hasBlocks() {
@@ -78,6 +84,12 @@ export class DagContainer {
         .then(blocks => {
           this.blocks = blocks;
         })
+    );
+
+    await this.errors.capture(
+      this.casperService.getLatestBlockInfo().then(block => {
+        this.lastFinalizedBlock = block;
+      })
     );
   }
 }

--- a/explorer/ui/src/styles/custom.scss
+++ b/explorer/ui/src/styles/custom.scss
@@ -1,5 +1,6 @@
 @import 'sb-admin/variables.scss';
-@import "account-selector";
+@import 'account-selector';
+@import 'toggle-button';
 
 #mainNav.navbar-dark {
   .username {

--- a/explorer/ui/src/styles/toggle-button.scss
+++ b/explorer/ui/src/styles/toggle-button.scss
@@ -1,0 +1,162 @@
+// Colors
+$brand-primary: #29b5a8;
+$gray: #6b7381;
+$gray-light: lighten($gray, 15%);
+$gray-lighter: lighten($gray, 30%);
+
+// Button Colors
+$btn-default-color: $gray;
+$btn-default-bg: $gray-lighter;
+
+// Toggle Sizes
+$toggle-default-size: 1.5rem;
+$toggle-default-font-size: 0.75rem;
+$toggle-default-label-width: 4rem;
+
+// Mixin for Switch Colors
+// Variables: @color, @bg, @active-bg
+@mixin toggle-color(
+  $color: $btn-default-color,
+  $bg: $btn-default-bg,
+  $active-bg: $brand-primary
+) {
+  color: $color;
+  background: $bg;
+  &:before,
+  &:after {
+    color: $color;
+  }
+
+  &.active {
+    background-color: $active-bg;
+  }
+}
+
+// Mixin for Default Switch Styles
+@mixin toggle-mixin(
+  $size: $toggle-default-size,
+  $margin: $toggle-default-label-width,
+  $font-size: $toggle-default-font-size
+) {
+  margin: 0 $margin;
+  padding: 0;
+  position: relative;
+  border: none;
+  height: $size;
+  width: $size * 2;
+  border-radius: $size;
+
+  &:focus,
+  &.focus {
+    &,
+    &.active {
+      outline: none;
+    }
+  }
+
+  &:before,
+  &:after {
+    line-height: $size;
+    width: $margin;
+    text-align: center;
+    font-weight: 600;
+    font-size: $font-size;
+    text-transform: uppercase;
+    letter-spacing: 2px;
+    position: absolute;
+    bottom: 0;
+    transition: opacity 0.25s;
+  }
+  &:before {
+    content: 'Off';
+    left: -$margin;
+  }
+  &:after {
+    content: 'On';
+    right: -$margin;
+    opacity: 0.5;
+  }
+
+  > .handle {
+    position: absolute;
+    top: ($size * 0.25) / 2;
+    left: ($size * 0.25) / 2;
+    width: $size * 0.75;
+    height: $size * 0.75;
+    border-radius: $size * 0.75;
+    background: #fff;
+    transition: left 0.25s;
+  }
+  &.active {
+    transition: background-color 0.25s;
+
+    > .handle {
+      left: $size + (($size * 0.25) / 2);
+      transition: left 0.25s;
+    }
+
+    &:before {
+      opacity: 0.5;
+    }
+
+    &:after {
+      opacity: 1;
+    }
+  }
+
+  &.btn-sm {
+    &:before,
+    &:after {
+      line-height: $size;
+      color: #fff;
+      letter-spacing: 0.75px;
+      left: $size * 0.275;
+      width: $size * 1.55;
+    }
+
+    &:before {
+      text-align: right;
+    }
+
+    &:after {
+      text-align: left;
+      opacity: 0;
+    }
+
+    &.active {
+      &:before {
+        opacity: 0;
+      }
+
+      &:after {
+        opacity: 1;
+      }
+    }
+  }
+
+  &.btn-xs {
+    &:before,
+    &:after {
+      display: none;
+    }
+  }
+}
+
+// Apply Mixin to different sizes & colors
+.btn-toggle {
+  @include toggle-mixin;
+
+  @include toggle-color;
+
+  &.btn-lg {
+    @include toggle-mixin($size: 2.5rem, $font-size: 1rem, $margin: 5rem);
+  }
+
+  &.btn-sm {
+    @include toggle-mixin($font-size: 0.55rem, $margin: 0.5rem);
+  }
+
+  &.btn-xs {
+    @include toggle-mixin($size: 1rem, $margin: 0);
+  }
+}

--- a/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
@@ -34,10 +34,9 @@ object BlockImplicits {
     def getSummary: BlockSummary =
       BlockSummary(block.blockHash, block.header, block.signature)
 
-    def getBlockInfo: BlockInfo = {
-      val summary = BlockSummary(block.blockHash, block.header, block.signature)
+    def getBlockInfo: BlockInfo =
       BlockInfo()
-        .withSummary(summary)
+        .withSummary(block.getSummary)
         .withStatus(
           BlockInfo
             .Status()
@@ -49,7 +48,6 @@ object BlockImplicits {
               )
             )
         )
-    }
   }
 
   implicit class BlockSummaryOps(val summary: BlockSummary) extends AnyVal {

--- a/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
@@ -3,6 +3,8 @@ package io.casperlabs.models
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.Block.{GlobalState, Justification}
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
+import io.casperlabs.casper.consensus.info.BlockInfo
+import io.casperlabs.casper.consensus.info.BlockInfo.Status.Stats
 import io.casperlabs.casper.consensus.state.ProtocolVersion
 
 object BlockImplicits {
@@ -31,6 +33,23 @@ object BlockImplicits {
 
     def getSummary: BlockSummary =
       BlockSummary(block.blockHash, block.header, block.signature)
+
+    def getBlockInfo: BlockInfo = {
+      val summary = BlockSummary(block.blockHash, block.header, block.signature)
+      BlockInfo()
+        .withSummary(summary)
+        .withStatus(
+          BlockInfo
+            .Status()
+            .withStats(
+              Stats(
+                block.serializedSize,
+                block.getBody.deploys.count(_.isError),
+                block.getBody.deploys.map(_.cost).sum
+              )
+            )
+        )
+    }
   }
 
   implicit class BlockSummaryOps(val summary: BlockSummary) extends AnyVal {

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -179,11 +179,7 @@ object GrpcCasperService {
           TaskLike[F].apply {
             MultiParentCasperRef
               .withCasper[F, BlockInfo](
-                casper =>
-                  for {
-                    lastFinalizedBlock <- casper.lastFinalizedBlock
-                    blockInfo          = lastFinalizedBlock.getBlockInfo
-                  } yield blockInfo,
+                _.lastFinalizedBlock.map(_.getBlockInfo),
                 "Could not get last finalized block.",
                 MonadThrowable[F].raiseError(Unavailable("Casper instance not available yet."))
               )

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -71,6 +71,12 @@ service CasperService {
             get: "v2/accounts/{account_public_key_base16=*}/deploys"
         };
     }
+
+    rpc GetLastFinalizedBlockInfo (GetLastFinalizedBlockInfoRequest) returns (io.casperlabs.casper.consensus.info.BlockInfo) {
+        option (google.api.http) = {
+    		get: "v2/last-finalized-block"
+    	};
+    }
 }
 
 message DeployRequest {
@@ -148,3 +154,6 @@ message ListDeployInfosResponse {
     string next_page_token = 2;
     string prev_page_token = 3;
 }
+
+
+message GetLastFinalizedBlockInfoRequest {}


### PR DESCRIPTION
### Overview
First, I added a RPC API to fetch the last finalized blockInfo, so that I can construct the finalized validators set from the blockInfo. Then I added a table below the explorer to show the validators list. Looks like:
![](http://g.recordit.co/IrYHKC01Ma.gif)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-152

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
