### PR TITLE
NODE-1053: Don't accept deploys from the future

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
@@ -46,6 +46,13 @@ object Errors {
     ): DeployHeaderError =
       InvalidChainName(deployHash, deployChainName, expectedChainName)
 
+    def timestampInFuture(
+        deployHash: ByteString,
+        timestamp: Long,
+        drift: Int
+    ): DeployHeaderError =
+      TimestampInFuture(deployHash, timestamp, drift)
+
     final case class MissingHeader(deployHash: ByteString) extends DeployHeaderError {
       def errorMessage: String =
         s"Deploy ${PrettyPrinter.buildString(deployHash)} does not contain a header"
@@ -89,6 +96,15 @@ object Errors {
     ) extends DeployHeaderError {
       def errorMessage: String =
         s"Deploy ${PrettyPrinter.buildString(deployHash)} with chain name '$deployChainName' is invalid. Expected empty chain or '$expectedChainName'."
+    }
+
+    final case class TimestampInFuture(
+        deployHash: ByteString,
+        timestamp: Long,
+        drift: Int
+    ) extends DeployHeaderError {
+      def errorMessage: String =
+        s"Deploy ${PrettyPrinter.buildString(deployHash)} has timestamp $timestamp which is more than ${drift}ms in the future."
     }
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -37,7 +37,7 @@ import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.models.ArbitraryConsensus
 import io.casperlabs.models.BlockImplicits.BlockOps
-import io.casperlabs.p2p.EffectsTestInstances.LogStub
+import io.casperlabs.p2p.EffectsTestInstances.{LogStub, LogicalTime}
 import io.casperlabs.shared.Time
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.BlockMsgWithTransform
@@ -62,6 +62,7 @@ class ValidationTest
     with BlockGenerator
     with StorageFixture
     with ArbitraryConsensus {
+  implicit val timeEff                                = new LogicalTime[Task](System.currentTimeMillis)
   override implicit val log: LogIO[Task] with LogStub = LogStub[Task]()
   implicit val raiseValidateErr                       = validation.raiseValidateErrorThroughApplicativeError[Task]
   implicit val versions = {
@@ -328,6 +329,14 @@ class ValidationTest
     )
   }
 
+  it should "not accept deploys too far in the future" in withoutStorage {
+    val deploy = DeployOps.randomTimstampInFuture()
+    Validation.deployHeader[Task](deploy, chainName) shouldBeF List(
+      DeployHeaderError
+        .timestampInFuture(deploy.deployHash, deploy.getHeader.timestamp, Validation.DRIFT)
+    )
+  }
+
   it should "not accept too many dependencies" in withoutStorage {
     val deploy = DeployOps.randomTooManyDependencies()
     Validation.deployHeader[Task](deploy, chainName) shouldBeF List(
@@ -364,7 +373,7 @@ class ValidationTest
       for {
         _                       <- createChain[Task](1)
         block                   <- dagStorage.lookupByIdUnsafe(0)
-        modifiedTimestampHeader = block.header.get.withTimestamp(99999999)
+        modifiedTimestampHeader = block.header.get.withTimestamp(Long.MaxValue)
         _ <- Validation
               .timestamp[Task](
                 block.withHeader(modifiedTimestampHeader)
@@ -1167,32 +1176,41 @@ class ValidationTest
   }
 
   it should "work for valid deploys" in withStorage {
-    implicit blockStorage => implicit dagStorage => _ =>
-      val deployA = DeployOps.randomNonzeroTTL()
-      val deployB = DeployOps
-        .randomNonzeroTTL()
-        .withTimestamp(deployA.getHeader.timestamp + deployA.getHeader.ttlMillis)
-      val deployC = DeployOps
-        .randomNonzeroTTL()
-        .withDependencies(List(deployA.deployHash, deployB.deployHash))
-        .withTimestamp(deployB.getHeader.timestamp + deployB.getHeader.ttlMillis)
-      val timeA = deployA.getHeader.timestamp + deployA.getHeader.ttlMillis - 1
-      val timeB = deployB.getHeader.timestamp + deployB.getHeader.ttlMillis - 1
-      val timeC = deployC.getHeader.timestamp + deployC.getHeader.ttlMillis - 1
+    implicit blockStorage => implicit dagStorage =>
+      _ =>
+        // The last validation would fail if the deploy timestamp was in the future,
+        // so pretend that all these blocks with their deploys happened a week ago.
+        val timestamp = System.currentTimeMillis - 7 * 24 * 60 * 60 * 1000
+        val deployA   = DeployOps.randomNonzeroTTL().withTimestamp(timestamp)
+        val deployB = DeployOps
+          .randomNonzeroTTL()
+          .withTimestamp(deployA.getHeader.timestamp + deployA.getHeader.ttlMillis)
+        val deployC = DeployOps
+          .randomNonzeroTTL()
+          .withDependencies(List(deployA.deployHash, deployB.deployHash))
+          .withTimestamp(deployB.getHeader.timestamp + deployB.getHeader.ttlMillis)
 
-      for {
-        blockA <- createBlock[Task](Seq.empty, deploys = Vector(deployA.processed(1)))
-                   .map(_.changeTimestamp(timeA))
-        _ <- blockStorage.put(blockA.blockHash, blockA, Seq.empty)
-        blockB <- createBlock[Task](List(blockA.blockHash), deploys = Vector(deployB.processed(1)))
-                   .map(_.changeTimestamp(timeB))
-        _ <- blockStorage.put(blockB.blockHash, blockB, Seq.empty)
-        blockC <- createBlock[Task](List(blockB.blockHash), deploys = Vector(deployC.processed(1)))
-                   .map(_.changeTimestamp(timeC))
-        _      <- blockStorage.put(blockC.blockHash, blockC, Seq.empty)
-        dag    <- dagStorage.getRepresentation
-        result <- Validation.deployHeaders[Task](blockC, dag, chainName).attempt
-      } yield result shouldBe Right(())
+        val timeA = deployA.getHeader.timestamp + deployA.getHeader.ttlMillis - 1
+        val timeB = deployB.getHeader.timestamp + deployB.getHeader.ttlMillis - 1
+        val timeC = deployC.getHeader.timestamp + deployC.getHeader.ttlMillis - 1
+
+        for {
+          blockA <- createBlock[Task](Seq.empty, deploys = Vector(deployA.processed(1)))
+                     .map(_.changeTimestamp(timeA))
+          _ <- blockStorage.put(blockA.blockHash, blockA, Seq.empty)
+          blockB <- createBlock[Task](
+                     List(blockA.blockHash),
+                     deploys = Vector(deployB.processed(1))
+                   ).map(_.changeTimestamp(timeB))
+          _ <- blockStorage.put(blockB.blockHash, blockB, Seq.empty)
+          blockC <- createBlock[Task](
+                     List(blockB.blockHash),
+                     deploys = Vector(deployC.processed(1))
+                   ).map(_.changeTimestamp(timeC))
+          _      <- blockStorage.put(blockC.blockHash, blockC, Seq.empty)
+          dag    <- dagStorage.getRepresentation
+          result <- Validation.deployHeaders[Task](blockC, dag, chainName).attempt
+        } yield result shouldBe Right(())
   }
 
   "deployUniqueness" should "return InvalidRepeatDeploy when a deploy is present in an ancestor" in withStorage {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
@@ -4,11 +4,12 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.util.ProtoUtil
-import io.casperlabs.casper.validation.Validation.{MAX_DEPENDENCIES, MAX_TTL, MIN_TTL}
+import io.casperlabs.casper.validation.Validation.{DRIFT, MAX_DEPENDENCIES, MAX_TTL, MIN_TTL}
 import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.models.{ArbitraryConsensus, DeployImplicits}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
+import io.casperlabs.casper.validation.ValidationImpl
 
 object DeployOps extends ArbitraryConsensus {
   implicit class ChangeDeployOps(deploy: Deploy) {
@@ -75,6 +76,18 @@ object DeployOps extends ArbitraryConsensus {
       d   <- arbitrary[Deploy]
       ttl <- Gen.choose(MAX_TTL + 1, Int.MaxValue)
     } yield d.withTtl(ttl)
+
+    sample(genDeploy)
+  }
+
+  def randomTimstampInFuture(): Deploy = {
+    implicit val c = ConsensusConfig()
+
+    val genDeploy = for {
+      d     <- arbitrary[Deploy]
+      now   = System.currentTimeMillis
+      drift <- Gen.choose(DRIFT + 1000, Int.MaxValue)
+    } yield d.withTimestamp(now + drift)
 
     sample(genDeploy)
   }

--- a/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
+++ b/comm/src/test/scala/io/casperlabs/p2p/EffectsTestInstances.scala
@@ -21,8 +21,8 @@ import izumi.functional.mono.SyncSafe
 /** Eagerly evaluated instances to do reasoning about applied effects */
 object EffectsTestInstances {
 
-  class LogicalTime[F[_]: Sync] extends Time[F] {
-    var clock: Long = 0
+  class LogicalTime[F[_]: Sync](init: => Long = 0) extends Time[F] {
+    var clock: Long = init
 
     def currentMillis: F[Long] = Sync[F].delay {
       this.clock = clock + 1
@@ -36,7 +36,7 @@ object EffectsTestInstances {
 
     def sleep(duration: FiniteDuration): F[Unit] = Sync[F].delay(())
 
-    def reset(): Unit = this.clock = 0
+    def reset(): Unit = this.clock = init
   }
 
   class NodeDiscoveryStub[F[_]: Sync]() extends NodeDiscovery[F] {


### PR DESCRIPTION
### Overview
Currently the node would have accepted deploys with timestamp at arbitrary future dates, then try and try again to include them in a block, repeatedly filtering them out until they finally are in the past. 

While this might be a valid use case, it's not fair to expect validators to hoard an unlimited number of future deploys. This can be achieved in the dApp, or a dedicated component which stages the deploys until the timestamp arrives.

The PR adds an extra validation to reject deploys more than the already established 15 seconds drift into the future.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1053

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
