### PR TITLE
EE-804: sub_call gas cost check

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -1379,6 +1379,13 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "measure-gas-subcall"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.20.0",
+]
+
+[[package]]
 name = "memchr"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/execution-engine/contracts/test/measure-gas-subcall/Cargo.toml
+++ b/execution-engine/contracts/test/measure-gas-subcall/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "measure-gas-subcall"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
+
+[features]
+default = []
+std = ["contract-ffi/std" ]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/measure-gas-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/measure-gas-subcall/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    execution::Phase,
+    unwrap_or_revert::UnwrapOrRevert,
+};
+
+#[repr(u16)]
+enum CustomError {
+    UnexpectedPhaseInline = 0,
+    UnexpectedPhaseSub = 1,
+}
+
+#[no_mangle]
+pub extern "C" fn get_phase_ext() {
+    let phase = runtime::get_phase();
+    runtime::ret(phase, Vec::new())
+}
+
+#[no_mangle]
+pub extern "C" fn noop_ext() {
+    runtime::ret((), Vec::new())
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    const NOOP_EXT: &str = "noop_ext";
+    const GET_PHASE_EXT: &str = "get_phase_ext";
+
+    let method_name: String = runtime::get_arg(0)
+        .unwrap_or_revert_with(Error::MissingArgument)
+        .unwrap_or_revert_with(Error::InvalidArgument);
+    match method_name.as_str() {
+        "no-subcall" => {
+            let phase = runtime::get_phase();
+            if phase != Phase::Session {
+                runtime::revert(Error::User(CustomError::UnexpectedPhaseInline as u16))
+            }
+        }
+        "do-nothing" => {
+            let reference = storage::store_function_at_hash(NOOP_EXT, BTreeMap::new());
+            runtime::call_contract::<_, ()>(reference, &(), &Vec::new());
+        }
+        "do-something" => {
+            let reference = storage::store_function_at_hash(GET_PHASE_EXT, BTreeMap::new());
+            let phase: Phase = runtime::call_contract(reference, &(), &Vec::new());
+            if phase != Phase::Session {
+                runtime::revert(Error::User(CustomError::UnexpectedPhaseSub as u16))
+            }
+        }
+        _ => {}
+    }
+}

--- a/execution-engine/engine-tests/src/test/contract_api/mod.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/mod.rs
@@ -19,6 +19,8 @@ mod mint_purse;
 #[cfg(test)]
 mod revert;
 #[cfg(test)]
+mod subcall;
+#[cfg(test)]
 mod transfer;
 #[cfg(test)]
 mod transfer_purse_to_account;

--- a/execution-engine/engine-tests/src/test/contract_api/subcall.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/subcall.rs
@@ -1,0 +1,64 @@
+use crate::{
+    support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+};
+
+#[ignore]
+#[test]
+fn should_charge_gas_for_subcall() {
+    const CONTRACT_NAME: &str = "measure_gas_subcall.wasm";
+    const DO_NOTHING: &str = "do-nothing";
+    const DO_SOMETHING: &str = "do-something";
+    const NO_SUBCALL: &str = "no-subcall";
+
+    let do_nothing_request =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_NAME, (DO_NOTHING,)).build();
+
+    let do_something_request =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_NAME, (DO_SOMETHING,))
+            .build();
+
+    let no_subcall_request =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_NAME, (NO_SUBCALL,)).build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder
+        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .exec(do_nothing_request)
+        .expect_success()
+        .commit()
+        .exec(do_something_request)
+        .expect_success()
+        .commit()
+        .exec(no_subcall_request)
+        .expect_success()
+        .commit()
+        .finish();
+
+    let do_nothing_cost = builder.exec_costs(0)[0];
+
+    let do_something_cost = builder.exec_costs(1)[0];
+
+    let no_subcall_cost = builder.exec_costs(2)[0];
+
+    assert_ne!(
+        do_nothing_cost, do_something_cost,
+        "should have different costs"
+    );
+
+    assert_ne!(
+        no_subcall_cost, do_something_cost,
+        "should have different costs"
+    );
+
+    assert!(
+        do_nothing_cost < do_something_cost,
+        "should cost more to do something via subcall"
+    );
+
+    assert!(
+        no_subcall_cost < do_nothing_cost,
+        "do nothing in a subcall should cost more than no subcall"
+    );
+}


### PR DESCRIPTION
This PR adds an EE engine test to assert expected gas cost behavior across sub_call, filling a gap in test coverage and preceding upcoming work around gas cost accounting.

https://casperlabs.atlassian.net/browse/EE-804

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.