### PR TITLE
NODE-1052: Fix deploy result order

### DIFF
--- a/explorer/ui/src/components/Faucet.tsx
+++ b/explorer/ui/src/components/Faucet.tsx
@@ -142,7 +142,7 @@ const StatusCell = observer((props: { request: FaucetRequest }) => {
   const info = props.request.deployInfo;
   const iconAndMessage: () => [any, string | undefined] = () => {
     if (info) {
-      const attempts = info.processingResultsList.slice().reverse();
+      const attempts = info.processingResultsList;
       const success = attempts.find(x => !x.isError);
       const failure = attempts.find(x => x.isError);
       const blockHash = (result: DeployInfo.ProcessingResult.AsObject) => {

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -31,6 +31,7 @@ message BlockInfo {
 
 message DeployInfo {
     io.casperlabs.casper.consensus.Deploy deploy = 1;
+    // List of blocks the deploy has been processed in, with results, ordered by newest to oldest.
     repeated ProcessingResult processing_results = 2;
     Status status = 3;
 

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -479,7 +479,7 @@ class SQLiteDeployStorage[F[_]: Time: Sync](
               .transact(readXa)
               .map(_.groupBy(_._1).map {
                 case (deployHash: DeployHash, l: Seq[(DeployHash, ProcessingResult)]) =>
-                  (deployHash, l.map(_._2))
+                  (deployHash, l.map(_._2).sortBy(-_.getBlockInfo.getSummary.getHeader.timestamp))
               })
           })
 


### PR DESCRIPTION
### Overview
Makes sure that the newest block processing result is the first one we show in the `DeployInfo` body.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1052

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
