### PR TITLE
NO-TICKET: Include git hash on `--version` switch.

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -287,6 +287,7 @@ dependencies = [
  "protobuf 2.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-rust-grpc 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2848,6 +2849,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "vergen"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3224,7 @@ dependencies = [
 "checksum unix_socket 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aa2700417c405c38f5e6902d699345241c28c0b7ade4abaad71e35a87eb1564"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "74e463a508e390cc7447e70f640fbf44ad52e1bd095314ace1fdf99516d32add"
 "checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -26,6 +26,7 @@ engine-wasm-prep = { path = "../engine-wasm-prep", package = "casperlabs-engine-
 
 [build-dependencies]
 protoc-rust-grpc = "0.6.1"
+vergen = "3"
 
 [dev-dependencies]
 parity-wasm = "0.31"

--- a/execution-engine/engine-grpc-server/build.rs
+++ b/execution-engine/engine-grpc-server/build.rs
@@ -1,4 +1,9 @@
+use vergen::{generate_cargo_keys, ConstantsFlags};
+
 fn main() {
+    // Generate the 'cargo:' key output
+    generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate the cargo keys!");
+
     println!("cargo:rerun-if-changed=../../protobuf/io/casperlabs/casper/consensus/state.proto");
     println!("cargo:rerun-if-changed=../../protobuf/io/casperlabs/ipc/ipc.proto");
     println!("cargo:rerun-if-changed=../../protobuf/io/casperlabs/ipc/transforms.proto");

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -100,6 +100,14 @@ lazy_static! {
     static ref LOG_SETTINGS: log_settings::LogSettings = get_log_settings();
 }
 
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+const APP_LONG_VERSION: &str = concat!(
+    env!("CARGO_PKG_VERSION"),
+    " (",
+    env!("VERGEN_SHA_SHORT"),
+    ")"
+);
+
 fn main() {
     set_panic_hook();
 
@@ -162,7 +170,8 @@ fn set_panic_hook() {
 /// Gets command line arguments
 fn get_args() -> ArgMatches<'static> {
     App::new(APP_NAME)
-        .version(env!("CARGO_PKG_VERSION"))
+        .version(APP_VERSION)
+        .long_version(APP_LONG_VERSION)
         .arg(
             Arg::with_name(ARG_LOG_LEVEL)
                 .required(false)


### PR DESCRIPTION
### Overview
This originates from discussion today over slack, that EE was missing a GIT sha, and tests lead to confusing results. This commit uses `vergen` MIT/Apache licensed crate and will include GIT sha when ran grpc server with `--version`.

NOTE: `vergen` assumes `.git/HEAD` to be relative to `execution-engine/Cargo.toml` which is not true in our case. I reported this issue to the maintainer rustyhorde/vergen#21 and I'll bump the crate version once new version is released with the fix.

```
$ cargo run -p casperlabs-engine-grpc-server -- --version
warning: profile override spec `casperlabs-engine-tests` did not match any packages
    Finished dev [unoptimized + debuginfo] target(s) in 0.17s
     Running `target/debug/casperlabs-engine-grpc-server --version`
CasperLabs Execution Engine Server 0.10.0 (5e04d76ff)
```

Source: https://casperlabs-team.slack.com/archives/CENA68V7Z/p1576233603141300

### Which JIRA ticket does this PR relate to?

No ticket, took me a few minutes to set it up based on `vergen` docs and earlier experience.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
