### PR TITLE
NODE-1092: No base64 in GraphQL.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/package.scala
@@ -7,7 +7,7 @@ import io.casperlabs.casper.consensus.Block._
 import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
 import io.casperlabs.casper.consensus.info._
-import io.casperlabs.crypto.codec.{Base16, Base64}
+import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.node.api.graphql.schema.utils.{DateType, ProtocolVersionType}
 import io.casperlabs.models.BlockImplicits._
 import sangria.schema._
@@ -45,8 +45,8 @@ package object types {
       Field(
         "approverPublicKey",
         StringType,
-        "Base-64 encoded public key of approver".some,
-        resolve = c => Base64.encode(c.value.approverPublicKey.toByteArray)
+        "Base-16 encoded public key of approver".some,
+        resolve = c => Base16.encode(c.value.approverPublicKey.toByteArray)
       ),
       Field(
         "signature",
@@ -70,8 +70,8 @@ package object types {
       Field(
         "accountId",
         StringType,
-        "Base-64 encoded account public key".some,
-        resolve = c => Base64.encode(c.value.getHeader.accountPublicKey.toByteArray)
+        "Base-16 encoded account public key".some,
+        resolve = c => Base16.encode(c.value.getHeader.accountPublicKey.toByteArray)
       ),
       Field(
         "timestamp",
@@ -179,8 +179,8 @@ package object types {
       Field(
         "validatorPublicKey",
         StringType,
-        "Base-64 encoded public key of a validator created the block".some,
-        resolve = c => Base64.encode(c.value._1.getSummary.validatorPublicKey.toByteArray)
+        "Base-16 encoded public key of a validator created the block".some,
+        resolve = c => Base16.encode(c.value._1.getSummary.validatorPublicKey.toByteArray)
       ),
       Field(
         "validatorBlockSeqNum",


### PR DESCRIPTION
### Overview
Some fields were returned in Base64 in GraphQL queries: account ID, validator key; these had to be manually converted to Base16 to be used in further input for queries, which is very inconvenient.

It was decided in the CLI client to use base16 only, so let's stick to that.

This is kind of a breaking change, but hopefully it's worth it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1092

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
We could add some headers to be able to switch, but currently all arguments explicitly say `Base16` in their name. The gRPC counterpart now allows raw input as well.