### PR TITLE
NODE-1078: Stream of finalized blocks.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -1,8 +1,10 @@
 package io.casperlabs.casper
 
+import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus.info.BlockInfo
 import simulacrum.typeclass
 
 @typeclass trait EventEmitter[F[_]] {
   def blockAdded(blockInfo: BlockInfo): F[Unit]
+  def newLFB(lfb: BlockHash, indirectlyFinalized: Set[BlockHash] = Set.empty): F[Unit]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -175,7 +175,8 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
                   secondary.map(PrettyPrinter.buildString).mkString("{", ", ", "}")
                 Log[F].info(
                   s"New last finalized block hashes are ${mainParentFinalizedStr -> null}, ${secondaryParentsFinalizedStr -> null}."
-                ) >> EventEmitter[F].newLFB(mainParent, secondary)
+                ) >> LastFinalizedBlockHashContainer[F].set(mainParent) *> EventEmitter[F]
+                  .newLFB(mainParent, secondary)
               }
             }
       } yield ()

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -16,7 +16,8 @@ import io.casperlabs.casper.consensus.state.ProtocolVersion
 import io.casperlabs.casper.consensus.Block.Justification
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.equivocations.EquivocationDetector
-import io.casperlabs.casper.finality.CommitteeWithConsensusValue
+import io.casperlabs.casper.finality.MultiParentFinalizer.FinalizedBlocks
+import io.casperlabs.casper.finality.MultiParentFinalizer
 import io.casperlabs.casper.finality.votingmatrix.FinalityDetectorVotingMatrix
 import io.casperlabs.casper.util._
 import io.casperlabs.casper.util.ProtocolVersions.Config
@@ -58,7 +59,7 @@ final case class CasperState(
 )
 
 @silent("is never used")
-class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: DagStorage: DeployBuffer: ExecutionEngineService: LastFinalizedBlockHashContainer: FinalityDetectorVotingMatrix: DeployStorage: Validation: Fs2Compiler: DeploySelection: CasperLabsProtocol: EventEmitter](
+class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: DagStorage: DeployBuffer: ExecutionEngineService: LastFinalizedBlockHashContainer: MultiParentFinalizer: DeployStorage: Validation: Fs2Compiler: DeploySelection: CasperLabsProtocol: EventEmitter](
     validatorSemaphoreMap: SemaphoreMap[F, ByteString],
     statelessExecutor: MultiParentCasperImpl.StatelessExecutor[F],
     validatorId: Option[ValidatorIdentity],
@@ -155,36 +156,35 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
       hashPrefix = PrettyPrinter.buildString(block.blockHash)
       // Update the last finalized block; remove finalized deploys from the buffer
       _ <- Log[F].debug(s"Updating last finalized block after adding ${hashPrefix -> "block"}")
-      updatedLFB <- if (status == Valid) updateLastFinalizedBlock(block, dag)
-                   else false.pure[F]
+      finalizedBlocks <- if (status == Valid) updateLastFinalizedBlock(block, dag)
+                        else Set.empty[BlockHash].pure[F]
       // Remove any deploys from the buffer which are in finalized blocks.
       _ <- {
         Log[F]
           .debug(s"Removing finalized deploys after adding ${hashPrefix -> "block"}") *>
-          LastFinalizedBlockHashContainer[F].get >>= { lfb =>
-          DeployBuffer.removeFinalizedDeploys[F](lfb).forkAndLog
-        }
-      }.whenA(updatedLFB)
+          DeployBuffer.removeFinalizedDeploys[F](finalizedBlocks).forkAndLog
+      }.whenA(finalizedBlocks.nonEmpty)
       _ <- Log[F].debug(s"Finished adding ${hashPrefix -> "block"}")
     } yield status
   }
 
   /** Update the finalized block; return true if it changed. */
-  private def updateLastFinalizedBlock(block: Block, dag: DagRepresentation[F]): F[Boolean] =
+  private def updateLastFinalizedBlock(block: Block, dag: DagRepresentation[F]): F[Set[BlockHash]] =
     Metrics[F].timer("updateLastFinalizedBlock") {
       for {
-        lastFinalizedBlockHash <- LastFinalizedBlockHashContainer[F].get
-        result <- FinalityDetectorVotingMatrix[F].onNewBlockAddedToTheBlockDag(
-                   dag,
-                   block,
-                   lastFinalizedBlockHash
-                 )
-        changed <- result.fold(false.pure[F]) {
-                    case CommitteeWithConsensusValue(validator, quorum, consensusValue) =>
+        result <- MultiParentFinalizer[F].onNewBlockAdded(block)
+        changed <- result.fold(Set.empty[BlockHash].pure[F]) {
+                    case fb @ FinalizedBlocks(mainParent, secondary) => {
+                      val mainParentFinalizedStr = PrettyPrinter.buildString(
+                        mainParent
+                      )
+                      val secondaryParentsFinalizedStr =
+                        secondary.map(PrettyPrinter.buildString).mkString("{", ", ", "}")
                       Log[F].info(
-                        s"New last finalized block hash is ${PrettyPrinter.buildString(consensusValue)}."
+                        s"New last finalized block hashes are ${mainParentFinalizedStr -> null}, ${secondaryParentsFinalizedStr -> null}."
                       ) >>
-                        LastFinalizedBlockHashContainer[F].set(consensusValue).as(true)
+                        LastFinalizedBlockHashContainer[F].set(mainParent).as(fb.finalizedBlocks)
+                    }
                   }
       } yield changed
     }
@@ -523,12 +523,17 @@ object MultiParentCasperImpl {
               hashes =>
                 DagOperations.latestCommonAncestorsMainParent[F](dag, hashes).map(_.messageHash)
             }
-      implicit0(finalizer: FinalityDetectorVotingMatrix[F]) <- FinalityDetectorVotingMatrix
-                                                                .of[F](
-                                                                  dag,
-                                                                  lca,
-                                                                  faultToleranceThreshold
-                                                                )
+      finalityDetector <- FinalityDetectorVotingMatrix
+                           .of[F](
+                             dag,
+                             lca,
+                             faultToleranceThreshold
+                           )
+      implicit0(multiParentFinalizer: MultiParentFinalizer[F]) <- MultiParentFinalizer.empty[F](
+                                                                   dag,
+                                                                   lca,
+                                                                   finalityDetector
+                                                                 )
       _ <- LastFinalizedBlockHashContainer[F].set(lca)
     } yield new MultiParentCasperImpl[F](
       semaphoreMap,

--- a/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetector.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetector.scala
@@ -1,0 +1,15 @@
+package io.casperlabs.casper.finality
+
+import io.casperlabs.casper.Estimator.BlockHash
+import io.casperlabs.casper.consensus.Block
+import io.casperlabs.storage.dag.DagRepresentation
+
+trait FinalityDetector[F[_]] {
+
+  /** Signal whether any block is finalized when `block` is added to the DAG. */
+  def onNewBlockAddedToTheBlockDag(
+      dag: DagRepresentation[F],
+      block: Block,
+      latestFinalizedBlock: BlockHash
+  ): F[Option[CommitteeWithConsensusValue]]
+}

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -1,0 +1,70 @@
+package io.casperlabs.casper.finality
+
+import cats.Applicative
+import cats.syntax.functor._
+import cats.syntax.flatMap._
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Ref, Semaphore}
+import io.casperlabs.casper.Estimator.BlockHash
+import io.casperlabs.casper.consensus.Block
+import io.casperlabs.casper.finality.MultiParentFinalizer.FinalizedBlocks
+import io.casperlabs.storage.dag.DagRepresentation
+import simulacrum.typeclass
+
+@typeclass trait MultiParentFinalizer[F[_]] {
+
+  /** Returns set of finalized blocks.
+    *
+    * NOTE: This mimicks [[FinalityDetectorVotingMatrix]] API because we are working with the multi-parent
+    * fork choice.
+    */
+  def onNewBlockAdded(block: Block): F[Option[FinalizedBlocks]]
+}
+
+object MultiParentFinalizer {
+  final case class FinalizedBlocks(
+      mainChain: BlockHash,
+      secondaryParents: Set[BlockHash] = Set.empty
+  )
+  // TODO: Populate `latestLFB` and `finalizedBlocks` from the DB on startup.
+  def create[F[_]: Concurrent](
+      dag: DagRepresentation[F],
+      latestLFB: BlockHash,            // Last LFB from the main chain
+      finalizedBlocks: Set[BlockHash], // Set of blocks finalized so far. Will be used as a cache.
+      finalityDetector: FinalityDetector[F]
+  ): F[MultiParentFinalizer[F]] =
+    for {
+      finalizedBlocksCache <- Ref[F].of[Set[BlockHash]](finalizedBlocks)
+      lfbCache             <- Ref[F].of[BlockHash](latestLFB)
+      semaphore            <- Semaphore[F](1)
+    } yield new MultiParentFinalizer[F] {
+
+      /** Returns set of finalized blocks */
+      override def onNewBlockAdded(block: Block): F[Option[FinalizedBlocks]] =
+        semaphore.withPermit(for {
+          previousLFB    <- lfbCache.get
+          finalizedBlock <- finalityDetector.onNewBlockAddedToTheBlockDag(dag, block, previousLFB)
+          finalized <- finalizedBlock.fold(Applicative[F].pure(None: Option[FinalizedBlocks])) {
+                        case CommitteeWithConsensusValue(_, _, newLFB) =>
+                          for {
+                            _              <- lfbCache.set(newLFB)
+                            finalizedSoFar <- finalizedBlocksCache.get
+                            justFinalized <- FinalityDetectorUtil.finalizedIndirectly[F](
+                                              newLFB,
+                                              finalizedSoFar,
+                                              dag
+                                            )
+                            _ <- finalizedBlocksCache.update(_ ++ justFinalized + newLFB)
+                            // TODO: Persist finalized blocks in the DB.
+                          } yield Some(FinalizedBlocks(newLFB, justFinalized))
+                      }
+        } yield finalized)
+    }
+
+  def empty[F[_]: Concurrent](
+      dag: DagRepresentation[F],
+      latestLFB: BlockHash,
+      finalityDetector: FinalityDetector[F]
+  ): F[MultiParentFinalizer[F]] =
+    create[F](dag, latestLFB, Set(latestLFB), finalityDetector)
+}

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -58,7 +58,6 @@ object MultiParentFinalizer {
                                               dag
                                             )
                             _ <- finalizedBlocksCache.update(_ ++ justFinalized + newLFB)
-                            // TODO: Persist finalized blocks in the DB.
                           } yield Some(FinalizedBlocks(newLFB, justFinalized))
                       }
         } yield finalized)

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -25,7 +25,10 @@ object MultiParentFinalizer {
   final case class FinalizedBlocks(
       mainChain: BlockHash,
       secondaryParents: Set[BlockHash] = Set.empty
-  )
+  ) {
+    def finalizedBlocks: Set[BlockHash] = secondaryParents + mainChain
+  }
+
   // TODO: Populate `latestLFB` and `finalizedBlocks` from the DB on startup.
   def create[F[_]: Concurrent](
       dag: DagRepresentation[F],

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
@@ -8,7 +8,7 @@ import cats.{Applicative, Monad}
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.PrettyPrinter
 import io.casperlabs.casper.consensus.Block
-import io.casperlabs.casper.finality.CommitteeWithConsensusValue
+import io.casperlabs.casper.finality.{CommitteeWithConsensusValue, FinalityDetector}
 import io.casperlabs.casper.finality.votingmatrix.FinalityDetectorVotingMatrix._votingMatrixS
 import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.catscontrib.MonadThrowable
@@ -18,7 +18,7 @@ import io.casperlabs.storage.dag.DagRepresentation
 
 class FinalityDetectorVotingMatrix[F[_]: Concurrent: Log] private (rFTT: Double)(
     implicit private val matrix: _votingMatrixS[F]
-) {
+) extends FinalityDetector[F] {
 
   /**
     * Incremental update voting matrix when a new block added to the dag
@@ -27,7 +27,7 @@ class FinalityDetectorVotingMatrix[F[_]: Concurrent: Log] private (rFTT: Double)
     * @param latestFinalizedBlock latest finalized block
     * @return
     */
-  def onNewBlockAddedToTheBlockDag(
+  override def onNewBlockAddedToTheBlockDag(
       dag: DagRepresentation[F],
       block: Block,
       latestFinalizedBlock: BlockHash

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1049,15 +1049,6 @@ abstract class HashSetCasperTest
     val BlockMsgWithTransform(Some(genesisWithEqualBonds), transformsWithEqualBonds) =
       buildGenesis(Map.empty, equalBonds, 0L)
 
-    def checkLastFinalizedBlock(
-        node: HashSetCasperTestNode[Task],
-        expected: Block
-    )(implicit pos: org.scalactic.source.Position): Task[Unit] =
-      node.casperEff.lastFinalizedBlock map { block =>
-        PrettyPrinter.buildString(block) shouldBe PrettyPrinter.buildString(expected)
-        ()
-      }
-
     for {
       nodes <- networkEff(
                 validatorKeys.take(3),
@@ -1067,31 +1058,31 @@ abstract class HashSetCasperTest
               )
       deployDatas <- (1L to 10L).toList.traverse(_ => ProtoUtil.basicDeploy[Task]())
 
-      _ <- nodes(0).deployBuffer.addDeploy(deployDatas(0)) *> nodes(0).propose()
+      _ <- nodes(0).deployAndPropose(deployDatas(0))
       _ <- nodes(1).receive()
       _ <- nodes(2).receive()
 
-      block2 <- nodes(1).deployBuffer.addDeploy(deployDatas(1)) *> nodes(1).propose()
+      block2 <- nodes(1).deployAndPropose(deployDatas(1))
       _      <- nodes(0).receive()
       _      <- nodes(2).receive()
 
-      block3 <- nodes(2).deployBuffer.addDeploy(deployDatas(2)) *> nodes(2).propose()
+      block3 <- nodes(2).deployAndPropose(deployDatas(2))
       _      <- nodes(0).receive()
       _      <- nodes(1).receive()
 
-      block4 <- nodes(0).deployBuffer.addDeploy(deployDatas(3)) *> nodes(0).propose()
+      block4 <- nodes(0).deployAndPropose(deployDatas(3))
       _      <- nodes(1).receive()
       _      <- nodes(2).receive()
 
-      block5 <- nodes(1).deployBuffer.addDeploy(deployDatas(4)) *> nodes(1).propose()
+      block5 <- nodes(1).deployAndPropose(deployDatas(4))
       _      <- nodes(0).receive()
       _      <- nodes(2).receive()
 
-      block6 <- nodes(2).deployBuffer.addDeploy(deployDatas(5)) *> nodes(2).propose()
+      block6 <- nodes(2).deployAndPropose(deployDatas(5))
       _      <- nodes(0).receive()
       _      <- nodes(1).receive()
 
-      _                     <- checkLastFinalizedBlock(nodes(0), block2)
+      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block2
       pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
       _                     = pendingOrProcessedNum should be(1)
 
@@ -1099,7 +1090,7 @@ abstract class HashSetCasperTest
       _ <- nodes(1).receive()
       _ <- nodes(2).receive()
 
-      _                     <- checkLastFinalizedBlock(nodes(0), block3)
+      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
       pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
       _                     = pendingOrProcessedNum should be(2) // deploys contained in block 4 and block 7
 
@@ -1107,7 +1098,7 @@ abstract class HashSetCasperTest
       _ <- nodes(0).receive()
       _ <- nodes(2).receive()
 
-      _                     <- checkLastFinalizedBlock(nodes(0), block4)
+      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block4
       pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
       _                     = pendingOrProcessedNum should be(1) // deploys contained in block 7
 
@@ -1115,7 +1106,7 @@ abstract class HashSetCasperTest
       _ <- nodes(0).receive()
       _ <- nodes(1).receive()
 
-      _                     <- checkLastFinalizedBlock(nodes(0), block5)
+      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block5
       pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
       _                     = pendingOrProcessedNum should be(1) // deploys contained in block 7
 
@@ -1123,7 +1114,7 @@ abstract class HashSetCasperTest
       _ <- nodes(1).receive()
       _ <- nodes(2).receive()
 
-      _                     <- checkLastFinalizedBlock(nodes(0), block6)
+      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block6
       pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
       _                     = pendingOrProcessedNum should be(2) // deploys contained in block 7 and block 10
 

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -1,0 +1,173 @@
+package io.casperlabs.casper.finality
+
+import cats.Monad
+import cats.data.StateT
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.Estimator.BlockHash
+import io.casperlabs.casper.consensus.info.BlockInfo
+import io.casperlabs.casper.helper.BlockUtil.generateValidator
+import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
+import io.casperlabs.casper.util.BondingUtil.Bond
+import monix.eval.Task
+import org.scalatest.FlatSpec
+import io.casperlabs.casper.helper.ByteStringPrettifier._
+import io.casperlabs.casper.scalatestcontrib._
+import io.casperlabs.models.Message
+import io.casperlabs.storage.dag.DagRepresentation
+import io.casperlabs.storage.dag.DagRepresentation.Validator
+
+class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with StorageFixture {
+
+  behavior of "FinalityDetectorUtilTest"
+
+  // Who creates what doesn't matter in these tests.
+  val v1     = generateValidator("V1")
+  val v2     = generateValidator("V2")
+  val v1Bond = Bond(v1, 2)
+  val v2Bond = Bond(v2, 3)
+  val bonds  = Seq(v1Bond, v2Bond)
+
+  "finalizedIndirectly" should "finalize blocks in the p-past-cone of the block from the main chain" in withStorage {
+    implicit blockStorage => implicit dagStorage =>
+      _ =>
+        //
+        // G=A= = =B
+        //   \\A1/
+        // When B gets finalized A1 gets finalized indirectly.
+
+        for {
+          genesis <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY, bonds)
+          a       <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
+          a1      <- createAndStoreBlockFull[Task](v2, Seq(a), Seq.empty, bonds)
+          b       <- createAndStoreBlockFull[Task](v1, Seq(a, a1), Seq.empty, bonds)
+          dag     <- dagStorage.getRepresentation
+          finalizedIndirectly <- FinalityDetectorUtil.finalizedIndirectly[Task](
+                                  b.blockHash,
+                                  Set(genesis.blockHash, a.blockHash),
+                                  dag
+                                )
+        } yield assert(finalizedIndirectly == Set(a1.blockHash))
+  }
+
+  it should "not consider previously finalized blocks" in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      import FinalityDetectorUtilTest._
+      // Record how many times (if any) each node was visited.
+      type G[A] = StateT[Task, Map[BlockHash, Int], A]
+
+      /**
+        *           B = E
+        *          //   |
+        *         A = D |
+        *       // \   \|
+        *      G = C = F*
+        *
+        *  A main chain is G <- C <- F.
+        *  When F is finalized it's indirectly finalizing its p-past-cone:
+        *  {D, E, B, A}. There are three paths to reach A:
+        *  1. F -> D -> A
+        *  2. F -> E -> B -> A
+        *  3. F -> C -> A
+        *  `finalizedIndirectly` should not visit the same node twice.
+        *  It should also not traverse subgraphs of already finalized nodes,
+        *  i.e. since A is finalized with C, `finalizedIndirectly(F)` should not visit that node.
+        */
+      for {
+        genesis   <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        a         <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
+        b         <- createAndStoreBlockFull[Task](v1, Seq(a), Seq.empty, bonds)
+        c         <- createAndStoreBlockFull[Task](v1, Seq(genesis, a), Seq.empty, bonds)
+        dag       <- dagStorage.getRepresentation
+        stateTDag = stateTDagRepresentation(Task.catsAsync, dag) // For some reason scalac cannot infer this.
+        expectedNodesVisitedA = Map(
+          c.blockHash -> 1,
+          a.blockHash -> 1
+        )
+        _ <- FinalityDetectorUtil
+              .finalizedIndirectly[G](
+                c.blockHash,
+                Set(genesis.blockHash),
+                stateTDag
+              )
+              .run(Map.empty) shouldBeF ((expectedNodesVisitedA, Set(a.blockHash)))
+        d <- createAndStoreBlockFull[Task](v1, Seq(a), Seq.empty, bonds)
+        e <- createAndStoreBlockFull[Task](v1, Seq(b), Seq.empty, bonds)
+        f <- createAndStoreBlockFull[Task](v1, Seq(c, d, e), Seq.empty, bonds)
+        // Notice how neither C nor A are being visited.
+        expectedNodesVisitedB = Map(
+          f -> 1,
+          d -> 1,
+          e -> 1,
+          b -> 1
+        ).map(p => (p._1.blockHash, p._2))
+        _ <- FinalityDetectorUtil
+              .finalizedIndirectly[G](
+                f.blockHash,
+                Set(c.blockHash, a.blockHash, genesis.blockHash),
+                stateTDag
+              )
+              .run(Map.empty) shouldBeF (
+              (
+                expectedNodesVisitedB,
+                Set(d.blockHash, e.blockHash, b.blockHash)
+              )
+            )
+      } yield ()
+  }
+
+}
+
+object FinalityDetectorUtilTest {
+  import cats.implicits._
+
+  def stateTDagRepresentation[A, F[_]: Monad](
+      implicit D: DagRepresentation[F]
+  ): DagRepresentation[StateT[F, Map[BlockHash, Int], *]] =
+    new DagRepresentation[StateT[F, Map[BlockHash, Int], *]] {
+      // Record how many times (if any) each node was visited.
+      override def lookup(blockHash: BlockHash): StateT[F, Map[BlockHash, Int], Option[Message]] =
+        StateT
+          .modify[F, Map[BlockHash, Int]](_ |+| Map(blockHash -> 1))
+          .flatMapF(_ => D.lookup(blockHash))
+
+      // We're not interested in these
+      override def children(blockHash: BlockHash): StateT[F, Map[BlockHash, Int], Set[BlockHash]] =
+        ???
+
+      /** Return blocks that having a specify justification */
+      override def justificationToBlocks(
+          blockHash: BlockHash
+      ): StateT[F, Map[BlockHash, Int], Set[BlockHash]] = ???
+
+      override def contains(blockHash: BlockHash): StateT[F, Map[BlockHash, Int], Boolean] = ???
+
+      /** Return block summaries with ranks in the DAG between start and end, inclusive. */
+      override def topoSort(
+          startBlockNumber: Level,
+          endBlockNumber: Level
+      ): fs2.Stream[StateT[F, Map[BlockHash, Int], *], Vector[BlockInfo]] = ???
+
+      /** Return block summaries with ranks of blocks in the DAG from a start index to the end. */
+      override def topoSort(
+          startBlockNumber: Level
+      ): fs2.Stream[StateT[F, Map[BlockHash, Int], *], Vector[BlockInfo]] = ???
+
+      override def topoSortTail(
+          tailLength: Int
+      ): fs2.Stream[StateT[F, Map[BlockHash, Int], *], Vector[BlockInfo]] = ???
+
+      override def latestMessageHash(
+          validator: Validator
+      ): StateT[F, Map[BlockHash, Int], Set[BlockHash]] = ???
+
+      override def latestMessage(
+          validator: Validator
+      ): StateT[F, Map[BlockHash, Int], Set[Message]] = ???
+
+      override def latestMessageHashes
+          : StateT[F, Map[BlockHash, Int], Map[Validator, Set[BlockHash]]] = ???
+
+      override def latestMessages: StateT[F, Map[BlockHash, Int], Map[Validator, Set[Message]]] =
+        ???
+    }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -10,7 +10,6 @@ import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
 import io.casperlabs.casper.util.BondingUtil.Bond
 import monix.eval.Task
 import org.scalatest.FlatSpec
-import io.casperlabs.casper.helper.ByteStringPrettifier._
 import io.casperlabs.casper.scalatestcontrib._
 import io.casperlabs.models.Message
 import io.casperlabs.storage.dag.DagRepresentation

--- a/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
@@ -1,0 +1,163 @@
+package io.casperlabs.casper.finality
+
+import cats.Functor
+import cats.data.NonEmptyList
+import io.casperlabs.catscontrib.{Fs2Compiler, MonadThrowable}
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.Estimator.BlockHash
+import io.casperlabs.casper.PrettyPrinter
+import io.casperlabs.casper.consensus.Block
+import io.casperlabs.casper.finality.MultiParentFinalizer.FinalizedBlocks
+import io.casperlabs.casper.finality.votingmatrix.FinalityDetectorVotingMatrix
+import io.casperlabs.casper.helper.BlockUtil.generateValidator
+import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
+import io.casperlabs.casper.util.BondingUtil.Bond
+import io.casperlabs.casper.util.ProtoUtil
+import io.casperlabs.shared.{LogStub, Time}
+import io.casperlabs.storage.block.BlockStorage
+import io.casperlabs.storage.dag.{DagRepresentation, IndexedDagStorage}
+import monix.eval.Task
+import org.scalatest.FlatSpec
+
+class MultiParentFinalizerTest extends FlatSpec with BlockGenerator with StorageFixture {
+
+  behavior of "MultiParentFinalizer"
+
+  // Who creates what doesn't matter in these tests.
+  val v1     = generateValidator("A")
+  val v2     = generateValidator("Z")
+  val v1Bond = Bond(v1, 3)
+  val v2Bond = Bond(v2, 3)
+  val bonds  = Seq(v1Bond, v2Bond)
+
+  it should "cache block finalization so it doesn't revisit already finalized blocks." in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      for {
+        genesis <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        dag     <- dagStorage.getRepresentation
+        multiParentFinalizer <- MultiParentFinalizer.empty[Task](
+                                 dag,
+                                 genesis.blockHash,
+                                 MultiParentFinalizerTest.immediateFinality
+                               )
+        a                     <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
+        b                     <- createAndStoreBlockFull[Task](v2, Seq(genesis, a), Seq.empty, bonds)
+        newlyFinalizedBlocksA <- multiParentFinalizer.onNewBlockAdded(b)
+        // `b` is in main chain, `a` is secondary parent.
+        _ = assert(newlyFinalizedBlocksA.contains(FinalizedBlocks(b.blockHash, Set(a.blockHash))))
+        c <- createAndStoreBlockFull[Task](v1, Seq(b, a), Seq.empty, bonds)
+        // `c`'s main parent is `b`, secondary is a. Since `a` was already finalized through `b`,
+        // it should not be returned now.
+        newlyFinalizedBlocksB <- multiParentFinalizer.onNewBlockAdded(c)
+        _                     = assert(newlyFinalizedBlocksB.contains(FinalizedBlocks(c.blockHash)))
+      } yield ()
+  }
+
+  it should "cache LFB from the main chain; not return LFB when new block doesn't vote on LFB's child" in withStorage {
+    implicit blockStorage => implicit dagStorage => _ =>
+      implicit val noopLog = LogStub[Task]()
+
+      /** `B` is LFB but `C` doesn't vote for any of `B`'s children (empty vote).
+        * `MultiParentFinalizer` should cache LFB (`B`) and kick off new LFB calculation from it.
+        * Adding `C` should not return any LFB.
+        *
+        *  G = A = B*
+        *      \\= C
+        */
+      for {
+        genesis   <- createAndStoreBlock[Task](Seq(), ByteString.EMPTY, bonds)
+        dag       <- dagStorage.getRepresentation
+        finalizer <- FinalityDetectorVotingMatrix.of[Task](dag, genesis.blockHash, 0.1)
+        implicit0(multiParentFinalizer: MultiParentFinalizer[Task]) <- MultiParentFinalizer
+                                                                        .empty[Task](
+                                                                          dag,
+                                                                          genesis.blockHash,
+                                                                          finalizer
+                                                                        )
+        a        <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
+        nelBonds = NonEmptyList.fromListUnsafe(bonds.toList)
+        b <- MultiParentFinalizerTest
+              .finalizeBlock[Task](a.blockHash, nelBonds)
+              .flatMap(ProtoUtil.unsafeGetBlock[Task](_))
+        finalizedA <- multiParentFinalizer.onNewBlockAdded(b)
+        _          = assert(finalizedA.contains(FinalizedBlocks(a.blockHash)))
+
+        // `aPrime` is sibiling of `a`, another child of Genesis.
+        // Since `a` has already been finalized `aPrime` should never become chosen as new LFB.
+        // We are testing whether `MultiParentFinalizer` caches new LFB properly.
+        aPrime <- createAndStoreBlockFull[Task](v2, Seq(genesis), Seq.empty, bonds)
+        bPrime <- MultiParentFinalizerTest
+                   .finalizeBlock[Task](aPrime.blockHash, nelBonds)
+                   .flatMap(ProtoUtil.unsafeGetBlock[Task](_))
+        finalizedB <- multiParentFinalizer.onNewBlockAdded(bPrime)
+        _          = assert(finalizedB.isEmpty)
+      } yield ()
+  }
+}
+
+object MultiParentFinalizerTest extends BlockGenerator {
+  import cats.implicits._
+
+  /** Assembles a String that represents a DAG structure.
+    * One block per line in the form of: {rank} {main parent hash} {block hash} {validator id}.
+    */
+  def printDagTopoSort[F[_]: Fs2Compiler: Functor](dag: DagRepresentation[F]): F[String] =
+    dag
+      .topoSort(startBlockNumber = 0) // Start from Genesis.
+      .compile
+      .toVector
+      .map(_.flatten)
+      .map(
+        _.map(
+          blockInfo =>
+            s"${blockInfo.getSummary.getHeader.rank}:\t${PrettyPrinter.buildString(
+              blockInfo.getSummary.getHeader.parentHashes.headOption.getOrElse(ByteString.EMPTY)
+            )} <- ${PrettyPrinter
+              .buildString(blockInfo.getSummary.blockHash)} : ${PrettyPrinter
+              .buildString(blockInfo.getSummary.getHeader.validatorPublicKey)}"
+        ).mkString("\n")
+      )
+
+  /** Creates a chain of blocks that build on top of each other.
+    * Starts with `start` block hash.
+    *
+    * Returns last block hash in chain.
+    */
+  def createChainOfBlocks[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage: MultiParentFinalizer](
+      start: BlockHash,
+      bonds: NonEmptyList[Bond]
+  ): F[BlockHash] =
+    bonds.map(_.validatorPublicKey).toList.foldLeftM(start) {
+      case (prevHash, validatorId) =>
+        for {
+          block <- createAndStoreBlock[F](Seq(prevHash), validatorId, bonds.toList)
+          _     <- MultiParentFinalizer[F].onNewBlockAdded(block) // Update finalizer
+        } yield block.blockHash
+    }
+
+  /** Finalizes a `start` block.
+    *
+    * To finalize a block, we need level-1 summit (i.e. enough validators has to see enough validators voting for a block).
+    * The easiest way to achieve this is to a layer of messages that build on top of block we want to finalize.
+    *
+    * Returns last block hash in chain.
+    */
+  def finalizeBlock[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage: MultiParentFinalizer](
+      start: BlockHash,
+      bonds: NonEmptyList[Bond]
+  ): F[BlockHash] =
+    for {
+      a <- createChainOfBlocks[F](start, bonds)                          // Create level-0 summit
+      b <- createAndStoreBlock[F](Seq(a), bonds.head.validatorPublicKey) // Create level-1 summit
+    } yield b.blockHash
+
+  // Finalizes block it receives as argument.
+  val immediateFinality = new FinalityDetector[Task] {
+    override def onNewBlockAddedToTheBlockDag(
+        dag: DagRepresentation[Task],
+        block: Block,
+        latestFinalizedBlock: BlockHash
+    ): Task[Option[CommitteeWithConsensusValue]] =
+      Task(Some(CommitteeWithConsensusValue(Set.empty, 1L, block.blockHash)))
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
@@ -137,7 +137,7 @@ object MultiParentFinalizerTest extends BlockGenerator {
   /** Finalizes a `start` block.
     *
     * To finalize a block, we need level-1 summit (i.e. enough validators has to see enough validators voting for a block).
-    * The easiest way to achieve this is to a layer of messages that build on top of block we want to finalize.
+    * The easiest way to achieve this is to add a layer of messages that build on top of block we want to finalize.
     *
     * Returns last block hash in chain.
     */

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -10,6 +10,7 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.casper.MultiParentCasperImpl.Broadcaster
+import io.casperlabs.casper.finality.MultiParentFinalizer
 import io.casperlabs.casper.finality.votingmatrix.FinalityDetectorVotingMatrix
 import io.casperlabs.casper.validation.Validation
 import io.casperlabs.casper.{DeriveValidation, consensus, _}
@@ -52,7 +53,7 @@ class GossipServiceCasperTestNode[F[_]](
     dagStorage: DagStorage[F],
     deployStorage: DeployStorage[F],
     deployBuffer: DeployBuffer[F],
-    finalityDetector: FinalityDetectorVotingMatrix[F],
+    finalityDetector: MultiParentFinalizer[F],
     val timeEff: LogicalTime[F],
     metricEff: Metrics[F],
     casperState: Cell[F, CasperState],
@@ -153,6 +154,11 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
           _            <- blockStorage.put(genesis.blockHash, genesis, Seq.empty)
           finalityDetector <- FinalityDetectorVotingMatrix
                                .of[F](dag, genesis.blockHash, faultToleranceThreshold)
+          multiParentFinalizer <- MultiParentFinalizer.empty(
+                                   dag,
+                                   genesis.blockHash,
+                                   finalityDetector
+                                 )
           node = new GossipServiceCasperTestNode[F](
             identity,
             genesis,
@@ -169,7 +175,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
             dagStorage,
             deployStorage,
             deployBuffer,
-            finalityDetector,
+            multiParentFinalizer,
             timeEff,
             metricEff,
             casperState,
@@ -245,9 +251,14 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                 _                <- blockStorage.put(genesis.blockHash, genesis, Seq.empty)
                 dag              <- dagStorage.getRepresentation
                 finalityDetector <- FinalityDetectorVotingMatrix.of[F](dag, genesis.blockHash, 0.1)
-                chainName        = "casperlabs"
-                minTTL           = 1.minute
-                deployBuffer     = DeployBuffer.create[F](chainName, minTTL)
+                multiParentFinalizer <- MultiParentFinalizer.empty(
+                                         dag,
+                                         genesis.blockHash,
+                                         finalityDetector
+                                       )
+                chainName    = "casperlabs"
+                minTTL       = 1.minute
+                deployBuffer = DeployBuffer.create[F](chainName, minTTL)
                 node = new GossipServiceCasperTestNode[F](
                   peer,
                   genesis,
@@ -265,7 +276,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                   dagStorage,
                   deployStorage,
                   deployBuffer,
-                  finalityDetector,
+                  multiParentFinalizer,
                   timeEff,
                   metricEff,
                   casperState,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -70,7 +70,7 @@ class GossipServiceCasperTestNode[F[_]](
     Broadcaster.fromGossipServices(Some(validatorId), relaying)
   implicit val deploySelection   = DeploySelection.create[F](5 * 1024 * 1024)
   implicit val derivedValidation = DeriveValidation.deriveValidationImpl[F]
-  implicit val eventEmitter      = NoOpsEventEmitter.create[F]()
+  implicit val eventEmitter      = TestEventEmitter.create[F]
 
   // `addBlock` called in many ways:
   // - test proposes a block on the node that created it

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -2,6 +2,7 @@ package io.casperlabs.casper.helper
 
 import cats.Applicative
 import cats.implicits._
+import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.EventEmitter
 import io.casperlabs.casper.consensus.info.BlockInfo
 
@@ -9,5 +10,7 @@ object NoOpsEventEmitter {
   def create[F[_]: Applicative](): EventEmitter[F] =
     new EventEmitter[F] {
       override def blockAdded(block: BlockInfo): F[Unit] = ().pure[F]
+
+      override def newLFB(lfb: BlockHash, indirectlyFinalized: Set[BlockHash]): F[Unit] = ().pure[F]
     }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -1,10 +1,16 @@
 package io.casperlabs.casper.helper
 
 import cats.Applicative
+import cats.effect.Sync
 import cats.implicits._
 import io.casperlabs.casper.Estimator.BlockHash
-import io.casperlabs.casper.EventEmitter
+import io.casperlabs.casper.{EventEmitter, LastFinalizedBlockHashContainer}
 import io.casperlabs.casper.consensus.info.BlockInfo
+import io.casperlabs.mempool.DeployBuffer
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.storage.block.BlockStorage
+import io.casperlabs.storage.deploy.DeployStorage
+import io.casperlabs.shared.Log
 
 object NoOpsEventEmitter {
   def create[F[_]: Applicative](): EventEmitter[F] =
@@ -12,5 +18,22 @@ object NoOpsEventEmitter {
       override def blockAdded(block: BlockInfo): F[Unit] = ().pure[F]
 
       override def newLFB(lfb: BlockHash, indirectlyFinalized: Set[BlockHash]): F[Unit] = ().pure[F]
+    }
+}
+
+object TestEventEmitter {
+  // Can't reuse production version because it couples `EventEmitter` with `EventStream`.
+  def create[F[_]: Sync: DeployStorage: BlockStorage: Log: Metrics](
+      implicit lfbContainer: LastFinalizedBlockHashContainer[F]
+  ): EventEmitter[F] =
+    new EventEmitter[F] {
+      // Production `EventEmitter` publishes `BlockAdded` event to the observable.
+      // We don't need it in tests at the moment.
+      override def blockAdded(blockInfo: BlockInfo): F[Unit] = ().pure[F]
+
+      // Mimicks production `EventEmitter` impl.
+      // Some tests depend on what is being done there.
+      override def newLFB(lfb: BlockHash, indirectlyFinalized: Set[BlockHash]): F[Unit] =
+        lfbContainer.set(lfb) *> DeployBuffer.removeFinalizedDeploys[F](indirectlyFinalized + lfb)
     }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -23,9 +23,7 @@ object NoOpsEventEmitter {
 
 object TestEventEmitter {
   // Can't reuse production version because it couples `EventEmitter` with `EventStream`.
-  def create[F[_]: Sync: DeployStorage: BlockStorage: Log: Metrics](
-      implicit lfbContainer: LastFinalizedBlockHashContainer[F]
-  ): EventEmitter[F] =
+  def create[F[_]: Sync: DeployStorage: BlockStorage: Log: Metrics]: EventEmitter[F] =
     new EventEmitter[F] {
       // Production `EventEmitter` publishes `BlockAdded` event to the observable.
       // We don't need it in tests at the moment.
@@ -34,6 +32,6 @@ object TestEventEmitter {
       // Mimicks production `EventEmitter` impl.
       // Some tests depend on what is being done there.
       override def newLFB(lfb: BlockHash, indirectlyFinalized: Set[BlockHash]): F[Unit] =
-        lfbContainer.set(lfb) *> DeployBuffer.removeFinalizedDeploys[F](indirectlyFinalized + lfb)
+        DeployBuffer.removeFinalizedDeploys[F](indirectlyFinalized + lfb)
     }
 }

--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -1,22 +1,32 @@
 package io.casperlabs.node.api
 
 import cats.effect._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.apply._
+import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus.info.{BlockInfo, Event}
-import io.casperlabs.casper.EventEmitter
+import io.casperlabs.casper.{EventEmitter, LastFinalizedBlockHashContainer}
 import io.casperlabs.casper.consensus.info.Event.{BlockAdded, Value}
+import io.casperlabs.mempool.DeployBuffer
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.node.api.casper.StreamEventsRequest
 import io.casperlabs.node.api.graphql.FinalizedBlocksStream
+import io.casperlabs.storage.block.BlockStorage
+import io.casperlabs.storage.deploy.DeployStorage
 import monix.execution.Scheduler
 import monix.reactive.{Observable, OverflowStrategy}
 import monix.reactive.subjects.ConcurrentSubject
 import simulacrum.typeclass
+import io.casperlabs.shared.Log
+import io.casperlabs.catscontrib.effect.implicits.fiberSyntax
 
 @typeclass trait EventStream[F[_]] extends EventEmitter[F] {
   def subscribe(request: StreamEventsRequest): Observable[Event]
 }
 
 object EventStream {
-  def create[F[_]: Concurrent: FinalizedBlocksStream](
+  def create[F[_]: Concurrent: FinalizedBlocksStream: LastFinalizedBlockHashContainer: DeployStorage: BlockStorage: Log: Metrics](
       scheduler: Scheduler,
       eventStreamBufferSize: Int
   ): EventStream[F] = {
@@ -38,6 +48,15 @@ object EventStream {
           val event = Event().withBlockAdded(BlockAdded().withBlock(blockInfo))
           source.onNext(event)
         }
+
+      override def newLFB(lfb: BlockHash, indirectlyFinalized: Set[BlockHash]): F[Unit] =
+        for {
+          _ <- LastFinalizedBlockHashContainer[F].set(lfb)
+          _ <- Log[F]
+                .debug(s"Removing finalized deploys after adding ${lfb -> "block"}") *>
+                DeployBuffer.removeFinalizedDeploys(indirectlyFinalized + lfb).forkAndLog
+          // TODO: Persist finalized blocks in the DB.
+        } yield ()
     }
   }
 }


### PR DESCRIPTION
### Overview
Adds a `MultiparentFinalizer` that finds indirectly finalized blocks (p-past-cone of LFB from the main chain) and uses that where `FinalityDetectorByVotingMatrix` previously was.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1078

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
It doesn't implement actual _stream_ as I wasn't sure about what guarantees w.r.t. to processing of new LFBs it should have. Stream processing usually happens asynchronously to the producers which I think is problematic in our case (we MUST process every element of the LFB chain).
