### PR TITLE
NO-TICK: respect environment variable for clarity

### DIFF
--- a/hack/docker/docker-compose.yml
+++ b/hack/docker/docker-compose.yml
@@ -54,7 +54,7 @@ services:
     build:
       context: ./
       dockerfile: ./grpcwebproxy/Dockerfile
-    image: casperlabs/grpcwebproxy
+    image: casperlabs/grpcwebproxy:${CL_VERSION}
     container_name: grpcwebproxy
     ports:
       # This is just exposed for debug purposes. Access it through Nginx reverse proxy instead.
@@ -77,7 +77,7 @@ services:
   # CasperLabs Explorer available at https://localhost:8443
   # The URL needs to be enabled in Auth0 for login/logout to work.
   explorer:
-    image: casperlabs/explorer:latest
+    image: casperlabs/explorer:${CL_VERSION}
     container_name: explorer
     networks:
       - casperlabs


### PR DESCRIPTION
### Overview
switches clarity/grpcproxy to respect `CL_VERSION` variable

### Which JIRA ticket does this PR relate to?
none

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
