### PR TITLE
[NODE-1051]: Change findBlockHashesWithDeployHash to support multiple deploys

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/DeployFilters.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeployFilters.scala
@@ -101,13 +101,7 @@ object DeployFilters {
       deployHashes: List[ByteString]
   ): F[List[ByteString]] =
     for {
-      deployHashToBlocksMap <- deployHashes
-                                .traverse { deployHash =>
-                                  BlockStorage[F]
-                                    .findBlockHashesWithDeployHash(deployHash)
-                                    .map(deployHash -> _)
-                                }
-                                .map(_.toMap)
+      deployHashToBlocksMap <- BlockStorage[F].findBlockHashesWithDeployHashes(deployHashes)
 
       blockHashes = deployHashToBlocksMap.values.flatten.toList.distinct
 

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -185,12 +185,10 @@ class MultiParentCasperImpl[F[_]: Sync: Log: Metrics: Time: BlockStorage: DagSto
     Metrics[F].timer("removeFinalizedDeploys") {
       for {
         deployHashes <- DeployStorageReader[F].readProcessedHashes
-        blockHashes <- deployHashes
-                        .traverse { deployHash =>
-                          BlockStorage[F]
-                            .findBlockHashesWithDeployHash(deployHash)
-                        }
-                        .map(_.flatten.distinct)
+
+        blockHashes <- BlockStorage[F]
+                        .findBlockHashesWithDeployHashes(deployHashes)
+                        .map(_.values.flatten.toList.distinct)
 
         lastFinalizedBlock <- (LastFinalizedBlockHashContainer[F].get >>= dag.lookup).map(_.get)
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -200,11 +200,7 @@ object Validation {
 
       case None =>
         for {
-          deployToBlocksMap <- bs
-                                .findBlockHashesWithDeployHashes(deploys.map(_.deployHash))
-                                .map(_.mapValues { blockHashes =>
-                                  blockHashes.filterNot(_ == block.blockHash)
-                                })
+          deployToBlocksMap <- bs.findBlockHashesWithDeployHashes(deploys.map(_.deployHash))
 
           blockHashes = deployToBlocksMap.values.flatten.toSet
 

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Validation.scala
@@ -200,14 +200,11 @@ object Validation {
 
       case None =>
         for {
-          deployToBlocksMap <- deploys
-                                .traverse { deploy =>
-                                  bs.findBlockHashesWithDeployHash(deploy.deployHash).map {
-                                    blockHashes =>
-                                      deploy -> blockHashes.filterNot(_ == block.blockHash)
-                                  }
-                                }
-                                .map(_.toMap)
+          deployToBlocksMap <- bs
+                                .findBlockHashesWithDeployHashes(deploys.map(_.deployHash))
+                                .map(_.mapValues { blockHashes =>
+                                  blockHashes.filterNot(_ == block.blockHash)
+                                })
 
           blockHashes = deployToBlocksMap.values.flatten.toSet
 

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -106,7 +106,7 @@ object SQLiteStorage {
 
       override def findBlockHashesWithDeployHashes(
           deployHashes: List[DeployHash]
-      ): F[Map[DeployHash, Seq[BlockHash]]] =
+      ): F[Map[DeployHash, Set[BlockHash]]] =
         blockStorage.findBlockHashesWithDeployHashes(deployHashes)
 
       override def children(blockHash: BlockHash): F[Set[BlockHash]] =

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -15,7 +15,7 @@ import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Message
 import io.casperlabs.shared.Time
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
 import io.casperlabs.storage.block.{BlockStorage, SQLiteBlockStorage}
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.storage.dag.{DagRepresentation, DagStorage, SQLiteDagStorage}
@@ -106,6 +106,11 @@ object SQLiteStorage {
 
       override def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]] =
         blockStorage.findBlockHashesWithDeployHash(deployHash)
+
+      override def findBlockHashesWithDeployHashes(
+          deployHashes: List[DeployHash]
+      ): F[Map[DeployHash, Seq[BlockHash]]] =
+        blockStorage.findBlockHashesWithDeployHashes(deployHashes)
 
       override def children(blockHash: BlockHash): F[Set[BlockHash]] =
         dagStorage.children(blockHash)

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -104,9 +104,6 @@ object SQLiteStorage {
       override def getBlockSummary(blockHash: BlockHash): F[Option[BlockSummary]] =
         dagStorage.lookup(blockHash).map(_.map(_.blockSummary))
 
-      override def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]] =
-        blockStorage.findBlockHashesWithDeployHash(deployHash)
-
       override def findBlockHashesWithDeployHashes(
           deployHashes: List[DeployHash]
       ): F[Map[DeployHash, Seq[BlockHash]]] =

--- a/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
@@ -49,8 +49,6 @@ trait BlockStorage[F[_]] {
 
   def getBlockInfoByPrefix(blockHashPrefix: String): F[Option[BlockInfo]]
 
-  def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]]
-
   /**
     * Note: if there are no blocks for the specified deployHash,
     * Result.get(deployHash) returns Some(Seq.empty[BlockHash]) instead of None
@@ -108,14 +106,6 @@ object BlockStorage {
         blockHash: BlockHash
     )(implicit applicativeF: Applicative[F]): F[Boolean] =
       incAndMeasure("contains", super.contains(blockHash))
-
-    abstract override def findBlockHashesWithDeployHash(
-        deployHash: BlockHash
-    ): F[Seq[BlockHash]] =
-      incAndMeasure(
-        "findBlockHashesWithDeployHash",
-        super.findBlockHashesWithDeployHash(deployHash)
-      )
 
     abstract override def findBlockHashesWithDeployHashes(
         deployHashes: List[DeployHash]

--- a/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
@@ -8,6 +8,7 @@ import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.metrics.Metered
 import io.casperlabs.storage.BlockMsgWithTransform
+import io.casperlabs.storage.block.BlockStorage.DeployHash
 
 import scala.language.higherKinds
 
@@ -49,6 +50,14 @@ trait BlockStorage[F[_]] {
   def getBlockInfoByPrefix(blockHashPrefix: String): F[Option[BlockInfo]]
 
   def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]]
+
+  /**
+    * Note: if there are no blocks for the specified deployHash,
+    * Result.get(deployHash) returns Some(Seq.empty[BlockHash]) instead of None
+    */
+  def findBlockHashesWithDeployHashes(
+      deployHashes: List[DeployHash]
+  ): F[Map[DeployHash, Seq[BlockHash]]]
 
   def checkpoint(): F[Unit]
 
@@ -100,10 +109,20 @@ object BlockStorage {
     )(implicit applicativeF: Applicative[F]): F[Boolean] =
       incAndMeasure("contains", super.contains(blockHash))
 
-    abstract override def findBlockHashesWithDeployHash(deployHash: BlockHash): F[Seq[BlockHash]] =
+    abstract override def findBlockHashesWithDeployHash(
+        deployHash: BlockHash
+    ): F[Seq[BlockHash]] =
       incAndMeasure(
         "findBlockHashesWithDeployHash",
         super.findBlockHashesWithDeployHash(deployHash)
+      )
+
+    abstract override def findBlockHashesWithDeployHashes(
+        deployHashes: List[DeployHash]
+    ): F[Map[DeployHash, Seq[BlockHash]]] =
+      incAndMeasure(
+        "findBlockHashesWithDeployHashes",
+        super.findBlockHashesWithDeployHashes(deployHashes)
       )
   }
 

--- a/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
@@ -51,7 +51,7 @@ trait BlockStorage[F[_]] {
 
   /**
     * Note: if there are no blocks for the specified deployHash,
-    * Result.get(deployHash) returns Some(Seq.empty[BlockHash]) instead of None
+    * Result.get(deployHash) returns Some(Set.empty[BlockHash]) instead of None
     */
   def findBlockHashesWithDeployHashes(
       deployHashes: List[DeployHash]

--- a/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
@@ -55,7 +55,7 @@ trait BlockStorage[F[_]] {
     */
   def findBlockHashesWithDeployHashes(
       deployHashes: List[DeployHash]
-  ): F[Map[DeployHash, Seq[BlockHash]]]
+  ): F[Map[DeployHash, Set[BlockHash]]]
 
   def checkpoint(): F[Unit]
 
@@ -109,7 +109,7 @@ object BlockStorage {
 
     abstract override def findBlockHashesWithDeployHashes(
         deployHashes: List[DeployHash]
-    ): F[Map[DeployHash, Seq[BlockHash]]] =
+    ): F[Map[DeployHash, Set[BlockHash]]] =
       incAndMeasure(
         "findBlockHashesWithDeployHashes",
         super.findBlockHashesWithDeployHashes(deployHashes)

--- a/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
@@ -9,7 +9,7 @@ import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, MeteredBlockStorage}
+import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash, MeteredBlockStorage}
 import io.casperlabs.storage.{BlockMsgWithTransform, BlockStorageMetricsSource}
 
 import scala.collection.JavaConverters._
@@ -68,6 +68,11 @@ class CachingBlockStorage[F[_]: Sync](
 
   override def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]] =
     underlying.findBlockHashesWithDeployHash(deployHash)
+
+  override def findBlockHashesWithDeployHashes(
+      deployHashes: List[DeployHash]
+  ): F[Map[DeployHash, Seq[BlockHash]]] =
+    underlying.findBlockHashesWithDeployHashes(deployHashes)
 
   override def checkpoint(): F[Unit] =
     underlying.checkpoint()

--- a/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
@@ -66,9 +66,6 @@ class CachingBlockStorage[F[_]: Sync](
     // Not caching because in the future the finality status will get updated.
     underlying.getBlockInfo(blockHash)
 
-  override def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]] =
-    underlying.findBlockHashesWithDeployHash(deployHash)
-
   override def findBlockHashesWithDeployHashes(
       deployHashes: List[DeployHash]
   ): F[Map[DeployHash, Seq[BlockHash]]] =

--- a/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
@@ -68,7 +68,7 @@ class CachingBlockStorage[F[_]: Sync](
 
   override def findBlockHashesWithDeployHashes(
       deployHashes: List[DeployHash]
-  ): F[Map[DeployHash, Seq[BlockHash]]] =
+  ): F[Map[DeployHash, Set[BlockHash]]] =
     underlying.findBlockHashesWithDeployHashes(deployHashes)
 
   override def checkpoint(): F[Unit] =

--- a/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
@@ -155,12 +155,6 @@ class SQLiteBlockStorage[F[_]: Bracket[*[_], Throwable]: Fs2Compiler](
       .option
       .transact(readXa)
 
-  override def findBlockHashesWithDeployHash(deployHash: ByteString): F[Seq[BlockHash]] =
-    sql"""|SELECT block_hash
-          |FROM deploy_process_results
-          |WHERE deploy_hash=$deployHash
-          |ORDER BY create_time_millis""".stripMargin.query[BlockHash].to[Seq].transact(readXa)
-
   override def findBlockHashesWithDeployHashes(
       deployHashes: List[DeployHash]
   ): F[Map[DeployHash, Set[BlockHash]]] =

--- a/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.storage.block
 
 import cats._
+import cats.data.NonEmptyList
 import cats.effect._
 import cats.implicits._
 import com.google.protobuf.ByteString
@@ -10,12 +11,13 @@ import doobie.util.transactor.Transactor
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.consensus.{Block, BlockSummary, Deploy}
+import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
 import io.casperlabs.catscontrib.Fs2Compiler
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.metrics.Metrics.Source
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, MeteredBlockStorage}
+import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash, MeteredBlockStorage}
 import io.casperlabs.storage.util.DoobieCodecs
 import io.casperlabs.storage.{BlockMsgWithTransform, BlockStorageMetricsSource}
 
@@ -158,6 +160,29 @@ class SQLiteBlockStorage[F[_]: Bracket[*[_], Throwable]: Fs2Compiler](
           |FROM deploy_process_results
           |WHERE deploy_hash=$deployHash
           |ORDER BY create_time_millis""".stripMargin.query[BlockHash].to[Seq].transact(readXa)
+
+  override def findBlockHashesWithDeployHashes(
+      deployHashes: List[DeployHash]
+  ): F[Map[DeployHash, Seq[BlockHash]]] =
+    NonEmptyList
+      .fromList[ByteString](deployHashes)
+      .fold(Map.empty[DeployHash, Seq[BlockHash]].pure[F]) { nfl =>
+        val sql = fr"""|SELECT deploy_hash, block_hash
+                       |FROM deploy_process_results
+                       |WHERE """.stripMargin ++ Fragments.in(fr"deploy_hash", nfl)
+
+        sql
+          .query[(DeployHash, BlockHash)]
+          .to[Seq]
+          .transact(readXa)
+          .map(_.groupBy(_._1))
+          .map { deployHashToBlockHashesMap: Map[DeployHash, Seq[(DeployHash, BlockHash)]] =>
+            deployHashes.map { d =>
+              val value = deployHashToBlockHashesMap.get(d).fold(Seq.empty[BlockHash])(_.map(_._2))
+              (d, value)
+            }.toMap
+          }
+      }
 
   override def checkpoint(): F[Unit] = ().pure[F]
 

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -240,9 +240,6 @@ object CachingBlockStorageTest {
       override def getBlockInfoByPrefix(blockHashPrefix: String): Task[Option[BlockInfo]] =
         underlyingBlockStorage.getBlockInfoByPrefix(blockHashPrefix)
 
-      override def findBlockHashesWithDeployHash(deployHash: BlockHash): Task[Seq[BlockHash]] =
-        underlyingBlockStorage.findBlockHashesWithDeployHash(deployHash)
-
       override def findBlockHashesWithDeployHashes(
           deployHashes: List[DeployHash]
       ): Task[Map[DeployHash, Seq[BlockHash]]] =

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -242,7 +242,7 @@ object CachingBlockStorageTest {
 
       override def findBlockHashesWithDeployHashes(
           deployHashes: List[DeployHash]
-      ): Task[Map[DeployHash, Seq[BlockHash]]] =
+      ): Task[Map[DeployHash, Set[BlockHash]]] =
         underlyingBlockStorage.findBlockHashesWithDeployHashes(deployHashes)
 
       override def checkpoint(): Task[Unit] = ???

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -7,7 +7,7 @@ import doobie.util.transactor.Transactor
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
 import io.casperlabs.storage.block.CachingBlockStorageTest.{
   createSQLiteBlockStorage,
   CachingBlockStorageTestData,
@@ -242,6 +242,11 @@ object CachingBlockStorageTest {
 
       override def findBlockHashesWithDeployHash(deployHash: BlockHash): Task[Seq[BlockHash]] =
         underlyingBlockStorage.findBlockHashesWithDeployHash(deployHash)
+
+      override def findBlockHashesWithDeployHashes(
+          deployHashes: List[DeployHash]
+      ): Task[Map[DeployHash, Seq[BlockHash]]] =
+        underlyingBlockStorage.findBlockHashesWithDeployHashes(deployHashes)
 
       override def checkpoint(): Task[Unit] = ???
 


### PR DESCRIPTION
### Overview
This PR changes `findBlockHashesWithDeployHash` to support multiple deployHashes, so that we can use the index on (deploy_hash, block_hash) directly. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1051

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
