### PR TITLE
NODE-1075: Concurrent calls to EE

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -148,6 +148,9 @@ cache-neighborhood-before = 5
 # How far to go to the future (by ranks) for caching neighborhood of looked up block
 cache-neighborhood-after = 6
 
+# How many records to pull from the DB in a chunk of a stream.
+deploy-stream-chunk-size = 20
+
 # io.casperlabs.node.configuration.Configuration.GrpcServer
 [grpc]
 

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -46,6 +46,9 @@ max-num-of-connections = 500
 # Maximum size of message that can be sent via transport layer.
 max-message-size = 4194304
 
+# Target parallelism for execution engine requests.
+engine-parallelism = 1
+
 # Size of chunks to split larger payloads into when streamed via transport layer.
 chunk-size = 1048576
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -113,7 +113,8 @@ class NodeRuntime private[node] (
                                                                           Task
                                                                         ](
                                                                           conf.grpc.socket,
-                                                                          conf.server.maxMessageSize
+                                                                          conf.server.maxMessageSize,
+                                                                          conf.server.engineParallelism
                                                                         )
       //TODO: We may want to adjust threading model for better performance
       (writeTransactor, readTransactor) <- effects.doobieTransactors(

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -122,15 +122,13 @@ class NodeRuntime private[node] (
                                             transactEC = dbIOScheduler,
                                             conf.server.dataDir
                                           )
-      deployStorageChunkSize = 20 //TODO: Move to config
-
       _ <- Resource.liftF(runRdmbsMigrations(conf.server.dataDir))
 
       implicit0(
         storage: BlockStorage[Task] with DagStorage[Task] with DeployStorage[Task]
       ) <- Resource.liftF(
             SQLiteStorage.create[Task](
-              deployStorageChunkSize = deployStorageChunkSize,
+              deployStorageChunkSize = conf.blockstorage.deployStreamChunkSize,
               readXa = readTransactor,
               writeXa = writeTransactor,
               wrapBlockStorage = (underlyingBlockStorage: BlockStorage[Task]) =>

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -67,6 +67,7 @@ object Configuration extends ParserImplicits {
       dataDir: Path,
       maxNumOfConnections: Int,
       maxMessageSize: Int,
+      engineParallelism: Int,
       chunkSize: Int,
       relayFactor: Int,
       relaySaturation: Int,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -101,7 +101,8 @@ object Configuration extends ParserImplicits {
   case class BlockStorage(
       cacheMaxSizeBytes: Long,
       cacheNeighborhoodBefore: Int,
-      cacheNeighborhoodAfter: Int
+      cacheNeighborhoodAfter: Int,
+      deployStreamChunkSize: Int
   ) extends SubConfig
 
   case class Grpc(

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -195,6 +195,10 @@ private[configuration] final case class Options private (
       gen[Int]("Maximum size of message that can be sent via transport layer.")
 
     @scallop
+    val serverEngineParallelism =
+      gen[Int]("Target parallelism for execution engine requests.")
+
+    @scallop
     val serverChunkSize =
       gen[Int]("Size of chunks to split larger payloads into when streamed via transport layer.")
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -483,6 +483,11 @@ private[configuration] final case class Options private (
     )
 
     @scallop
+    val blockstorageDeployStreamChunkSize = gen[Int](
+      "How many records to pull from the DB in a chunk of a stream."
+    )
+
+    @scallop
     val casperValidatorPublicKey =
       gen[String](
         "base-64 or PEM encoding of the public key to use for signing a proposed blocks. " +

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -85,6 +85,7 @@ min-ttl = "1hour"
 cache-max-size-bytes = 1
 cache-neighborhood-before = 1
 cache-neighborhood-after = 1
+deploy-stream-chunk-size = 1
 
 [metrics]
 prometheus = false

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -20,6 +20,7 @@ bootstrap = "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?
 data-dir = "/tmp"
 max-num-of-connections = 1
 max-message-size = 1
+engine-parallelism = 1
 chunk-size = 1
 relay-factor = 1
 relay-saturation = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -73,6 +73,7 @@ class ConfigurationSpec
       dataDir = Paths.get("/tmp"),
       maxNumOfConnections = 1,
       maxMessageSize = 1,
+      engineParallelism = 1,
       chunkSize = 1,
       relayFactor = 1,
       relaySaturation = 1,

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -136,7 +136,8 @@ class ConfigurationSpec
     val blockStorage = Configuration.BlockStorage(
       cacheMaxSizeBytes = 1,
       cacheNeighborhoodBefore = 1,
-      cacheNeighborhoodAfter = 1
+      cacheNeighborhoodAfter = 1,
+      deployStreamChunkSize = 1
     )
     val kamonSettings = Configuration.Kamon(
       prometheus = false,


### PR DESCRIPTION
### Overview
The execution engine can be configured with a `--threads` setting to process concurrent requests on more than 1 thread. The PR adds a `--server-engine-parallelism` setting that makes sure we try to make use of this by preparing at least that many requests and sending them with with such concurrency level.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1075

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
There was another option to also do parallelism on the level where we're pulling the data from the database, which we now do in batches of 20 deploys, but the compounded effect of the two would be difficult to reason about. The 20 is mainly to limit the outstanding memory, so we don't retrieve wasm just to discard it because the block is full after 5 deploys.
