### PR TITLE
NODE-1076: Fix generating and rendering large DAG with vdag

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -223,12 +223,13 @@ object DeployRuntime {
           .visualizeDag(depth, showJustificationLines)
           .rethrow
 
-      val useJdkRenderer = Sync[F].delay(Graphviz.useEngine(new GraphvizJdkEngine))
+      val useJdkRenderer = Sync[F].delay(Graphviz.useDefaultEngines())
 
       def writeToFile(out: String, format: Format, dag: String) =
         Sync[F].delay(
           Graphviz
             .fromString(dag)
+            .totalMemory(1000000000)
             .render(format)
             .toFile(new File(s"$out"))
         ) >> Sync[F].delay(println(s"Wrote $out"))

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -204,11 +204,11 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
     casperServiceStub
       .streamBlockInfos(StreamBlockInfosRequest(depth = depth, view = BlockInfo.View.BASIC))
       .toListL
-      .map { infos =>
-        type G[A] = StateT[Id, StringBuffer, A]
+      .flatMap { infos =>
+        type G[A] = StateT[Task, StringBuffer, A]
         implicit val ser = new graphz.StringSerializer[G]
         val state        = GraphzGenerator.dagAsCluster[G](infos, GraphConfig(showJustificationLines))
-        state.runS(new StringBuffer).toString
+        state.runS(new StringBuffer).map(_.toString)
       }
       .attempt
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,7 +66,7 @@ object Dependencies {
   val scalacheck             = "org.scalacheck"             %% "scalacheck"                     % "1.13.5" % "test"
   val scalacheckNoTest       = "org.scalacheck"             %% "scalacheck"                     % "1.13.5"
   val scalacheckShapeless    = "com.github.alexarchambault" %% "scalacheck-shapeless_1.13"      % "1.1.8" % "test"
-  val graphvizJava           = "guru.nidi"                  % "graphviz-java"                   % "0.8.3"
+  val graphvizJava           = "guru.nidi"                  % "graphviz-java"                   % "0.12.1"
   val scalactic              = "org.scalactic"              %% "scalactic"                      % "3.0.5" % "test"
   val scalapbCompiler        = "com.thesamet.scalapb"       %% "compilerplugin"                 % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime         = "com.thesamet.scalapb"       %% "scalapb-runtime"                % scalapb.compiler.Version.scalapbVersion % "protobuf"


### PR DESCRIPTION
This PR fixes a `StackOverflow` error when generating graph visualization of large number of blocks with Scala client's `vdag` command, for example with:

    casperlabs-client --host deploy.casperlabs.io vdag --depth 1000000 -o dag.svg

Also, it changes the engine used by the graphviz-java to render graphics from the generated DOT graph description. Now it tries to use command line dot from Graphviz and only as a fall-back it will use the pure Java engine. This is because the pure Java engine used currently (exclusively) fails to render a DAG of more than 1000 blocks, like the one available on deploy.casperlabs.io currently.

Note, the problem with the JDK engine seemed to be related to: https://github.com/nidi3/graphviz-java/issues/12 However, using newer version of graphviz-java and setting larger amount of memory as described in the cited issue did not help. To be precise, the error message is now different, so it is possible that one problem was fixed, but there is still another one.

Using the command line dot engine (which just calls `dot` from Graphviz as an external process) is a working solution, however it requires user to install [Graphiz](https://www.graphviz.org/).

### Overview
https://casperlabs.atlassian.net/browse/NODE-1076

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
