### PR TITLE
EE-791: add trie_store::operations::keys

### DIFF
--- a/execution-engine/engine-storage/src/trie/mod.rs
+++ b/execution-engine/engine-storage/src/trie/mod.rs
@@ -126,7 +126,7 @@ impl FromBytes for PointerBlock {
     }
 }
 
-impl ::std::ops::Index<usize> for PointerBlock {
+impl core::ops::Index<usize> for PointerBlock {
     type Output = Option<Pointer>;
 
     #[inline]
@@ -136,11 +136,51 @@ impl ::std::ops::Index<usize> for PointerBlock {
     }
 }
 
-impl ::std::ops::IndexMut<usize> for PointerBlock {
+impl core::ops::IndexMut<usize> for PointerBlock {
     #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         let PointerBlock(dat) = self;
         &mut dat[index]
+    }
+}
+
+impl core::ops::Index<core::ops::Range<usize>> for PointerBlock {
+    type Output = [Option<Pointer>];
+
+    #[inline]
+    fn index(&self, index: core::ops::Range<usize>) -> &[Option<Pointer>] {
+        let &PointerBlock(ref dat) = self;
+        &dat[index]
+    }
+}
+
+impl core::ops::Index<core::ops::RangeTo<usize>> for PointerBlock {
+    type Output = [Option<Pointer>];
+
+    #[inline]
+    fn index(&self, index: core::ops::RangeTo<usize>) -> &[Option<Pointer>] {
+        let &PointerBlock(ref dat) = self;
+        &dat[index]
+    }
+}
+
+impl core::ops::Index<core::ops::RangeFrom<usize>> for PointerBlock {
+    type Output = [Option<Pointer>];
+
+    #[inline]
+    fn index(&self, index: core::ops::RangeFrom<usize>) -> &[Option<Pointer>] {
+        let &PointerBlock(ref dat) = self;
+        &dat[index]
+    }
+}
+
+impl core::ops::Index<core::ops::RangeFull> for PointerBlock {
+    type Output = [Option<Pointer>];
+
+    #[inline]
+    fn index(&self, index: core::ops::RangeFull) -> &[Option<Pointer>] {
+        let &PointerBlock(ref dat) = self;
+        &dat[index]
     }
 }
 
@@ -189,6 +229,13 @@ impl<K, V> Trie<K, V> {
     /// Constructs a [`Trie::Extension`] from a given affix and pointer.
     pub fn extension(affix: Vec<u8>, pointer: Pointer) -> Self {
         Trie::Extension { affix, pointer }
+    }
+
+    pub fn key(&self) -> Option<&K> {
+        match self {
+            Trie::Leaf { key, .. } => Some(key),
+            _ => None,
+        }
     }
 }
 

--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -514,7 +514,7 @@ where
     let new_node = {
         let index: usize = existing_leaf_path[shared_path.len()].into();
         let existing_leaf_pointer =
-            pointer_block[child_index.into()].expect("parent has lost the existing leaf");
+            pointer_block[<usize>::from(child_index)].expect("parent has lost the existing leaf");
         Trie::node(&[(index, existing_leaf_pointer)])
     };
     // Re-add the parent node to parents

--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -11,7 +11,7 @@ use engine_shared::{
 
 use crate::{
     transaction_source::{Readable, Writable},
-    trie::{self, Parents, Pointer, Trie},
+    trie::{self, Parents, Pointer, Trie, RADIX},
     trie_store::TrieStore,
 };
 
@@ -728,4 +728,80 @@ where
             Ok(WriteResult::Written(root_hash))
         }
     }
+}
+
+/// Returns the keys at a given root hash.
+///
+/// Notes:
+/// * This should be rewritten as an Iterator in the future.
+/// * The root doesn't necessarily need to be the apex of the trie. It can be the "root" of a
+///   sub-trie.
+#[allow(dead_code)]
+pub fn keys<K, V, T, S, E>(
+    _correlation_id: CorrelationId,
+    txn: &T,
+    store: &S,
+    root: &Blake2bHash,
+) -> Result<Vec<K>, E>
+where
+    K: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+    V: ToBytes + FromBytes + Clone + Eq + std::fmt::Debug,
+    T: Readable<Handle = S::Handle>,
+    S: TrieStore<K, V>,
+    S::Error: From<T::Error>,
+    E: From<S::Error> + From<contract_ffi::bytesrepr::Error>,
+{
+    let mut ret = Vec::new();
+
+    #[allow(clippy::type_complexity)]
+    let mut visited: Vec<(Trie<K, V>, Option<usize>, Vec<u8>)> = {
+        let root = match store.get(txn, root)? {
+            None => return Ok(ret),
+            Some(current_root) => current_root,
+        };
+        vec![(root, None, vec![])]
+    };
+
+    while let Some((trie, maybe_index, mut path)) = visited.pop() {
+        let mut maybe_next_trie: Option<Trie<K, V>> = None;
+
+        match trie {
+            Trie::Leaf { key, .. } => {
+                debug_assert!({
+                    let key_bytes = key.to_bytes()?;
+                    key_bytes.starts_with(&path)
+                });
+                ret.push(key);
+            }
+            Trie::Node { ref pointer_block } => {
+                let mut index: usize = maybe_index.unwrap_or_default();
+                while index < RADIX {
+                    if let Some(ref pointer) = pointer_block[index] {
+                        maybe_next_trie = store.get(txn, pointer.hash())?;
+                        debug_assert!(maybe_next_trie.is_some());
+                        visited.push((trie, Some(index + 1), path.clone()));
+                        path.push(index as u8);
+                        break;
+                    }
+                    index += 1;
+                }
+            }
+            Trie::Extension { affix, pointer } => {
+                maybe_next_trie = store.get(txn, pointer.hash())?;
+                debug_assert!({
+                    match &maybe_next_trie {
+                        Some(Trie::Node { .. }) => true,
+                        _ => false,
+                    }
+                });
+                path.extend(affix);
+            }
+        }
+
+        if let Some(next_trie) = maybe_next_trie {
+            visited.push((next_trie, None, path));
+        }
+    }
+
+    Ok(ret)
 }

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
@@ -1,0 +1,142 @@
+mod partial_tries {
+    use engine_shared::newtypes::CorrelationId;
+
+    use crate::{
+        error::{self, in_memory},
+        transaction_source::{Transaction, TransactionSource},
+        trie::Trie,
+        trie_store::operations::{
+            self,
+            tests::{
+                InMemoryTestContext, LmdbTestContext, TestKey, TestValue, TEST_LEAVES,
+                TEST_TRIE_GENERATORS,
+            },
+        },
+    };
+
+    #[test]
+    fn lmdb_keys_from_n_leaf_partial_trie_had_expected_results() {
+        for (num_leaves, generator) in TEST_TRIE_GENERATORS.iter().enumerate() {
+            let correlation_id = CorrelationId::new();
+            let (root_hash, tries) = generator().unwrap();
+            let context = LmdbTestContext::new(&tries).unwrap();
+            let test_leaves = TEST_LEAVES;
+            let (used, _) = test_leaves.split_at(num_leaves);
+
+            let expected = {
+                let mut tmp = used
+                    .iter()
+                    .filter_map(Trie::key)
+                    .cloned()
+                    .collect::<Vec<TestKey>>();
+                tmp.sort();
+                tmp
+            };
+            let actual = {
+                let txn = context.environment.create_read_txn().unwrap();
+                let mut tmp = operations::keys::<TestKey, TestValue, _, _, error::Error>(
+                    correlation_id,
+                    &txn,
+                    &context.store,
+                    &root_hash,
+                )
+                .unwrap();
+                txn.commit().unwrap();
+                tmp.sort();
+                tmp
+            };
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn in_memory_keys_from_n_leaf_partial_trie_had_expected_results() {
+        for (num_leaves, generator) in TEST_TRIE_GENERATORS.iter().enumerate() {
+            let correlation_id = CorrelationId::new();
+            let (root_hash, tries) = generator().unwrap();
+            let context = InMemoryTestContext::new(&tries).unwrap();
+            let test_leaves = TEST_LEAVES;
+            let (used, _) = test_leaves.split_at(num_leaves);
+
+            let expected = {
+                let mut tmp = used
+                    .iter()
+                    .filter_map(Trie::key)
+                    .cloned()
+                    .collect::<Vec<TestKey>>();
+                tmp.sort();
+                tmp
+            };
+            let actual = {
+                let txn = context.environment.create_read_txn().unwrap();
+                let mut tmp = operations::keys::<TestKey, TestValue, _, _, in_memory::Error>(
+                    correlation_id,
+                    &txn,
+                    &context.store,
+                    &root_hash,
+                )
+                .unwrap();
+                txn.commit().unwrap();
+                tmp.sort();
+                tmp
+            };
+            assert_eq!(actual, expected);
+        }
+    }
+}
+
+mod full_tries {
+    use engine_shared::newtypes::{Blake2bHash, CorrelationId};
+
+    use crate::{
+        error::in_memory,
+        transaction_source::{Transaction, TransactionSource},
+        trie::Trie,
+        trie_store::operations::{
+            self,
+            tests::{InMemoryTestContext, TestKey, TestValue, TEST_LEAVES, TEST_TRIE_GENERATORS},
+        },
+    };
+
+    #[test]
+    fn in_memory_keys_from_n_leaf_full_trie_had_expected_results() {
+        let correlation_id = CorrelationId::new();
+        let context = InMemoryTestContext::new(&[]).unwrap();
+        let mut states: Vec<Blake2bHash> = Vec::new();
+
+        for (state_index, generator) in TEST_TRIE_GENERATORS.iter().enumerate() {
+            let (root_hash, tries) = generator().unwrap();
+            context.update(&tries).unwrap();
+            states.push(root_hash);
+
+            for (num_leaves, state) in states[..state_index].iter().enumerate() {
+                let test_leaves = TEST_LEAVES;
+                let (used, _unused) = test_leaves.split_at(num_leaves);
+
+                let expected = {
+                    let mut tmp = used
+                        .iter()
+                        .filter_map(Trie::key)
+                        .cloned()
+                        .collect::<Vec<TestKey>>();
+                    tmp.sort();
+                    tmp
+                };
+                let actual = {
+                    let txn = context.environment.create_read_txn().unwrap();
+                    let mut tmp = operations::keys::<TestKey, TestValue, _, _, in_memory::Error>(
+                        correlation_id,
+                        &txn,
+                        &context.store,
+                        &state,
+                    )
+                    .unwrap();
+                    txn.commit().unwrap();
+                    tmp.sort();
+                    tmp
+                };
+                assert_eq!(actual, expected);
+            }
+        }
+    }
+}

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -1,4 +1,5 @@
 mod ee_699;
+mod keys;
 mod proptests;
 mod read;
 mod scan;
@@ -32,7 +33,7 @@ use crate::{
 const TEST_KEY_LENGTH: usize = 7;
 
 /// A short key type for tests.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct TestKey([u8; TEST_KEY_LENGTH]);
 
 impl ToBytes for TestKey {

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/proptests.rs
@@ -7,6 +7,7 @@ use proptest::{
 };
 
 use super::*;
+use crate::trie_store::operations;
 
 const DEFAULT_MIN_LENGTH: usize = 0;
 
@@ -76,6 +77,24 @@ where
             if ReadResult::Found(*value) != result {
                 return Ok(false);
             }
+        }
+        let expected = {
+            let mut tmp = pairs[..=index]
+                .iter()
+                .map(|(k, _)| k)
+                .cloned()
+                .collect::<Vec<TestKey>>();
+            tmp.sort();
+            tmp
+        };
+        let actual = {
+            let mut tmp =
+                operations::keys::<_, _, _, _, E>(correlation_id, &txn, store, root_hash)?;
+            tmp.sort();
+            tmp
+        };
+        if expected != actual {
+            return Ok(false);
         }
     }
     Ok(true)

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/scan.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/scan.rs
@@ -39,7 +39,7 @@ where
         match parent {
             Trie::Leaf { .. } => panic!("parents should not contain any leaves"),
             Trie::Node { pointer_block } => {
-                let pointer_tip_hash = pointer_block[index.into()].map(|ptr| *ptr.hash());
+                let pointer_tip_hash = pointer_block[<usize>::from(index)].map(|ptr| *ptr.hash());
                 assert_eq!(Some(expected_tip_hash), pointer_tip_hash);
                 tip = Trie::Node { pointer_block };
             }


### PR DESCRIPTION
### Overview
This PR introduces `engine_storage::trie_store::operations::keys` which returns all of the keys at a given root hash and acts as a kind of "integrity check" on the structure of the trie.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-791

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
