### PR TITLE
NODE-1061: Fix Scala client's vdag command

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -11,11 +11,6 @@ import io.casperlabs.catscontrib.Catscontrib._
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.graphz._
 
-package object Constant {
-  // For debugging it is usefull to change Invis to Dotted.
-  val Invisible = Invis
-}
-
 final case class ValidatorBlock(
     blockHash: String,
     parentsHashes: List[String],
@@ -28,6 +23,10 @@ object GraphzGenerator {
   type BlockHash        = ByteString
   type Rank             = Long
   type ValidatorsBlocks = Map[Rank, List[ValidatorBlock]]
+
+  // For debugging it is usefull to change Invis to Dotted.
+  //
+  val Invisible = Invis
 
   final case class DagInfo[G[_]](
       validators: Map[String, ValidatorsBlocks] = Map.empty,
@@ -81,7 +80,7 @@ object GraphzGenerator {
       _ <- genesisBlocks.traverse(b => g.node(b, style = Some(Bold), shape = Box))
 
       // draw invisible fake genesis block if needed
-      _ <- fakeGenesisBlocks.traverse(b => g.node(b, style = Some(Constant.Invisible), shape = Box))
+      _ <- fakeGenesisBlocks.traverse(b => g.node(b, style = Some(Invisible), shape = Box))
 
       // draw invisible edges from genesis block or the fake genesis block
       // to first node of each validator for alignment
@@ -96,11 +95,11 @@ object GraphzGenerator {
                 }
             )
             .traverse {
-              case (genesis_block, node) =>
+              case (genesisBlock, node) =>
                 g.edge(
-                  genesis_block,
+                  genesisBlock,
                   node._2,
-                  style = Some(Constant.Invisible)
+                  style = Some(Invisible)
                 )
             }
 
@@ -219,7 +218,7 @@ object GraphzGenerator {
     blocks.get(rank) match {
       case Some(blocks) =>
         blocks.map(b => (styleFor(b.blockHash, lastFinalizedBlockHash), b.blockHash))
-      case None => List((Some(Constant.Invisible), s"${rank.show}_$validatorId"))
+      case None => List((Some(Invisible), s"${rank.show}_$validatorId"))
     }
 
   private def validatorCluster[G[_]: Monad: GraphSerializer](
@@ -246,7 +245,7 @@ object GraphzGenerator {
                 })
             )
             .traverse {
-              case ((_, n1), (_, n2)) => g.edge(n1, n2, style = Some(Constant.Invisible))
+              case ((_, n1), (_, n2)) => g.edge(n1, n2, style = Some(Invisible))
             }
 
       _ <- g.close

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -128,7 +128,7 @@ object GraphzGenerator {
 
     val validators = blockInfos
       .map(_.getSummary)
-      .filter(_.validatorPublicKey.size > 0)
+      .filterNot(_.validatorPublicKey.isEmpty)
       .foldMap { b =>
         val blockHash       = hexShort(b.blockHash)
         val blockSenderHash = hexShort(b.validatorPublicKey)
@@ -168,7 +168,7 @@ object GraphzGenerator {
       .traverse {
         case ValidatorBlock(blockHash, parentsHashes, _) =>
           parentsHashes
-            .filter(p => allBlockHashes.contains(p))
+            .filter(allBlockHashes)
             .zipWithIndex
             .traverse {
               case (p, index) =>

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -53,6 +53,10 @@ object GraphzGenerator {
 
     val allBlockHashes = blockInfos.map(b => hexShort(b.getSummary.blockHash)).toSet
 
+    // In the current model only genesis block has empty validatorPublicKey,
+    // and there must be only one genesis block. However, if that ever changes
+    // or there is a bug and there is more than one block like that,
+    // then we want to visualise all of them.
     val genesisBlocks =
       blockInfos
         .map(_.getSummary)

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -215,15 +215,12 @@ object GraphzGenerator {
       rank: Rank,
       blocks: ValidatorsBlocks,
       lastFinalizedBlockHash: String
-  ): List[(Option[GraphStyle], String)] = {
-    val blocksForRank = blocks.getOrElse(rank, List.empty)
-    blocksForRank.size match {
-      case 0 => List((Some(Constant.Invisible), s"${rank.show}_$validatorId"))
-      case _ =>
-        blocksForRank
-          .map(b => (styleFor(b.blockHash, lastFinalizedBlockHash), b.blockHash))
+  ): List[(Option[GraphStyle], String)] =
+    blocks.get(rank) match {
+      case Some(blocks) =>
+        blocks.map(b => (styleFor(b.blockHash, lastFinalizedBlockHash), b.blockHash))
+      case None => List((Some(Constant.Invisible), s"${rank.show}_$validatorId"))
     }
-  }
 
   private def validatorCluster[G[_]: Monad: GraphSerializer](
       id: String,

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -56,8 +56,7 @@ object GraphzGenerator {
     val genesisBlocks =
       blockInfos
         .map(_.getSummary)
-        .filter(_.validatorPublicKey.size == 0)
-        .take(1)
+        .filter(_.validatorPublicKey.isEmpty)
         .map(b => hexShort(b.blockHash))
 
     val fakeGenesisBlocks = if (genesisBlocks.size > 0) List.empty else List("alignment_node")

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -86,17 +86,15 @@ object GraphzGenerator {
       // draw invisible edges from genesis block or the fake genesis block
       // to first node of each validator for alignment
       _ <- (if (genesisBlocks.size > 0) genesisBlocks else fakeGenesisBlocks)
-            .map(
+            .flatMap(
               genesisBlock =>
-                validatorsList.map {
+                validatorsList.flatMap {
                   case (id, blocks) =>
                     nodesForRank(id, firstRank, blocks, lastFinalizedBlockHash).map(
                       node => (genesisBlock, node)
                     )
                 }
             )
-            .flatten
-            .flatten
             .traverse {
               case (genesis_block, node) =>
                 g.edge(
@@ -242,16 +240,14 @@ object GraphzGenerator {
 
       // Draw invisible edges from nodes rank i to nodes rank i+1 for alignment.
       _ <- ranks.reverse.tail.reverse
-            .map(
+            .flatMap(
               rank =>
-                nodesForRank(id, rank, blocks, lastFinalizedBlockHash).map(n1 => {
+                nodesForRank(id, rank, blocks, lastFinalizedBlockHash).flatMap(n1 => {
                   nodesForRank(id, rank + 1, blocks, lastFinalizedBlockHash).map(n2 => {
                     (n1, n2)
                   })
                 })
             )
-            .flatten
-            .flatten
             .traverse {
               case ((_, n1), (_, n2)) => g.edge(n1, n2, style = Some(Constant.Invisible))
             }

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -227,9 +227,22 @@ object GraphzGenerator {
       _ <- nodes.traverse {
             case (style, name) => g.node(name, style = style, shape = Box)
           }
-      _ <- nodes.zip(nodes.drop(1)).traverse {
-            case ((_, n1), (_, n2)) => g.edge(n1, n2, style = Some(Constant.Invisible))
-          }
+
+      _ <- ranks.reverse.tail.reverse
+            .map(
+              rank =>
+                nodesForRank(id, rank, blocks, lastFinalizedBlockHash).map(n1 => {
+                  nodesForRank(id, rank + 1, blocks, lastFinalizedBlockHash).map(n2 => {
+                    (n1, n2)
+                  })
+                })
+            )
+            .flatten
+            .flatten
+            .traverse {
+              case ((_, n1), (_, n2)) => g.edge(n1, n2, style = Some(Constant.Invisible))
+            }
+
       _ <- g.close
     } yield g
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -746,7 +746,8 @@ class CasperLabsClient:
         block_infos = list(self.showBlocks(depth))
         dot_dag_description = vdag.generate_dot(block_infos, show_justification_lines)
         if not out:
-            return dot_dag_description
+            yield dot_dag_description
+            return
 
         parts = out.split(".")
         file_format = parts[-1]


### PR DESCRIPTION
### Overview
This PR fixes few bugs in the Scala client's vdag command:
- equivocating blocks were not handled correctly, only one of the pair of equivocating blocks was drawn,
- unnecessary validator lane was drawn for genesis block if it happened to be in the visualized set of blocks,
- for sets without genesis block an extra block was drawn outside of validator lanes; this block was a parent of one of the visualized blocks.

Now the only block drawn outside of validators' lanes can be the genesis block, if it is in the visualized set of blocks.

#### Examples (after fixing):

1. Plot of a set of blocks that does not include genesis block 
![Imgur](https://i.imgur.com/MK7LoJc.png)

2. Plot with genesis block and two equivocating blocks
![Imgur](https://i.imgur.com/g3gVDC0.png)

#### Examples (BEFORE FIXING):

The same DAG as above 2 (hashes changed because the blocks were produced by different test run). 
![Imgur](https://i.imgur.com/nkWF7ba.png)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1061

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
NA
