### PR TITLE
NODE-982: Not allowing proposals until the synchronization is finished.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -125,7 +125,9 @@ object BlockAPI {
           } yield result
 
         case false =>
-          raise(Aborted("There is another propose in progress."))
+          raise(
+            Aborted("There is another propose in progress, or hasn't synced yet. Try again later.")
+          )
       }
     }
   }

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -126,7 +126,7 @@ object BlockAPI {
 
         case false =>
           raise(
-            Aborted("There is another propose in progress, or hasn't synced yet. Try again later.")
+            Aborted("There is another propose in progress, or node hasn't synced yet. Try again later.")
           )
       }
     }

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -126,7 +126,9 @@ object BlockAPI {
 
         case false =>
           raise(
-            Aborted("There is another propose in progress, or node hasn't synced yet. Try again later.")
+            Aborted(
+              "There is another propose in progress, or node hasn't synced yet. Try again later."
+            )
           )
       }
     }


### PR DESCRIPTION
### Overview
If a node that is still midway through synchronizing with the network proposes a block, every other node will try to merge it as a secondary parent next time, which will result in comparison against a huge volume of blocks. 

The PR changes the setup so that while the initial synchronization is running, the node is not allowed to propose a block.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-982

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The initial scope of the ticket was larger, talking about some control mechanism to also monitor nodes falling behind the others, but that was before we added other workarounds, like using the LFB. This change makes sense on its own, and the title of the ticket was changed a long time ago to just deal with the initial phase.
