### PR TITLE
NO_TICKET: Fix installation of dependencies and bump Python client version to 0.7.4

### DIFF
--- a/integration-testing/client/CasperLabsClient/requirements.txt
+++ b/integration-testing/client/CasperLabsClient/requirements.txt
@@ -2,3 +2,5 @@ grpcio>=1.20
 pyblake2==1.1.2
 ed25519==1.4
 protobuf==3.9.1
+cryptography==2.8
+pycryptodome==3.9.4

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -210,7 +210,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.7.1",
+    version="0.7.4",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",
@@ -223,6 +223,8 @@ setup(
         "grpcio>=1.20",
         "pyblake2==1.1.2",
         "ed25519==1.4",
+        "cryptography==2.8",
+        "pycryptodome==3.9.4",
     ],
     cmdclass={"install": CInstall, "develop": CDevelop},
     description="Python Client for interacting with a CasperLabs Node",


### PR DESCRIPTION
### Overview
This PR fixes installation of dependencies of the Python client and bumps it's version number to 0.7.4.

### Which JIRA ticket does this PR relate to?
NA

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
