### PR TITLE
EE-802: Use consistent naming scheme for size-related constants

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/account.rs
+++ b/execution-engine/contract-ffi/src/contract_api/account.rs
@@ -9,15 +9,19 @@ use crate::{
     unwrap_or_revert::UnwrapOrRevert,
     value::account::{
         ActionType, AddKeyFailure, PurseId, RemoveKeyFailure, SetThresholdFailure,
-        UpdateKeyFailure, Weight, PURSE_ID_SIZE_SERIALIZED,
+        UpdateKeyFailure, Weight, PURSE_ID_SERIALIZED_LENGTH,
     },
 };
 
 pub fn get_main_purse() -> PurseId {
-    let dest_ptr = contract_api::alloc_bytes(PURSE_ID_SIZE_SERIALIZED);
+    let dest_ptr = contract_api::alloc_bytes(PURSE_ID_SERIALIZED_LENGTH);
     let bytes = unsafe {
         ext_ffi::get_main_purse(dest_ptr);
-        Vec::from_raw_parts(dest_ptr, PURSE_ID_SIZE_SERIALIZED, PURSE_ID_SIZE_SERIALIZED)
+        Vec::from_raw_parts(
+            dest_ptr,
+            PURSE_ID_SERIALIZED_LENGTH,
+            PURSE_ID_SERIALIZED_LENGTH,
+        )
     };
     deserialize(&bytes).unwrap_or_revert()
 }

--- a/execution-engine/contract-ffi/src/contract_api/runtime.rs
+++ b/execution-engine/contract-ffi/src/contract_api/runtime.rs
@@ -8,13 +8,15 @@ use super::{
 use crate::{
     args_parser::ArgsParser,
     bytesrepr::{self, deserialize, FromBytes, ToBytes},
-    execution::{Phase, PHASE_SIZE},
+    execution::{Phase, PHASE_SERIALIZED_LENGTH},
     ext_ffi,
     key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     uref::URef,
     value::{
-        account::{BlockTime, PublicKey, BLOCKTIME_SER_SIZE, PUBLIC_KEY_SIZE},
+        account::{
+            BlockTime, PublicKey, BLOCKTIME_SERIALIZED_LENGTH, PUBLIC_KEY_SERIALIZED_LENGTH,
+        },
         Contract, Value,
     },
 };
@@ -117,25 +119,36 @@ pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
 /// When in the sub call - returns public key of the account that made the
 /// deploy.
 pub fn get_caller() -> PublicKey {
-    let dest_ptr = alloc_bytes(PUBLIC_KEY_SIZE);
+    let dest_ptr = alloc_bytes(PUBLIC_KEY_SERIALIZED_LENGTH);
     unsafe { ext_ffi::get_caller(dest_ptr) };
-    let bytes = unsafe { Vec::from_raw_parts(dest_ptr, PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE) };
+    let bytes = unsafe {
+        Vec::from_raw_parts(
+            dest_ptr,
+            PUBLIC_KEY_SERIALIZED_LENGTH,
+            PUBLIC_KEY_SERIALIZED_LENGTH,
+        )
+    };
     deserialize(&bytes).unwrap_or_revert()
 }
 
 pub fn get_blocktime() -> BlockTime {
-    let dest_ptr = alloc_bytes(BLOCKTIME_SER_SIZE);
+    let dest_ptr = alloc_bytes(BLOCKTIME_SERIALIZED_LENGTH);
     let bytes = unsafe {
         ext_ffi::get_blocktime(dest_ptr);
-        Vec::from_raw_parts(dest_ptr, BLOCKTIME_SER_SIZE, BLOCKTIME_SER_SIZE)
+        Vec::from_raw_parts(
+            dest_ptr,
+            BLOCKTIME_SERIALIZED_LENGTH,
+            BLOCKTIME_SERIALIZED_LENGTH,
+        )
     };
     deserialize(&bytes).unwrap_or_revert()
 }
 
 pub fn get_phase() -> Phase {
-    let dest_ptr = alloc_bytes(PHASE_SIZE);
+    let dest_ptr = alloc_bytes(PHASE_SERIALIZED_LENGTH);
     unsafe { ext_ffi::get_phase(dest_ptr) };
-    let bytes = unsafe { Vec::from_raw_parts(dest_ptr, PHASE_SIZE, PHASE_SIZE) };
+    let bytes =
+        unsafe { Vec::from_raw_parts(dest_ptr, PHASE_SERIALIZED_LENGTH, PHASE_SERIALIZED_LENGTH) };
     deserialize(&bytes).unwrap_or_revert()
 }
 

--- a/execution-engine/contract-ffi/src/contract_api/storage.rs
+++ b/execution-engine/contract-ffi/src/contract_api/storage.rs
@@ -9,7 +9,7 @@ use crate::{
     bytesrepr::{self, deserialize, ToBytes},
     contract_api::{runtime, Error},
     ext_ffi,
-    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
+    key::{Key, KEY_UREF_SERIALIZED_LENGTH},
     unwrap_or_revert::UnwrapOrRevert,
     uref::AccessRights,
     value::{Contract, Value},
@@ -157,15 +157,15 @@ pub fn store_function_at_hash(name: &str, named_keys: BTreeMap<String, Key>) -> 
 
 /// Returns a new unforgable pointer, where value is initialized to `init`
 pub fn new_turef<T: Into<Value>>(init: T) -> TURef<T> {
-    let key_ptr = alloc_bytes(UREF_KEY_SERIALIZED_LENGTH);
+    let key_ptr = alloc_bytes(KEY_UREF_SERIALIZED_LENGTH);
     let value: Value = init.into();
     let (value_ptr, value_size, _bytes2) = to_ptr(&value);
     let bytes = unsafe {
         ext_ffi::new_uref(key_ptr, value_ptr, value_size); // new_uref creates a URef with ReadWrite access writes
         Vec::from_raw_parts(
             key_ptr,
-            UREF_KEY_SERIALIZED_LENGTH,
-            UREF_KEY_SERIALIZED_LENGTH,
+            KEY_UREF_SERIALIZED_LENGTH,
+            KEY_UREF_SERIALIZED_LENGTH,
         )
     };
     let key: Key = deserialize(&bytes).unwrap_or_revert();

--- a/execution-engine/contract-ffi/src/contract_api/storage.rs
+++ b/execution-engine/contract-ffi/src/contract_api/storage.rs
@@ -9,7 +9,7 @@ use crate::{
     bytesrepr::{self, deserialize, ToBytes},
     contract_api::{runtime, Error},
     ext_ffi,
-    key::{Key, UREF_SIZE},
+    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
     unwrap_or_revert::UnwrapOrRevert,
     uref::AccessRights,
     value::{Contract, Value},
@@ -157,12 +157,16 @@ pub fn store_function_at_hash(name: &str, named_keys: BTreeMap<String, Key>) -> 
 
 /// Returns a new unforgable pointer, where value is initialized to `init`
 pub fn new_turef<T: Into<Value>>(init: T) -> TURef<T> {
-    let key_ptr = alloc_bytes(UREF_SIZE);
+    let key_ptr = alloc_bytes(UREF_KEY_SERIALIZED_LENGTH);
     let value: Value = init.into();
     let (value_ptr, value_size, _bytes2) = to_ptr(&value);
     let bytes = unsafe {
         ext_ffi::new_uref(key_ptr, value_ptr, value_size); // new_uref creates a URef with ReadWrite access writes
-        Vec::from_raw_parts(key_ptr, UREF_SIZE, UREF_SIZE)
+        Vec::from_raw_parts(
+            key_ptr,
+            UREF_KEY_SERIALIZED_LENGTH,
+            UREF_KEY_SERIALIZED_LENGTH,
+        )
     };
     let key: Key = deserialize(&bytes).unwrap_or_revert();
     if let Key::URef(uref) = key {

--- a/execution-engine/contract-ffi/src/contract_api/system.rs
+++ b/execution-engine/contract-ffi/src/contract_api/system.rs
@@ -8,9 +8,9 @@ use crate::{
     ext_ffi,
     system_contracts::SystemContract,
     unwrap_or_revert::UnwrapOrRevert,
-    uref::UREF_SIZE_SERIALIZED,
+    uref::UREF_SERIALIZED_LENGTH,
     value::{
-        account::{PublicKey, PurseId, PURSE_ID_SIZE_SERIALIZED},
+        account::{PublicKey, PurseId, PURSE_ID_SERIALIZED_LENGTH},
         U512,
     },
 };
@@ -24,7 +24,7 @@ fn get_system_contract(system_contract: SystemContract) -> ContractRef {
     let system_contract_index = system_contract.into();
     let uref = {
         let result = {
-            let mut uref_data_raw = [0u8; UREF_SIZE_SERIALIZED];
+            let mut uref_data_raw = [0u8; UREF_SERIALIZED_LENGTH];
             let value = unsafe {
                 ext_ffi::get_system_contract(
                     system_contract_index,
@@ -56,14 +56,14 @@ pub fn get_proof_of_stake() -> ContractRef {
 }
 
 pub fn create_purse() -> PurseId {
-    let purse_id_ptr = alloc_bytes(PURSE_ID_SIZE_SERIALIZED);
+    let purse_id_ptr = alloc_bytes(PURSE_ID_SERIALIZED_LENGTH);
     unsafe {
-        let ret = ext_ffi::create_purse(purse_id_ptr, PURSE_ID_SIZE_SERIALIZED);
+        let ret = ext_ffi::create_purse(purse_id_ptr, PURSE_ID_SERIALIZED_LENGTH);
         if ret == 0 {
             let bytes = Vec::from_raw_parts(
                 purse_id_ptr,
-                PURSE_ID_SIZE_SERIALIZED,
-                PURSE_ID_SIZE_SERIALIZED,
+                PURSE_ID_SERIALIZED_LENGTH,
+                PURSE_ID_SERIALIZED_LENGTH,
             );
             deserialize(&bytes).unwrap_or_revert()
         } else {

--- a/execution-engine/contract-ffi/src/execution.rs
+++ b/execution-engine/contract-ffi/src/execution.rs
@@ -8,7 +8,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 
 use crate::bytesrepr::{Error, FromBytes, ToBytes};
 
-pub const PHASE_SIZE: usize = 1;
+pub const PHASE_SERIALIZED_LENGTH: usize = 1;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, FromPrimitive, ToPrimitive)]
 #[repr(u8)]

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -10,7 +10,7 @@ use hex_fmt::HexFmt;
 use crate::{
     bytesrepr::{Error, FromBytes, ToBytes},
     contract_api::{ContractRef, TURef},
-    uref::{AccessRights, URef, UREF_SIZE_SERIALIZED},
+    uref::{AccessRights, URef, UREF_SERIALIZED_LENGTH},
 };
 
 const ACCOUNT_ID: u8 = 0;
@@ -18,22 +18,22 @@ const HASH_ID: u8 = 1;
 const UREF_ID: u8 = 2;
 const LOCAL_ID: u8 = 3;
 
-pub const ACCOUNT_SIZE: usize = 32;
-pub const HASH_SIZE: usize = 32;
-pub const LOCAL_KEY_SIZE: usize = 32;
-pub const LOCAL_SEED_SIZE: usize = 32;
+pub const ACCOUNT_LENGTH: usize = 32;
+pub const HASH_LENGTH: usize = 32;
+pub const LOCAL_KEY_LENGTH: usize = 32;
+pub const LOCAL_SEED_LENGTH: usize = 32;
 
-const KEY_ID_SIZE: usize = 1; // u8 used to determine the ID
-const ACCOUNT_KEY_SIZE: usize = KEY_ID_SIZE + ACCOUNT_SIZE;
-const HASH_KEY_SIZE: usize = KEY_ID_SIZE + HASH_SIZE;
-pub const UREF_SIZE: usize = KEY_ID_SIZE + UREF_SIZE_SERIALIZED;
-const LOCAL_SIZE: usize = KEY_ID_SIZE + LOCAL_KEY_SIZE;
+const KEY_ID_SERIALIZED_LENGTH: usize = 1; // u8 used to determine the ID
+const ACCOUNT_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + ACCOUNT_LENGTH;
+const HASH_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + HASH_LENGTH;
+pub const UREF_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH;
+const LOCAL_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + LOCAL_KEY_LENGTH;
 
 /// Creates a 32-byte BLAKE2b hash digest from a given a piece of data
-fn hash(bytes: &[u8]) -> [u8; LOCAL_KEY_SIZE] {
-    let mut ret = [0u8; LOCAL_KEY_SIZE];
+fn hash(bytes: &[u8]) -> [u8; LOCAL_KEY_LENGTH] {
+    let mut ret = [0u8; LOCAL_KEY_LENGTH];
     // Safe to unwrap here because our digest length is constant and valid
-    let mut hasher = VarBlake2b::new(LOCAL_KEY_SIZE).unwrap();
+    let mut hasher = VarBlake2b::new(LOCAL_KEY_LENGTH).unwrap();
     hasher.input(bytes);
     hasher.variable_result(|hash| ret.clone_from_slice(hash));
     ret
@@ -42,16 +42,16 @@ fn hash(bytes: &[u8]) -> [u8; LOCAL_KEY_SIZE] {
 #[repr(C)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum Key {
-    Account([u8; ACCOUNT_SIZE]),
-    Hash([u8; HASH_SIZE]),
+    Account([u8; ACCOUNT_LENGTH]),
+    Hash([u8; HASH_LENGTH]),
     URef(URef),
-    Local([u8; LOCAL_KEY_SIZE]),
+    Local([u8; LOCAL_KEY_LENGTH]),
 }
 
 impl Key {
-    pub fn local(seed: [u8; LOCAL_SEED_SIZE], key_bytes: &[u8]) -> Self {
+    pub fn local(seed: [u8; LOCAL_SEED_LENGTH], key_bytes: &[u8]) -> Self {
         let bytes_to_hash: Vec<u8> = seed.iter().chain(key_bytes.iter()).copied().collect();
-        let hash: [u8; LOCAL_KEY_SIZE] = hash(&bytes_to_hash);
+        let hash: [u8; LOCAL_KEY_LENGTH] = hash(&bytes_to_hash);
         Key::Local(hash)
     }
 
@@ -67,16 +67,16 @@ impl Key {
     /// Calculates serialized size without actually serializing data.
     pub fn serialized_size(&self) -> usize {
         match self {
-            Key::Account(_) => ACCOUNT_KEY_SIZE,
-            Key::Hash(_) => HASH_KEY_SIZE,
-            Key::URef(_) => UREF_SIZE,
-            Key::Local(_) => LOCAL_SIZE,
+            Key::Account(_) => ACCOUNT_KEY_SERIALIZED_LENGTH,
+            Key::Hash(_) => HASH_KEY_SERIALIZED_LENGTH,
+            Key::URef(_) => UREF_KEY_SERIALIZED_LENGTH,
+            Key::Local(_) => LOCAL_KEY_SERIALIZED_LENGTH,
         }
     }
 
     /// Returns max size a [`Key`] can be serialized into.
     pub const fn serialized_size_hint() -> usize {
-        UREF_SIZE
+        UREF_KEY_SERIALIZED_LENGTH
     }
 }
 
@@ -111,8 +111,8 @@ fn drop_hex_prefix(s: &str) -> &str {
 
 /// Tries to decode `input` as a 32-byte array.  `input` may be prefixed with "0x".  Returns `None`
 /// if `input` cannot be parsed as hex, or if it does not parse to exactly 32 bytes.
-fn decode_from_hex(input: &str) -> Option<[u8; HASH_SIZE]> {
-    const UNDECORATED_INPUT_LEN: usize = 2 * HASH_SIZE;
+fn decode_from_hex(input: &str) -> Option<[u8; HASH_LENGTH]> {
+    const UNDECORATED_INPUT_LEN: usize = 2 * HASH_LENGTH;
 
     let undecorated_input = drop_hex_prefix(input);
 
@@ -120,9 +120,9 @@ fn decode_from_hex(input: &str) -> Option<[u8; HASH_SIZE]> {
         return None;
     }
 
-    let mut output = [0u8; HASH_SIZE];
+    let mut output = [0u8; HASH_LENGTH];
     let _bytes_written = base16::decode_slice(undecorated_input, &mut output).ok()?;
-    debug_assert!(_bytes_written == HASH_SIZE);
+    debug_assert!(_bytes_written == HASH_LENGTH);
     Some(output)
 }
 
@@ -195,14 +195,14 @@ impl Key {
         }
     }
 
-    pub fn as_hash(&self) -> Option<[u8; HASH_SIZE]> {
+    pub fn as_hash(&self) -> Option<[u8; HASH_LENGTH]> {
         match self {
             Key::Hash(hash) => Some(*hash),
             _ => None,
         }
     }
 
-    pub fn as_local(&self) -> Option<[u8; LOCAL_KEY_SIZE]> {
+    pub fn as_local(&self) -> Option<[u8; LOCAL_KEY_LENGTH]> {
         match self {
             Key::Local(local) => Some(*local),
             _ => None,
@@ -227,25 +227,25 @@ impl ToBytes for Key {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         match self {
             Key::Account(addr) => {
-                let mut result = Vec::with_capacity(ACCOUNT_KEY_SIZE);
+                let mut result = Vec::with_capacity(ACCOUNT_KEY_SERIALIZED_LENGTH);
                 result.push(ACCOUNT_ID);
                 result.append(&mut addr.to_bytes()?);
                 Ok(result)
             }
             Key::Hash(hash) => {
-                let mut result = Vec::with_capacity(HASH_KEY_SIZE);
+                let mut result = Vec::with_capacity(HASH_KEY_SERIALIZED_LENGTH);
                 result.push(HASH_ID);
                 result.append(&mut hash.to_bytes()?);
                 Ok(result)
             }
             Key::URef(uref) => {
-                let mut result = Vec::with_capacity(UREF_SIZE);
+                let mut result = Vec::with_capacity(UREF_KEY_SERIALIZED_LENGTH);
                 result.push(UREF_ID);
                 result.append(&mut uref.to_bytes()?);
                 Ok(result)
             }
             Key::Local(hash) => {
-                let mut result = Vec::with_capacity(LOCAL_SIZE);
+                let mut result = Vec::with_capacity(LOCAL_KEY_SERIALIZED_LENGTH);
                 result.push(LOCAL_ID);
                 result.append(&mut hash.to_bytes()?);
                 Ok(result)
@@ -297,7 +297,8 @@ impl FromBytes for Vec<Key> {
 impl ToBytes for Vec<Key> {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let size = self.len() as u32;
-        let mut result: Vec<u8> = Vec::with_capacity(4 + (size as usize) * UREF_SIZE);
+        let mut result: Vec<u8> =
+            Vec::with_capacity(4 + (size as usize) * UREF_KEY_SERIALIZED_LENGTH);
         result.extend(size.to_bytes()?);
         result.extend(
             self.iter()
@@ -325,7 +326,8 @@ mod tests {
     use crate::{
         bytesrepr::{Error, FromBytes, ToBytes},
         key::{
-            Key, ACCOUNT_KEY_SIZE, HASH_KEY_SIZE, HASH_SIZE, LOCAL_KEY_SIZE, LOCAL_SIZE, UREF_SIZE,
+            Key, ACCOUNT_KEY_SERIALIZED_LENGTH, HASH_KEY_SERIALIZED_LENGTH, HASH_LENGTH,
+            LOCAL_KEY_LENGTH, LOCAL_KEY_SERIALIZED_LENGTH, UREF_KEY_SERIALIZED_LENGTH,
         },
         uref::{AccessRights, URef},
     };
@@ -503,7 +505,7 @@ mod tests {
 
     #[test]
     fn check_key_hash_getters() {
-        let hash = [42; HASH_SIZE];
+        let hash = [42; HASH_LENGTH];
         let key1 = Key::Hash(hash);
         assert!(key1.as_account().is_none());
         assert_eq!(key1.as_hash(), Some(hash));
@@ -523,7 +525,7 @@ mod tests {
 
     #[test]
     fn check_key_local_getters() {
-        let local = [42; LOCAL_KEY_SIZE];
+        let local = [42; LOCAL_KEY_LENGTH];
         let key1 = Key::Local(local);
         assert!(key1.as_account().is_none());
         assert!(key1.as_hash().is_none());
@@ -534,15 +536,15 @@ mod tests {
     #[test]
     fn serialized_size() {
         let account = [42; 32];
-        let hash = [42; HASH_SIZE];
+        let hash = [42; HASH_LENGTH];
         let uref = URef::new([42; 32], AccessRights::READ_ADD_WRITE);
-        let local = [42; LOCAL_KEY_SIZE];
+        let local = [42; LOCAL_KEY_LENGTH];
 
         let keys = [
-            (Key::Account(account), ACCOUNT_KEY_SIZE),
-            (Key::Hash(hash), HASH_KEY_SIZE),
-            (Key::URef(uref), UREF_SIZE),
-            (Key::Local(local), LOCAL_SIZE),
+            (Key::Account(account), ACCOUNT_KEY_SERIALIZED_LENGTH),
+            (Key::Hash(hash), HASH_KEY_SERIALIZED_LENGTH),
+            (Key::URef(uref), UREF_KEY_SERIALIZED_LENGTH),
+            (Key::Local(local), LOCAL_KEY_SERIALIZED_LENGTH),
         ];
 
         for &(key, const_size) in keys.iter() {
@@ -555,7 +557,12 @@ mod tests {
 
     #[test]
     fn key_size_hint() {
-        let mut sizes = vec![ACCOUNT_KEY_SIZE, HASH_KEY_SIZE, UREF_SIZE, LOCAL_SIZE];
+        let mut sizes = vec![
+            ACCOUNT_KEY_SERIALIZED_LENGTH,
+            HASH_KEY_SERIALIZED_LENGTH,
+            UREF_KEY_SERIALIZED_LENGTH,
+            LOCAL_KEY_SERIALIZED_LENGTH,
+        ];
         sizes.sort();
         assert_eq!(sizes.last().cloned().unwrap(), Key::serialized_size_hint());
     }

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -18,22 +18,22 @@ const HASH_ID: u8 = 1;
 const UREF_ID: u8 = 2;
 const LOCAL_ID: u8 = 3;
 
-pub const ACCOUNT_LENGTH: usize = 32;
-pub const HASH_LENGTH: usize = 32;
-pub const LOCAL_KEY_LENGTH: usize = 32;
+pub const KEY_ACCOUNT_LENGTH: usize = 32;
+pub const KEY_HASH_LENGTH: usize = 32;
+pub const KEY_LOCAL_LENGTH: usize = 32;
 pub const LOCAL_SEED_LENGTH: usize = 32;
 
 const KEY_ID_SERIALIZED_LENGTH: usize = 1; // u8 used to determine the ID
-const ACCOUNT_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + ACCOUNT_LENGTH;
-const HASH_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + HASH_LENGTH;
-pub const UREF_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH;
-const LOCAL_KEY_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + LOCAL_KEY_LENGTH;
+const KEY_ACCOUNT_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_ACCOUNT_LENGTH;
+const KEY_HASH_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_HASH_LENGTH;
+pub const KEY_UREF_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH;
+const KEY_LOCAL_SERIALIZED_LENGTH: usize = KEY_ID_SERIALIZED_LENGTH + KEY_LOCAL_LENGTH;
 
 /// Creates a 32-byte BLAKE2b hash digest from a given a piece of data
-fn hash(bytes: &[u8]) -> [u8; LOCAL_KEY_LENGTH] {
-    let mut ret = [0u8; LOCAL_KEY_LENGTH];
+fn hash(bytes: &[u8]) -> [u8; KEY_LOCAL_LENGTH] {
+    let mut ret = [0u8; KEY_LOCAL_LENGTH];
     // Safe to unwrap here because our digest length is constant and valid
-    let mut hasher = VarBlake2b::new(LOCAL_KEY_LENGTH).unwrap();
+    let mut hasher = VarBlake2b::new(KEY_LOCAL_LENGTH).unwrap();
     hasher.input(bytes);
     hasher.variable_result(|hash| ret.clone_from_slice(hash));
     ret
@@ -42,16 +42,16 @@ fn hash(bytes: &[u8]) -> [u8; LOCAL_KEY_LENGTH] {
 #[repr(C)]
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum Key {
-    Account([u8; ACCOUNT_LENGTH]),
-    Hash([u8; HASH_LENGTH]),
+    Account([u8; KEY_ACCOUNT_LENGTH]),
+    Hash([u8; KEY_HASH_LENGTH]),
     URef(URef),
-    Local([u8; LOCAL_KEY_LENGTH]),
+    Local([u8; KEY_LOCAL_LENGTH]),
 }
 
 impl Key {
     pub fn local(seed: [u8; LOCAL_SEED_LENGTH], key_bytes: &[u8]) -> Self {
         let bytes_to_hash: Vec<u8> = seed.iter().chain(key_bytes.iter()).copied().collect();
-        let hash: [u8; LOCAL_KEY_LENGTH] = hash(&bytes_to_hash);
+        let hash: [u8; KEY_LOCAL_LENGTH] = hash(&bytes_to_hash);
         Key::Local(hash)
     }
 
@@ -67,16 +67,16 @@ impl Key {
     /// Calculates serialized size without actually serializing data.
     pub fn serialized_size(&self) -> usize {
         match self {
-            Key::Account(_) => ACCOUNT_KEY_SERIALIZED_LENGTH,
-            Key::Hash(_) => HASH_KEY_SERIALIZED_LENGTH,
-            Key::URef(_) => UREF_KEY_SERIALIZED_LENGTH,
-            Key::Local(_) => LOCAL_KEY_SERIALIZED_LENGTH,
+            Key::Account(_) => KEY_ACCOUNT_SERIALIZED_LENGTH,
+            Key::Hash(_) => KEY_HASH_SERIALIZED_LENGTH,
+            Key::URef(_) => KEY_UREF_SERIALIZED_LENGTH,
+            Key::Local(_) => KEY_LOCAL_SERIALIZED_LENGTH,
         }
     }
 
     /// Returns max size a [`Key`] can be serialized into.
     pub const fn serialized_size_hint() -> usize {
-        UREF_KEY_SERIALIZED_LENGTH
+        KEY_UREF_SERIALIZED_LENGTH
     }
 }
 
@@ -111,8 +111,8 @@ fn drop_hex_prefix(s: &str) -> &str {
 
 /// Tries to decode `input` as a 32-byte array.  `input` may be prefixed with "0x".  Returns `None`
 /// if `input` cannot be parsed as hex, or if it does not parse to exactly 32 bytes.
-fn decode_from_hex(input: &str) -> Option<[u8; HASH_LENGTH]> {
-    const UNDECORATED_INPUT_LEN: usize = 2 * HASH_LENGTH;
+fn decode_from_hex(input: &str) -> Option<[u8; KEY_HASH_LENGTH]> {
+    const UNDECORATED_INPUT_LEN: usize = 2 * KEY_HASH_LENGTH;
 
     let undecorated_input = drop_hex_prefix(input);
 
@@ -120,9 +120,9 @@ fn decode_from_hex(input: &str) -> Option<[u8; HASH_LENGTH]> {
         return None;
     }
 
-    let mut output = [0u8; HASH_LENGTH];
+    let mut output = [0u8; KEY_HASH_LENGTH];
     let _bytes_written = base16::decode_slice(undecorated_input, &mut output).ok()?;
-    debug_assert!(_bytes_written == HASH_LENGTH);
+    debug_assert!(_bytes_written == KEY_HASH_LENGTH);
     Some(output)
 }
 
@@ -195,14 +195,14 @@ impl Key {
         }
     }
 
-    pub fn as_hash(&self) -> Option<[u8; HASH_LENGTH]> {
+    pub fn as_hash(&self) -> Option<[u8; KEY_HASH_LENGTH]> {
         match self {
             Key::Hash(hash) => Some(*hash),
             _ => None,
         }
     }
 
-    pub fn as_local(&self) -> Option<[u8; LOCAL_KEY_LENGTH]> {
+    pub fn as_local(&self) -> Option<[u8; KEY_LOCAL_LENGTH]> {
         match self {
             Key::Local(local) => Some(*local),
             _ => None,
@@ -227,25 +227,25 @@ impl ToBytes for Key {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         match self {
             Key::Account(addr) => {
-                let mut result = Vec::with_capacity(ACCOUNT_KEY_SERIALIZED_LENGTH);
+                let mut result = Vec::with_capacity(KEY_ACCOUNT_SERIALIZED_LENGTH);
                 result.push(ACCOUNT_ID);
                 result.append(&mut addr.to_bytes()?);
                 Ok(result)
             }
             Key::Hash(hash) => {
-                let mut result = Vec::with_capacity(HASH_KEY_SERIALIZED_LENGTH);
+                let mut result = Vec::with_capacity(KEY_HASH_SERIALIZED_LENGTH);
                 result.push(HASH_ID);
                 result.append(&mut hash.to_bytes()?);
                 Ok(result)
             }
             Key::URef(uref) => {
-                let mut result = Vec::with_capacity(UREF_KEY_SERIALIZED_LENGTH);
+                let mut result = Vec::with_capacity(KEY_UREF_SERIALIZED_LENGTH);
                 result.push(UREF_ID);
                 result.append(&mut uref.to_bytes()?);
                 Ok(result)
             }
             Key::Local(hash) => {
-                let mut result = Vec::with_capacity(LOCAL_KEY_SERIALIZED_LENGTH);
+                let mut result = Vec::with_capacity(KEY_LOCAL_SERIALIZED_LENGTH);
                 result.push(LOCAL_ID);
                 result.append(&mut hash.to_bytes()?);
                 Ok(result)
@@ -298,7 +298,7 @@ impl ToBytes for Vec<Key> {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let size = self.len() as u32;
         let mut result: Vec<u8> =
-            Vec::with_capacity(4 + (size as usize) * UREF_KEY_SERIALIZED_LENGTH);
+            Vec::with_capacity(4 + (size as usize) * KEY_UREF_SERIALIZED_LENGTH);
         result.extend(size.to_bytes()?);
         result.extend(
             self.iter()
@@ -326,8 +326,8 @@ mod tests {
     use crate::{
         bytesrepr::{Error, FromBytes, ToBytes},
         key::{
-            Key, ACCOUNT_KEY_SERIALIZED_LENGTH, HASH_KEY_SERIALIZED_LENGTH, HASH_LENGTH,
-            LOCAL_KEY_LENGTH, LOCAL_KEY_SERIALIZED_LENGTH, UREF_KEY_SERIALIZED_LENGTH,
+            Key, KEY_ACCOUNT_SERIALIZED_LENGTH, KEY_HASH_LENGTH, KEY_HASH_SERIALIZED_LENGTH,
+            KEY_LOCAL_LENGTH, KEY_LOCAL_SERIALIZED_LENGTH, KEY_UREF_SERIALIZED_LENGTH,
         },
         uref::{AccessRights, URef},
     };
@@ -505,7 +505,7 @@ mod tests {
 
     #[test]
     fn check_key_hash_getters() {
-        let hash = [42; HASH_LENGTH];
+        let hash = [42; KEY_HASH_LENGTH];
         let key1 = Key::Hash(hash);
         assert!(key1.as_account().is_none());
         assert_eq!(key1.as_hash(), Some(hash));
@@ -525,7 +525,7 @@ mod tests {
 
     #[test]
     fn check_key_local_getters() {
-        let local = [42; LOCAL_KEY_LENGTH];
+        let local = [42; KEY_LOCAL_LENGTH];
         let key1 = Key::Local(local);
         assert!(key1.as_account().is_none());
         assert!(key1.as_hash().is_none());
@@ -536,15 +536,15 @@ mod tests {
     #[test]
     fn serialized_size() {
         let account = [42; 32];
-        let hash = [42; HASH_LENGTH];
+        let hash = [42; KEY_HASH_LENGTH];
         let uref = URef::new([42; 32], AccessRights::READ_ADD_WRITE);
-        let local = [42; LOCAL_KEY_LENGTH];
+        let local = [42; KEY_LOCAL_LENGTH];
 
         let keys = [
-            (Key::Account(account), ACCOUNT_KEY_SERIALIZED_LENGTH),
-            (Key::Hash(hash), HASH_KEY_SERIALIZED_LENGTH),
-            (Key::URef(uref), UREF_KEY_SERIALIZED_LENGTH),
-            (Key::Local(local), LOCAL_KEY_SERIALIZED_LENGTH),
+            (Key::Account(account), KEY_ACCOUNT_SERIALIZED_LENGTH),
+            (Key::Hash(hash), KEY_HASH_SERIALIZED_LENGTH),
+            (Key::URef(uref), KEY_UREF_SERIALIZED_LENGTH),
+            (Key::Local(local), KEY_LOCAL_SERIALIZED_LENGTH),
         ];
 
         for &(key, const_size) in keys.iter() {
@@ -558,10 +558,10 @@ mod tests {
     #[test]
     fn key_size_hint() {
         let mut sizes = vec![
-            ACCOUNT_KEY_SERIALIZED_LENGTH,
-            HASH_KEY_SERIALIZED_LENGTH,
-            UREF_KEY_SERIALIZED_LENGTH,
-            LOCAL_KEY_SERIALIZED_LENGTH,
+            KEY_ACCOUNT_SERIALIZED_LENGTH,
+            KEY_HASH_SERIALIZED_LENGTH,
+            KEY_UREF_SERIALIZED_LENGTH,
+            KEY_LOCAL_SERIALIZED_LENGTH,
         ];
         sizes.sort();
         assert_eq!(sizes.last().cloned().unwrap(), Key::serialized_size_hint());

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -5,13 +5,14 @@ use bitflags::bitflags;
 use hex_fmt::HexFmt;
 
 use crate::{
-    bytesrepr::{self, OPTION_SIZE, U32_SIZE},
+    bytesrepr::{self, OPTION_TAG_SERIALIZED_LENGTH, U32_SERIALIZED_LENGTH},
     contract_api::TURef,
 };
 
-pub const UREF_ADDR_SIZE: usize = 32;
-pub const ACCESS_RIGHTS_SIZE: usize = 1;
-pub const UREF_SIZE_SERIALIZED: usize = UREF_ADDR_SIZE + OPTION_SIZE + ACCESS_RIGHTS_SIZE;
+pub const UREF_ADDR_LENGTH: usize = 32;
+pub const ACCESS_RIGHTS_SERIALIZED_LENGTH: usize = 1;
+pub const UREF_SERIALIZED_LENGTH: usize =
+    UREF_ADDR_LENGTH + OPTION_TAG_SERIALIZED_LENGTH + ACCESS_RIGHTS_SERIALIZED_LENGTH;
 
 bitflags! {
     #[allow(clippy::derive_hash_xor_eq)]
@@ -73,7 +74,7 @@ impl bytesrepr::FromBytes for AccessRights {
 
 /// Represents an unforgeable reference
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-pub struct URef([u8; UREF_ADDR_SIZE], Option<AccessRights>);
+pub struct URef([u8; UREF_ADDR_LENGTH], Option<AccessRights>);
 
 impl core::fmt::Display for URef {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -95,7 +96,7 @@ impl core::fmt::Debug for URef {
 
 impl URef {
     /// Creates a [`URef`] from an id and access rights.
-    pub fn new(id: [u8; UREF_ADDR_SIZE], access_rights: AccessRights) -> Self {
+    pub fn new(id: [u8; UREF_ADDR_LENGTH], access_rights: AccessRights) -> Self {
         URef(id, Some(access_rights))
     }
 
@@ -103,14 +104,14 @@ impl URef {
     /// is the preferred constructor for most common use-cases.
     #[cfg(feature = "gens")]
     pub(crate) fn unsafe_new(
-        id: [u8; UREF_ADDR_SIZE],
+        id: [u8; UREF_ADDR_LENGTH],
         maybe_access_rights: Option<AccessRights>,
     ) -> Self {
         URef(id, maybe_access_rights)
     }
 
     /// Returns the address of this URef.
-    pub fn addr(&self) -> [u8; UREF_ADDR_SIZE] {
+    pub fn addr(&self) -> [u8; UREF_ADDR_LENGTH] {
         self.0
     }
 
@@ -181,7 +182,7 @@ impl URef {
 
 impl bytesrepr::ToBytes for URef {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut result = Vec::with_capacity(UREF_SIZE_SERIALIZED);
+        let mut result = Vec::with_capacity(UREF_SERIALIZED_LENGTH);
         result.append(&mut self.0.to_bytes()?);
         result.append(&mut self.1.to_bytes()?);
         Ok(result)
@@ -214,7 +215,7 @@ impl bytesrepr::FromBytes for Vec<URef> {
 impl bytesrepr::ToBytes for Vec<URef> {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let size = self.len() as u32;
-        let mut result: Vec<u8> = Vec::with_capacity(U32_SIZE);
+        let mut result: Vec<u8> = Vec::with_capacity(U32_SERIALIZED_LENGTH);
         result.extend(size.to_bytes()?);
         result.extend(
             self.iter()

--- a/execution-engine/contract-ffi/src/value/account.rs
+++ b/execution-engine/contract-ffi/src/value/account.rs
@@ -17,7 +17,7 @@ use crate::{
         U8_SERIALIZED_LENGTH,
     },
     contract_api::{runtime, Error as ApiError},
-    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
+    key::{Key, KEY_UREF_SERIALIZED_LENGTH},
     unwrap_or_revert::UnwrapOrRevert,
     uref::{AccessRights, URef, UREF_SERIALIZED_LENGTH},
 };
@@ -822,8 +822,8 @@ impl ToBytes for Account {
             * (PUBLIC_KEY_SERIALIZED_LENGTH + WEIGHT_SERIALIZED_LENGTH)
             + U32_SERIALIZED_LENGTH;
         let named_keys_size =
-            UREF_KEY_SERIALIZED_LENGTH * self.named_keys.len() + U32_SERIALIZED_LENGTH;
-        let purse_id_size = UREF_KEY_SERIALIZED_LENGTH;
+            KEY_UREF_SERIALIZED_LENGTH * self.named_keys.len() + U32_SERIALIZED_LENGTH;
+        let purse_id_size = KEY_UREF_SERIALIZED_LENGTH;
         let serialized_account_size = PUBLIC_KEY_LENGTH // pub key
             + named_keys_size
             + purse_id_size

--- a/execution-engine/contract-ffi/src/value/contract.rs
+++ b/execution-engine/contract-ffi/src/value/contract.rs
@@ -1,8 +1,8 @@
 use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
 use crate::{
-    bytesrepr::{Error, FromBytes, ToBytes, U32_SIZE, U64_SIZE},
-    key::{Key, UREF_SIZE},
+    bytesrepr::{Error, FromBytes, ToBytes, U32_SERIALIZED_LENGTH, U64_SERIALIZED_LENGTH},
+    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
     value::ProtocolVersion,
 };
 
@@ -57,16 +57,18 @@ impl Contract {
 
 impl ToBytes for Contract {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        if self.bytes.len() + UREF_SIZE * self.named_keys.len() + U64_SIZE
-            >= u32::max_value() as usize - U32_SIZE * 2
+        if self.bytes.len()
+            + UREF_KEY_SERIALIZED_LENGTH * self.named_keys.len()
+            + U64_SERIALIZED_LENGTH
+            >= u32::max_value() as usize - U32_SERIALIZED_LENGTH * 2
         {
             return Err(Error::OutOfMemoryError);
         }
-        let size: usize = U32_SIZE +                    //size for length of bytes
+        let size: usize = U32_SERIALIZED_LENGTH +                    //size for length of bytes
                     self.bytes.len() +                  //size for elements of bytes
-                    U32_SIZE +                          //size for length of named_keys
-                    UREF_SIZE * self.named_keys.len() + //size for named_keys elements
-                    U64_SIZE; //size for protocol_version
+                    U32_SERIALIZED_LENGTH +                          //size for length of named_keys
+                    UREF_KEY_SERIALIZED_LENGTH * self.named_keys.len() + //size for named_keys elements
+                    U64_SERIALIZED_LENGTH; //size for protocol_version
 
         let mut result = Vec::with_capacity(size);
         result.append(&mut self.bytes.to_bytes()?);

--- a/execution-engine/contract-ffi/src/value/contract.rs
+++ b/execution-engine/contract-ffi/src/value/contract.rs
@@ -2,7 +2,7 @@ use alloc::{collections::BTreeMap, string::String, vec::Vec};
 
 use crate::{
     bytesrepr::{Error, FromBytes, ToBytes, U32_SERIALIZED_LENGTH, U64_SERIALIZED_LENGTH},
-    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
+    key::{Key, KEY_UREF_SERIALIZED_LENGTH},
     value::ProtocolVersion,
 };
 
@@ -58,16 +58,16 @@ impl Contract {
 impl ToBytes for Contract {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         if self.bytes.len()
-            + UREF_KEY_SERIALIZED_LENGTH * self.named_keys.len()
+            + KEY_UREF_SERIALIZED_LENGTH * self.named_keys.len()
             + U64_SERIALIZED_LENGTH
             >= u32::max_value() as usize - U32_SERIALIZED_LENGTH * 2
         {
             return Err(Error::OutOfMemoryError);
         }
-        let size: usize = U32_SERIALIZED_LENGTH +                    //size for length of bytes
-                    self.bytes.len() +                  //size for elements of bytes
-                    U32_SERIALIZED_LENGTH +                          //size for length of named_keys
-                    UREF_KEY_SERIALIZED_LENGTH * self.named_keys.len() + //size for named_keys elements
+        let size: usize = U32_SERIALIZED_LENGTH +                        //size for length of bytes
+                    self.bytes.len() +                                   //size for elements of bytes
+                    U32_SERIALIZED_LENGTH +                              //size for length of named_keys
+                    KEY_UREF_SERIALIZED_LENGTH * self.named_keys.len() + //size for named_keys elements
                     U64_SERIALIZED_LENGTH; //size for protocol_version
 
         let mut result = Vec::with_capacity(size);

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         Error, FromBytes, ToBytes, U128_SERIALIZED_LENGTH, U256_SERIALIZED_LENGTH,
         U32_SERIALIZED_LENGTH, U512_SERIALIZED_LENGTH, U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH,
     },
-    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
+    key::{Key, KEY_UREF_SERIALIZED_LENGTH},
     uref::URef,
 };
 
@@ -137,7 +137,7 @@ impl ToBytes for Value {
             }
             Value::Contract(c) => Ok(iter::once(CONTRACT_ID).chain(c.to_bytes()?).collect()),
             Value::NamedKey(n, k) => {
-                if n.len() + UREF_KEY_SERIALIZED_LENGTH
+                if n.len() + KEY_UREF_SERIALIZED_LENGTH
                     >= u32::max_value() as usize - U32_SERIALIZED_LENGTH - U8_SERIALIZED_LENGTH
                 {
                     return Err(Error::OutOfMemoryError);
@@ -145,7 +145,7 @@ impl ToBytes for Value {
                 let size: usize = U8_SERIALIZED_LENGTH + //size for ID
                   U32_SERIALIZED_LENGTH +                 //size for length of String
                   n.len() +           //size of String
-                  UREF_KEY_SERIALIZED_LENGTH; //size of urefs
+                  KEY_UREF_SERIALIZED_LENGTH; //size of urefs
                 let mut result = Vec::with_capacity(size);
                 result.push(NAMEDKEY_ID);
                 result.append(&mut n.to_bytes()?);
@@ -153,7 +153,7 @@ impl ToBytes for Value {
                 Ok(result)
             }
             Value::Key(k) => {
-                let size: usize = U8_SERIALIZED_LENGTH + UREF_KEY_SERIALIZED_LENGTH;
+                let size: usize = U8_SERIALIZED_LENGTH + KEY_UREF_SERIALIZED_LENGTH;
                 let mut result = Vec::with_capacity(size);
                 result.push(KEY_ID);
                 result.append(&mut k.to_bytes()?);

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -19,9 +19,10 @@ pub use self::{
 };
 use crate::{
     bytesrepr::{
-        Error, FromBytes, ToBytes, U128_SIZE, U256_SIZE, U32_SIZE, U512_SIZE, U64_SIZE, U8_SIZE,
+        Error, FromBytes, ToBytes, U128_SERIALIZED_LENGTH, U256_SERIALIZED_LENGTH,
+        U32_SERIALIZED_LENGTH, U512_SERIALIZED_LENGTH, U64_SERIALIZED_LENGTH, U8_SERIALIZED_LENGTH,
     },
-    key::{Key, UREF_SIZE},
+    key::{Key, UREF_KEY_SERIALIZED_LENGTH},
     uref::URef,
 };
 
@@ -62,52 +63,63 @@ impl ToBytes for Value {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         match self {
             Value::Int32(i) => {
-                let mut result = Vec::with_capacity(U8_SIZE + U32_SIZE);
+                let mut result = Vec::with_capacity(U8_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH);
                 result.push(INT32_ID);
                 result.append(&mut i.to_bytes()?);
                 Ok(result)
             }
             Value::UInt128(u) => {
-                let mut result = Vec::with_capacity(U8_SIZE + U128_SIZE);
+                let mut result = Vec::with_capacity(U8_SERIALIZED_LENGTH + U128_SERIALIZED_LENGTH);
                 result.push(U128_ID);
                 result.append(&mut u.to_bytes()?);
                 Ok(result)
             }
             Value::UInt256(u) => {
-                let mut result = Vec::with_capacity(U8_SIZE + U256_SIZE);
+                let mut result = Vec::with_capacity(U8_SERIALIZED_LENGTH + U256_SERIALIZED_LENGTH);
                 result.push(U256_ID);
                 result.append(&mut u.to_bytes()?);
                 Ok(result)
             }
             Value::UInt512(u) => {
-                let mut result = Vec::with_capacity(U8_SIZE + U512_SIZE);
+                let mut result = Vec::with_capacity(U8_SERIALIZED_LENGTH + U512_SERIALIZED_LENGTH);
                 result.push(U512_ID);
                 result.append(&mut u.to_bytes()?);
                 Ok(result)
             }
             Value::ByteArray(arr) => {
-                if arr.len() >= u32::max_value() as usize - U8_SIZE - U32_SIZE {
+                if arr.len()
+                    >= u32::max_value() as usize - U8_SERIALIZED_LENGTH - U32_SERIALIZED_LENGTH
+                {
                     return Err(Error::OutOfMemoryError);
                 }
-                let mut result = Vec::with_capacity(U8_SIZE + U32_SIZE + arr.len());
+                let mut result =
+                    Vec::with_capacity(U8_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH + arr.len());
                 result.push(BYTEARRAY_ID);
                 result.append(&mut arr.to_bytes()?);
                 Ok(result)
             }
             Value::ListInt32(arr) => {
-                if arr.len() * size_of::<i32>() >= u32::max_value() as usize - U8_SIZE - U32_SIZE {
+                if arr.len() * size_of::<i32>()
+                    >= u32::max_value() as usize - U8_SERIALIZED_LENGTH - U32_SERIALIZED_LENGTH
+                {
                     return Err(Error::OutOfMemoryError);
                 }
-                let mut result = Vec::with_capacity(U8_SIZE + U32_SIZE + U32_SIZE * arr.len());
+                let mut result = Vec::with_capacity(
+                    U8_SERIALIZED_LENGTH
+                        + U32_SERIALIZED_LENGTH
+                        + U32_SERIALIZED_LENGTH * arr.len(),
+                );
                 result.push(LISTINT32_ID);
                 result.append(&mut arr.to_bytes()?);
                 Ok(result)
             }
             Value::String(s) => {
-                if s.len() >= u32::max_value() as usize - U8_SIZE - U32_SIZE {
+                if s.len()
+                    >= u32::max_value() as usize - U8_SERIALIZED_LENGTH - U32_SERIALIZED_LENGTH
+                {
                     return Err(Error::OutOfMemoryError);
                 }
-                let size = U8_SIZE + U32_SIZE + s.len();
+                let size = U8_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH + s.len();
                 let mut result = Vec::with_capacity(size);
                 result.push(STRING_ID);
                 result.append(&mut s.to_bytes()?);
@@ -125,13 +137,15 @@ impl ToBytes for Value {
             }
             Value::Contract(c) => Ok(iter::once(CONTRACT_ID).chain(c.to_bytes()?).collect()),
             Value::NamedKey(n, k) => {
-                if n.len() + UREF_SIZE >= u32::max_value() as usize - U32_SIZE - U8_SIZE {
+                if n.len() + UREF_KEY_SERIALIZED_LENGTH
+                    >= u32::max_value() as usize - U32_SERIALIZED_LENGTH - U8_SERIALIZED_LENGTH
+                {
                     return Err(Error::OutOfMemoryError);
                 }
-                let size: usize = U8_SIZE + //size for ID
-                  U32_SIZE +                 //size for length of String
+                let size: usize = U8_SERIALIZED_LENGTH + //size for ID
+                  U32_SERIALIZED_LENGTH +                 //size for length of String
                   n.len() +           //size of String
-                  UREF_SIZE; //size of urefs
+                  UREF_KEY_SERIALIZED_LENGTH; //size of urefs
                 let mut result = Vec::with_capacity(size);
                 result.push(NAMEDKEY_ID);
                 result.append(&mut n.to_bytes()?);
@@ -139,14 +153,14 @@ impl ToBytes for Value {
                 Ok(result)
             }
             Value::Key(k) => {
-                let size: usize = U8_SIZE + UREF_SIZE;
+                let size: usize = U8_SERIALIZED_LENGTH + UREF_KEY_SERIALIZED_LENGTH;
                 let mut result = Vec::with_capacity(size);
                 result.push(KEY_ID);
                 result.append(&mut k.to_bytes()?);
                 Ok(result)
             }
             Value::ListString(arr) => {
-                let size: usize = U8_SIZE + U32_SIZE + arr.len();
+                let size: usize = U8_SERIALIZED_LENGTH + U32_SERIALIZED_LENGTH + arr.len();
                 let mut result = Vec::with_capacity(size);
                 result.push(LISTSTRING_ID);
                 let bytes = arr.to_bytes()?;
@@ -158,7 +172,7 @@ impl ToBytes for Value {
             }
             Value::Unit => Ok(vec![UNIT_ID]),
             Value::UInt64(num) => {
-                let mut result = Vec::with_capacity(U8_SIZE + U64_SIZE);
+                let mut result = Vec::with_capacity(U8_SERIALIZED_LENGTH + U64_SERIALIZED_LENGTH);
                 result.push(U64_ID);
                 result.append(&mut num.to_bytes()?);
                 Ok(result)

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -21,14 +21,14 @@ use contract_ffi::{
     system_contracts::mint::Error,
     unwrap_or_revert::UnwrapOrRevert,
     uref::{AccessRights, URef},
-    value::{account::KEY_SIZE, U512},
+    value::{account::PUBLIC_KEY_LENGTH, U512},
 };
 
 use capabilities::{ARef, RAWRef};
 use internal_purse_id::{DepositId, WithdrawId};
 use mint::Mint;
 
-const SYSTEM_ACCOUNT: [u8; KEY_SIZE] = [0u8; KEY_SIZE];
+const SYSTEM_ACCOUNT: [u8; PUBLIC_KEY_LENGTH] = [0u8; PUBLIC_KEY_LENGTH];
 
 pub struct CLMint;
 

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -24,7 +24,7 @@ use contract_ffi::{
     args_parser::ArgsParser,
     bytesrepr::ToBytes,
     execution::Phase,
-    key::{Key, HASH_LENGTH},
+    key::{Key, KEY_HASH_LENGTH},
     system_contracts::mint,
     uref::{AccessRights, URef, UREF_ADDR_LENGTH},
     value::{
@@ -625,13 +625,13 @@ where
             }
             ExecutableDeployItem::StoredContractByHash { hash, .. } => {
                 let hash_len = hash.len();
-                if hash_len != HASH_LENGTH {
+                if hash_len != KEY_HASH_LENGTH {
                     return Err(error::Error::InvalidHashLength {
-                        expected: HASH_LENGTH,
+                        expected: KEY_HASH_LENGTH,
                         actual: hash_len,
                     });
                 }
-                let mut arr = [0u8; HASH_LENGTH];
+                let mut arr = [0u8; KEY_HASH_LENGTH];
                 arr.copy_from_slice(&hash);
                 Key::Hash(arr)
             }

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -24,9 +24,9 @@ use contract_ffi::{
     args_parser::ArgsParser,
     bytesrepr::ToBytes,
     execution::Phase,
-    key::{Key, HASH_SIZE},
+    key::{Key, HASH_LENGTH},
     system_contracts::mint,
-    uref::{AccessRights, URef, UREF_ADDR_SIZE},
+    uref::{AccessRights, URef, UREF_ADDR_LENGTH},
     value::{
         account::{BlockTime, PublicKey, PurseId},
         Account, ProtocolVersion, Value, U512,
@@ -625,13 +625,13 @@ where
             }
             ExecutableDeployItem::StoredContractByHash { hash, .. } => {
                 let hash_len = hash.len();
-                if hash_len != HASH_SIZE {
+                if hash_len != HASH_LENGTH {
                     return Err(error::Error::InvalidHashLength {
-                        expected: HASH_SIZE,
+                        expected: HASH_LENGTH,
                         actual: hash_len,
                     });
                 }
-                let mut arr = [0u8; HASH_SIZE];
+                let mut arr = [0u8; HASH_LENGTH];
                 arr.copy_from_slice(&hash);
                 Key::Hash(arr)
             }
@@ -650,14 +650,14 @@ where
             }
             ExecutableDeployItem::StoredContractByURef { uref, .. } => {
                 let len = uref.len();
-                if len != UREF_ADDR_SIZE {
+                if len != UREF_ADDR_LENGTH {
                     return Err(error::Error::InvalidHashLength {
-                        expected: UREF_ADDR_SIZE,
+                        expected: UREF_ADDR_LENGTH,
                         actual: len,
                     });
                 }
                 let read_only_uref = {
-                    let mut arr = [0u8; UREF_ADDR_SIZE];
+                    let mut arr = [0u8; UREF_ADDR_LENGTH];
                     arr.copy_from_slice(&uref);
                     URef::new(arr, AccessRights::READ)
                 };

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -22,7 +22,7 @@ use contract_ffi::{
     system_contracts::{self, mint, SystemContract},
     uref::{AccessRights, URef},
     value::{
-        account::{ActionType, PublicKey, PurseId, Weight, PUBLIC_KEY_SIZE},
+        account::{ActionType, PublicKey, PurseId, Weight, PUBLIC_KEY_SERIALIZED_LENGTH},
         Account, ProtocolVersion, Value, U512,
     },
 };
@@ -733,7 +733,8 @@ where
     fn add_associated_key(&mut self, public_key_ptr: u32, weight_value: u8) -> Result<i32, Trap> {
         let public_key = {
             // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, PUBLIC_KEY_SIZE)?;
+            let source_serialized =
+                self.bytes_from_mem(public_key_ptr, PUBLIC_KEY_SERIALIZED_LENGTH)?;
             // Public key deserialized
             let source: PublicKey = deserialize(&source_serialized).map_err(Error::BytesRepr)?;
             source
@@ -755,7 +756,8 @@ where
     fn remove_associated_key(&mut self, public_key_ptr: u32) -> Result<i32, Trap> {
         let public_key = {
             // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, PUBLIC_KEY_SIZE)?;
+            let source_serialized =
+                self.bytes_from_mem(public_key_ptr, PUBLIC_KEY_SERIALIZED_LENGTH)?;
             // Public key deserialized
             let source: PublicKey = deserialize(&source_serialized).map_err(Error::BytesRepr)?;
             source
@@ -774,7 +776,8 @@ where
     ) -> Result<i32, Trap> {
         let public_key = {
             // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, PUBLIC_KEY_SIZE)?;
+            let source_serialized =
+                self.bytes_from_mem(public_key_ptr, PUBLIC_KEY_SERIALIZED_LENGTH)?;
             // Public key deserialized
             let source: PublicKey = deserialize(&source_serialized).map_err(Error::BytesRepr)?;
             source

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -14,7 +14,7 @@ use blake2::{
 use contract_ffi::{
     bytesrepr::{deserialize, ToBytes},
     execution::Phase,
-    key::{Key, LOCAL_SEED_SIZE},
+    key::{Key, LOCAL_SEED_LENGTH},
     uref::{AccessRights, URef},
     value::{
         account::{
@@ -260,7 +260,7 @@ where
         self.base_key
     }
 
-    pub fn seed(&self) -> [u8; LOCAL_SEED_SIZE] {
+    pub fn seed(&self) -> [u8; LOCAL_SEED_LENGTH] {
         match self.base_key {
             Key::Account(bytes) => bytes,
             Key::Hash(bytes) => bytes,
@@ -332,7 +332,7 @@ where
     /// DO NOT EXPOSE THIS VIA THE FFI
     pub fn read_ls_with_seed(
         &mut self,
-        seed: [u8; LOCAL_SEED_SIZE],
+        seed: [u8; LOCAL_SEED_LENGTH],
         key_bytes: &[u8],
     ) -> Result<Option<Value>, Error> {
         let key = Key::local(seed, key_bytes);

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -9,7 +9,7 @@ use rand::RngCore;
 
 use contract_ffi::{
     execution::Phase,
-    key::{Key, LOCAL_SEED_SIZE},
+    key::{Key, LOCAL_SEED_LENGTH},
     uref::{AccessRights, URef},
     value::{
         self,
@@ -101,7 +101,7 @@ fn create_uref(address_generator: &mut AddressGenerator, rights: AccessRights) -
     Key::URef(URef::new(address, rights))
 }
 
-fn random_local_key<G: RngCore>(entropy_source: &mut G, seed: [u8; LOCAL_SEED_SIZE]) -> Key {
+fn random_local_key<G: RngCore>(entropy_source: &mut G, seed: [u8; LOCAL_SEED_LENGTH]) -> Key {
     let mut key = [0u8; 64];
     entropy_source.fill_bytes(&mut key);
     Key::local(seed, &key)
@@ -593,7 +593,7 @@ fn local_key_writeable_invalid() {
     let access_rights = HashMap::new();
     let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
-        let seed = [1u8; LOCAL_SEED_SIZE];
+        let seed = [1u8; LOCAL_SEED_LENGTH];
         let key = random_local_key(&mut rng, seed);
         runtime_context.validate_writeable(&key)
     };
@@ -619,7 +619,7 @@ fn local_key_readable_invalid() {
     let access_rights = HashMap::new();
     let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
-        let seed = [1u8; LOCAL_SEED_SIZE];
+        let seed = [1u8; LOCAL_SEED_LENGTH];
         let key = random_local_key(&mut rng, seed);
         runtime_context.validate_readable(&key)
     };
@@ -645,7 +645,7 @@ fn local_key_addable_invalid() {
     let access_rights = HashMap::new();
     let query = |runtime_context: RuntimeContext<InMemoryGlobalStateView>| {
         let mut rng = rand::thread_rng();
-        let seed = [1u8; LOCAL_SEED_SIZE];
+        let seed = [1u8; LOCAL_SEED_LENGTH];
         let key = random_local_key(&mut rng, seed);
         runtime_context.validate_addable(&key)
     };

--- a/execution-engine/engine-core/src/tracking_copy/byte_size.rs
+++ b/execution-engine/engine-core/src/tracking_copy/byte_size.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use contract_ffi::{
-    bytesrepr::I32_SIZE,
+    bytesrepr::I32_SERIALIZED_LENGTH,
     key::Key,
     value::{Account, Contract, Value},
 };
@@ -58,7 +58,7 @@ impl ByteSize for Value {
                 | Value::UInt64(_) => 0,
                 Value::ByteArray(vec) => std::mem::size_of::<Vec<u8>>() + vec.capacity(),
                 Value::ListInt32(list) => {
-                    std::mem::size_of::<Vec<i32>>() + list.capacity() * I32_SIZE
+                    std::mem::size_of::<Vec<i32>>() + list.capacity() * I32_SERIALIZED_LENGTH
                 }
                 Value::String(s) => s.byte_size(),
                 Value::ListString(list) => list.iter().fold(0, |sum, el| sum + el.byte_size()),

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -8,7 +8,7 @@ use contract_ffi::{
     key::Key,
     uref::{AccessRights, URef},
     value::{
-        account::{AssociatedKeys, PublicKey, PurseId, Weight, KEY_SIZE},
+        account::{AssociatedKeys, PublicKey, PurseId, Weight, PUBLIC_KEY_LENGTH},
         Account, Contract, ProtocolVersion, Value,
     },
 };
@@ -175,9 +175,10 @@ fn tracking_copy_add_i32() {
 fn tracking_copy_add_named_key() {
     let correlation_id = CorrelationId::new();
     // DB now holds an `Account` so that we can test adding a `NamedKey`
-    let associated_keys = AssociatedKeys::new(PublicKey::new([0u8; KEY_SIZE]), Weight::new(1));
+    let associated_keys =
+        AssociatedKeys::new(PublicKey::new([0u8; PUBLIC_KEY_LENGTH]), Weight::new(1));
     let account = contract_ffi::value::Account::new(
-        [0u8; KEY_SIZE],
+        [0u8; PUBLIC_KEY_LENGTH],
         BTreeMap::new(),
         PurseId::new(URef::new([0u8; 32], AccessRights::READ_ADD_WRITE)),
         associated_keys,

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -10,7 +10,7 @@ use std::{
     string::ToString,
 };
 
-use contract_ffi::value::account::KEY_SIZE;
+use contract_ffi::value::account::PUBLIC_KEY_LENGTH;
 use engine_core::{engine_state, DEPLOY_HASH_LENGTH};
 
 pub use transforms::TransformMap;
@@ -36,7 +36,7 @@ pub enum MappingError {
 
 impl MappingError {
     pub fn invalid_public_key_length(actual: usize) -> Self {
-        let expected = KEY_SIZE;
+        let expected = PUBLIC_KEY_LENGTH;
         MappingError::InvalidPublicKeyLength { expected, actual }
     }
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/uref.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/uref.rs
@@ -63,7 +63,7 @@ impl TryFrom<Key_URef> for URef {
 mod tests {
     use rand;
 
-    use contract_ffi::uref::UREF_ADDR_SIZE;
+    use contract_ffi::uref::UREF_ADDR_LENGTH;
 
     use super::*;
     use crate::engine_server::mappings::test_utils;
@@ -94,11 +94,11 @@ mod tests {
         assert!(URef::try_from(empty_pb_uref).is_err());
 
         let mut pb_uref_invalid_addr = Key_URef::new();
-        pb_uref_invalid_addr.set_uref(vec![1; UREF_ADDR_SIZE - 1]);
+        pb_uref_invalid_addr.set_uref(vec![1; UREF_ADDR_LENGTH - 1]);
         assert!(URef::try_from(pb_uref_invalid_addr).is_err());
 
         // Check Protobuf URef with `AccessRights::UNKNOWN` parses to a URef with no access rights.
-        let addr: [u8; UREF_ADDR_SIZE] = rand::random();
+        let addr: [u8; UREF_ADDR_LENGTH] = rand::random();
         let mut pb_uref = Key_URef::new();
         pb_uref.set_uref(addr.to_vec());
         pb_uref.set_access_rights(Key_URef_AccessRights::UNKNOWN);

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -1,11 +1,11 @@
 use contract_ffi::{
     bytesrepr::{self, FromBytes, ToBytes},
-    uref::{AccessRights, URef, UREF_SIZE_SERIALIZED},
+    uref::{AccessRights, URef, UREF_SERIALIZED_LENGTH},
 };
-use engine_wasm_prep::wasm_costs::{WasmCosts, WASM_COSTS_SIZE_SERIALIZED};
+use engine_wasm_prep::wasm_costs::{WasmCosts, WASM_COSTS_SERIALIZED_LENGTH};
 
-const PROTOCOL_DATA_SIZE_SERIALIZED: usize =
-    WASM_COSTS_SIZE_SERIALIZED + UREF_SIZE_SERIALIZED + UREF_SIZE_SERIALIZED;
+const PROTOCOL_DATA_SERIALIZED_LENGTH: usize =
+    WASM_COSTS_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH;
 
 /// Represents a protocol's data. Intended to be associated with a given protocol version.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -67,7 +67,7 @@ impl ProtocolData {
 
 impl ToBytes for ProtocolData {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut ret: Vec<u8> = Vec::with_capacity(PROTOCOL_DATA_SIZE_SERIALIZED);
+        let mut ret: Vec<u8> = Vec::with_capacity(PROTOCOL_DATA_SERIALIZED_LENGTH);
         ret.append(&mut self.wasm_costs.to_bytes()?);
         ret.append(&mut self.mint.to_bytes()?);
         ret.append(&mut self.proof_of_stake.to_bytes()?);

--- a/execution-engine/engine-storage/src/trie/mod.rs
+++ b/execution-engine/engine-storage/src/trie/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 
 pub const RADIX: usize = 256;
 
-const U32_SIZE: usize = size_of::<u32>();
+const U32_SERIALIZED_LENGTH: usize = size_of::<u32>();
 
 /// A parent is represented as a pair of a child index and a node or extension.
 pub type Parents<K, V> = Vec<(u8, Trie<K, V>)>;
@@ -51,7 +51,7 @@ impl Pointer {
 impl ToBytes for Pointer {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut hash_bytes = self.hash().to_bytes()?;
-        let mut ret = Vec::with_capacity(U32_SIZE + hash_bytes.len());
+        let mut ret = Vec::with_capacity(U32_SERIALIZED_LENGTH + hash_bytes.len());
         ret.append(&mut self.tag().to_bytes()?);
         ret.append(&mut hash_bytes);
         Ok(ret)
@@ -249,11 +249,13 @@ where
             Trie::Leaf { key, value } => {
                 let mut key_bytes = ToBytes::to_bytes(key)?;
                 let mut value_bytes = ToBytes::to_bytes(value)?;
-                if key_bytes.len() + value_bytes.len() > u32::max_value() as usize - U32_SIZE {
+                if key_bytes.len() + value_bytes.len()
+                    > u32::max_value() as usize - U32_SERIALIZED_LENGTH
+                {
                     return Err(bytesrepr::Error::OutOfMemoryError);
                 }
                 let mut ret: Vec<u8> =
-                    Vec::with_capacity(U32_SIZE + key_bytes.len() + value_bytes.len());
+                    Vec::with_capacity(U32_SERIALIZED_LENGTH + key_bytes.len() + value_bytes.len());
                 ret.append(&mut self.tag().to_bytes()?);
                 ret.append(&mut key_bytes);
                 ret.append(&mut value_bytes);
@@ -261,7 +263,8 @@ where
             }
             Trie::Node { pointer_block } => {
                 let mut pointer_block_bytes = ToBytes::to_bytes(pointer_block.deref())?;
-                let mut ret: Vec<u8> = Vec::with_capacity(U32_SIZE + pointer_block_bytes.len());
+                let mut ret: Vec<u8> =
+                    Vec::with_capacity(U32_SERIALIZED_LENGTH + pointer_block_bytes.len());
                 ret.append(&mut self.tag().to_bytes()?);
                 ret.append(&mut pointer_block_bytes);
                 Ok(ret)
@@ -269,11 +272,14 @@ where
             Trie::Extension { affix, pointer } => {
                 let mut affix_bytes = ToBytes::to_bytes(affix)?;
                 let mut pointer_bytes = ToBytes::to_bytes(pointer)?;
-                if affix_bytes.len() + pointer_bytes.len() > u32::max_value() as usize - U32_SIZE {
+                if affix_bytes.len() + pointer_bytes.len()
+                    > u32::max_value() as usize - U32_SERIALIZED_LENGTH
+                {
                     return Err(bytesrepr::Error::OutOfMemoryError);
                 }
-                let mut ret: Vec<u8> =
-                    Vec::with_capacity(U32_SIZE + affix_bytes.len() + pointer_bytes.len());
+                let mut ret: Vec<u8> = Vec::with_capacity(
+                    U32_SERIALIZED_LENGTH + affix_bytes.len() + pointer_bytes.len(),
+                );
                 ret.append(&mut self.tag().to_bytes()?);
                 ret.append(&mut affix_bytes);
                 ret.append(&mut pointer_bytes);

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
@@ -3,7 +3,7 @@ use proptest::{arbitrary, array, collection, prop_oneof, strategy::Strategy};
 use contract_ffi::{
     bytesrepr::{self, FromBytes, ToBytes},
     gens,
-    key::LOCAL_SEED_SIZE,
+    key::LOCAL_SEED_LENGTH,
     uref::URef,
 };
 use engine_shared::{make_array_newtype, newtypes::Blake2bHash};
@@ -11,28 +11,28 @@ use engine_shared::{make_array_newtype, newtypes::Blake2bHash};
 use super::{HashedTrie, TestValue};
 use crate::trie::Trie;
 
-pub const BASIC_SIZE: usize = 4;
-pub const SIMILAR_SIZE: usize = 4;
-pub const FANCY_SIZE: usize = 5;
-pub const LONG_SIZE: usize = 8;
+pub const BASIC_LENGTH: usize = 4;
+pub const SIMILAR_LENGTH: usize = 4;
+pub const FANCY_LENGTH: usize = 5;
+pub const LONG_LENGTH: usize = 8;
 
 const PUBLIC_KEY_BASIC_ID: u8 = 0;
 const PUBLIC_KEY_SIMILAR_ID: u8 = 1;
 const PUBLIC_KEY_FANCY_ID: u8 = 2;
 const PUBLIC_KEY_LONG_ID: u8 = 3;
 
-pub const KEY_HASH_SIZE: usize = 32;
-pub const KEY_LOCAL_SIZE: usize = 32;
+pub const KEY_HASH_LENGTH: usize = 32;
+pub const KEY_LOCAL_LENGTH: usize = 32;
 
 const KEY_ACCOUNT_ID: u8 = 0;
 const KEY_HASH_ID: u8 = 1;
 const KEY_UREF_ID: u8 = 2;
 const KEY_LOCAL_ID: u8 = 3;
 
-make_array_newtype!(Basic, u8, BASIC_SIZE);
-make_array_newtype!(Similar, u8, SIMILAR_SIZE);
-make_array_newtype!(Fancy, u8, FANCY_SIZE);
-make_array_newtype!(Long, u8, LONG_SIZE);
+make_array_newtype!(Basic, u8, BASIC_LENGTH);
+make_array_newtype!(Similar, u8, SIMILAR_LENGTH);
+make_array_newtype!(Fancy, u8, FANCY_LENGTH);
+make_array_newtype!(Long, u8, LONG_LENGTH);
 
 macro_rules! impl_distribution_for_array_newtype {
     ($name:ident, $ty:ty, $len:expr) => {
@@ -46,10 +46,10 @@ macro_rules! impl_distribution_for_array_newtype {
     };
 }
 
-impl_distribution_for_array_newtype!(Basic, u8, BASIC_SIZE);
-impl_distribution_for_array_newtype!(Similar, u8, SIMILAR_SIZE);
-impl_distribution_for_array_newtype!(Fancy, u8, FANCY_SIZE);
-impl_distribution_for_array_newtype!(Long, u8, LONG_SIZE);
+impl_distribution_for_array_newtype!(Basic, u8, BASIC_LENGTH);
+impl_distribution_for_array_newtype!(Similar, u8, SIMILAR_LENGTH);
+impl_distribution_for_array_newtype!(Fancy, u8, FANCY_LENGTH);
+impl_distribution_for_array_newtype!(Long, u8, LONG_LENGTH);
 
 macro_rules! make_array_newtype_arb {
     ($name:ident, $ty:ty, $len:expr, $fn_name:ident) => {
@@ -63,10 +63,10 @@ macro_rules! make_array_newtype_arb {
     };
 }
 
-make_array_newtype_arb!(Basic, u8, BASIC_SIZE, basic_arb);
-make_array_newtype_arb!(Similar, u8, SIMILAR_SIZE, similar_arb);
-make_array_newtype_arb!(Fancy, u8, FANCY_SIZE, fancy_arb);
-make_array_newtype_arb!(Long, u8, LONG_SIZE, long_arb);
+make_array_newtype_arb!(Basic, u8, BASIC_LENGTH, basic_arb);
+make_array_newtype_arb!(Similar, u8, SIMILAR_LENGTH, similar_arb);
+make_array_newtype_arb!(Fancy, u8, FANCY_LENGTH, fancy_arb);
+make_array_newtype_arb!(Long, u8, LONG_LENGTH, long_arb);
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum PublicKey {
@@ -139,15 +139,15 @@ fn public_key_arb() -> impl Strategy<Value = PublicKey> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TestKey {
     Account(PublicKey),
-    Hash([u8; KEY_HASH_SIZE]),
+    Hash([u8; KEY_HASH_LENGTH]),
     URef(URef),
-    Local([u8; KEY_LOCAL_SIZE]),
+    Local([u8; KEY_LOCAL_LENGTH]),
 }
 
 impl TestKey {
-    pub fn local(seed: [u8; LOCAL_SEED_SIZE], key_bytes: &[u8]) -> Self {
+    pub fn local(seed: [u8; LOCAL_SEED_LENGTH], key_bytes: &[u8]) -> Self {
         let bytes_to_hash: Vec<u8> = seed.iter().chain(key_bytes.iter()).copied().collect();
-        let hash: [u8; KEY_LOCAL_SIZE] = Blake2bHash::new(&bytes_to_hash).into();
+        let hash: [u8; KEY_LOCAL_LENGTH] = Blake2bHash::new(&bytes_to_hash).into();
         TestKey::Local(hash)
     }
 }
@@ -187,7 +187,7 @@ impl FromBytes for TestKey {
                 Ok((TestKey::Account(public_key), rem))
             }
             KEY_HASH_ID => {
-                let (hash, rem): ([u8; KEY_HASH_SIZE], &[u8]) = FromBytes::from_bytes(rem)?;
+                let (hash, rem): ([u8; KEY_HASH_LENGTH], &[u8]) = FromBytes::from_bytes(rem)?;
                 Ok((TestKey::Hash(hash), rem))
             }
             KEY_UREF_ID => {
@@ -195,7 +195,7 @@ impl FromBytes for TestKey {
                 Ok((TestKey::URef(uref), rem))
             }
             KEY_LOCAL_ID => {
-                let (local, rem): ([u8; KEY_LOCAL_SIZE], &[u8]) = FromBytes::from_bytes(rem)?;
+                let (local, rem): ([u8; KEY_LOCAL_LENGTH], &[u8]) = FromBytes::from_bytes(rem)?;
                 Ok((TestKey::Local(local), rem))
             }
             _ => Err(bytesrepr::Error::FormattingError),

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -2,10 +2,10 @@ use std::collections::BTreeMap;
 
 use pwasm_utils::rules::{InstructionType, Metering, Set};
 
-use contract_ffi::bytesrepr::{self, FromBytes, ToBytes, U32_SIZE};
+use contract_ffi::bytesrepr::{self, FromBytes, ToBytes, U32_SERIALIZED_LENGTH};
 
 const NUM_FIELDS: usize = 10;
-pub const WASM_COSTS_SIZE_SERIALIZED: usize = NUM_FIELDS * U32_SIZE;
+pub const WASM_COSTS_SERIALIZED_LENGTH: usize = NUM_FIELDS * U32_SERIALIZED_LENGTH;
 
 // Taken (partially) from parity-ethereum
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
@@ -53,7 +53,7 @@ impl WasmCosts {
 
 impl ToBytes for WasmCosts {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut ret: Vec<u8> = Vec::with_capacity(WASM_COSTS_SIZE_SERIALIZED);
+        let mut ret: Vec<u8> = Vec::with_capacity(WASM_COSTS_SERIALIZED_LENGTH);
         ret.append(&mut self.regular.to_bytes()?);
         ret.append(&mut self.div.to_bytes()?);
         ret.append(&mut self.mul.to_bytes()?);


### PR DESCRIPTION
### Overview
Constants representing array lengths now end in _LENGTH, and the ones
representing serialized byte sizes now end in _SERIALIZED_LENGTH.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-802

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
