### PR TITLE
NODE-657: Added raw ID versions to the API.

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -130,7 +130,7 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
 
   def showBlock(hash: String): Task[Either[Throwable, BlockInfo]] =
     casperServiceStub
-      .getBlockInfo(GetBlockInfoRequest(hash, BlockInfo.View.FULL))
+      .getBlockInfo(GetBlockInfoRequest(hash, view = BlockInfo.View.FULL))
       .attempt
 
   def showDeploy(
@@ -139,7 +139,7 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       json: Boolean
   ): Task[Either[Throwable, String]] =
     casperServiceStub
-      .getDeployInfo(GetDeployInfoRequest(hash, DeployInfo.View.BASIC))
+      .getDeployInfo(GetDeployInfoRequest(hash, view = DeployInfo.View.BASIC))
       .map(Printer.print(_, bytesStandard, json))
       .attempt
 
@@ -149,7 +149,7 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       json: Boolean
   ): Task[Either[Throwable, String]] =
     casperServiceStub
-      .streamBlockDeploys(StreamBlockDeploysRequest(hash, DeployInfo.View.BASIC))
+      .streamBlockDeploys(StreamBlockDeploysRequest(hash, view = DeployInfo.View.BASIC))
       .zipWithIndex
       .map {
         case (d, idx) =>

--- a/node/src/main/scala/io/casperlabs/node/api/Utils.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Utils.scala
@@ -12,44 +12,54 @@ import scala.util.Try
 
 object Utils {
   def check[F[_]: MonadThrowable, A](
-      s: A,
+      str: A,
       desc: String,
-      b: A => Boolean
+      cond: A => Boolean
   ): F[A] =
-    MonadThrowable[F].raiseError[A](new IllegalArgumentException(s"$desc")).whenA(!b(s)) >> s
-      .pure[F]
+    MonadThrowable[F]
+      .raiseError[A](new IllegalArgumentException(s"$desc"))
+      .whenA(!cond(str))
+      .as(str)
+
+  // The API accepts base16 in case we want to use them in RESTful URLs but also raw bytes,
+  // to make it less cumbersome for clients. Use whihever is present.
+  private def fallback(hashBase16: String, hash: ByteString) =
+    if (hashBase16.isEmpty) Base16.encode(hash.toByteArray) else hashBase16
 
   def validateBlockHashPrefix[F[_]: MonadThrowable](
-      p: String,
+      prefixBase16: String,
+      prefix: ByteString,
       adaptError: PartialFunction[Throwable, Throwable] = PartialFunction.empty
   ): F[String] =
     Utils
       .check[F, String](
-        p,
+        fallback(prefixBase16, prefix),
         "BlockHash prefix must be >= 4 and <= 64 base16 characters (2 to 32 bytes) long",
         _.matches("[a-f0-9]{4,64}")
       )
       .adaptErr(adaptError)
 
   def validateDeployHash[F[_]: MonadThrowable](
-      p: String,
+      hashBase16: String,
+      hash: ByteString,
       adaptError: PartialFunction[Throwable, Throwable] = PartialFunction.empty
   ): F[String] =
     Utils
       .check[F, String](
-        p,
+        fallback(hashBase16, hash),
         "DeployHash must be 64 base16 characters (32 bytes) long",
         _.matches("[a-f0-9]{64}")
       )
       .adaptError(adaptError)
 
   def validateAccountPublicKey[F[_]: MonadThrowable](
-      p: String,
+      keyBase16: String,
+      key: ByteString,
       adaptError: PartialFunction[Throwable, Throwable] = PartialFunction.empty
   ): F[String] =
     Utils
       .check[F, String](
-        p,
+        fallback(keyBase16, key),
         "AccountPublicKey must be 64 base16 characters (32 bytes) long",
         _.matches("[a-f0-9]{64}")
       )

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
@@ -62,7 +62,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
             resolve = Projector { (context, projections) =>
               (for {
                 blockHashPrefix <- validateBlockHashPrefix[F](
-                                    context.arg(blocks.arguments.BlockHashPrefix)
+                                    context.arg(blocks.arguments.BlockHashPrefix),
+                                    ByteString.EMPTY
                                   )
                 res <- BlockAPI
                         .getBlockInfoWithDeploysOpt[F](
@@ -91,7 +92,7 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
             OptionType(blocks.types.DeployInfoType),
             arguments = blocks.arguments.DeployHash :: Nil,
             resolve = { c =>
-              (validateDeployHash[F](c.arg(blocks.arguments.DeployHash)) >>= (
+              (validateDeployHash[F](c.arg(blocks.arguments.DeployHash), ByteString.EMPTY) >>= (
                   deployHash => BlockAPI.getDeployInfoOpt[F](deployHash, deployView)
               )).unsafeToFuture
             }
@@ -112,7 +113,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
                   accountPublicKeyBase16 = c.arg(blocks.arguments.AccountPublicKeyBase16)
                   after                  = c.arg(blocks.arguments.After)
                   accountPublicKeyBase16 <- validateAccountPublicKey[F](
-                                             accountPublicKeyBase16
+                                             accountPublicKeyBase16,
+                                             ByteString.EMPTY
                                            )
                   (pageSize, pageTokenParams) <- MonadThrowable[F]
                                                   .fromTry(
@@ -171,7 +173,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
 
               val program = for {
                 blockHashBase16Prefix <- validateBlockHashPrefix[F](
-                                          c.arg(blocks.arguments.BlockHashPrefix)
+                                          c.arg(blocks.arguments.BlockHashPrefix),
+                                          ByteString.EMPTY
                                         )
                 maybeBlockProps <- BlockAPI
                                     .getBlockInfoWithDeploysOpt[F](

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -23,16 +23,16 @@ service CasperService {
 
     // Get the block summary with extra information about finality.
     rpc GetBlockInfo(GetBlockInfoRequest) returns (io.casperlabs.casper.consensus.info.BlockInfo) {
-    	option (google.api.http) = {
-    		get: "/v2/blocks/{block_hash_base16=*}"
-    	};
+        option (google.api.http) = {
+            get: "/v2/blocks/{block_hash_base16=*}"
+        };
     }
 
     // Get slices of the DAG, going backwards, rank by rank.
     rpc StreamBlockInfos(StreamBlockInfosRequest) returns (stream io.casperlabs.casper.consensus.info.BlockInfo) {
-    	option (google.api.http) = {
-    		get: "/v2/blocks"
-    	};
+        option (google.api.http) = {
+            get: "/v2/blocks"
+        };
     }
 
     // Retrieve information about a single deploy by hash.
@@ -74,8 +74,8 @@ service CasperService {
 
     rpc GetLastFinalizedBlockInfo (GetLastFinalizedBlockInfoRequest) returns (io.casperlabs.casper.consensus.info.BlockInfo) {
         option (google.api.http) = {
-    		get: "v2/last-finalized-block"
-    	};
+            get: "v2/last-finalized-block"
+        };
     }
 }
 
@@ -84,23 +84,23 @@ message DeployRequest {
 }
 
 message GetBlockInfoRequest {
-	// Either the full or just the first few characters of the block hash in base16 encoding,
-	// so that it works with the client's redacted displays.
+    // Either the full or just the first few characters of the block hash in base16 encoding,
+    // so that it works with the client's redacted displays.
     string block_hash_base16 = 1;
     // Alternative to the base16 encoded value (which is intended for URL compatibility).
-	bytes block_hash = 3;
-	io.casperlabs.casper.consensus.info.BlockInfo.View view = 2;
+    bytes block_hash = 3;
+    io.casperlabs.casper.consensus.info.BlockInfo.View view = 2;
 }
 
 message StreamBlockInfosRequest {
-	// How many of the top ranks of the DAG to show. 0 will not return anything.
-	uint32 depth = 1;
+    // How many of the top ranks of the DAG to show. 0 will not return anything.
+    uint32 depth = 1;
 
-	// Optionally specify the maximum rank to to go back from.
-	// 0 means go from the current tip of the DAG.
-	uint64 max_rank = 2;
+    // Optionally specify the maximum rank to to go back from.
+    // 0 means go from the current tip of the DAG.
+    uint64 max_rank = 2;
 
-	io.casperlabs.casper.consensus.info.BlockInfo.View view = 3;
+    io.casperlabs.casper.consensus.info.BlockInfo.View view = 3;
 }
 
 
@@ -108,14 +108,14 @@ message StreamBlockInfosRequest {
 message GetDeployInfoRequest {
     string deploy_hash_base16 = 1;
     // Alternative to the base16 encoded value (which is intended for URL compatibility).
-	bytes deploy_hash = 3;
+    bytes deploy_hash = 3;
     io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
 }
 
 message StreamBlockDeploysRequest {
     string block_hash_base16 = 1;
     // Alternative to the base16 encoded value (which is intended for URL compatibility).
-	bytes block_hash = 3;
+    bytes block_hash = 3;
     io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
 }
 
@@ -137,14 +137,14 @@ message StateQuery {
 message GetBlockStateRequest {
     string block_hash_base16 = 1;
     // Alternative to the base16 encoded value (which is intended for URL compatibility).
-	bytes block_hash = 3;
+    bytes block_hash = 3;
     StateQuery query = 2;
 }
 
 message BatchGetBlockStateRequest {
     string block_hash_base16 = 1;
     // Alternative to the base16 encoded value (which is intended for URL compatibility).
-	bytes block_hash = 3;
+    bytes block_hash = 3;
     repeated StateQuery queries = 2;
 }
 
@@ -155,7 +155,7 @@ message BatchGetBlockStateResponse {
 message ListDeployInfosRequest {
     string account_public_key_base16 = 1;
     // Alternative to the base16 encoded value (which is intended for URL compatibility).
-	bytes account_public_key = 5;
+    bytes account_public_key = 5;
     io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
     uint32 page_size = 3;
     string page_token = 4;

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -86,7 +86,9 @@ message DeployRequest {
 message GetBlockInfoRequest {
 	// Either the full or just the first few characters of the block hash in base16 encoding,
 	// so that it works with the client's redacted displays.
-	string block_hash_base16 = 1;
+    string block_hash_base16 = 1;
+    // Alternative to the base16 encoded value (which is intended for URL compatibility).
+	bytes block_hash = 3;
 	io.casperlabs.casper.consensus.info.BlockInfo.View view = 2;
 }
 
@@ -105,11 +107,15 @@ message StreamBlockInfosRequest {
 
 message GetDeployInfoRequest {
     string deploy_hash_base16 = 1;
+    // Alternative to the base16 encoded value (which is intended for URL compatibility).
+	bytes deploy_hash = 3;
     io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
 }
 
 message StreamBlockDeploysRequest {
     string block_hash_base16 = 1;
+    // Alternative to the base16 encoded value (which is intended for URL compatibility).
+	bytes block_hash = 3;
     io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
 }
 
@@ -130,11 +136,15 @@ message StateQuery {
 
 message GetBlockStateRequest {
     string block_hash_base16 = 1;
+    // Alternative to the base16 encoded value (which is intended for URL compatibility).
+	bytes block_hash = 3;
     StateQuery query = 2;
 }
 
 message BatchGetBlockStateRequest {
     string block_hash_base16 = 1;
+    // Alternative to the base16 encoded value (which is intended for URL compatibility).
+	bytes block_hash = 3;
     repeated StateQuery queries = 2;
 }
 
@@ -144,6 +154,8 @@ message BatchGetBlockStateResponse {
 
 message ListDeployInfosRequest {
     string account_public_key_base16 = 1;
+    // Alternative to the base16 encoded value (which is intended for URL compatibility).
+	bytes account_public_key = 5;
     io.casperlabs.casper.consensus.info.DeployInfo.View view = 2;
     uint32 page_size = 3;
     string page_token = 4;


### PR DESCRIPTION
### Overview
I added Base16 version of every ID the API accepts in info requests because I thought we'd have to support REST annotations. It's a bit cumbersome to have to transform every ID in Clarity to Base16, when I have them in their raw format. The PR adds raw versions to the API, so the IDs received in the DTO classes can be passed back as is.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-657

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I haven't added the same treatment to the `StateQuery.keyBase16` field because of the `LOCAL` variant that consists of 2 base16 parts concatenated and with a `:` separator. I thought it would have been confusing that for `ACCOUNT`, `HASH` and `UREF` you can use either string or bytes, but for `LOCAL` only string.

@piokuc I don't know if you want to use this from the Python client.

I left Clarity as it was.

The same treatment could be done on GraphQL if @zie1ony and @igor-ramazanov agree.
