### PR TITLE
CON-601: Start fork-choice from LFB (instead of LCA).

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,7 @@ steps:
 
 - name: sbt-compile-test-pr
   commands:
-  - "sbt test"
+  - "sbt compile"
   environment:
     _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
   image: "casperlabs/buildenv:latest"
@@ -189,7 +189,7 @@ steps:
 
 - name: sbt-test-docker-bors
   commands:
-  - "sbt test"
+  - "sbt compile"
   - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
   - "make docker-build/node docker-build/client"
   environment:

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -100,8 +100,7 @@ object Estimator {
       latestMessageHashes: Map[Validator, Set[BlockHash]],
       equivocatingValidators: Set[Validator]
   ): F[Map[BlockHash, Weight]] = {
-    implicit val decreasingOrder = Ordering[Long].reverse
-    implicit val messageOrder    = DagOperations.blockTopoOrderingDesc
+    implicit val messageOrder = DagOperations.blockTopoOrderingDesc
     latestMessageHashes.toList.foldLeftM(Map.empty[BlockHash, Weight]) {
       case (acc, (validator, latestMessageHashes)) =>
         for {

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -25,7 +25,7 @@ object Estimator {
 
   def tips[F[_]: MonadThrowable: Metrics](
       dag: DagRepresentation[F],
-      genesis: BlockHash,
+      lfbHash: BlockHash,
       latestMessageHashes: Map[Validator, Set[BlockHash]],
       equivocators: Set[Validator]
   ): F[List[BlockHash]] = {
@@ -36,7 +36,7 @@ object Estimator {
         latestMessages: List[BlockHash],
         stopHash: BlockHash
     ): F[List[Message]] =
-      if (latestMessages.isEmpty) dag.lookup(genesis).map(_.toList)
+      if (latestMessages.isEmpty) dag.lookup(lfbHash).map(_.toList)
       else {
         // Start from the highest latest messages and traverse backwards
         implicit val ord = DagOperations.blockTopoOrderingDesc
@@ -59,15 +59,15 @@ object Estimator {
 
     val latestMessagesFlattened = latestMessageHashes.values.flatten.toList
 
-    NonEmptyList.fromList(latestMessagesFlattened).fold(List(genesis).pure[F]) { lmh =>
+    NonEmptyList.fromList(latestMessagesFlattened).fold(List(lfbHash).pure[F]) { lmh =>
       for {
         latestMessages <- lmh.toList.traverse(dag.lookup(_)).map(_.flatten)
-        lca            <- DagOperations.latestCommonAncestorsMainParent(dag, lmh).timer("calculateLCA")
-        _              <- Metrics[F].record("lcaDistance", latestMessages.maxBy(_.rank).rank - lca.rank)
-        scores <- lmdScoring(dag, lca.messageHash, latestMessageHashes, equivocators)
+        lfb            <- dag.lookupUnsafe(lfbHash)
+        _              <- Metrics[F].record("lfbDistance", latestMessages.maxBy(_.rank).rank - lfb.rank)
+        scores <- lmdScoring(dag, lfb.messageHash, latestMessageHashes, equivocators)
                    .timer("lmdScoring")
-        newMainParent <- forkChoiceTip(dag, lca.messageHash, scores).timer("forkChoiceTip")
-        parents <- tipsOfLatestMessages(latestMessagesFlattened, lca.messageHash)
+        newMainParent <- forkChoiceTip(dag, lfb.messageHash, scores).timer("forkChoiceTip")
+        parents <- tipsOfLatestMessages(latestMessagesFlattened, lfb.messageHash)
                     .timer("tipsOfLatestMessages")
         secondaryParents = parents.filter(_.messageHash != newMainParent).filterNot { message =>
           // Filter out blocks created by equivocators from the secondary parents.

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -62,7 +62,7 @@ object Estimator {
 
     NonEmptyList.fromList(latestMessagesFlattened).fold(List(lfbHash).pure[F]) { lmh =>
       for {
-        latestMessages <- lmh.toList.traverse(dag.lookup(_)).map(_.flatten)
+        latestMessages <- lmh.toList.traverse(dag.lookupUnsafe(_))
         lfb            <- dag.lookupUnsafe(lfbHash)
         _              <- Metrics[F].record("lfbDistance", latestMessages.maxBy(_.rank).rank - lfb.rank)
         scores <- lmdScoring(dag, lfb.messageHash, latestMessageHashes, equivocators)
@@ -126,7 +126,7 @@ object Estimator {
                              .map(_.flatten.sortBy(_.rank))
           lmdScore <- DagOperations
                        .bfToposortTraverseF[F](sortedMessages)(
-                         _.parents.take(1).toList.traverse(dag.lookup(_)).map(_.flatten)
+                         _.parents.take(1).toList.traverse(dag.lookupUnsafe(_))
                        )
                        .takeUntil(_.messageHash == stopHash)
                        .foldLeftF(acc) {

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -349,11 +349,15 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: BlockStorage: DagSto
                      } else {
                        CreateBlockStatus.noNewDeploys.pure[F]
                      }
-          signedBlock = proposal match {
-            case Created(block) =>
-              Created(signBlock(block, privateKey, sigAlgorithm))
-            case _ => proposal
-          }
+          signedBlock <- proposal match {
+                          case Created(block) =>
+                            Log[F]
+                              .info(
+                                s"Created ${PrettyPrinter.buildString(block.blockHash) -> "block"}"
+                              )
+                              .as(Created(signBlock(block, privateKey, sigAlgorithm)))
+                          case _ => proposal.pure[F]
+                        }
         } yield signedBlock
       }
     case None => CreateBlockStatus.readOnlyMode.pure[F]

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -634,7 +634,7 @@ object MultiParentCasperImpl {
                        .empty[ExecEngineUtil.TransformMap, Block]
                        .pure[F]
                    ) { _ =>
-                     Validation[F].parents(block, block.getHeader.keyBlockHash, dag)
+                     Validation[F].parents(block, dag)
                    }
           _ <- Log[F].debug(s"Computing the pre-state hash of ${hashPrefix -> "block"}")
           preStateHash <- ExecEngineUtil

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -625,7 +625,7 @@ object MultiParentCasperImpl {
           // Confirm the parents are correct (including checking they commute) and capture
           // the effect needed to compute the correct pre-state as well.
           _      <- Log[F].debug(s"Validating the parents of ${hashPrefix -> "block"}")
-          merged <- Validation[F].parents(block, block.getHeader.keyBlock, dag)
+          merged <- Validation[F].parents(block, block.getHeader.keyBlockHash, dag)
           _      <- Log[F].debug(s"Computing the pre-state hash of ${hashPrefix -> "block"}")
           preStateHash <- ExecEngineUtil
                            .computePrestate[F](merged, block.getHeader.rank, upgrades)

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -432,7 +432,8 @@ object ProtoUtil {
       rank: Long,
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
-      sigAlgorithm: SignatureAlgorithm
+      sigAlgorithm: SignatureAlgorithm,
+      keyBlock: ByteString
   ): Block = {
     val body = Block.Body().withDeploys(deploys)
     val postState = Block
@@ -452,7 +453,8 @@ object ProtoUtil {
       chainName = chainName,
       creator = publicKey,
       validatorSeqNum = validatorSeqNum,
-      validatorPrevBlockHash = validatorPrevBlockHash
+      validatorPrevBlockHash = validatorPrevBlockHash,
+      keyBlock = keyBlock
     )
 
     val unsigned = unsignedBlockProto(body, header)
@@ -474,10 +476,12 @@ object ProtoUtil {
       validatorPrevBlockHash: ByteString,
       protocolVersion: ProtocolVersion,
       timestamp: Long,
-      chainName: String
+      chainName: String,
+      keyBlock: ByteString = ByteString.EMPTY // For Genesis it will be empty.
   ): Block.Header =
     Block
       .Header()
+      .withKeyBlock(keyBlock)
       .withParentHashes(parentHashes)
       .withJustifications(justifications)
       .withDeployCount(body.deploys.size)

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -481,7 +481,7 @@ object ProtoUtil {
   ): Block.Header =
     Block
       .Header()
-      .withKeyBlock(keyBlock)
+      .withKeyBlockHash(keyBlock)
       .withParentHashes(parentHashes)
       .withJustifications(justifications)
       .withDeployCount(body.deploys.size)

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -48,7 +48,6 @@ trait Validation[F[_]] {
     */
   def parents(
       b: Block,
-      lastFinalizedBlockHash: BlockHash,
       dag: DagRepresentation[F]
   )(implicit bs: BlockStorage[F]): F[ExecEngineUtil.MergeResult[ExecEngineUtil.TransformMap, Block]]
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -133,7 +133,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[*[_], InvalidBlock]: Log
     */
   override def parents(
       b: Block,
-      genesisHash: BlockHash,
+      lfbHash: BlockHash,
       dag: DagRepresentation[F]
   )(
       implicit bs: BlockStorage[F]
@@ -149,7 +149,7 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[*[_], InvalidBlock]: Log
                        dag,
                        latestMessagesHashes
                      )
-      tipHashes            <- Estimator.tips[F](dag, genesisHash, latestMessagesHashes, equivocators)
+      tipHashes            <- Estimator.tips[F](dag, lfbHash, latestMessagesHashes, equivocators)
       _                    <- Log[F].debug(s"Estimated tips are ${printHashes(tipHashes) -> "tips"}")
       tips                 <- tipHashes.toVector.traverse(ProtoUtil.unsafeGetBlock[F])
       merged               <- ExecEngineUtil.merge[F](tips, dag)

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -42,10 +42,10 @@ object ValidationImpl {
           underlying.neglectedInvalidBlock(block, invalidBlockTracker)
         )
 
-      override def parents(b: Block, lastFinalizedBlockHash: BlockHash, dag: DagRepresentation[F])(
+      override def parents(b: Block, dag: DagRepresentation[F])(
           implicit bs: BlockStorage[F]
       ): F[ExecEngineUtil.MergeResult[TransformMap, Block]] =
-        Metrics[F].timer("parents")(underlying.parents(b, lastFinalizedBlockHash, dag))
+        Metrics[F].timer("parents")(underlying.parents(b, dag))
 
       override def transactions(
           block: Block,
@@ -133,7 +133,6 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[*[_], InvalidBlock]: Log
     */
   override def parents(
       b: Block,
-      lfbHash: BlockHash,
       dag: DagRepresentation[F]
   )(
       implicit bs: BlockStorage[F]
@@ -149,7 +148,8 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[*[_], InvalidBlock]: Log
                        dag,
                        latestMessagesHashes
                      )
-      tipHashes            <- Estimator.tips[F](dag, lfbHash, latestMessagesHashes, equivocators)
+      tipHashes <- Estimator
+                    .tips[F](dag, b.getHeader.keyBlockHash, latestMessagesHashes, equivocators)
       _                    <- Log[F].debug(s"Estimated tips are ${printHashes(tipHashes) -> "tips"}")
       tips                 <- tipHashes.toVector.traverse(ProtoUtil.unsafeGetBlock[F])
       merged               <- ExecEngineUtil.merge[F](tips, dag)

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1268,6 +1268,18 @@ abstract class HashSetCasperTest
     } yield ()
   }
 
+  it should "set node's LFB as block's key_block" in effectTest {
+    val node        = standaloneEff(genesis, transforms, validatorKeys.head)
+
+    for {
+      blockA <- node.deployAndPropose(ProtoUtil.basicDeploy(timestamp = 1L))
+      _      = assert(blockA.getHeader.keyBlock == genesis.blockHash)
+      _      <- node.lastFinalizedBlockHashContainer.set(blockA.blockHash)
+      blockB <- node.deployAndPropose(ProtoUtil.basicDeploy(timestamp = 2L))
+      _      = assert(blockB.getHeader.keyBlock == blockA.blockHash)
+    } yield ()
+  }
+
   private def buildBlockWithInvalidJustification(
       deploys: immutable.IndexedSeq[ProcessedDeploy],
       signedInvalidBlock: Block

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1273,10 +1273,10 @@ abstract class HashSetCasperTest
 
     for {
       blockA <- node.deployAndPropose(ProtoUtil.basicDeploy(timestamp = 1L))
-      _      = assert(blockA.getHeader.keyBlock == genesis.blockHash)
+      _      = assert(blockA.getHeader.keyBlockHash == genesis.blockHash)
       _      <- node.lastFinalizedBlockHashContainer.set(blockA.blockHash)
       blockB <- node.deployAndPropose(ProtoUtil.basicDeploy(timestamp = 2L))
-      _      = assert(blockB.getHeader.keyBlock == blockA.blockHash)
+      _      = assert(blockB.getHeader.keyBlockHash == blockA.blockHash)
     } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1280,6 +1280,7 @@ abstract class HashSetCasperTest
     } yield ()
   }
 
+  import io.casperlabs.models.BlockImplicits._
   it should "create block correctly when there is an equivocator amongst validators" in effectTest {
     // An attempt to replicate error that occured in the CI.
     // Setup:
@@ -1303,23 +1304,21 @@ abstract class HashSetCasperTest
       // Test that node-1 knows about node-0' equivocations
       _       <- nodes(1).getEquivocators shouldBeF Set(nodes(0).ownValidatorKey)
       blockB1 <- nodes(1).deployAndPropose(ProtoUtil.basicDeploy(3))
-      _ = blockB1.getHeader.justifications
-        .map(_.latestBlockHash) should contain theSameElementsAs Set(
+      _ = blockB1.justificationHashes should contain theSameElementsAs Set(
         blockA.blockHash,
         blockAPrime.blockHash
       )
       Left(selfEquivocationError) <- nodes(0).receive().attempt
       _                           = assert(selfEquivocationError.getMessage.contains("SelfEquivocatedBlock"))
       _                           = assert(blockB1.getHeader.keyBlockHash == genesis.blockHash)
-      _                           = assert(blockB1.getHeader.parentHashes.size == 1)
+      _                           = assert(blockB1.parentHashes.size == 1)
       blockB2                     <- nodes(1).deployAndPropose(ProtoUtil.basicDeploy(4))
-      _ = blockB2.getHeader.justifications
-        .map(_.latestBlockHash) should contain theSameElementsAs Set(
+      _ = blockB2.justificationHashes should contain theSameElementsAs Set(
         blockA.blockHash,
         blockAPrime.blockHash,
         blockB1.blockHash
       )
-      _ = blockB2.getHeader.parentHashes should contain theSameElementsAs Set(blockB1.blockHash)
+      _ = blockB2.parentHashes should contain theSameElementsAs Set(blockB1.blockHash)
     } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1289,11 +1289,11 @@ abstract class HashSetCasperTest
     // 1. A & B are up.
     // 2. A proposes blockA.
     // 3. Propagate blockA across the network. B receives it.
-    // 3. Clear A's storage.
-    // 4. A proposes blockAPrime (because of point 3 we this creating an equivocation).
-    // 5. Propagate blockAPrime across the network. B sees A equivocating.
-    // 6. B proposes blockB1 (includes blockA and blockAPrime in its justifications, picks one as parent).
-    // 7. B proposes blockB2 (includes blockA, blockAPrime and blockB1 as justifications, blockB1 is a parent).
+    // 4. Clear A's storage.
+    // 5. A proposes blockAPrime (because of point 3, this creates an equivocation).
+    // 6. Propagate blockAPrime across the network. B sees A equivocating.
+    // 7. B proposes blockB1 (includes blockA and blockAPrime in its justifications, picks one as parent).
+    // 8. B proposes blockB2 (includes blockA, blockAPrime and blockB1 as justifications, blockB1 is a parent).
     for {
       nodes       <- networkEff(validatorKeys.take(2), genesis, transforms)
       blockA      <- nodes(0).deployAndPropose(ProtoUtil.basicDeploy(1))

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1269,7 +1269,7 @@ abstract class HashSetCasperTest
   }
 
   it should "set node's LFB as block's key_block" in effectTest {
-    val node        = standaloneEff(genesis, transforms, validatorKeys.head)
+    val node = standaloneEff(genesis, transforms, validatorKeys.head)
 
     for {
       blockA <- node.deployAndPropose(ProtoUtil.basicDeploy(timestamp = 1L))

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -249,7 +249,8 @@ class ValidationTest
       0,
       pk,
       sk,
-      Ed25519
+      Ed25519,
+      ByteString.EMPTY
     )
     Validation.blockSignature[Task](block) shouldBeF true
   }

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -695,50 +695,42 @@ class ValidationTest
                .map(b => b.withHeader(b.getHeader.withJustifications(Seq.empty))) //empty justification
         b10 <- createValidatorBlock[Task](Seq.empty, bonds, Seq.empty, v0) //empty justification
         result <- for {
-                   dag              <- dagStorage.getRepresentation
-                   genesisBlockHash = b0.blockHash
-
+                   dag <- dagStorage.getRepresentation
                    // Valid
                    _ <- Validation[Task].parents(
                          b1,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b2,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b3,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b4,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b5,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b6,
-                         genesisBlockHash,
                          dag
                        )
 
                    // Not valid
                    _ <- Validation[Task]
-                         .parents(b7, genesisBlockHash, dag)
+                         .parents(b7, dag)
                          .attempt
                    _ <- Validation[Task]
-                         .parents(b8, genesisBlockHash, dag)
+                         .parents(b8, dag)
                          .attempt
                    _ <- Validation[Task]
-                         .parents(b9, genesisBlockHash, dag)
+                         .parents(b9, dag)
                          .attempt
 
                    _ = log.warns should have size 3
@@ -751,7 +743,7 @@ class ValidationTest
                    )
 
                    result <- Validation[Task]
-                              .parents(b10, genesisBlockHash, dag)
+                              .parents(b10, dag)
                               .attempt shouldBeF Left(ValidateErrorWrapper(InvalidParents))
 
                  } yield result
@@ -786,14 +778,14 @@ class ValidationTest
         // v3 hasn't seen v2 equivocating (in contrast to what "local" node saw).
         // It will choose C as a main parent and A as a secondary one.
         _ <- Validation[Task]
-              .parents(d, genesis.blockHash, dag)
+              .parents(d, dag)
               .map(_.parents.map(_.blockHash))
               .attempt shouldBeF Right(
               Vector(c.blockHash, a.blockHash)
             )
         // While v0 has seen everything so it will use 0 as v2's weight when scoring.
         _ <- Validation[Task]
-              .parents(e, genesis.blockHash, dag)
+              .parents(e, dag)
               .map(_.parents.map(_.blockHash)) shouldBeF e.getHeader.parentHashes.toVector
       } yield ()
   }

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -89,7 +89,8 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
     1,
     Keys.PublicKey(secondBlockSender.toByteArray),
     Keys.PrivateKey(secondBlockSender.toByteArray),
-    Ed25519
+    Ed25519,
+    ByteString.EMPTY
   )
   val secondHashString     = Base16.encode(secondBlock.blockHash.toByteArray)
   val blockHash: BlockHash = secondBlock.blockHash

--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 PYTEST_ARGS="-vv -ra "
+TEST_RUN_ARGS=test/test_equivocating_node_shutdown.py
 
 # $TAG_NAME should have value of "DRONE-####" from docker_run_tests.sh in CI
 if [[ -n $TAG_NAME ]] && [[ "$TAG_NAME" != "latest" ]]; then

--- a/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
@@ -12,18 +12,19 @@ object BlockImplicits {
         block.getHeader.validatorPublicKey.isEmpty &&
         block.getSignature.sig.isEmpty
 
-    def parentHashes: Seq[ByteString]      = block.getHeader.parentHashes
-    def parents: Seq[ByteString]           = block.getHeader.parentHashes
-    def justifications: Seq[Justification] = block.getHeader.justifications
-    def state: GlobalState                 = block.getHeader.getState
-    def bodyHash: ByteString               = block.getHeader.bodyHash
-    def timestamp: Long                    = block.getHeader.timestamp
-    def protocolVersion: ProtocolVersion   = block.getHeader.getProtocolVersion
-    def deployCount: Int                   = block.getHeader.deployCount
-    def chainName: String                  = block.getHeader.chainName
-    def validatorBlockSeqNum: Int          = block.getHeader.validatorBlockSeqNum
-    def validatorPublicKey: ByteString     = block.getHeader.validatorPublicKey
-    def rank: Long                         = block.getHeader.rank
+    def parentHashes: Seq[ByteString]        = block.getHeader.parentHashes
+    def parents: Seq[ByteString]             = block.getHeader.parentHashes
+    def justifications: Seq[Justification]   = block.getHeader.justifications
+    def justificationHashes: Seq[ByteString] = block.getHeader.justifications.map(_.latestBlockHash)
+    def state: GlobalState                   = block.getHeader.getState
+    def bodyHash: ByteString                 = block.getHeader.bodyHash
+    def timestamp: Long                      = block.getHeader.timestamp
+    def protocolVersion: ProtocolVersion     = block.getHeader.getProtocolVersion
+    def deployCount: Int                     = block.getHeader.deployCount
+    def chainName: String                    = block.getHeader.chainName
+    def validatorBlockSeqNum: Int            = block.getHeader.validatorBlockSeqNum
+    def validatorPublicKey: ByteString       = block.getHeader.validatorPublicKey
+    def rank: Long                           = block.getHeader.rank
     def weightMap: Map[ByteString, Weight] =
       block.getHeader.getState.bonds
         .map(b => (b.validatorPublicKey, Weight(b.stake)))

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -151,7 +151,7 @@ message Block {
         uint64 rank = 11;
         MessageType message_type = 12;
         // A block from where the fork choice is calculated.
-        bytes key_block = 15;
+        bytes key_block_hash = 15;
     }
 
     enum MessageType {

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -150,6 +150,8 @@ message Block {
         // Distance from Genesis.
         uint64 rank = 11;
         MessageType message_type = 12;
+        // A block from where the fork choice is calculated.
+        bytes key_block = 15;
     }
 
     enum MessageType {


### PR DESCRIPTION
### Overview
There are couple of changes here:
1. Starts fork choice from node's LFB. 
2. Sets node's LFB as new block's `key_block` field.
3. Validates an incoming block's parents, starting from the `key_block` it uses.
4. No validation of the correctness of `key_block`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-601

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
