### PR TITLE
NODE-978: Accept both base16 or base64 account key in the CLI 

### DIFF
--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
@@ -55,7 +55,7 @@ object Benchmarks {
         )
 
     def send(
-        recipientPublicKeyBase64: String,
+        recipientPublicKey: PublicKey,
         senderPrivateKey: PrivateKey,
         senderPublicKey: PublicKey,
         amount: Long
@@ -63,7 +63,7 @@ object Benchmarks {
       deployConfig = DeployConfig.empty,
       senderPublicKey = senderPublicKey,
       senderPrivateKey = senderPrivateKey,
-      recipientPublicKeyBase64 = recipientPublicKeyBase64,
+      recipientPublicKey = recipientPublicKey,
       amount = amount,
       exit = false,
       ignoreOutput = true
@@ -76,7 +76,6 @@ object Benchmarks {
       List.fill(accountsNum)(createAccountKeyPair())
     val recipient @ (_, recipientPublicKey): (Keys.PrivateKey, Keys.PublicKey) =
       createAccountKeyPair()
-    val recipientBase64 = Base64.encode(recipientPublicKey)
 
     def initializeAccounts(
         initialFundsPrivateKey: PrivateKey,
@@ -88,7 +87,7 @@ object Benchmarks {
               case (_, pk) =>
                 for {
                   _ <- send(
-                        recipientPublicKeyBase64 = Base64.encode(pk),
+                        recipientPublicKey = pk,
                         senderPrivateKey = initialFundsPrivateKey,
                         senderPublicKey = initialFundsPublicKey,
                         amount = initialFundsPerAccount
@@ -105,7 +104,7 @@ object Benchmarks {
         _ <- senders.traverse {
               case (sk, pk) =>
                 send(
-                  recipientPublicKeyBase64 = recipientBase64,
+                  recipientPublicKey = recipientPublicKey,
                   senderPrivateKey = sk,
                   senderPublicKey = pk,
                   amount = 1

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -80,14 +80,14 @@ object Main {
         )
       case Transfer(
           amount,
-          recipientPublicKeyBase64,
+          recipientPublicKey,
           contracts,
           privateKey
           ) =>
         DeployRuntime.transferCLI[F](
           contracts,
           privateKey,
-          recipientPublicKeyBase64,
+          recipientPublicKey,
           amount
         )
       case Deploy(
@@ -118,7 +118,7 @@ object Main {
           baseAccount <- publicKey match {
                           case None =>
                             // This should be safe because we validate that one of --from, --public-key is present.
-                            ByteString.copyFrom(Base16.decode(from.get)).pure[F]
+                            from.get.pure[F]
                           case Some(publicKeyFile) =>
                             for {
                               content <- DeployRuntime.readFileAsString[F](publicKeyFile)
@@ -128,7 +128,7 @@ object Main {
                                               s"Failed to parse public key file ${publicKeyFile.getPath()}"
                                             )
                                           )
-                            } yield ByteString.copyFrom(publicKey)
+                            } yield publicKey
                         }
           deploy = DeployRuntime.makeDeploy[F](
             baseAccount,

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream, File, InputStream}
 import java.nio.file.Files
 import io.casperlabs.client.configuration.Options.DeployOptions
 import io.casperlabs.casper.consensus.Deploy.{Arg, Code}, Code.Contract
+import io.casperlabs.crypto.Keys.PublicKey
 import io.casperlabs.crypto.codec.Base16
 import org.apache.commons.io._
 
@@ -135,7 +136,7 @@ sealed trait Formatting {
 }
 
 final case class MakeDeploy(
-    from: Option[String],
+    from: Option[PublicKey],
     publicKey: Option[File],
     deployConfig: DeployConfig,
     deployPath: Option[File]
@@ -153,7 +154,7 @@ final case class PrintDeploy(
     with Formatting
 
 final case class Deploy(
-    from: Option[String],
+    from: Option[PublicKey],
     deployConfig: DeployConfig,
     publicKey: Option[File],
     privateKey: Option[File]
@@ -189,7 +190,7 @@ final case class Bond(
 ) extends Configuration
 final case class Transfer(
     amount: Long,
-    recipientPublicKeyBase64: String,
+    recipientPublicKey: PublicKey,
     deployConfig: DeployConfig,
     privateKey: File
 ) extends Configuration

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -255,7 +255,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val from = opt[PublicKey](
       descr =
-        "The public key of the account which is the context of this deployment, base16 encoded.",
+        "The public key of the account which is the context of this deployment; base16 or base64 encoded.",
       required = false
     )
 
@@ -311,7 +311,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val from = opt[PublicKey](
       descr =
-        "The public key of the account which is the context of this deployment, base16 encoded.",
+        "The public key of the account which is the context of this deployment; base16 or base64 encoded.",
       required = false
     )
 
@@ -518,7 +518,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val targetAccount =
       opt[PublicKey](
-        descr = "The target account's public key (base16 encoded)",
+        descr = "The target account's public key; base16 or base64 encoded.",
         required = true
       )
   }


### PR DESCRIPTION
### Overview
In the Scala CLI the `deploy` and `make-deploy` commands expected the `--from` in Base16 format, but the `transfer` command wanted `--target` in Base64. 

In order to stay backwards compatible, the PR changes all those to look for 64 character Base16 strings first, but fall back to Base64 if the string has a different length or characters. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-978

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
