### PR TITLE
NODE-1042: Add test for query-state of local key

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -191,7 +191,11 @@ object DeployRuntime {
                      )
         localKeyValue = {
           val mintPublicHex = Base16.encode(mintPublic.getUref.uref.toByteArray) // Assuming that `mintPublic` is of `URef` type.
-          val purseAddrHex  = Base16.encode(account.getPurseId.uref.toByteArray)
+          val purseAddrHex = {
+            val purseAddr    = account.getPurseId.uref.toByteArray
+            val purseAddrSer = serializeArray(purseAddr)
+            Base16.encode(purseAddrSer)
+          }
           s"$mintPublicHex:$purseAddrHex"
         }
         balanceURef <- DeployService[F].queryState(blockHash, "local", localKeyValue, "").rethrow

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -34,6 +34,7 @@ INTEGRATION_CONTRACTS += \
 	endless-loop \
 	hello-name-call \
 	hello-name-define \
+	local-state \
 	mailing-list-call \
 	mailing-list-define \
 	modified-system-upgrader \
@@ -41,8 +42,8 @@ INTEGRATION_CONTRACTS += \
 	remove-associated-key \
 	standard-payment \
 	transfer-to-account \
-	unbonding-call \
-    local-state
+	unbonding-call
+
 
 INTEGRATION_CONTRACTS := $(patsubst %, build-integration-contract/%, $(INTEGRATION_CONTRACTS))
 

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -41,7 +41,8 @@ INTEGRATION_CONTRACTS += \
 	remove-associated-key \
 	standard-payment \
 	transfer-to-account \
-	unbonding-call
+	unbonding-call \
+    local-state
 
 INTEGRATION_CONTRACTS := $(patsubst %, build-integration-contract/%, $(INTEGRATION_CONTRACTS))
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -845,7 +845,7 @@ class CasperLabsClient:
         mintPublic = urefs[0]
 
         mintPublicHex = mintPublic.key.uref.uref.hex()
-        purseAddrHex = abi_byte_array(account.purse_id.uref).hex()
+        purseAddrHex = account.purse_id.uref.hex()
         localKeyValue = f"{mintPublicHex}:{purseAddrHex}"
 
         balanceURef = self.queryState(block_hash, localKeyValue, "", "local")
@@ -1113,7 +1113,7 @@ def vdag_command(casperlabs_client, args):
 def query_state_command(casperlabs_client, args):
 
     response = casperlabs_client.queryState(
-        args.block_hash, args.key, args.path, getattr(args, "type")
+        args.block_hash, args.key, args.path or "", getattr(args, "type")
     )
     print(hexify(response))
 
@@ -1311,7 +1311,7 @@ def main():
     parser.addCommand('query-state', query_state_command, 'Query a value in the global state.',
                       [[('-b', '--block-hash'), dict(required=True, type=str, help='Hash of the block to query the state of')],
                        [('-k', '--key'), dict(required=True, type=str, help='Base16 encoding of the base key')],
-                       [('-p', '--path'), dict(required=True, type=str, help="Path to the value to query. Must be of the form 'key1/key2/.../keyn'")],
+                       [('-p', '--path'), dict(required=False, type=str, help="Path to the value to query. Must be of the form 'key1/key2/.../keyn'")],
                        [('-t', '--type'), dict(required=True, choices=('hash', 'uref', 'address', 'local'), help="Type of base key. Must be one of 'hash', 'uref', 'address' or 'local'. For 'local' key type, 'key' value format is {seed}:{rest}, where both parts are hex encoded.")]])
 
     parser.addCommand('balance', balance_command, 'Returns the balance of the account at the specified block.',

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1033,7 +1033,7 @@ def check_cli_local_key(cli):
         "--session", cli.resource("local_state.wasm"))
     block_hash = propose_check_no_errors(cli)
 # CasperLabs/docker $ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
-    local_key = account.public_key_hex + ":" + "66" * 32
+    local_key = account.public_key_hex + ":" + bytes([66 for _ in range(32)]).hex()
     result = cli("query-state",
                  "--block-hash", block_hash,
                  "--key", local_key,

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1041,3 +1041,19 @@ def check_cli_local_key(cli):
                  # --path should not be really needed but it is obligatory for Python client atm
                  "--path", "")
     logging.info(f"query-state result => {result}")
+
+    cli("deploy",
+        "--from", account.public_key_hex,
+        "--private-key", cli.private_key_path(account),
+        "--public-key", cli.public_key_path(account),
+        "--payment-amount", 10000000,
+        "--session", cli.resource("local_state.wasm"))
+    block_hash = propose_check_no_errors(cli)
+
+    result = cli("query-state",
+                 "--block-hash", block_hash,
+                 "--key", local_key,
+                 "--type", "local",
+                 # --path should not be really needed but it is obligatory for Python client atm
+                 "--path", "")
+    logging.info(f"query-state result => {result}")

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1033,14 +1033,12 @@ def check_cli_local_key(cli):
         "--session", cli.resource("local_state.wasm"))
     block_hash = propose_check_no_errors(cli)
 # CasperLabs/docker $ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
-    local_key = account.public_key_hex + ":" + bytes([66 for _ in range(32)]).hex()
+    local_key = account.public_key_hex + ":" + bytes([66] * 32).hex()
     result = cli("query-state",
                  "--block-hash", block_hash,
                  "--key", local_key,
-                 "--type", "local",
-                 # --path should not be really needed but it is obligatory for Python client atm
-                 "--path", "")
-    logging.info(f"query-state result => {result}")
+                 "--type", "local")
+    assert result.string_value == 'Hello, world!'
 
     cli("deploy",
         "--from", account.public_key_hex,
@@ -1053,7 +1051,5 @@ def check_cli_local_key(cli):
     result = cli("query-state",
                  "--block-hash", block_hash,
                  "--key", local_key,
-                 "--type", "local",
-                 # --path should not be really needed but it is obligatory for Python client atm
-                 "--path", "")
-    logging.info(f"query-state result => {result}")
+                 "--type", "local")
+    assert result.string_value == 'Hello, world! Hello, world!'

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1013,3 +1013,31 @@ def check_ttl_late(cli, temp_dir):
 
     expected = "OUT_OF_RANGE: No new deploys"
     assert expected in str(excinfo.value) or expected in excinfo.value.output
+
+
+def test_cli_local_key_scala(scala_cli):
+    check_cli_local_key(scala_cli)
+
+
+def test_cli_local_key_python(cli):
+    check_cli_local_key(cli)
+
+
+def check_cli_local_key(cli):
+    account = cli.node.test_account
+    cli("deploy",
+        "--from", account.public_key_hex,
+        "--private-key", cli.private_key_path(account),
+        "--public-key", cli.public_key_path(account),
+        "--payment-amount", 10000000,
+        "--session", cli.resource("local_state.wasm"))
+    block_hash = propose_check_no_errors(cli)
+# CasperLabs/docker $ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
+    local_key = account.public_key_hex + ":" + "66" * 32
+    result = cli("query-state",
+                 "--block-hash", block_hash,
+                 "--key", local_key,
+                 "--type", "local",
+                 # --path should not be really needed but it is obligatory for Python client atm
+                 "--path", "")
+    logging.info(f"query-state result => {result}")


### PR DESCRIPTION
### Overview
This PR adds an Integration test that checks if Scala client accepts local keys for query.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1042

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
