### PR TITLE
OP-970: point broken techspec links to new

### DIFF
--- a/docs/QUERYING.md
+++ b/docs/QUERYING.md
@@ -30,7 +30,7 @@ purpose. `Address`-type keys have accounts as the associated value
 (more details on accounts will follow), `Hash`-type keys store "smart
 contracts", and `URef`-type keys store any data which can be
 represented in the [CasperLabs
-ABI](https://techspec.casperlabs.io/technical-details/block-storage/global-state#abi)
+ABI](https://slack-redir.net/link?url=https%3A%2F%2Ftechspec.casperlabs.io%2Fen%2Flatest%2Fimplementation%2Fappendix.html%23b-serialization-format)
 (except accounts). An account is a cryptographically-secured
 entry-point into the system. All changes to the global state must be
 tied to an account.

--- a/docs/QUERYING.md
+++ b/docs/QUERYING.md
@@ -30,7 +30,7 @@ purpose. `Address`-type keys have accounts as the associated value
 (more details on accounts will follow), `Hash`-type keys store "smart
 contracts", and `URef`-type keys store any data which can be
 represented in the [CasperLabs
-ABI](https://slack-redir.net/link?url=https%3A%2F%2Ftechspec.casperlabs.io%2Fen%2Flatest%2Fimplementation%2Fappendix.html%23b-serialization-format)
+ABI](https://techspec.casperlabs.io/en/latest/implementation/appendix.html#b-serialization-format)
 (except accounts). An account is a cryptographically-secured
 entry-point into the system. All changes to the global state must be
 tied to an account.

--- a/hack/USAGE.md
+++ b/hack/USAGE.md
@@ -23,7 +23,7 @@ purpose. `Address`-type keys have accounts as the associated value
 (more details on accounts will follow), `Hash`-type keys store "smart
 contracts", and `URef`-type keys store any data which can be
 represented in the [CasperLabs
-ABI](https://techspec.casperlabs.io/technical-details/block-storage/global-state#abi)
+ABI](https://slack-redir.net/link?url=https%3A%2F%2Ftechspec.casperlabs.io%2Fen%2Flatest%2Fimplementation%2Fappendix.html%23b-serialization-format)
 (except accounts). An account is a cryptographically-secured
 entry-point into the system. All changes to the global state must be
 tied to an account. These changes occur via "session code" submitted

--- a/hack/USAGE.md
+++ b/hack/USAGE.md
@@ -23,7 +23,7 @@ purpose. `Address`-type keys have accounts as the associated value
 (more details on accounts will follow), `Hash`-type keys store "smart
 contracts", and `URef`-type keys store any data which can be
 represented in the [CasperLabs
-ABI](https://slack-redir.net/link?url=https%3A%2F%2Ftechspec.casperlabs.io%2Fen%2Flatest%2Fimplementation%2Fappendix.html%23b-serialization-format)
+ABI](https://techspec.casperlabs.io/en/latest/implementation/appendix.html#b-serialization-format)
 (except accounts). An account is a cryptographically-secured
 entry-point into the system. All changes to the global state must be
 tied to an account. These changes occur via "session code" submitted


### PR DESCRIPTION
### Overview
Links broke with the move to the new techspec.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-970

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Old Link: https://app.gitbook.com/@casperlabs/s/techspec/technical-details/block-storage/global-state#abi

New Link: https://techspec.casperlabs.io/en/latest/implementation/appendix.html#b-serialization-format
