### PR TITLE
NODE-1082: Era with Instant and FiniteDuration

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -2,7 +2,7 @@ package io.casperlabs.casper.highway
 
 import io.casperlabs.casper.consensus.{BlockSummary, Era}
 
-class EraRuntime(conf: HighwayConf, era: Era) {
+class EraRuntime(conf: HighwayConf, val era: Era) {
 
   val bookingBoundaries =
     conf.criticalBoundaries(
@@ -25,6 +25,7 @@ class EraRuntime(conf: HighwayConf, era: Era) {
 
   val isBookingBoundary = isBoundary(bookingBoundaries)(_, _)
   val isKeyBoundary     = isBoundary(keyBoundaries)(_, _)
+  val isSwitchBoundary  = (mpbr: Ticks, br: Ticks) => mpbr < era.endTick && era.endTick <= br
 
 }
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -1,0 +1,43 @@
+package io.casperlabs.casper.highway
+
+import io.casperlabs.casper.consensus.{BlockSummary, Era}
+
+class EraRuntime(conf: HighwayConf, era: Era) {
+
+  val bookingBoundaries =
+    conf.criticalBoundaries(
+      Ticks(era.startTick),
+      Ticks(era.endTick),
+      delayTicks = conf.bookingTicks
+    )
+
+  val keyBoundaries =
+    conf.criticalBoundaries(
+      Ticks(era.startTick),
+      Ticks(era.endTick),
+      delayTicks = conf.keyTicks
+    )
+
+  private def isBoundary(boundaries: List[Ticks])(
+      mainParentBlockRoundId: Ticks,
+      blockRoundId: Ticks
+  ) = boundaries.exists(t => mainParentBlockRoundId < t && t <= blockRoundId)
+
+  val isBookingBoundary = isBoundary(bookingBoundaries)(_, _)
+  val isKeyBoundary     = isBoundary(keyBoundaries)(_, _)
+
+}
+
+object EraRuntime {
+  def fromGenesis(conf: HighwayConf, genesis: BlockSummary): EraRuntime =
+    new EraRuntime(
+      conf,
+      Era(
+        keyBlockHash = genesis.blockHash,
+        bookingBlockHash = genesis.blockHash,
+        startTick = conf.genesisEraStartTick,
+        endTick = conf.genesisEraEndTick,
+        bonds = genesis.getHeader.getState.bonds
+      )
+    )
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -2,7 +2,7 @@ package io.casperlabs.casper.highway
 
 import io.casperlabs.casper.consensus.{BlockSummary, Era}
 
-class EraRuntime(conf: HighwayConf, val era: Era) {
+class EraRuntime[F[_]](conf: HighwayConf, val era: Era) {
 
   val bookingBoundaries =
     conf.criticalBoundaries(
@@ -30,8 +30,8 @@ class EraRuntime(conf: HighwayConf, val era: Era) {
 }
 
 object EraRuntime {
-  def fromGenesis(conf: HighwayConf, genesis: BlockSummary): EraRuntime =
-    new EraRuntime(
+  def fromGenesis[F[_]](conf: HighwayConf, genesis: BlockSummary): EraRuntime[F] =
+    new EraRuntime[F](
       conf,
       Era(
         keyBlockHash = genesis.blockHash,

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -18,6 +18,12 @@ class EraRuntime[F[_]](conf: HighwayConf, val era: Era) {
       delayTicks = conf.keyTicks
     )
 
+  /** When we handle an incoming block or create a new one we may have to do additional work:
+    * - if the block is a booking block, we have to execute the auction to pick the validators for the upcoming era
+    * - when see a switch block, we have to look for a main ancestor which was a key block, to decide which era it belongs to.
+    * These blocks can be identified by their round ID being after a boundary (a deadline),
+    * while their main parent was still before the deadline.
+    */
   private def isBoundary(boundaries: List[Ticks])(
       mainParentBlockRoundId: Ticks,
       blockRoundId: Ticks
@@ -25,7 +31,16 @@ class EraRuntime[F[_]](conf: HighwayConf, val era: Era) {
 
   val isBookingBoundary = isBoundary(bookingBoundaries)(_, _)
   val isKeyBoundary     = isBoundary(keyBoundaries)(_, _)
-  val isSwitchBoundary  = (mpbr: Ticks, br: Ticks) => mpbr < era.endTick && era.endTick <= br
+
+  /** Switch blocks are the first blocks which are created _after_ the era ends.
+    * They are still created by the validators of this era, and they signal the
+    * end of the era. Otherwise there might be just one more millisecond round
+    * in the era that you have to wait for. Switch blocks are what the child
+    * era is going to build on, however, the validators of _this_ era are the
+    * ones that can finalize it by building ballots on top of it. The cannot
+    * build more blocks on them though.
+    */
+  val isSwitchBoundary = (mpbr: Ticks, br: Ticks) => mpbr < era.endTick && era.endTick <= br
 
 }
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -1,0 +1,99 @@
+package io.casperlabs.casper.highway
+
+import java.util.concurrent.TimeUnit
+import java.time.{Instant, LocalDateTime, ZoneId}
+import scala.concurrent.duration._
+
+final case class HighwayConf(
+    /** Real-world time unit for one tick. */
+    tickUnit: TimeUnit,
+    /** Starting tick for the genesis era, measured in ticks since the Unix epoch. */
+    genesisEraStartTick: Tick,
+    /** Method for calculating the end of the era based on the start tick. */
+    eraDuration: HighwayConf.EraDuration,
+    /** Number of ticks to go back before the start of the era for picking the booking block. */
+    bookingBlockTicks: Tick,
+    /** Number of ticks after the booking before we pick the key block, collecting the magic bits along the way. */
+    entropyTicks: Tick,
+    /** Stopping condition for producing ballots after the end of the era. */
+    postEraVotingDuration: HighwayConf.VotingDuration
+)
+
+object HighwayConf {
+
+  /** By default we want eras to start on Sunday Midnight.
+    * We want to be able to calculate the end of an era when we start it.
+    */
+  sealed trait EraDuration
+  object EraDuration {
+
+    /** Fixed length eras are easy to deal with, but over the years can accumulate leap seconds
+      * which menas they will eventually move away from starting at the desired midnight.
+      * In practice this shouldn't be a problem with the Java time library because it spreads
+      * leap seconds throughout the day so that they appear to be exactly 86400 seconds.
+      */
+    case class Ticks(ticks: Tick) extends EraDuration
+
+    /** Fixed endings can be calculated with the calendar, to make eras take exactly one week (or a month),
+      * but it means eras might have different lengths.
+      */
+    case class Calendar(length: Long, unit: CalendarUnit) extends EraDuration
+
+    sealed trait CalendarUnit
+    object CalendarUnit {
+      case object SECONDS extends CalendarUnit
+      case object MINUTES extends CalendarUnit
+      case object HOURS   extends CalendarUnit
+      case object DAYS    extends CalendarUnit
+      case object WEEKS   extends CalendarUnit
+      case object MONTHS  extends CalendarUnit
+      case object YEARS   extends CalendarUnit
+    }
+  }
+
+  /** Describe how long after the end of the era validator need to keep producing ballots to finalize the last few blocks. */
+  sealed trait VotingDuration
+  object VotingDuration {
+
+    /** Produce ballots according to the leader schedule for up to a certain number of ticks, e.g. 2 days. */
+    case class Ticks(ticks: Tick) extends VotingDuration
+
+    /** Produce ballots until a certain level of summits are achieved on top of the switch blocks. */
+    case class SummitLevel(k: Int) extends VotingDuration
+  }
+
+  implicit class Ops(val conf: HighwayConf) extends AnyVal {
+
+    def toTimestamp(t: Tick): Timestamp =
+      Timestamp(conf.tickUnit.toMillis(t))
+
+    def toTicks(t: Timestamp): Tick =
+      Tick(conf.tickUnit.convert(t, TimeUnit.MILLISECONDS))
+
+    def eraEndTick(startTick: Tick): Long = {
+      import EraDuration.CalendarUnit._
+      val UTC = ZoneId.of("UTC")
+
+      conf.eraDuration match {
+        case EraDuration.Ticks(ticks) =>
+          startTick + ticks
+
+        case EraDuration.Calendar(length, unit) =>
+          val s = LocalDateTime.ofInstant(Instant.ofEpochMilli(toTimestamp(startTick)), UTC)
+          val e = unit match {
+            case SECONDS => s.plusSeconds(length)
+            case MINUTES => s.plusMinutes(length)
+            case HOURS   => s.plusHours(length)
+            case DAYS    => s.plusDays(length)
+            case WEEKS   => s.plusWeeks(length)
+            case MONTHS  => s.plusMonths(length)
+            case YEARS   => s.plusYears(length)
+          }
+          val t = e.atZone(UTC).toInstant.toEpochMilli
+          toTicks(Timestamp(t))
+      }
+    }
+
+    //def genesisEraLengthMultiplier
+  }
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -90,7 +90,7 @@ final case class HighwayConf(
     */
   def criticalBoundaries(startTick: Ticks, endTick: Ticks, delayTicks: Ticks): List[Ticks] = {
     def loop(acc: List[Ticks], nextStartTick: Ticks): List[Ticks] = {
-      val boundary = Ticks(nextStartTick - delayTicks)
+      val boundary = nextStartTick minus delayTicks
       if (boundary < startTick) loop(acc, eraEndTick(nextStartTick))
       else if (boundary < endTick) loop(boundary :: acc, eraEndTick(nextStartTick))
       else acc

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -20,9 +20,15 @@ final case class HighwayConf(
 ) {
   import HighwayConf._
 
+  /** Number of ticks to go back before the start of the era for picking the key block. */
+  def keyTicks: Ticks =
+    Ticks(bookingTicks - entropyTicks)
+
+  /** Convert a tick based time to Unix timestamp. */
   def toTimestamp(t: Ticks): Timestamp =
     Timestamp(tickUnit.toMillis(t))
 
+  /** Convert a Unix timestamp to ticks. */
   def toTicks(t: Timestamp): Ticks =
     Ticks(tickUnit.convert(t, TimeUnit.MILLISECONDS))
 
@@ -79,7 +85,7 @@ final case class HighwayConf(
     * For example era 2 will use 1a, and era 3 will use 1b:
     *   1a     1b     2      3
     * | .      .   |  .   |  .   |
-    * The function return the list of ticks that are a certain delay
+    * The function returns the list of ticks that are a certain delay
     * back from the start of a upcoming era.
     */
   def criticalBoundaries(startTick: Ticks, endTick: Ticks, delayTicks: Ticks): List[Ticks] = {

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -22,7 +22,7 @@ final case class HighwayConf(
 
   /** Number of ticks to go back before the start of the era for picking the key block. */
   def keyTicks: Ticks =
-    Ticks(bookingTicks - entropyTicks)
+    bookingTicks minus entropyTicks
 
   /** Convert a tick based time to Unix timestamp. */
   def toTimestamp(t: Ticks): Timestamp =
@@ -38,7 +38,7 @@ final case class HighwayConf(
 
     duration match {
       case EraDuration.FixedLength(ticks) =>
-        Ticks(startTick + ticks)
+        startTick plus ticks
 
       case EraDuration.Calendar(length, unit) =>
         val s = LocalDateTime.ofInstant(Instant.ofEpochMilli(toTimestamp(startTick)), UTC)

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -7,32 +7,41 @@ import scala.concurrent.duration._
 final case class HighwayConf(
     /** Real-world time unit for one tick. */
     tickUnit: TimeUnit,
-    /** Starting tick for the genesis era, measured in ticks since the Unix epoch. */
-    genesisEraStartTick: Ticks,
+    /** Starting tick for the genesis era. */
+    genesisEraStartTick: Instant,
     /** Method for calculating the end of the era based on the start tick. */
     eraDuration: HighwayConf.EraDuration,
-    /** Number of ticks to go back before the start of the era for picking the booking block. */
-    bookingTicks: Ticks,
-    /** Number of ticks after the booking before we pick the key block, collecting the magic bits along the way. */
-    entropyTicks: Ticks,
+    /** Amount of time to go back before the start of the era for picking the booking block. */
+    bookingTicks: FiniteDuration,
+    /** Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way. */
+    entropyTicks: FiniteDuration,
     /** Stopping condition for producing ballots after the end of the era. */
     postEraVotingDuration: HighwayConf.VotingDuration
 ) {
   import HighwayConf._
 
-  /** Number of ticks to go back before the start of the era for picking the key block. */
-  def keyTicks: Ticks =
+  private val NanosPerSec = 1000000000L
+
+  /** Time to go back before the start of the era for picking the key block. */
+  def keyTicks: FiniteDuration =
     bookingTicks minus entropyTicks
 
-  /** Convert a tick based time to Unix timestamp. */
-  def toTimestamp(t: Ticks): Timestamp =
-    Timestamp(tickUnit.toMillis(t))
+  /** Convert a `timeUnit` specific (it's up to the caller to make sure this is compatible)
+    * number of ticks since the Unix epch to an instant in time.
+    */
+  def toInstant(t: Ticks): Instant = {
+    val n = tickUnit.toNanos(t)
+    val s = tickUnit.toSeconds(t)
+    Instant.ofEpochSecond(s, n - s * NanosPerSec)
+  }
 
-  /** Convert a Unix timestamp to ticks. */
-  def toTicks(t: Timestamp): Ticks =
-    Ticks(tickUnit.convert(t, TimeUnit.MILLISECONDS))
+  /** Convert an instant in time to the number of ticks we can store in the era model,
+    * or assign to a round ID in a block.
+    */
+  def toTicks(t: Instant): Ticks =
+    Ticks(tickUnit.convert(t.getEpochSecond * NanosPerSec + t.getNano.toLong, TimeUnit.NANOSECONDS))
 
-  private def eraEndTick(startTick: Ticks, duration: EraDuration): Ticks = {
+  private def eraEndTick(startTick: Instant, duration: EraDuration): Instant = {
     import EraDuration.CalendarUnit._
     val UTC = ZoneId.of("UTC")
 
@@ -41,7 +50,7 @@ final case class HighwayConf(
         startTick plus ticks
 
       case EraDuration.Calendar(length, unit) =>
-        val s = LocalDateTime.ofInstant(Instant.ofEpochMilli(toTimestamp(startTick)), UTC)
+        val s = LocalDateTime.ofInstant(startTick, UTC)
         val e = unit match {
           case SECONDS => s.plusSeconds(length)
           case MINUTES => s.plusMinutes(length)
@@ -51,13 +60,12 @@ final case class HighwayConf(
           case MONTHS  => s.plusMonths(length)
           case YEARS   => s.plusYears(length)
         }
-        val t = e.atZone(UTC).toInstant.toEpochMilli
-        toTicks(Timestamp(t))
+        e.atZone(UTC).toInstant
     }
   }
 
   /** Calculate the era end tick based on a start tick. */
-  def eraEndTick(startTick: Ticks): Ticks =
+  def eraEndTick(startTick: Instant): Instant =
     eraEndTick(startTick, eraDuration)
 
   /** The booking block is picked from a previous era, e.g. with 7 day eras
@@ -70,10 +78,10 @@ final case class HighwayConf(
     * genesis to look at, so the genesis era has to be longer to produce many
     * booking blocks, one for era 2, and one for era 3.
     */
-  def genesisEraEndTick: Ticks = {
+  def genesisEraEndTick: Instant = {
     val endTick    = eraEndTick(genesisEraStartTick)
-    val length     = endTick - genesisEraStartTick
-    val multiplier = 1 + bookingTicks / length
+    val length     = endTick.toEpochMilli - genesisEraStartTick.toEpochMilli
+    val multiplier = 1 + bookingTicks.toMillis / length
     (1 until multiplier.toInt).foldLeft(endTick)((t, _) => eraEndTick(t))
   }
 
@@ -88,11 +96,15 @@ final case class HighwayConf(
     * The function returns the list of ticks that are a certain delay
     * back from the start of a upcoming era.
     */
-  def criticalBoundaries(startTick: Ticks, endTick: Ticks, delayTicks: Ticks): List[Ticks] = {
-    def loop(acc: List[Ticks], nextStartTick: Ticks): List[Ticks] = {
+  def criticalBoundaries(
+      startTick: Instant,
+      endTick: Instant,
+      delayTicks: FiniteDuration
+  ): List[Instant] = {
+    def loop(acc: List[Instant], nextStartTick: Instant): List[Instant] = {
       val boundary = nextStartTick minus delayTicks
-      if (boundary < startTick) loop(acc, eraEndTick(nextStartTick))
-      else if (boundary < endTick) loop(boundary :: acc, eraEndTick(nextStartTick))
+      if (boundary isBefore startTick) loop(acc, eraEndTick(nextStartTick))
+      else if (boundary isBefore endTick) loop(boundary :: acc, eraEndTick(nextStartTick))
       else acc
     }
     loop(Nil, endTick).reverse
@@ -112,7 +124,7 @@ object HighwayConf {
       * In practice this shouldn't be a problem with the Java time library because it spreads
       * leap seconds throughout the day so that they appear to be exactly 86400 seconds.
       */
-    case class FixedLength(ticks: Ticks) extends EraDuration
+    case class FixedLength(ticks: FiniteDuration) extends EraDuration
 
     /** Fixed endings can be calculated with the calendar, to make eras take exactly one week (or a month),
       * but it means eras might have different lengths. Using this might mean that a different platform
@@ -137,7 +149,7 @@ object HighwayConf {
   object VotingDuration {
 
     /** Produce ballots according to the leader schedule for up to a certain number of ticks, e.g. 2 days. */
-    case class FixedLength(ticks: Ticks) extends VotingDuration
+    case class FixedLength(ticks: FiniteDuration) extends VotingDuration
 
     /** Produce ballots until a certain level of summits are achieved on top of the switch blocks. */
     case class SummitLevel(k: Int) extends VotingDuration

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -115,7 +115,8 @@ object HighwayConf {
     case class FixedLength(ticks: Ticks) extends EraDuration
 
     /** Fixed endings can be calculated with the calendar, to make eras take exactly one week (or a month),
-      * but it means eras might have different lengths.
+      * but it means eras might have different lengths. Using this might mean that a different platform
+      * which handles leap seconds differently could assign different tick IDs.
       */
     case class Calendar(length: Long, unit: CalendarUnit) extends EraDuration
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -4,7 +4,7 @@ import shapeless.tag.@@
 
 package highway {
   sealed trait TimestampTag
-  sealed trait TickTag
+  sealed trait TicksTag
 }
 
 package object highway {
@@ -13,7 +13,7 @@ package object highway {
   type Timestamp = Long @@ TimestampTag
   def Timestamp(t: Long) = t.asInstanceOf[Timestamp]
 
-  /** Ticks or rounds in an arbitrary time unit. */
-  type Tick = Long @@ TickTag
-  def Tick(t: Long) = t.asInstanceOf[Tick]
+  /** Ticks (a point in time or a duration) in an arbitrary time unit. */
+  type Ticks = Long @@ TicksTag
+  def Ticks(t: Long) = t.asInstanceOf[Ticks]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -16,4 +16,8 @@ package object highway {
   /** Ticks (a point in time or a duration) in an arbitrary time unit. */
   type Ticks = Long @@ TicksTag
   def Ticks(t: Long) = t.asInstanceOf[Ticks]
+  implicit class TicksOps(val a: Ticks) extends AnyVal {
+    def plus(b: Ticks)  = Ticks(a + b)
+    def minus(b: Ticks) = Ticks(a - b)
+  }
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -1,0 +1,19 @@
+package io.casperlabs.casper
+
+import shapeless.tag.@@
+
+package highway {
+  sealed trait TimestampTag
+  sealed trait TickTag
+}
+
+package object highway {
+
+  /** Time since Unix epoch in milliseconds. */
+  type Timestamp = Long @@ TimestampTag
+  def Timestamp(t: Long) = t.asInstanceOf[Timestamp]
+
+  /** Ticks or rounds in an arbitrary time unit. */
+  type Tick = Long @@ TickTag
+  def Tick(t: Long) = t.asInstanceOf[Tick]
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -1,5 +1,7 @@
 package io.casperlabs.casper
 
+import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 import shapeless.tag.@@
 
 package highway {
@@ -13,11 +15,13 @@ package object highway {
   type Timestamp = Long @@ TimestampTag
   def Timestamp(t: Long) = t.asInstanceOf[Timestamp]
 
-  /** Ticks (a point in time or a duration) in an arbitrary time unit. */
+  /** Ticks since Unix epoch in the Highway specific time unit. */
   type Ticks = Long @@ TicksTag
   def Ticks(t: Long) = t.asInstanceOf[Ticks]
-  implicit class TicksOps(val a: Ticks) extends AnyVal {
-    def plus(b: Ticks)  = Ticks(a + b)
-    def minus(b: Ticks) = Ticks(a - b)
+
+  implicit class InstantOps(val a: Instant) extends AnyVal {
+    def plus(b: FiniteDuration)  = a.plusNanos(b.toNanos)
+    def minus(b: FiniteDuration) = a.minusNanos(b.toNanos)
   }
+
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -1,39 +1,57 @@
 package io.casperlabs.casper.highway
 
+import com.google.protobuf.ByteString
 import java.util.concurrent.TimeUnit
 import io.casperlabs.casper.consensus.BlockSummary
 import org.scalatest._
 
 class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
+  import MilliTicks._
 
   val conf = HighwayConf(
     TimeUnit.MILLISECONDS,
-    MilliTicks.date(2019, 12, 9),
-    eraDuration = EraDuration.FixedLength(MilliTicks.days(7)),
-    bookingTicks = MilliTicks.days(10),
-    entropyTicks = MilliTicks.hours(3),
+    date(2019, 12, 9),
+    eraDuration = EraDuration.FixedLength(days(7)),
+    bookingTicks = days(10),
+    entropyTicks = hours(3),
     VotingDuration.FixedLength(Ticks(0))
   )
 
-  val genesis = BlockSummary()
+  val genesis = BlockSummary().withBlockHash(ByteString.copyFromUtf8("genesis"))
 
   "EraRuntime" when {
     "started with the genesis block" should {
       val runtime = EraRuntime.fromGenesis(conf, genesis)
 
+      "use the genesis ticks for the era" in {
+        runtime.era.startTick shouldBe conf.genesisEraStartTick
+        runtime.era.endTick shouldBe conf.genesisEraEndTick
+      }
+
+      "use the genesis block as key and booking block" in {
+        runtime.era.keyBlockHash shouldBe genesis.blockHash
+        runtime.era.bookingBlockHash shouldBe genesis.blockHash
+        runtime.era.leaderSeed shouldBe 0L
+      }
+
+      "not assign a parent era" in {
+        runtime.era.parentKeyBlockHash shouldBe ByteString.EMPTY
+      }
+
       "recognize booking block boundaries" in {
         def check(parentDay: Int, blockDay: Int) =
           runtime.isBookingBoundary(
-            MilliTicks.date(2019, 12, parentDay),
-            MilliTicks.date(2019, 12, blockDay)
+            date(2019, 12, parentDay),
+            date(2019, 12, blockDay)
           )
         runtime.bookingBoundaries should contain theSameElementsInOrderAs List(
-          MilliTicks.date(2019, 12, 13),
-          MilliTicks.date(2019, 12, 20)
+          date(2019, 12, 13),
+          date(2019, 12, 20)
         )
         check(4, 7) shouldBe false   // before the era
         check(11, 13) shouldBe true  // block falls on the first 10 day boundary
+        check(13, 13) shouldBe false // parent and child on the same exact round, but parent was first
         check(13, 14) shouldBe false // parent block falls on the first 10 day boundary but the child does not
         check(19, 20) shouldBe true  // block falls on the second 10 day boundary
         check(25, 28) shouldBe false // after the era
@@ -42,18 +60,28 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
       "recognize key block boundaries" in {
         def check(parentDay: Int, blockDay: Int) =
           runtime.isKeyBoundary(
-            MilliTicks.date(2019, 12, parentDay),
-            MilliTicks.date(2019, 12, blockDay)
+            date(2019, 12, parentDay),
+            date(2019, 12, blockDay)
           )
         runtime.keyBoundaries should contain theSameElementsInOrderAs List(
-          MilliTicks.date(2019, 12, 13) + MilliTicks.hours(3),
-          MilliTicks.date(2019, 12, 20) + MilliTicks.hours(3)
+          date(2019, 12, 13) plus hours(3),
+          date(2019, 12, 20) plus hours(3)
         )
         check(11, 13) shouldBe false
         check(13, 14) shouldBe true
+        check(14, 14) shouldBe false
         check(19, 20) shouldBe false
         check(20, 21) shouldBe true
         check(25, 28) shouldBe false
+      }
+
+      "recognize the switch block boundary" in {
+        val end  = conf.genesisEraEndTick
+        val `1h` = hours(1)
+        runtime.isSwitchBoundary(end minus `1h`, end plus `1h`) shouldBe true
+        runtime.isSwitchBoundary(end minus `1h`, end) shouldBe true
+        runtime.isSwitchBoundary(end, end) shouldBe false
+        runtime.isSwitchBoundary(end, end plus `1h`) shouldBe false
       }
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.casper.highway
 
+import cats.Id
 import com.google.protobuf.ByteString
 import java.util.concurrent.TimeUnit
 import io.casperlabs.casper.consensus.BlockSummary
@@ -22,7 +23,7 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
 
   "EraRuntime" when {
     "started with the genesis block" should {
-      val runtime = EraRuntime.fromGenesis(conf, genesis)
+      val runtime = EraRuntime.fromGenesis[Id](conf, genesis)
 
       "use the genesis ticks for the era" in {
         runtime.era.startTick shouldBe conf.genesisEraStartTick

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -1,0 +1,61 @@
+package io.casperlabs.casper.highway
+
+import java.util.concurrent.TimeUnit
+import io.casperlabs.casper.consensus.BlockSummary
+import org.scalatest._
+
+class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
+  import HighwayConf._
+
+  val conf = HighwayConf(
+    TimeUnit.MILLISECONDS,
+    MilliTicks.date(2019, 12, 9),
+    eraDuration = EraDuration.FixedLength(MilliTicks.days(7)),
+    bookingTicks = MilliTicks.days(10),
+    entropyTicks = MilliTicks.hours(3),
+    VotingDuration.FixedLength(Ticks(0))
+  )
+
+  val genesis = BlockSummary()
+
+  "EraRuntime" when {
+    "started with the genesis block" should {
+      val runtime = EraRuntime.fromGenesis(conf, genesis)
+
+      "recognize booking block boundaries" in {
+        def check(parentDay: Int, blockDay: Int) =
+          runtime.isBookingBoundary(
+            MilliTicks.date(2019, 12, parentDay),
+            MilliTicks.date(2019, 12, blockDay)
+          )
+        runtime.bookingBoundaries should contain theSameElementsInOrderAs List(
+          MilliTicks.date(2019, 12, 13),
+          MilliTicks.date(2019, 12, 20)
+        )
+        check(4, 7) shouldBe false   // before the era
+        check(11, 13) shouldBe true  // block falls on the first 10 day boundary
+        check(13, 14) shouldBe false // parent block falls on the first 10 day boundary but the child does not
+        check(19, 20) shouldBe true  // block falls on the second 10 day boundary
+        check(25, 28) shouldBe false // after the era
+      }
+
+      "recognize key block boundaries" in {
+        def check(parentDay: Int, blockDay: Int) =
+          runtime.isKeyBoundary(
+            MilliTicks.date(2019, 12, parentDay),
+            MilliTicks.date(2019, 12, blockDay)
+          )
+        runtime.keyBoundaries should contain theSameElementsInOrderAs List(
+          MilliTicks.date(2019, 12, 13) + MilliTicks.hours(3),
+          MilliTicks.date(2019, 12, 20) + MilliTicks.hours(3)
+        )
+        check(11, 13) shouldBe false
+        check(13, 14) shouldBe true
+        check(19, 20) shouldBe false
+        check(20, 21) shouldBe true
+        check(25, 28) shouldBe false
+      }
+    }
+  }
+
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -11,12 +11,12 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
   import MilliTicks._
 
   val conf = HighwayConf(
-    TimeUnit.MILLISECONDS,
-    date(2019, 12, 9),
+    tickUnit = TimeUnit.MILLISECONDS,
+    genesisEraStartTick = date(2019, 12, 9),
     eraDuration = EraDuration.FixedLength(days(7)),
     bookingTicks = days(10),
     entropyTicks = hours(3),
-    VotingDuration.FixedLength(Ticks(0))
+    postEraVotingDuration = VotingDuration.FixedLength(Ticks(0))
   )
 
   val genesis = BlockSummary().withBlockHash(ByteString.copyFromUtf8("genesis"))

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -8,7 +8,6 @@ import org.scalatest._
 
 class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
-  import MilliTicks._
 
   val conf = HighwayConf(
     tickUnit = TimeUnit.MILLISECONDS,
@@ -16,7 +15,7 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
     eraDuration = EraDuration.FixedLength(days(7)),
     bookingTicks = days(10),
     entropyTicks = hours(3),
-    postEraVotingDuration = VotingDuration.FixedLength(Ticks(0))
+    postEraVotingDuration = VotingDuration.FixedLength(days(2))
   )
 
   val genesis = BlockSummary().withBlockHash(ByteString.copyFromUtf8("genesis"))
@@ -26,8 +25,8 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
       val runtime = EraRuntime.fromGenesis[Id](conf, genesis)
 
       "use the genesis ticks for the era" in {
-        runtime.era.startTick shouldBe conf.genesisEraStartTick
-        runtime.era.endTick shouldBe conf.genesisEraEndTick
+        conf.toInstant(Ticks(runtime.era.startTick)) shouldBe conf.genesisEraStartTick
+        conf.toInstant(Ticks(runtime.era.endTick)) shouldBe conf.genesisEraEndTick
       }
 
       "use the genesis block as key and booking block" in {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -1,19 +1,37 @@
 package io.casperlabs.casper.highway
 
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import org.scalatest._
 
 class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
 
+  val Zero = hours(0)
+
   val init = HighwayConf(
-    genesisEraStartTick = Ticks(0),
+    genesisEraStartTick = date(2000, 1, 3),
     tickUnit = TimeUnit.MILLISECONDS,
-    eraDuration = EraDuration.FixedLength(Ticks(0)),
-    bookingTicks = Ticks(0),
-    entropyTicks = Ticks(0),
-    postEraVotingDuration = VotingDuration.FixedLength(Ticks(0))
+    eraDuration = EraDuration.FixedLength(Zero),
+    bookingTicks = Zero,
+    entropyTicks = Zero,
+    postEraVotingDuration = VotingDuration.FixedLength(Zero)
   )
+
+  "toTicks" should {
+    "convert to the number of ticks since epoch" in {
+      init.toTicks(init.genesisEraStartTick) shouldBe Ticks(dateTimestamp(2000, 1, 3))
+    }
+  }
+
+  "toInstant" should {
+    "convert ticks to insants" in {
+      val a = Instant.ofEpochMilli(System.currentTimeMillis)
+      val b = init.toTicks(a)
+      val c = init.toInstant(b)
+      c shouldBe a
+    }
+  }
 
   "eraEndTick" when {
     // There was a leap second announced for 2008 Dec 31; that's surely included in JDK8.
@@ -22,17 +40,19 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
       "add the specified number of ticks" in {
         val conf = init.copy(
           tickUnit = TimeUnit.SECONDS,
-          eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60))
+          eraDuration = EraDuration.FixedLength(days(7))
         )
 
         // Start from the previous Monday midnight.
-        val startTick = conf.toTicks(dateTimestamp(2008, 12, 29))
+        val startTick = date(2008, 12, 29)
         val endTick   = conf.eraEndTick(startTick)
 
         // The GregorianCalendar doesn't deal with leap seconds,
         // while the LocalDateTime spreads it around; we should
         // not see any discrepancy.
-        endTick shouldBe dateTimestamp(2009, 1, 5) / 1000
+        endTick shouldBe date(2009, 1, 5)
+
+        conf.toTicks(endTick) shouldBe dateTimestamp(2009, 1, 5) / 1000
       }
     }
 
@@ -41,9 +61,9 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
         val conf = init.copy(
           eraDuration = EraDuration.Calendar(3, EraDuration.CalendarUnit.MONTHS)
         )
-        val startTick = conf.toTicks(dateTimestamp(2008, 12, 1))
+        val startTick = date(2008, 12, 1)
         val endTick   = conf.eraEndTick(startTick)
-        endTick shouldBe MilliTicks.date(2009, 3, 1)
+        endTick shouldBe date(2009, 3, 1)
       }
     }
   }
@@ -51,20 +71,20 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
   "genesisEraEndTick" should {
     "expand the genesis era to produce multiple booking blocks" in {
       val conf = init.copy(
-        genesisEraStartTick = MilliTicks.date(2019, 12, 16),
-        bookingTicks = MilliTicks.days(10),
-        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+        genesisEraStartTick = date(2019, 12, 16),
+        bookingTicks = days(10),
+        eraDuration = EraDuration.FixedLength(days(7))
       )
-      conf.genesisEraEndTick shouldBe MilliTicks.date(2019, 12, 30)
+      conf.genesisEraEndTick shouldBe date(2019, 12, 30)
     }
   }
 
   "criticalBoundaries" should {
     "collect all booking block ticks for the genesis era" in {
       val conf = init.copy(
-        genesisEraStartTick = MilliTicks.date(2019, 12, 2),
-        bookingTicks = MilliTicks.days(18),
-        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+        genesisEraStartTick = date(2019, 12, 2),
+        bookingTicks = days(18),
+        eraDuration = EraDuration.FixedLength(days(7))
       )
       val boundaries = conf.criticalBoundaries(
         conf.genesisEraStartTick,
@@ -73,26 +93,26 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
       )
 
       boundaries should contain theSameElementsInOrderAs List(
-        MilliTicks.date(2019, 12, 5),
-        MilliTicks.date(2019, 12, 12),
-        MilliTicks.date(2019, 12, 19)
+        date(2019, 12, 5),
+        date(2019, 12, 12),
+        date(2019, 12, 19)
       )
     }
 
     "collect just the single key tick for a normal era" in {
       val conf = init.copy(
-        bookingTicks = MilliTicks.days(10),
-        entropyTicks = MilliTicks.hours(2),
-        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+        bookingTicks = days(10),
+        entropyTicks = hours(2),
+        eraDuration = EraDuration.FixedLength(days(7))
       )
       val boundaries = conf.criticalBoundaries(
-        MilliTicks.date(2019, 12, 23),
-        MilliTicks.date(2019, 12, 30),
+        date(2019, 12, 23),
+        date(2019, 12, 30),
         conf.keyTicks
       )
 
       boundaries should contain only (
-        MilliTicks.date(2019, 12, 27) + MilliTicks.hours(2)
+        date(2019, 12, 27) plus hours(2)
       )
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -7,12 +7,12 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
 
   val init = HighwayConf(
-    TimeUnit.MILLISECONDS,
-    Ticks(0),
-    EraDuration.FixedLength(Ticks(0)),
-    Ticks(0),
-    Ticks(0),
-    VotingDuration.FixedLength(Ticks(0))
+    genesisEraStartTick = Ticks(0),
+    tickUnit = TimeUnit.MILLISECONDS,
+    eraDuration = EraDuration.FixedLength(Ticks(0)),
+    bookingTicks = Ticks(0),
+    entropyTicks = Ticks(0),
+    postEraVotingDuration = VotingDuration.FixedLength(Ticks(0))
   )
 
   "eraEndTick" when {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -56,7 +56,7 @@ class HighwayConfSpec extends WordSpec with Matchers {
     }
   }
 
-  "genesisEraEndtick" should {
+  "genesisEraEndTick" should {
     "expand the genesis era to produce multiple booking blocks" in {
       val conf = init.copy(
         genesisEraStartTick = Ticks(dateMillis(2019, 12, 16)),
@@ -64,6 +64,27 @@ class HighwayConfSpec extends WordSpec with Matchers {
         eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60 * 1000))
       )
       conf.genesisEraEndTick shouldBe dateMillis(2019, 12, 30)
+    }
+  }
+
+  "criticalBoundaries" should {
+    "collect all booking block ticks for the genesis era" in {
+      val conf = init.copy(
+        genesisEraStartTick = Ticks(dateMillis(2019, 12, 2)),
+        bookingTicks = Ticks(18 * 24 * 60 * 60 * 1000),
+        eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60 * 1000))
+      )
+      val boundaries = conf.criticalBoundaries(
+        conf.genesisEraStartTick,
+        conf.conf.genesisEraEndTick,
+        conf.bookingTicks
+      )
+
+      boundaries should contain theSameElementsInOrderAs List(
+        Ticks(dateMillis(2019, 12, 5)),
+        Ticks(dateMillis(2019, 12, 12)),
+        Ticks(dateMillis(2019, 12, 19))
+      )
     }
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -78,5 +78,22 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
         MilliTicks.date(2019, 12, 19)
       )
     }
+
+    "collect just the single key tick for a normal era" in {
+      val conf = init.copy(
+        bookingTicks = MilliTicks.days(10),
+        entropyTicks = MilliTicks.hours(2),
+        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+      )
+      val boundaries = conf.criticalBoundaries(
+        MilliTicks.date(2019, 12, 23),
+        MilliTicks.date(2019, 12, 30),
+        conf.keyTicks
+      )
+
+      boundaries should contain only (
+        MilliTicks.date(2019, 12, 27) + MilliTicks.hours(2)
+      )
+    }
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -47,13 +47,24 @@ class HighwayConfSpec extends WordSpec with Matchers {
     "eraDuration is given as Calendar" should {
       "add a specified calendar unit" in {
         val conf = init.copy(
-          tickUnit = TimeUnit.MILLISECONDS,
           eraDuration = EraDuration.Calendar(3, EraDuration.CalendarUnit.MONTHS)
         )
         val startTick = conf.toTicks(dateMillis(2008, 12, 1))
         val endTick   = conf.eraEndTick(startTick)
         endTick shouldBe dateMillis(2009, 3, 1)
       }
+    }
+  }
+
+  "genesisEraEndtick" should {
+    "expand the genesis era to produce multiple booking blocks" in {
+      val conf = init.copy(
+        genesisEraStartTick = Tick(dateMillis(2019, 12, 16)),
+        bookingTicks = Tick(10 * 24 * 60 * 60 * 1000),
+        eraDuration = EraDuration.Ticks(Tick(7 * 24 * 60 * 60 * 1000))
+      )
+
+      conf.genesisEraEndTick shouldBe dateMillis(2019, 12, 30)
     }
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -1,0 +1,59 @@
+package io.casperlabs.casper.highway
+
+import java.util.{Calendar, Date}
+import java.util.concurrent.TimeUnit
+import org.scalatest._
+
+class HighwayConfSpec extends WordSpec with Matchers {
+  import HighwayConf._
+
+  val init = HighwayConf(
+    TimeUnit.MILLISECONDS,
+    Tick(0),
+    EraDuration.Ticks(Tick(0)),
+    Tick(0),
+    Tick(0),
+    VotingDuration.Ticks(Tick(0))
+  )
+
+  def dateMillis(y: Int, m: Int, d: Int): Timestamp = {
+    val c = Calendar.getInstance
+    c.clear()
+    c.set(y, m - 1, d)
+    Timestamp(c.getTimeInMillis)
+  }
+
+  "eraEndTick" when {
+    // There was a leap second announced for 2008 Dec 31; that's surely included in JDK8.
+
+    "eraDuration is given as Ticks" should {
+      "add the specified number of ticks" in {
+        val conf = init.copy(
+          tickUnit = TimeUnit.SECONDS,
+          eraDuration = EraDuration.Ticks(Tick(7 * 24 * 60 * 60))
+        )
+
+        // Start from the previous Monday midnight.
+        val startTick = conf.toTicks(dateMillis(2008, 12, 29))
+        val endTick   = conf.eraEndTick(startTick)
+
+        // The GregorianCalendar doesn't deal with leap seconds,
+        // while the LocalDateTime spreads it around; we should
+        // not see any discrepancy.
+        endTick shouldBe dateMillis(2009, 1, 5) / 1000
+      }
+    }
+
+    "eraDuration is given as Calendar" should {
+      "add a specified calendar unit" in {
+        val conf = init.copy(
+          tickUnit = TimeUnit.MILLISECONDS,
+          eraDuration = EraDuration.Calendar(3, EraDuration.CalendarUnit.MONTHS)
+        )
+        val startTick = conf.toTicks(dateMillis(2008, 12, 1))
+        val endTick   = conf.eraEndTick(startTick)
+        endTick shouldBe dateMillis(2009, 3, 1)
+      }
+    }
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -1,10 +1,9 @@
 package io.casperlabs.casper.highway
 
-import java.util.{Calendar, Date}
 import java.util.concurrent.TimeUnit
 import org.scalatest._
 
-class HighwayConfSpec extends WordSpec with Matchers {
+class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
 
   val init = HighwayConf(
@@ -15,13 +14,6 @@ class HighwayConfSpec extends WordSpec with Matchers {
     Ticks(0),
     VotingDuration.FixedLength(Ticks(0))
   )
-
-  def dateMillis(y: Int, m: Int, d: Int): Timestamp = {
-    val c = Calendar.getInstance
-    c.clear()
-    c.set(y, m - 1, d)
-    Timestamp(c.getTimeInMillis)
-  }
 
   "eraEndTick" when {
     // There was a leap second announced for 2008 Dec 31; that's surely included in JDK8.
@@ -34,13 +26,13 @@ class HighwayConfSpec extends WordSpec with Matchers {
         )
 
         // Start from the previous Monday midnight.
-        val startTick = conf.toTicks(dateMillis(2008, 12, 29))
+        val startTick = conf.toTicks(dateTimestamp(2008, 12, 29))
         val endTick   = conf.eraEndTick(startTick)
 
         // The GregorianCalendar doesn't deal with leap seconds,
         // while the LocalDateTime spreads it around; we should
         // not see any discrepancy.
-        endTick shouldBe dateMillis(2009, 1, 5) / 1000
+        endTick shouldBe dateTimestamp(2009, 1, 5) / 1000
       }
     }
 
@@ -49,9 +41,9 @@ class HighwayConfSpec extends WordSpec with Matchers {
         val conf = init.copy(
           eraDuration = EraDuration.Calendar(3, EraDuration.CalendarUnit.MONTHS)
         )
-        val startTick = conf.toTicks(dateMillis(2008, 12, 1))
+        val startTick = conf.toTicks(dateTimestamp(2008, 12, 1))
         val endTick   = conf.eraEndTick(startTick)
-        endTick shouldBe dateMillis(2009, 3, 1)
+        endTick shouldBe MilliTicks.date(2009, 3, 1)
       }
     }
   }
@@ -59,31 +51,31 @@ class HighwayConfSpec extends WordSpec with Matchers {
   "genesisEraEndTick" should {
     "expand the genesis era to produce multiple booking blocks" in {
       val conf = init.copy(
-        genesisEraStartTick = Ticks(dateMillis(2019, 12, 16)),
-        bookingTicks = Ticks(10 * 24 * 60 * 60 * 1000),
-        eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60 * 1000))
+        genesisEraStartTick = MilliTicks.date(2019, 12, 16),
+        bookingTicks = MilliTicks.days(10),
+        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
       )
-      conf.genesisEraEndTick shouldBe dateMillis(2019, 12, 30)
+      conf.genesisEraEndTick shouldBe MilliTicks.date(2019, 12, 30)
     }
   }
 
   "criticalBoundaries" should {
     "collect all booking block ticks for the genesis era" in {
       val conf = init.copy(
-        genesisEraStartTick = Ticks(dateMillis(2019, 12, 2)),
-        bookingTicks = Ticks(18 * 24 * 60 * 60 * 1000),
-        eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60 * 1000))
+        genesisEraStartTick = MilliTicks.date(2019, 12, 2),
+        bookingTicks = MilliTicks.days(18),
+        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
       )
       val boundaries = conf.criticalBoundaries(
         conf.genesisEraStartTick,
-        conf.conf.genesisEraEndTick,
+        conf.genesisEraEndTick,
         conf.bookingTicks
       )
 
       boundaries should contain theSameElementsInOrderAs List(
-        Ticks(dateMillis(2019, 12, 5)),
-        Ticks(dateMillis(2019, 12, 12)),
-        Ticks(dateMillis(2019, 12, 19))
+        MilliTicks.date(2019, 12, 5),
+        MilliTicks.date(2019, 12, 12),
+        MilliTicks.date(2019, 12, 19)
       )
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -9,11 +9,11 @@ class HighwayConfSpec extends WordSpec with Matchers {
 
   val init = HighwayConf(
     TimeUnit.MILLISECONDS,
-    Tick(0),
-    EraDuration.Ticks(Tick(0)),
-    Tick(0),
-    Tick(0),
-    VotingDuration.Ticks(Tick(0))
+    Ticks(0),
+    EraDuration.FixedLength(Ticks(0)),
+    Ticks(0),
+    Ticks(0),
+    VotingDuration.FixedLength(Ticks(0))
   )
 
   def dateMillis(y: Int, m: Int, d: Int): Timestamp = {
@@ -30,7 +30,7 @@ class HighwayConfSpec extends WordSpec with Matchers {
       "add the specified number of ticks" in {
         val conf = init.copy(
           tickUnit = TimeUnit.SECONDS,
-          eraDuration = EraDuration.Ticks(Tick(7 * 24 * 60 * 60))
+          eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60))
         )
 
         // Start from the previous Monday midnight.
@@ -59,11 +59,10 @@ class HighwayConfSpec extends WordSpec with Matchers {
   "genesisEraEndtick" should {
     "expand the genesis era to produce multiple booking blocks" in {
       val conf = init.copy(
-        genesisEraStartTick = Tick(dateMillis(2019, 12, 16)),
-        bookingTicks = Tick(10 * 24 * 60 * 60 * 1000),
-        eraDuration = EraDuration.Ticks(Tick(7 * 24 * 60 * 60 * 1000))
+        genesisEraStartTick = Ticks(dateMillis(2019, 12, 16)),
+        bookingTicks = Ticks(10 * 24 * 60 * 60 * 1000),
+        eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60 * 1000))
       )
-
       conf.genesisEraEndTick shouldBe dateMillis(2019, 12, 30)
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
@@ -1,0 +1,17 @@
+package io.casperlabs.casper.highway
+
+import java.util.Calendar
+
+trait TickUtils {
+  def dateTimestamp(y: Int, m: Int, d: Int): Timestamp = {
+    val c = Calendar.getInstance
+    c.clear()
+    c.set(y, m - 1, d)
+    Timestamp(c.getTimeInMillis)
+  }
+
+  object MilliTicks {
+    def days(d: Long)                = Ticks(d * 24 * 60 * 60 * 1000)
+    def date(y: Int, m: Int, d: Int) = Ticks(dateTimestamp(y, m, d))
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
@@ -11,7 +11,8 @@ trait TickUtils {
   }
 
   object MilliTicks {
-    def days(d: Long)                = Ticks(d * 24 * 60 * 60 * 1000)
+    def days(d: Long)                = hours(d * 24)
+    def hours(h: Long)               = Ticks(h * 60 * 60 * 1000)
     def date(y: Int, m: Int, d: Int) = Ticks(dateTimestamp(y, m, d))
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
@@ -1,6 +1,8 @@
 package io.casperlabs.casper.highway
 
 import java.util.Calendar
+import java.time.Instant
+import scala.concurrent.duration._
 
 trait TickUtils {
   def dateTimestamp(y: Int, m: Int, d: Int): Timestamp = {
@@ -10,9 +12,7 @@ trait TickUtils {
     Timestamp(c.getTimeInMillis)
   }
 
-  object MilliTicks {
-    def days(d: Long)                = hours(d * 24)
-    def hours(h: Long)               = Ticks(h * 60 * 60 * 1000)
-    def date(y: Int, m: Int, d: Int) = Ticks(dateTimestamp(y, m, d))
-  }
+  def days(d: Long)                = d.days
+  def hours(h: Long)               = h.hours
+  def date(y: Int, m: Int, d: Int) = Instant.ofEpochMilli(dateTimestamp(y, m, d))
 }

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -228,10 +228,10 @@ message Era {
     bytes key_block_hash = 1;
     // Identifier of the parent era.
     bytes parent_key_block_hash = 2;
-    // First round (basically the timestamp) of the era.
-    uint64 start_round_id = 3;
+    // Number of ticks since Unix epoch (in the protocol specific units) when the era starts.
+    uint64 start_tick = 3;
     // Last round of the era (non-inclusive), after which the first block is the switch block.
-    uint64 end_round_id = 4;
+    uint64 end_tick = 4;
     // The hash of the booking block which was reachable from the key block;
     // this is where the bonds are coming, included in the era for reference.
     bytes booking_block_hash = 5;

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -135,6 +135,7 @@ message Block {
         GlobalState state = 3;
         // Hash of the body structure as a whole.
         bytes body_hash = 4;
+        // Unix timestamp from when the block was created.
         uint64 timestamp = 5;
         state.ProtocolVersion protocol_version = 13;
         uint32 deploy_count = 7;
@@ -151,7 +152,16 @@ message Block {
         uint64 rank = 11;
         MessageType message_type = 12;
         // A block from where the fork choice is calculated.
+        // Corresponds to the era the block belongs to.
         bytes key_block_hash = 15;
+        // The round ID (the idealistic protocol timestamp) to which the block belongs;
+        // this will be slightly different from the timestamp, which is the wall clock time
+        // of when the block was _actually_ created.
+        uint64 round_id = 16;
+        // A random bit set by the creator of the block which is goes towards the leader seed
+        // of the era. Only leader blocks (i.e. lambda messages) have to set it; should be
+        // empty for ballots.
+        bool magic_bit = 17;
     }
 
     enum MessageType {
@@ -210,4 +220,23 @@ message GenesisCandidate {
 
     // Approvals from bonded validators with signatures over the `block_hash`.
     repeated Approval approvals = 2;
+}
+
+
+message Era {
+    // Key block of the era, which is basically its identifier.
+    bytes key_block_hash = 1;
+    // Identifier of the parent era.
+    bytes parent_key_block_hash = 2;
+    // First round (basically the timestamp) of the era.
+    uint64 start_round_id = 3;
+    // Last round of the era (non-inclusive), after which the first block is the switch block.
+    uint64 end_round_id = 4;
+    // The hash of the booking block which was reachable from the key block;
+    // this is where the bonds are coming, included in the era for reference.
+    bytes booking_block_hash = 5;
+    // The random seed compiled from the magic bits between the booking block and the key block.
+    int64 leader_seed = 6;
+    // Bonded validator weights from the booking block.
+    repeated Bond bonds = 7;
 }


### PR DESCRIPTION
### Overview
As @goral09 pointed out in https://github.com/CasperLabs/CasperLabs/pull/1474 the `Ticks` data type mixes time instants and durations, and could carry a unit as well. 

Since these are mostly available in Scala and Java, here's an alternative PR that uses `Instant` and `FiniteDuration` instead of the single `Long`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1082

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
