### PR TITLE
NODE-1063: Add transfer command to Python client

### DIFF
--- a/integration-testing/casperlabs_local_net/cli.py
+++ b/integration-testing/casperlabs_local_net/cli.py
@@ -78,7 +78,7 @@ class CLI:
 
         output = binary_output.decode("utf-8")
 
-        if command in ("deploy", "send-deploy", "bond", "unbond"):
+        if command in ("deploy", "send-deploy", "bond", "unbond", "transfer"):
             return output.split()[2]
             # "Success! Deploy 0d4036bebb95de793b28de452d594531a29f8dc3c5394526094d30723fa5ff65 deployed."
 
@@ -94,6 +94,10 @@ class CLI:
 
         if command in ("show-deploy", "show-block", "query-state"):
             return parse(output)
+
+        if command in ("balance",):
+            # 'Balance:\n9d39b7fba47d07c1af6f711efe604a112ab371e2deefb99a613d2b3dcdfba414 : 1000000000'
+            return int(output.split(":")[-1])
 
         return output
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -518,6 +518,7 @@ class CasperLabsClient:
         session_uref: bytes = None,
         ttl_millis: int = 0,
         dependencies: list = None,
+        chain_name: str = None,
     ):
         """
         Create a protobuf deploy object. See deploy for description of parameters.
@@ -571,6 +572,7 @@ class CasperLabsClient:
             dependencies=dependencies
             and [bytes.fromhex(d) for d in dependencies]
             or [],
+            chain_name=chain_name or "",
         )
 
         deploy_hash = blake2b_hash(_serialize(header))
@@ -609,6 +611,7 @@ class CasperLabsClient:
         session_uref: bytes = None,
         ttl_millis: int = 0,
         dependencies=None,
+        chain_name: str = None,
     ):
         """
         Deploy a smart contract source file to Casper on an existing running node.
@@ -640,6 +643,9 @@ class CasperLabsClient:
                               deploy will remain valid for.
         :dependencies:        List of deploy hashes (base16 encoded) which
                               must be executed before this deploy.
+        :chain_name:          Name of the chain to optionally restrict the
+                              deploy from being accidentally included
+                              anywhere else.
         :return:              Tuple: (deserialized DeployServiceResponse object, deploy_hash)
         """
 
@@ -660,6 +666,7 @@ class CasperLabsClient:
             session_uref=session_uref,
             ttl_millis=ttl_millis,
             dependencies=dependencies,
+            chain_name=chain_name,
         )
 
         pk = (
@@ -1057,6 +1064,7 @@ def _deploy_kwargs(args, private_key_accepted=True):
         session_uref=args.session_uref and bytes.fromhex(args.session_uref),
         ttl_millis=args.ttl,
         dependencies=args.dependencies,
+        chain_name=args.chain_name,
     )
     if private_key_accepted:
         d["private_key"] = args.private_key or None

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -985,7 +985,22 @@ def unbond_command(casperlabs_client, args):
             )
         )
 
-    logging.info(f" XXX unbond_command: args.session_args={args.session_args}")
+    return deploy_command(casperlabs_client, args)
+
+
+@guarded_command
+def transfer_command(casperlabs_client, args):
+    _set_session(args, "transfer_to_account.wasm")
+
+    if not args.session_args:
+        args.session_args = ABI.args_to_json(
+            ABI.args(
+                [
+                    ABI.account("account", args.account),
+                    ABI.long_value("amount", args.amount),
+                ]
+            )
+        )
 
     return deploy_command(casperlabs_client, args)
 
@@ -1166,6 +1181,7 @@ def natural(number):
 def deploy_options(keys_required=False, private_key_accepted=True):
     return ([
         [('-f', '--from'), dict(required=True, type=str, help="The public key of the account which is the context of this deployment, base16 encoded.")],
+        [('-chain-name',), dict(required=False, type=str, help="Name of the chain to optionally restrict the deploy from being accidentally included anywhere else.")],
         [('--dependencies',), dict(required=False, nargs="+", default=None, help="List of deploy hashes (base16 encoded) which must be executed before this deploy.")],
         [('--payment-amount',), dict(required=False, type=int, default=None, help="Standard payment amount. Use this with the default payment, or override with --payment-args if custom payment code is used.")],
         [('--gas-price',), dict(required=False, type=int, default=10, help='The price of gas for this transaction in units dust/gas. Must be positive integer.')],
@@ -1287,6 +1303,11 @@ def main():
     parser.addCommand('unbond', unbond_command, 'Issues unbonding request',
                       [[('-a', '--amount'),
                        dict(required=False, default=None, type=int, help='Amount of motes to unbond. If not provided then a request to unbond with full staked amount is made.')]] + deploy_options(keys_required=True))
+
+    parser.addCommand('transfer', transfer_command, 'Transfers funds between accounts',
+                      [[('-a', '--amount'), dict(required=False, default=None, type=int, help='Amount of motes to transfer. Note: a mote is the smallest, indivisible unit of a token.')],
+                       [('-t', '--target-account'), dict(required=True, type=str, help="base64 representation of target account's public key")],
+                       ] + deploy_options(keys_required=True))
 
     parser.addCommand('propose', propose_command, 'Force a node to propose a block based on its accumulated deploys.', [])
 

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -1032,7 +1032,7 @@ def check_cli_local_key(cli):
         "--payment-amount", 10000000,
         "--session", cli.resource("local_state.wasm"))
     block_hash = propose_check_no_errors(cli)
-# CasperLabs/docker $ ./client.sh node-0 query-state --block-hash '"9d"' --key '"a91208047c"' --path file.xxx --type hash
+
     local_key = account.public_key_hex + ":" + bytes([66] * 32).hex()
     result = cli("query-state",
                  "--block-hash", block_hash,
@@ -1053,3 +1053,31 @@ def check_cli_local_key(cli):
                  "--key", local_key,
                  "--type", "local")
     assert result.string_value == 'Hello, world! Hello, world!'
+
+
+def test_transfer_cli_python(cli):
+    check_transfer_cli(cli)
+
+
+def test_transfer_cli_scala(scala_cli):
+    check_transfer_cli(scala_cli)
+
+
+def check_transfer_cli(cli):
+    account = cli.node.test_account
+    genesis_account = cli.node.genesis_account
+
+    amount = 1000
+    block_hash = cli("show-blocks", "--depth", 1)[0].summary.block_hash
+    balance = cli("balance", "--block-hash", block_hash, "--address", account.public_key_hex)
+
+    for i in range(2):
+        cli("transfer",
+            "--private-key", cli.private_key_path(genesis_account),
+            "--payment-amount", 10000000,
+            "--target-account", account.public_key,
+            "--amount", amount)
+        block_hash = propose_check_no_errors(cli)
+        new_balance = cli("balance", "--block-hash", block_hash, "--address", account.public_key_hex)
+        assert new_balance == balance + amount
+        balance = new_balance


### PR DESCRIPTION
### Overview
This PR adds transfer command to the Python client.

Also, a generic test for Scala and Python CLI transfer command.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1063

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
