### PR TITLE
NODE-1030: Requeue orphans in  the background thread.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -2,7 +2,7 @@ package io.casperlabs.casper
 
 import cats.data.NonEmptyList
 import cats.effect.concurrent.Semaphore
-import cats.effect.{Concurrent, Resource, Sync}
+import cats.effect.{Concurrent, Sync}
 import cats.implicits._
 import cats.mtl.FunctorRaise
 import cats.Applicative
@@ -247,14 +247,17 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
           _ <- Log[F].info(
                 s"${parents.size} parents out of ${tipHashes.size} latest blocks will be used."
               )
-
           // Push any unfinalized deploys which are still in the buffer back to pending state if the
           // blocks they were contained have become orphans since we last tried to propose a block.
           // Doing this here rather than after adding blocks because it's quite costly; the downside
           // is that the auto-proposer will not pick up the change in the pending set immediately.
-          requeued <- DeployBuffer.requeueOrphanedDeploys[F](merged.parents.map(_.blockHash).toSet)
-          _        <- Log[F].info(s"Re-queued $requeued orphaned deploys.").whenA(requeued > 0)
-
+          // Requeueing operation is changing status of orphaned deploys in the DB.
+          // It's done as a transaction. If operation won't make it in time before
+          // immediate `createProposal`, those deploys will be considered for the next block.
+          _ <- (DeployBuffer.requeueOrphanedDeploys[F](merged.parents.map(_.blockHash).toSet) >>= {
+                requeued =>
+                  Log[F].info(s"Re-queued $requeued orphaned deploys.").whenA(requeued > 0)
+              }).forkAndLog
           timestamp <- Time[F].currentMillis
           props     <- CreateMessageProps(publicKey, latestMessages, merged)
           remainingHashes <- DeployBuffer.remainingDeploys[F](

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -491,7 +491,7 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
   }
 
   /** The new gossiping first syncs the missing DAG, then downloads and adds the blocks in topological order.
-    * However the EquivocationDetector wants t  o know about dependencies so it can assign different statuses,
+    * However the EquivocationDetector wants to know about dependencies so it can assign different statuses,
     * so we'll make the synchronized DAG known via a partial block message, so any missing dependencies can
     * be tracked, i.e. Casper will know about the pending graph.  */
   def addMissingDependencies(block: Block): F[Unit] =

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -310,7 +310,7 @@ abstract class HashSetCasperTest
       signedBlock <- (node0.deployBuffer.addDeploy(data1) *> node0.casperEff.createBlock)
                       .map { case Created(block) => block }
 
-      // NOTE: Includes only data1 since data0 will be requeued in the background fiber.
+      // NOTE: It can include both data0 and data1 because they don't conflict.
       _ = signedBlock.getBody.deploys.map(_.getDeploy) should contain only (data0, data1)
 
       _ <- node0.casperEff.addBlock(signedBlock)

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -311,7 +311,7 @@ abstract class HashSetCasperTest
                       .map { case Created(block) => block }
 
       // NOTE: Includes only data1 since data0 will be requeued in the background fiber.
-      _ = signedBlock.getBody.deploys.map(_.getDeploy) should contain only (data1)
+      _ = signedBlock.getBody.deploys.map(_.getDeploy) should contain only (data0, data1)
 
       _ <- node0.casperEff.addBlock(signedBlock)
       _ <- node0.casperEff.contains(signedBlock) shouldBeF true


### PR DESCRIPTION
### Overview
Instead of waiting for requeued orphans during block creation, requeue in the background fiber. We don't have to requeue immediately and this will cut down the times for block creation. We don't have to worry whether an incoming block (while we are requeueing) includes one of the orphaned deploys (basically creating a replay on our own) because during block creation we [filter them out](https://github.com/CasperLabs/CasperLabs/blob/b1427e0786c67008bf5fc70739152c98840e6385/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala#L98).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1030

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
