### PR TITLE
NODE-1057: Add child_hashes to BlockInfo.Status

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -25,6 +25,7 @@ import io.casperlabs.storage.deploy.{DeployStorage, DeployStorageReader}
 import cats.Applicative
 import io.casperlabs.casper.MultiParentCasperImpl.Broadcaster
 import io.casperlabs.mempool.DeployBuffer
+import io.casperlabs.storage.dag.DagStorage
 
 object BlockAPI {
 
@@ -164,9 +165,10 @@ object BlockAPI {
         }
       }
 
-  def getBlockInfoWithDeploys[F[_]: MonadThrowable: MultiParentCasperRef: BlockStorage: DeployStorage](
+  def getBlockInfoWithDeploys[F[_]: MonadThrowable: MultiParentCasperRef: BlockStorage: DeployStorage: DagStorage](
       blockHash: BlockHash,
-      maybeDeployView: Option[DeployInfo.View]
+      maybeDeployView: Option[DeployInfo.View],
+      blockView: BlockInfo.View
   ): F[BlockAndMaybeDeploys] =
     for {
       blockInfo <- BlockStorage[F]
@@ -179,37 +181,55 @@ object BlockAPI {
                           )
                       )(_.pure[F])
                     )
-      withDeploys <- maybeWithDeploys[F](blockInfo, maybeDeployView)
+      withDeploys <- withViews[F](blockInfo, maybeDeployView, blockView)
     } yield withDeploys
 
-  def getBlockInfoWithDeploysOpt[F[_]: Monad: BlockStorage: DeployStorage](
+  def getBlockInfoWithDeploysOpt[F[_]: Monad: BlockStorage: DeployStorage: DagStorage](
       blockHashBase16: String,
-      maybeDeployView: Option[DeployInfo.View]
+      maybeDeployView: Option[DeployInfo.View],
+      blockView: BlockInfo.View
   ): F[Option[BlockAndMaybeDeploys]] =
     BlockStorage[F]
       .getBlockInfoByPrefix(blockHashBase16)
       .flatMap(
         _.traverse(
-          maybeWithDeploys[F](_, maybeDeployView)
+          withViews[F](_, maybeDeployView, blockView)
         )
       )
 
-  private def maybeWithDeploys[F[_]: Applicative: DeployStorage](
+  private def withViews[F[_]: Monad: DeployStorage: DagStorage](
       blockInfo: BlockInfo,
-      maybeDeployView: Option[DeployInfo.View]
-  ): F[BlockAndMaybeDeploys] =
-    maybeDeployView.fold((blockInfo -> none[List[Block.ProcessedDeploy]]).pure[F]) { implicit dv =>
-      DeployStorageReader[F]
-        .getProcessedDeploys(blockInfo.getSummary.blockHash)
-        .map { deploys =>
-          blockInfo -> deploys.some
-        }
+      maybeDeployView: Option[DeployInfo.View],
+      blockView: BlockInfo.View
+  ): F[BlockAndMaybeDeploys] = {
+    val deploysF = maybeDeployView.fold((none[List[Block.ProcessedDeploy]]).pure[F]) {
+      implicit dv =>
+        DeployStorageReader[F]
+          .getProcessedDeploys(blockInfo.getSummary.blockHash)
+          .map(_.some)
     }
 
-  def getBlockInfo[F[_]: MonadThrowable: Log: MultiParentCasperRef: BlockStorage: DeployStorage](
-      blockHashBase16: String
+    val childrenF = blockView match {
+      case BlockInfo.View.BASIC | BlockInfo.View.Unrecognized(_) =>
+        List.empty[ByteString].pure[F]
+      case BlockInfo.View.FULL =>
+        for {
+          dag      <- DagStorage[F].getRepresentation
+          children <- dag.children(blockInfo.getSummary.blockHash)
+        } yield children.toList
+    }
+
+    (deploysF, childrenF).mapN {
+      case (maybeDeploys, maybeChildren) =>
+        blockInfo.withStatus(blockInfo.getStatus.withChildHashes(maybeChildren)) -> maybeDeploys
+    }
+  }
+
+  def getBlockInfo[F[_]: MonadThrowable: Log: MultiParentCasperRef: BlockStorage: DeployStorage: DagStorage](
+      blockHashBase16: String,
+      blockView: BlockInfo.View
   ): F[BlockInfo] =
-    getBlockInfoWithDeploysOpt[F](blockHashBase16, None).flatMap(
+    getBlockInfoWithDeploysOpt[F](blockHashBase16, None, blockView).flatMap(
       _.fold(
         MonadThrowable[F]
           .raiseError[BlockInfo](
@@ -221,10 +241,11 @@ object BlockAPI {
   /** Return block infos and maybe the corresponding deploy summaries in the a slice of the DAG.
     * Use `maxRank` 0 to get the top slice,
     * then we pass previous ranks to paginate backwards. */
-  def getBlockInfosWithDeploys[F[_]: MonadThrowable: Log: MultiParentCasperRef: DeployStorage: Fs2Compiler](
+  def getBlockInfosWithDeploys[F[_]: MonadThrowable: Log: MultiParentCasperRef: DeployStorage: DagStorage: Fs2Compiler](
       depth: Int,
-      maxRank: Long = 0,
-      maybeDeployView: Option[DeployInfo.View]
+      maxRank: Long,
+      maybeDeployView: Option[DeployInfo.View],
+      blockView: BlockInfo.View
   ): F[List[BlockAndMaybeDeploys]] =
     unsafeWithCasper[F, List[BlockAndMaybeDeploys]]("Could not show blocks.") { implicit casper =>
       casper.dag flatMap { dag =>
@@ -247,16 +268,17 @@ object BlockAPI {
           MonadThrowable[F].raiseError(InvalidArgument(ex.getMessage))
       } flatMap { infosByRank =>
         infosByRank.flatten.reverse.toList.traverse { info =>
-          maybeWithDeploys[F](info, maybeDeployView)
+          withViews[F](info, maybeDeployView, blockView)
         }
       }
     }
 
   /** Return block infos in the a slice of the DAG. Use `maxRank` 0 to get the top slice,
     * then we pass previous ranks to paginate backwards. */
-  def getBlockInfos[F[_]: MonadThrowable: Log: MultiParentCasperRef: DeployStorage: Fs2Compiler](
+  def getBlockInfos[F[_]: MonadThrowable: Log: MultiParentCasperRef: DeployStorage: DagStorage: Fs2Compiler](
       depth: Int,
-      maxRank: Long = 0
+      maxRank: Long = 0,
+      blockView: BlockInfo.View = BlockInfo.View.BASIC
   ): F[List[BlockInfo]] =
-    getBlockInfosWithDeploys[F](depth, maxRank, None).map(_.map(_._1))
+    getBlockInfosWithDeploys[F](depth, maxRank, None, blockView).map(_.map(_._1))
 }

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -10,6 +10,7 @@ import io.casperlabs.casper._
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.state.ProtocolVersion
+import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.helper.{NoOpsCasperEffect, StorageFixture}
 import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.casper.util.BondingUtil.Bond
@@ -107,12 +108,13 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
         effects             <- effectsForSimpleCasperSetup(blockStorage, dagStorage)
         (logEff, casperRef) = effects
 
-        blockInfo <- BlockAPI.getBlockInfo[Task](secondBlockQuery)(
+        blockInfo <- BlockAPI.getBlockInfo[Task](secondBlockQuery, BlockInfo.View.BASIC)(
                       Sync[Task],
                       logEff,
                       casperRef,
                       blockStorage,
-                      deployStorage
+                      deployStorage,
+                      dagStorage
                     )
         _ = blockInfo.getSummary.blockHash should be(blockHash)
         _ = blockInfo.getStatus.getStats.blockSizeBytes should be(secondBlock.serializedSize)
@@ -130,18 +132,46 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
       } yield ()
   }
 
+  it should "return children in FULL view" in withStorage {
+    implicit blockStorage => implicit dagStorage => implicit deployStorage =>
+      for {
+        effects             <- effectsForSimpleCasperSetup(blockStorage, dagStorage)
+        (logEff, casperRef) = effects
+
+        basicInfo <- BlockAPI.getBlockInfo[Task](genesisHashString, BlockInfo.View.BASIC)(
+                      Sync[Task],
+                      logEff,
+                      casperRef,
+                      blockStorage,
+                      deployStorage,
+                      dagStorage
+                    )
+        fullInfo <- BlockAPI.getBlockInfo[Task](genesisHashString, BlockInfo.View.FULL)(
+                     Sync[Task],
+                     logEff,
+                     casperRef,
+                     blockStorage,
+                     deployStorage,
+                     dagStorage
+                   )
+        _ = basicInfo.getStatus.childHashes shouldBe empty
+        _ = fullInfo.getStatus.childHashes should not be empty
+      } yield ()
+  }
+
   it should "return error when no block exists" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage =>
       for {
         effects             <- emptyEffects(blockStorage, dagStorage)
         (logEff, casperRef) = effects
         blockQueryResponse <- BlockAPI
-                               .getBlockInfo[Task](badTestHashQuery)(
+                               .getBlockInfo[Task](badTestHashQuery, BlockInfo.View.BASIC)(
                                  Sync[Task],
                                  logEff,
                                  casperRef,
                                  blockStorage,
-                                 deployStorage
+                                 deployStorage,
+                                 dagStorage
                                )
                                .attempt
       } yield {

--- a/explorer/grpc/package-lock.json
+++ b/explorer/grpc/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-grpc",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/explorer/sdk/package-lock.json
+++ b/explorer/sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "casperlabs-sdk",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -659,9 +659,9 @@
       "dev": true
     },
     "casperlabs-grpc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/casperlabs-grpc/-/casperlabs-grpc-0.2.0.tgz",
-      "integrity": "sha512-mR2MYrT4mR0YJURniTh7xrHtfU7Rvd6/+FKsE0mXj1CDn47GmLwFwqhHT/GK5LlV/UVAsc9kb10if7oBnRODLw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/casperlabs-grpc/-/casperlabs-grpc-0.4.0.tgz",
+      "integrity": "sha512-0w89YhVqFe+S4zqyNzBtiLue+d7iYSC0b0UDSBmsIAiP12pamKeoI/4HbTHeK5DeHLTmzYUWfYuO67V70OzEMA==",
       "requires": {
         "@improbable-eng/grpc-web": "^0.9.6",
         "@types/google-protobuf": "^3.7.1",

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -46,7 +46,7 @@ class _BlockDetails extends RefreshableComponent<Props, {}> {
   }
 
   componentDidUpdate() {
-    // Container and component stays the same during naviagation.
+    // Container and component stays the same during navigation.
     if (this.blockHashBase16 !== this.container.blockHashBase16) {
       this.container.init(decodeBase16(this.blockHashBase16));
       this.refresh();
@@ -159,8 +159,8 @@ const DeploysTable = observer(
                 {deploy.getIsError() ? (
                   <Icon name="times-circle" color="red" />
                 ) : (
-                  <Icon name="check-circle" color="green" />
-                )}
+                    <Icon name="check-circle" color="green" />
+                  )}
               </td>
               <td>{deploy.getErrorMessage()}</td>
             </tr>
@@ -185,6 +185,16 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
       'Parents',
       <ul>
         {header.getParentHashesList_asU8().map((x, idx) => (
+          <li key={idx}>
+            <BlockLink blockHash={x} />
+          </li>
+        ))}
+      </ul>
+    ],
+    [
+      'Children',
+      <ul>
+        {block.getStatus()!.getChildHashesList_asU8().map((x, idx) => (
           <li key={idx}>
             <BlockLink blockHash={x} />
           </li>

--- a/explorer/ui/src/containers/BlockContainer.ts
+++ b/explorer/ui/src/containers/BlockContainer.ts
@@ -24,7 +24,7 @@ export class BlockContainer {
     private errors: ErrorContainer,
     private casperService: CasperService,
     private balanceService: BalanceService
-  ) {}
+  ) { }
 
   /** Call whenever the page switches to a new block. */
   @action
@@ -43,7 +43,7 @@ export class BlockContainer {
   async loadBlock() {
     if (this.blockHash == null) return;
     await this.errors.capture(
-      this.casperService.getBlockInfo(this.blockHash).then(block => {
+      this.casperService.getBlockInfo(this.blockHash, BlockInfo.View.FULL).then(block => {
         this.block = block;
       })
     );

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -756,7 +756,7 @@ class CasperLabsClient:
         :return:                          Yields generated DOT source or file name when out provided.
                                           Generates endless stream of file names if stream is not None.
         """
-        block_infos = list(self.showBlocks(depth))
+        block_infos = list(self.showBlocks(depth, full_view=False))
         dot_dag_description = vdag.generate_dot(block_infos, show_justification_lines)
         if not out:
             yield dot_dag_description
@@ -780,7 +780,7 @@ class CasperLabsClient:
         previous_block_hashes = set(b.summary.block_hash for b in block_infos)
         while stream:
             time.sleep(delay_in_seconds)
-            block_infos = list(self.showBlocks(depth))
+            block_infos = list(self.showBlocks(depth, full_view=False))
             block_hashes = set(b.summary.block_hash for b in block_infos)
             if block_hashes != previous_block_hashes:
                 dot_dag_description = vdag.generate_dot(
@@ -1133,7 +1133,7 @@ def show_block_command(casperlabs_client, args):
 
 @guarded_command
 def show_blocks_command(casperlabs_client, args):
-    response = casperlabs_client.showBlocks(args.depth)
+    response = casperlabs_client.showBlocks(args.depth, full_view=False)
     _show_blocks(response)
 
 

--- a/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
@@ -34,21 +34,6 @@ object BlockImplicits {
 
     def getSummary: BlockSummary =
       BlockSummary(block.blockHash, block.header, block.signature)
-
-    def getBlockInfo: BlockInfo =
-      BlockInfo()
-        .withSummary(block.getSummary)
-        .withStatus(
-          BlockInfo
-            .Status()
-            .withStats(
-              Stats(
-                block.serializedSize,
-                block.getBody.deploys.count(_.isError),
-                block.getBody.deploys.map(_.cost).sum
-              )
-            )
-        )
   }
 
   implicit class BlockSummaryOps(val summary: BlockSummary) extends AnyVal {

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -29,12 +29,13 @@ import io.casperlabs.shared.Log
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.deploy.DeployStorage
+import io.casperlabs.storage.dag.DagStorage
 import monix.eval.{Task, TaskLike}
 import monix.reactive.Observable
 
 object GrpcCasperService {
 
-  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef: BlockStorage: ExecutionEngineService: DeployStorage: Validation: Fs2Compiler: DeployBuffer](
+  def apply[F[_]: Concurrent: TaskLike: Log: Metrics: MultiParentCasperRef: BlockStorage: ExecutionEngineService: DeployStorage: Validation: Fs2Compiler: DeployBuffer: DagStorage](
       isReadOnlyNode: Boolean
   ): F[CasperGrpcMonix.CasperService] =
     BlockAPI.establishMetrics[F] *> Sync[F].delay {
@@ -61,7 +62,8 @@ object GrpcCasperService {
             ) >>= { blockHashPrefix =>
               BlockAPI
                 .getBlockInfo[F](
-                  blockHashPrefix
+                  blockHashPrefix,
+                  request.view
                 )
             }
           }
@@ -70,7 +72,8 @@ object GrpcCasperService {
           val infos = TaskLike[F].apply {
             BlockAPI.getBlockInfos[F](
               depth = request.depth,
-              maxRank = request.maxRank
+              maxRank = request.maxRank,
+              blockView = request.view
             )
           }
           Observable.fromTask(infos).flatMap(Observable.fromIterable)
@@ -123,7 +126,7 @@ object GrpcCasperService {
                                 request.blockHash,
                                 adaptToInvalidArgument
                               )
-            info            <- BlockAPI.getBlockInfo[F](blockHashPrefix)
+            info            <- BlockAPI.getBlockInfo[F](blockHashPrefix, BlockInfo.View.BASIC)
             stateHash       = info.getSummary.state.postStateHash
             protocolVersion = info.getSummary.getHeader.getProtocolVersion
             values          <- request.queries.toList.traverse(getState(stateHash, _, protocolVersion))
@@ -199,7 +202,13 @@ object GrpcCasperService {
           TaskLike[F].apply {
             MultiParentCasperRef
               .withCasper[F, BlockInfo](
-                _.lastFinalizedBlock.map(_.getBlockInfo),
+                _.lastFinalizedBlock.flatMap { block =>
+                  BlockAPI
+                    .getBlockInfo[F](
+                      Base16.encode(block.blockHash.toByteArray),
+                      request.view
+                    )
+                },
                 "Could not get last finalized block.",
                 MonadThrowable[F].raiseError(Unavailable("Casper instance not available yet."))
               )

--- a/node/src/main/scala/io/casperlabs/node/api/Servers.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Servers.scala
@@ -26,6 +26,7 @@ import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.deploy.DeployStorage
+import io.casperlabs.storage.dag.DagStorage
 import io.netty.handler.ssl.SslContext
 import kamon.Kamon
 import monix.eval.{Task, TaskLike}
@@ -33,7 +34,6 @@ import monix.execution.Scheduler
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
-
 import scala.concurrent.ExecutionContext
 
 object Servers {
@@ -88,7 +88,7 @@ object Servers {
   }
 
   /** Start a gRPC server with services meant for users and dApp developers. */
-  def externalServersR[F[_]: Concurrent: TaskLike: Log: MultiParentCasperRef: Metrics: BlockStorage: ExecutionEngineService: DeployStorage: Validation: Fs2Compiler: DeployBuffer](
+  def externalServersR[F[_]: Concurrent: TaskLike: Log: MultiParentCasperRef: Metrics: BlockStorage: ExecutionEngineService: DeployStorage: Validation: Fs2Compiler: DeployBuffer: DagStorage](
       port: Int,
       maxMessageSize: Int,
       ingressScheduler: Scheduler,
@@ -116,7 +116,7 @@ object Servers {
       )
   }
 
-  def httpServerR[F[_]: Log: NodeDiscovery: ConnectionsCell: Timer: ConcurrentEffect: MultiParentCasperRef: BlockStorage: ContextShift: FinalizedBlocksStream: ExecutionEngineService: DeployStorage: Fs2Compiler: Metrics](
+  def httpServerR[F[_]: Log: NodeDiscovery: ConnectionsCell: Timer: ConcurrentEffect: MultiParentCasperRef: BlockStorage: ContextShift: FinalizedBlocksStream: ExecutionEngineService: DeployStorage: DagStorage: Fs2Compiler: Metrics](
       port: Int,
       conf: Configuration,
       id: NodeIdentifier,

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/GraphQL.scala
@@ -17,6 +17,7 @@ import io.casperlabs.shared.{Log, LogSource}
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.deploy.DeployStorage
+import io.casperlabs.storage.dag.DagStorage
 import io.circe.parser.parse
 import io.circe.syntax._
 import io.circe.{Json, JsonObject}
@@ -42,7 +43,7 @@ object GraphQL {
     Headers.of(Header("Upgrade", "websocket"), Header("Sec-WebSocket-Protocol", "graphql-ws"))
 
   /* Entry point */
-  def service[F[_]: ConcurrentEffect: ContextShift: Timer: Log: MultiParentCasperRef: BlockStorage: FinalizedBlocksStream: ExecutionEngineService: DeployStorage: Fs2Compiler: Metrics](
+  def service[F[_]: ConcurrentEffect: ContextShift: Timer: Log: MultiParentCasperRef: BlockStorage: FinalizedBlocksStream: ExecutionEngineService: DeployStorage: DagStorage: Fs2Compiler: Metrics](
       executionContext: ExecutionContext
   ): HttpRoutes[F] = {
     import io.casperlabs.node.api.graphql.RunToFuture.fromEffect

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/GraphQLSchemaBuilder.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.api.BlockAPI
-import io.casperlabs.casper.consensus.info.DeployInfo
+import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
 import io.casperlabs.casper.consensus.state
 import io.casperlabs.catscontrib.{Fs2Compiler, MonadThrowable}
 import io.casperlabs.crypto.Keys.PublicKey
@@ -25,9 +25,10 @@ import io.casperlabs.shared.Log
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.deploy.DeployStorage
+import io.casperlabs.storage.dag.DagStorage
 import sangria.schema._
 
-private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: RunToFuture: MultiParentCasperRef: BlockStorage: FinalizedBlocksStream: MonadThrowable: ExecutionEngineService: DeployStorage: Fs2Compiler] {
+private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: RunToFuture: MultiParentCasperRef: BlockStorage: FinalizedBlocksStream: MonadThrowable: ExecutionEngineService: DeployStorage: DagStorage: Fs2Compiler] {
 
   // GraphQL projections don't expose the body.
   val deployView = DeployInfo.View.BASIC
@@ -68,7 +69,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
                 res <- BlockAPI
                         .getBlockInfoWithDeploysOpt[F](
                           blockHashBase16 = blockHashPrefix,
-                          maybeDeployView = deployView(projections)
+                          maybeDeployView = deployView(projections),
+                          blockView = BlockInfo.View.BASIC
                         )
               } yield res).unsafeToFuture
             }
@@ -82,7 +84,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
                 .getBlockInfosWithDeploys[F](
                   depth = context.arg(blocks.arguments.Depth),
                   maxRank = context.arg(blocks.arguments.MaxRank),
-                  maybeDeployView = deployView(projections)
+                  maybeDeployView = deployView(projections),
+                  blockView = BlockInfo.View.BASIC
                 )
                 .unsafeToFuture
             }
@@ -179,7 +182,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
                 maybeBlockProps <- BlockAPI
                                     .getBlockInfoWithDeploysOpt[F](
                                       blockHashBase16Prefix,
-                                      maybeDeployView = None
+                                      maybeDeployView = None,
+                                      blockView = BlockInfo.View.BASIC
                                     )
                                     .map(_.map {
                                       case (info, _) =>
@@ -242,7 +246,8 @@ private[graphql] class GraphQLSchemaBuilder[F[_]: Fs2SubscriptionStream: Log: Ru
                 BlockAPI
                   .getBlockInfoWithDeploys[F](
                     blockHash = blockHash,
-                    maybeDeployView = deployView(terms)
+                    maybeDeployView = deployView(terms),
+                    blockView = BlockInfo.View.BASIC
                   )
                   .map(Action(_))
               }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -10,14 +10,14 @@ message BlockInfo {
     enum View {
         // Only includes information which is based on the header.
         BASIC = 0;
-        // Includes extra information that requires the full block,
-        // for example the size, number of errors in deploys, etc.
+        // Includes extra information such as children which require extra lookups.
         FULL = 1;
     }
 
     message Status {
         float fault_tolerance = 1;
         Stats stats = 2;
+        repeated bytes child_hashes = 3;
 
         // Statistics derived from the full block.
         message Stats {

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -168,4 +168,6 @@ message ListDeployInfosResponse {
 }
 
 
-message GetLastFinalizedBlockInfoRequest {}
+message GetLastFinalizedBlockInfoRequest {
+    io.casperlabs.casper.consensus.info.BlockInfo.View view = 1;
+}


### PR DESCRIPTION
### Overview
The Explorer view only shows child links to the blocks which are in the view. On some occasions the children were so far away that they couldn't be shown, but you only realised this when a blocks parent was out of view, not the other way around. 

The PR adds a `child_hashes` field to `BlockInfo.Status` so that we can access these. Currently accessing them requires a separate call, so on the `BASIC` view these are not included, only in `FULL`. Executing extra SQL queries at every point where `BlockInfo` records are returned would have been an overkill for this ticket, but maybe in the future we can do that too. 

Children show up in the Clarity Block Details view:
![image](https://user-images.githubusercontent.com/2684603/70849760-d5cc4980-1e7a-11ea-8bdb-6607a81fb6bf.png)

and in `show-block` as well:
```console
$ casperlabs-client --host localhost --port 40401 show-block 8e8b
summary {
  block_hash: "8e8bcb56764b87a0ac9d7346e7212e71c03bab4b0069a0d1d9fd567a3beac8b4"
  header {
    parent_hashes: "6d9422b0ffe3e1b404c388d5efe9ac942f905f3f5502ec8e4f379c1ea62f3382"
    ...
}
status {
  ...
  child_hashes: "57479f4fb36d6b90e65d97c3b7ba36f6295013d7be75cefbe582ba6e714da1b1"
  child_hashes: "1eb8d1a6f634921a750aaf4589d0baa7ed96a5604293a167c39cfff51a9fb2a6"
}
```

But not in the `show-blocks`, so we avoid the 1+N problem. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1057

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.


