### PR TITLE
NODE-1024: Add deploy_gas_price_avg to BlockInfo.Stats

### DIFF
--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -159,8 +159,8 @@ const DeploysTable = observer(
                 {deploy.getIsError() ? (
                   <Icon name="times-circle" color="red" />
                 ) : (
-                  <Icon name="check-circle" color="green" />
-                )}
+                    <Icon name="check-circle" color="green" />
+                  )}
               </td>
               <td>{deploy.getErrorMessage()}</td>
             </tr>
@@ -177,6 +177,7 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
   const id = encodeBase16(block.getSummary()!.getBlockHash_asU8());
   const header = block.getSummary()!.getHeader()!;
   const validatorId = encodeBase16(header.getValidatorPublicKey_asU8());
+  const stats = block.getStatus()!.getStats()!;
   return [
     ['Block Hash', id],
     ['Rank', header.getRank()],
@@ -212,21 +213,10 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
       })()
     ],
     ['Deploy Count', header.getDeployCount()],
-    [
-      'Deploy Error Count',
-      block
-        .getStatus()!
-        .getStats()!
-        .getDeployErrorCount()
-    ],
-    [
-      'Block Size (bytes)',
-      block
-        .getStatus()!
-        .getStats()!
-        .getBlockSizeBytes()
-        .toLocaleString()
-    ],
+    ['Deploy Error Count', stats.getDeployErrorCount()],
+    ['Deploy Cost Total', stats.getDeployCostTotal().toLocaleString()],
+    ['Deploy Gas Price Average', stats.getDeployGasPriceAvg().toLocaleString()],
+    ['Block Size (bytes)', stats.getBlockSizeBytes().toLocaleString()],
     [
       'Fault Tolerance',
       block

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -24,7 +24,7 @@ message BlockInfo {
             uint32 block_size_bytes = 1;
             uint32 deploy_error_count = 2;
             uint64 deploy_cost_total = 3;
-            // Average gas price across all successful deploys in the block weighted by the gas cost of the deploys.
+            // Average gas price across all deploys in the block weighted by the gas cost of the deploys.
             uint64 deploy_gas_price_avg = 4;
         }
     }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -24,6 +24,8 @@ message BlockInfo {
             uint32 block_size_bytes = 1;
             uint32 deploy_error_count = 2;
             uint64 deploy_cost_total = 3;
+            // Average gas price across all successful deploys in the block weighted by the gas cost of the deploys.
+            uint64 deploy_gas_price_avg = 4;
         }
     }
 }

--- a/storage/src/main/resources/db/migration/V20191214_1024__Add_deploy_gas_price_avg.sql
+++ b/storage/src/main/resources/db/migration/V20191214_1024__Add_deploy_gas_price_avg.sql
@@ -1,0 +1,4 @@
+-- At the time of this update, we have the price set to a constant 10 in the EE,
+-- and the clients are also set to send 10 by default, so it matches up.
+ALTER TABLE block_metadata
+    ADD COLUMN deploy_gas_price_avg INTEGER NOT NULL DEFAULT 10;

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -17,6 +17,7 @@ import io.casperlabs.metrics.Metrics.Source
 import io.casperlabs.shared.Time
 import io.casperlabs.storage.DeployStorageMetricsSource
 import io.casperlabs.storage.block.BlockStorage.DeployHash
+import io.casperlabs.storage.block.SQLiteBlockStorage.blockInfoCols
 import io.casperlabs.storage.util.DoobieCodecs
 
 import scala.collection.concurrent.TrieMap
@@ -470,7 +471,7 @@ class SQLiteDeployStorage[F[_]: Time: Sync](
           .fromList[ByteString](deployHashes)
           .fold(Map.empty[DeployHash, List[ProcessingResult]].pure[F])(nel => {
             val q = fr"""SELECT dpr.deploy_hash, dpr.cost, dpr.execution_error_message,
-                                bm.data, bm.block_size, bm.deploy_error_count, bm.deploy_cost_total
+                                """ ++ blockInfoCols("bm") ++ fr"""
                         FROM deploy_process_results dpr
                         JOIN block_metadata bm ON dpr.block_hash = bm.block_hash
                         WHERE """ ++ Fragments.in(fr"dpr.deploy_hash", nel)

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -57,8 +57,8 @@ trait DoobieCodecs {
   }
 
   protected implicit val readBlockInfo: Read[BlockInfo] = {
-    Read[(Array[Byte], Int, Int, Long)].map {
-      case (blockSummaryData, blockSize, deployErrorCount, deployCostTotal) =>
+    Read[(Array[Byte], Int, Int, Long, Long)].map {
+      case (blockSummaryData, blockSize, deployErrorCount, deployCostTotal, deployGasPriceAvg) =>
         val blockSummary = BlockSummary.parseFrom(blockSummaryData)
         val blockStatus = BlockInfo
           .Status()
@@ -68,6 +68,7 @@ trait DoobieCodecs {
               .withBlockSizeBytes(blockSize)
               .withDeployErrorCount(deployErrorCount)
               .withDeployCostTotal(deployCostTotal)
+              .withDeployGasPriceAvg(deployGasPriceAvg)
           )
         BlockInfo()
           .withSummary(blockSummary)


### PR DESCRIPTION
### Overview
The `BlockInfo` indicated how much the deploys cost in total, but it didn't contain an easy way to tell what price level they were executed with. This came up in some of Onur's papers, that fees are going to be split based on the average price in the previous era for example. The only way for a client to calculate the price would have been to retrieve all deploy headers as well. 

The PR adds the field to the `BlockInfo` and store it in the SQL table so it's always available.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1024

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
