### PR TITLE
CON-601: Start fork choice from the LFB instead LCA.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -29,6 +29,7 @@ trait MultiParentCasper[F[_]] {
   def deploy(deployData: Deploy): F[Either[Throwable, Unit]]
   def estimator(
       dag: DagRepresentation[F],
+      lfbHash: ByteString,
       latestMessages: Map[ByteString, Set[ByteString]],
       equivocators: Set[Validator]
   ): F[List[ByteString]]

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -148,7 +148,7 @@ object Estimator {
           startingBlock.pure[F]
         } else {
           val highestScoreChild =
-            reachableMainChildren.maxBy(b => scores(b) -> b.toStringUtf8)
+            reachableMainChildren.maxBy(b => scores(b) -> b)(DagOperations.bigIntByteStringOrdering)
           forkChoiceTip[F](
             dag,
             highestScoreChild,

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -100,7 +100,7 @@ object Estimator {
       latestMessageHashes: Map[Validator, Set[BlockHash]],
       equivocatingValidators: Set[Validator]
   ): F[Map[BlockHash, Weight]] = {
-    implicit val decreasingOrder = Ordering[Long].reverse
+    implicit val messageOrder = DagOperations.blockTopoOrderingDesc
     latestMessageHashes.toList.foldLeftM(Map.empty[BlockHash, Weight]) {
       case (acc, (validator, latestMessageHashes)) =>
         for {
@@ -108,7 +108,7 @@ object Estimator {
                              .traverse(dag.lookup(_))
                              .map(_.flatten.sortBy(_.rank))
           lmdScore <- DagOperations
-                       .bfTraverseF[F, Message](sortedMessages)(
+                       .bfToposortTraverseF[F](sortedMessages)(
                          _.parents.take(1).toList.traverse(dag.lookup(_)).map(_.flatten)
                        )
                        .takeUntil(_.messageHash == stopHash)

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -465,6 +465,7 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: BlockStorage: DagSto
                          rank,
                          upgrades
                        )
+        lfb <- LastFinalizedBlockHashContainer[F].get
         result <- Sync[F]
                    .delay {
                      if (checkpoint.deploysForBlock.isEmpty) {
@@ -492,7 +493,8 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: BlockStorage: DagSto
                          rank,
                          validatorId,
                          privateKey,
-                         sigAlgorithm
+                         sigAlgorithm,
+                         lfb
                        )
                        CreateBlockStatus.created(block)
                      }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -629,9 +629,8 @@ object MultiParentCasperImpl {
                      ExecEngineUtil.MergeResult
                        .empty[ExecEngineUtil.TransformMap, Block]
                        .pure[F]
-                   ) { ctx =>
-                     Validation[F]
-                       .parents(block, ctx.genesis.blockHash, dag)
+                   ) { _ =>
+                     Validation[F].parents(block, dag)
                    }
           _ <- Log[F].debug(s"Computing the pre-state hash of ${hashPrefix -> "block"}")
           preStateHash <- ExecEngineUtil

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -98,11 +98,41 @@ object DagOperations {
     StreamT.delay(Eval.now(build(Queue.empty[A].enqueue[A](start), HashSet.empty[k.K])))
   }
 
+  implicit val longByteStringOrdering: Ordering[(Long, ByteString)] =
+    Ordering.fromLessThan[(Long, ByteString)] {
+      case (a, b) =>
+        if (a._1 < b._1) true
+        else if (b._1 < a._1) false
+        else {
+          val aStr = a._2.toStringUtf8
+          val bStr = b._2.toStringUtf8
+          if (aStr < bStr) true
+          else if (bStr < aStr) false
+          else true
+        }
+    }
+
+  implicit val bigIntByteStringOrdering: Ordering[(BigInt, ByteString)] =
+    Ordering.fromLessThan[(BigInt, ByteString)] {
+      case (a, b) =>
+        if (a._1 < b._1) true
+        else if (b._1 < a._1) false
+        else {
+          val aStr = a._2.toStringUtf8
+          val bStr = b._2.toStringUtf8
+          if (aStr < bStr) true
+          else if (bStr < aStr) false
+          else true
+        }
+    }
+
   val blockTopoOrderingAsc: Ordering[Message] =
-    Ordering.by[Message, (Long, String)](m => (m.rank, m.messageHash.toStringUtf8)).reverse
+    Ordering
+      .by[Message, (Long, ByteString)](m => (m.rank, m.messageHash))(longByteStringOrdering)
+      .reverse
 
   val blockTopoOrderingDesc: Ordering[Message] =
-    Ordering.by(m => (m.rank, m.messageHash.toStringUtf8))
+    Ordering.by[Message, (Long, ByteString)](m => (m.rank, m.messageHash))(longByteStringOrdering)
 
   def bfToposortTraverseF[F[_]: Monad](
       start: List[Message]

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -99,9 +99,10 @@ object DagOperations {
   }
 
   val blockTopoOrderingAsc: Ordering[Message] =
-    Ordering.by[Message, Long](_.rank).reverse
+    Ordering.by[Message, (Long, String)](m => (m.rank, m.messageHash.toStringUtf8)).reverse
 
-  val blockTopoOrderingDesc: Ordering[Message] = Ordering.by(_.rank)
+  val blockTopoOrderingDesc: Ordering[Message] =
+    Ordering.by(m => (m.rank, m.messageHash.toStringUtf8))
 
   def bfToposortTraverseF[F[_]: Monad](
       start: List[Message]

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -98,7 +98,7 @@ object DagOperations {
     StreamT.delay(Eval.now(build(Queue.empty[A].enqueue[A](start), HashSet.empty[k.K])))
   }
 
-  implicit val longByteStringOrdering: Ordering[(Long, ByteString)] =
+  val longByteStringOrdering: Ordering[(Long, ByteString)] =
     Ordering.fromLessThan[(Long, ByteString)] {
       case (a, b) =>
         if (a._1 < b._1) true
@@ -112,7 +112,7 @@ object DagOperations {
         }
     }
 
-  implicit val bigIntByteStringOrdering: Ordering[(BigInt, ByteString)] =
+  val bigIntByteStringOrdering: Ordering[(BigInt, ByteString)] =
     Ordering.fromLessThan[(BigInt, ByteString)] {
       case (a, b) =>
         if (a._1 < b._1) true

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -376,7 +376,7 @@ object DagOperations {
       a.pure[F]
     } else {
       Ordering[A].compare(a, b) match {
-        case -1 =>
+        case x if x < 0 =>
           // Block `b` is "higher" in the chain
           next(b).flatMap(latestCommonAncestorF(a, _)(next))
         case 0 =>
@@ -386,7 +386,7 @@ object DagOperations {
             bb  <- next(b)
             lca <- latestCommonAncestorF(aa, bb)(next)
           } yield lca
-        case 1 =>
+        case x if x > 0 =>
           next(a).flatMap(latestCommonAncestorF(b, _)(next))
       }
     }

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -432,7 +432,8 @@ object ProtoUtil {
       rank: Long,
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
-      sigAlgorithm: SignatureAlgorithm
+      sigAlgorithm: SignatureAlgorithm,
+      keyBlock: ByteString
   ): Block = {
     val body = Block.Body().withDeploys(deploys)
     val postState = Block
@@ -452,7 +453,8 @@ object ProtoUtil {
       chainName = chainName,
       creator = publicKey,
       validatorSeqNum = validatorSeqNum,
-      validatorPrevBlockHash = validatorPrevBlockHash
+      validatorPrevBlockHash = validatorPrevBlockHash,
+      keyBlock = keyBlock
     )
 
     val unsigned = unsignedBlockProto(body, header)
@@ -474,10 +476,12 @@ object ProtoUtil {
       validatorPrevBlockHash: ByteString,
       protocolVersion: ProtocolVersion,
       timestamp: Long,
-      chainName: String
+      chainName: String,
+      keyBlock: ByteString = ByteString.EMPTY // For Genesis it will be empty.
   ): Block.Header =
     Block
       .Header()
+      .withKeyBlockHash(keyBlock)
       .withParentHashes(parentHashes)
       .withJustifications(justifications)
       .withDeployCount(body.deploys.size)

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -433,7 +433,7 @@ object ProtoUtil {
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
       sigAlgorithm: SignatureAlgorithm,
-      keyBlock: ByteString
+      keyBlockHash: ByteString
   ): Block = {
     val body = Block.Body().withDeploys(deploys)
     val postState = Block
@@ -454,7 +454,7 @@ object ProtoUtil {
       creator = publicKey,
       validatorSeqNum = validatorSeqNum,
       validatorPrevBlockHash = validatorPrevBlockHash,
-      keyBlock = keyBlock
+      keyBlockHash = keyBlockHash
     )
 
     val unsigned = unsignedBlockProto(body, header)
@@ -477,11 +477,11 @@ object ProtoUtil {
       protocolVersion: ProtocolVersion,
       timestamp: Long,
       chainName: String,
-      keyBlock: ByteString = ByteString.EMPTY // For Genesis it will be empty.
+      keyBlockHash: ByteString = ByteString.EMPTY // For Genesis it will be empty.
   ): Block.Header =
     Block
       .Header()
-      .withKeyBlockHash(keyBlock)
+      .withKeyBlockHash(keyBlockHash)
       .withParentHashes(parentHashes)
       .withJustifications(justifications)
       .withDeployCount(body.deploys.size)

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -48,7 +48,6 @@ trait Validation[F[_]] {
     */
   def parents(
       b: Block,
-      lastFinalizedBlockHash: BlockHash,
       dag: DagRepresentation[F]
   )(implicit bs: BlockStorage[F]): F[ExecEngineUtil.MergeResult[ExecEngineUtil.TransformMap, Block]]
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -133,7 +133,6 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[*[_], InvalidBlock]: Log
     */
   override def parents(
       b: Block,
-      genesisHash: BlockHash,
       dag: DagRepresentation[F]
   )(
       implicit bs: BlockStorage[F]

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -42,10 +42,10 @@ object ValidationImpl {
           underlying.neglectedInvalidBlock(block, invalidBlockTracker)
         )
 
-      override def parents(b: Block, lastFinalizedBlockHash: BlockHash, dag: DagRepresentation[F])(
+      override def parents(b: Block, dag: DagRepresentation[F])(
           implicit bs: BlockStorage[F]
       ): F[ExecEngineUtil.MergeResult[TransformMap, Block]] =
-        Metrics[F].timer("parents")(underlying.parents(b, lastFinalizedBlockHash, dag))
+        Metrics[F].timer("parents")(underlying.parents(b, dag))
 
       override def transactions(
           block: Block,
@@ -148,7 +148,8 @@ class ValidationImpl[F[_]: MonadThrowable: FunctorRaise[*[_], InvalidBlock]: Log
                        dag,
                        latestMessagesHashes
                      )
-      tipHashes            <- Estimator.tips[F](dag, genesisHash, latestMessagesHashes, equivocators)
+      tipHashes <- Estimator
+                    .tips[F](dag, b.getHeader.keyBlockHash, latestMessagesHashes, equivocators)
       _                    <- Log[F].debug(s"Estimated tips are ${printHashes(tipHashes) -> "tips"}")
       tips                 <- tipHashes.toVector.traverse(ProtoUtil.unsafeGetBlock[F])
       merged               <- ExecEngineUtil.merge[F](tips, dag)

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -195,6 +195,7 @@ object AutoProposerTest {
     override def contains(block: Block): F[Boolean]     = ???
     override def estimator(
         dag: DagRepresentation[F],
+        lfbHash: ByteString,
         lm: Map[Validator, Set[ByteString]],
         equivocators: Set[Validator]
     ): F[List[ByteString]]                    = ???

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -166,7 +166,8 @@ abstract class HashSetCasperTest
       dag                  <- MultiParentCasper[Task].dag
       latestMessageHashes  <- dag.latestMessageHashes
       equivocators         <- dag.getEquivocators
-      estimate             <- MultiParentCasper[Task].estimator(dag, latestMessageHashes, equivocators)
+      lfbHash              <- LastFinalizedBlockHashContainer[Task].get
+      estimate             <- MultiParentCasper[Task].estimator(dag, lfbHash, latestMessageHashes, equivocators)
       _                    = estimate shouldBe IndexedSeq(signedBlock.blockHash)
       _                    = node.tearDown()
     } yield ()
@@ -211,7 +212,8 @@ abstract class HashSetCasperTest
       dag                   <- MultiParentCasper[Task].dag
       latestMessageHashes   <- dag.latestMessageHashes
       equivocators          <- dag.getEquivocators
-      estimate              <- MultiParentCasper[Task].estimator(dag, latestMessageHashes, equivocators)
+      lfbHash               <- LastFinalizedBlockHashContainer[Task].get
+      estimate              <- MultiParentCasper[Task].estimator(dag, lfbHash, latestMessageHashes, equivocators)
 
       _ = estimate shouldBe IndexedSeq(signedBlock2.blockHash)
       _ <- node.tearDown()

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -731,24 +731,15 @@ class ValidationTest
                    _ <- Validation[Task]
                          .parents(b7, dag)
                          .attempt
-                         .map(r => {
-                           println(r)
-                           assert(r.isLeft)
-                         })
+                         .map(_ shouldBe 'left)
                    _ <- Validation[Task]
                          .parents(b8, dag)
                          .attempt
-                         .map(r => {
-                           println(r)
-                           assert(r.isLeft)
-                         })
+                         .map(_ shouldBe 'left)
                    _ <- Validation[Task]
                          .parents(b9, dag)
                          .attempt
-                         .map(r => {
-                           println(r)
-                           assert(r.isLeft)
-                         })
+                         .map(_ shouldBe 'left)
 
                    _ = log.warns should have size 3
                    _ = log.warns.forall(

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -249,7 +249,8 @@ class ValidationTest
       0,
       pk,
       sk,
-      Ed25519
+      Ed25519,
+      ByteString.EMPTY
     )
     Validation.blockSignature[Task](block) shouldBeF true
   }

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -695,50 +695,42 @@ class ValidationTest
                .map(b => b.withHeader(b.getHeader.withJustifications(Seq.empty))) //empty justification
         b10 <- createValidatorBlock[Task](Seq.empty, bonds, Seq.empty, v0) //empty justification
         result <- for {
-                   dag              <- dagStorage.getRepresentation
-                   genesisBlockHash = b0.blockHash
-
+                   dag <- dagStorage.getRepresentation
                    // Valid
                    _ <- Validation[Task].parents(
                          b1,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b2,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b3,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b4,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b5,
-                         genesisBlockHash,
                          dag
                        )
                    _ <- Validation[Task].parents(
                          b6,
-                         genesisBlockHash,
                          dag
                        )
 
                    // Not valid
                    _ <- Validation[Task]
-                         .parents(b7, genesisBlockHash, dag)
+                         .parents(b7, dag)
                          .attempt
                    _ <- Validation[Task]
-                         .parents(b8, genesisBlockHash, dag)
+                         .parents(b8, dag)
                          .attempt
                    _ <- Validation[Task]
-                         .parents(b9, genesisBlockHash, dag)
+                         .parents(b9, dag)
                          .attempt
 
                    _ = log.warns should have size 3
@@ -751,7 +743,7 @@ class ValidationTest
                    )
 
                    result <- Validation[Task]
-                              .parents(b10, genesisBlockHash, dag)
+                              .parents(b10, dag)
                               .attempt shouldBeF Left(ValidateErrorWrapper(InvalidParents))
 
                  } yield result
@@ -786,14 +778,14 @@ class ValidationTest
         // v3 hasn't seen v2 equivocating (in contrast to what "local" node saw).
         // It will choose C as a main parent and A as a secondary one.
         _ <- Validation[Task]
-              .parents(d, genesis.blockHash, dag)
+              .parents(d, dag)
               .map(_.parents.map(_.blockHash))
               .attempt shouldBeF Right(
               Vector(c.blockHash, a.blockHash)
             )
         // While v0 has seen everything so it will use 0 as v2's weight when scoring.
         _ <- Validation[Task]
-              .parents(e, genesis.blockHash, dag)
+              .parents(e, dag)
               .map(_.parents.map(_.blockHash)) shouldBeF e.getHeader.parentHashes.toVector
       } yield ()
   }

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -89,7 +89,8 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
     1,
     Keys.PublicKey(secondBlockSender.toByteArray),
     Keys.PrivateKey(secondBlockSender.toByteArray),
-    Ed25519
+    Ed25519,
+    ByteString.EMPTY
   )
   val secondHashString     = Base16.encode(secondBlock.blockHash.toByteArray)
   val blockHash: BlockHash = secondBlock.blockHash

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -367,10 +367,11 @@ private class SleepingMultiParentCasperImpl[F[_]: Monad: Time](underlying: Multi
   def deploy(d: Deploy): F[Either[Throwable, Unit]] = underlying.deploy(d)
   def estimator(
       dag: DagRepresentation[F],
+      lfbHash: ByteString,
       latestMessagesHashes: Map[Validator, Set[ByteString]],
       equivocators: Set[Validator]
   ): F[List[BlockHash]] =
-    underlying.estimator(dag, latestMessagesHashes, equivocators)
+    underlying.estimator(dag, lfbHash, latestMessagesHashes, equivocators)
   def dag: F[DagRepresentation[F]] = underlying.dag
   def lastFinalizedBlock: F[Block] = underlying.lastFinalizedBlock
 

--- a/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/equivocations/EquivocationDetectorTest.scala
@@ -33,6 +33,7 @@ class EquivocationDetectorTest
 
   def createBlockAndTestEquivocateDetector(
       parentsHashList: Seq[BlockHash],
+      lfb: Block,
       creator: Validator = ByteString.EMPTY,
       justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
       rankOfLowestBaseBlockExpect: Option[Long]
@@ -45,6 +46,7 @@ class EquivocationDetectorTest
       dag <- dagStorage.getRepresentation
       b <- createBlock[Task](
             parentsHashList,
+            keyBlockHash = lfb.blockHash,
             creator,
             justifications = justifications
           )
@@ -69,6 +71,7 @@ class EquivocationDetectorTest
 
   def createBlockAndCheckEquivocatorsFromViewOfBlock(
       parentsHashList: Seq[BlockHash],
+      lfb: Block,
       creator: Validator = ByteString.EMPTY,
       justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
       rankOfLowestBaseBlockExpect: Option[Long],
@@ -81,6 +84,7 @@ class EquivocationDetectorTest
     for {
       block <- createBlockAndTestEquivocateDetector(
                 parentsHashList,
+                lfb,
                 creator,
                 justifications,
                 rankOfLowestBaseBlockExpect
@@ -119,17 +123,20 @@ class EquivocationDetectorTest
                                                             )
           b1 <- createBlockAndTestEquivocateDetector(
                  Seq(genesis.blockHash),
+                 genesis,
                  v0,
                  rankOfLowestBaseBlockExpect = None
                )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b1.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b1.blockHash),
                 rankOfLowestBaseBlockExpect = None
               )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b1.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b1.blockHash),
                 rankOfLowestBaseBlockExpect = b1.getHeader.rank.some
@@ -164,16 +171,19 @@ class EquivocationDetectorTest
           genesis <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY)
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(genesis.blockHash),
+                genesis,
                 v0,
                 rankOfLowestBaseBlockExpect = None
               )
           b2 <- createBlockAndTestEquivocateDetector(
                  Seq(genesis.blockHash),
+                 genesis,
                  v0,
                  rankOfLowestBaseBlockExpect = Some(0)
                )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b2.blockHash),
+                genesis,
                 v1,
                 justifications = HashMap(v0 -> b2.blockHash),
                 rankOfLowestBaseBlockExpect = None
@@ -211,29 +221,34 @@ class EquivocationDetectorTest
           genesis <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY)
           b1 <- createBlockAndTestEquivocateDetector(
                  Seq(genesis.blockHash),
+                 genesis,
                  v1,
                  rankOfLowestBaseBlockExpect = None
                )
           b2 <- createBlockAndTestEquivocateDetector(
                  Seq(b1.blockHash),
+                 genesis,
                  v1,
                  justifications = HashMap(v1 -> b1.blockHash),
                  rankOfLowestBaseBlockExpect = None
                )
           b3 <- createBlockAndTestEquivocateDetector(
                  Seq(b2.blockHash),
+                 genesis,
                  v0,
                  justifications = HashMap(v1 -> b2.blockHash),
                  rankOfLowestBaseBlockExpect = None
                )
           b4 <- createBlockAndTestEquivocateDetector(
                  Seq(b3.blockHash),
+                 genesis,
                  v0,
                  justifications = HashMap(v0 -> b3.blockHash),
                  rankOfLowestBaseBlockExpect = None
                )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b4.blockHash),
+                genesis,
                 v1,
                 justifications = HashMap(v0 -> b4.blockHash, v1 -> b1.blockHash),
                 rankOfLowestBaseBlockExpect = None
@@ -270,24 +285,28 @@ class EquivocationDetectorTest
                                                             )
           b1 <- createBlockAndTestEquivocateDetector(
                  Seq(genesis.blockHash),
+                 genesis,
                  v0,
                  justifications = HashMap(v0 -> genesis.blockHash),
                  rankOfLowestBaseBlockExpect = None
                )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b1.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b1.blockHash),
                 rankOfLowestBaseBlockExpect = None
               )
           b3 <- createBlockAndTestEquivocateDetector(
                  Seq(b1.blockHash),
+                 genesis,
                  v0,
                  justifications = HashMap(v0 -> b1.blockHash),
                  rankOfLowestBaseBlockExpect = b1.getHeader.rank.some
                )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b3.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b3.blockHash),
                 rankOfLowestBaseBlockExpect = b1.getHeader.rank.some
@@ -326,18 +345,21 @@ class EquivocationDetectorTest
                                                             )
           b1 <- createBlockAndTestEquivocateDetector(
                  Seq(genesis.blockHash),
+                 genesis,
                  v0,
                  justifications = HashMap(v0 -> genesis.blockHash),
                  rankOfLowestBaseBlockExpect = None
                )
           b2 <- createBlockAndTestEquivocateDetector(
                  Seq(b1.blockHash),
+                 genesis,
                  v0,
                  justifications = HashMap(v0 -> b1.blockHash),
                  rankOfLowestBaseBlockExpect = None
                )
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b2.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b2.blockHash),
                 rankOfLowestBaseBlockExpect = None
@@ -345,6 +367,7 @@ class EquivocationDetectorTest
           // When v0 creates first equivocation, then the rank of lowest base block is the rank of b2
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b2.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b2.blockHash),
                 rankOfLowestBaseBlockExpect = b2.getHeader.rank.some
@@ -353,6 +376,7 @@ class EquivocationDetectorTest
           // equivocation is smaller, then update the rank of lowest base block to be the rank of b1
           _ <- createBlockAndTestEquivocateDetector(
                 Seq(b1.blockHash),
+                genesis,
                 v0,
                 justifications = HashMap(v0 -> b1.blockHash),
                 rankOfLowestBaseBlockExpect = b1.getHeader.rank.some
@@ -371,14 +395,10 @@ class EquivocationDetectorTest
         implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
                                                             CasperState()
                                                           )
-        genesis <- createBlockAndCheckEquivocatorsFromViewOfBlock(
-                    Seq(),
-                    ByteString.EMPTY,
-                    rankOfLowestBaseBlockExpect = None,
-                    visibleEquivocatorExpected = Set.empty
-                  )
+        genesis <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY)
         a1 <- createBlockAndCheckEquivocatorsFromViewOfBlock(
                Seq(genesis.blockHash),
+               genesis,
                v1,
                justifications = HashMap(v1 -> genesis.blockHash),
                rankOfLowestBaseBlockExpect = None,
@@ -386,6 +406,7 @@ class EquivocationDetectorTest
              )
         a2 <- createBlockAndCheckEquivocatorsFromViewOfBlock(
                Seq(genesis.blockHash),
+               genesis,
                v1,
                justifications = HashMap(v1 -> genesis.blockHash),
                rankOfLowestBaseBlockExpect = 0L.some,
@@ -393,6 +414,7 @@ class EquivocationDetectorTest
              )
         b <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(a2.blockHash),
+              genesis,
               v2,
               justifications = HashMap(v1 -> a2.blockHash, v2 -> genesis.blockHash),
               rankOfLowestBaseBlockExpect = None,
@@ -401,6 +423,7 @@ class EquivocationDetectorTest
 
         c <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(b.blockHash),
+              genesis,
               v1,
               justifications = HashMap(v1 -> a1.blockHash, v2 -> b.blockHash),
               rankOfLowestBaseBlockExpect = 0L.some,
@@ -410,6 +433,7 @@ class EquivocationDetectorTest
         // this block isn't shown in the diagram
         _ <- createBlockAndCheckEquivocatorsFromViewOfBlock(
               Seq(c.blockHash),
+              genesis,
               v1,
               justifications = HashMap(v1 -> c.blockHash, v2 -> b.blockHash),
               rankOfLowestBaseBlockExpect = 0L.some,

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -511,6 +511,7 @@ class FinalityDetectorByVotingMatrixTest
     for {
       block <- createBlock[F](
                 parentsHashList,
+                lastFinalizedBlockHash,
                 creator,
                 bonds,
                 justifications,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsCasperEffect.scala
@@ -35,6 +35,7 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStorage: DagStorage] private (
   def deploy(r: Deploy): F[Either[Throwable, Unit]] = Applicative[F].pure(Right(()))
   def estimator(
       dag: DagRepresentation[F],
+      lfbHash: ByteString,
       latestMessageHashes: Map[Validator, Set[ByteString]],
       equivocators: Set[Validator]
   ): F[List[BlockHash]] =

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -150,6 +150,8 @@ message Block {
         // Distance from Genesis.
         uint64 rank = 11;
         MessageType message_type = 12;
+        // A block from where the fork choice is calculated.
+        bytes key_block_hash = 15;
     }
 
     enum MessageType {


### PR DESCRIPTION
### Overview
Starts a fork choice calculation from the LFB, instead LCA. This is also happening during block validation. Note that LFB choice is not validated.

There's a, potentially, problematic place in the code where on node startup we set its LFB to be LCA of the latest messages as seen in the local DAG.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
