### PR TITLE
NODE-1082: Eras to use Instant and FiniteDuration instead of Ticks

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -5,14 +5,14 @@ import io.casperlabs.casper.consensus.{BlockSummary, Era}
 
 class EraRuntime[F[_]](conf: HighwayConf, val era: Era) {
 
-  val startTick = conf.toInstant(Ticks(era.startTick))
-  val endTick   = conf.toInstant(Ticks(era.endTick))
+  val start = conf.toInstant(Ticks(era.startTick))
+  val end   = conf.toInstant(Ticks(era.endTick))
 
   val bookingBoundaries =
-    conf.criticalBoundaries(startTick, endTick, delayTicks = conf.bookingTicks)
+    conf.criticalBoundaries(start, end, delayDuration = conf.bookingDuration)
 
   val keyBoundaries =
-    conf.criticalBoundaries(startTick, endTick, delayTicks = conf.keyTicks)
+    conf.criticalBoundaries(start, end, delayDuration = conf.keyDuration)
 
   /** When we handle an incoming block or create a new one we may have to do additional work:
     * - if the block is a booking block, we have to execute the auction to pick the validators for the upcoming era
@@ -36,8 +36,7 @@ class EraRuntime[F[_]](conf: HighwayConf, val era: Era) {
     * ones that can finalize it by building ballots on top of it. The cannot
     * build more blocks on them though.
     */
-  val isSwitchBoundary = (mpbr: Instant, br: Instant) =>
-    mpbr.isBefore(endTick) && !br.isBefore(endTick)
+  val isSwitchBoundary = (mpbr: Instant, br: Instant) => mpbr.isBefore(end) && !br.isBefore(end)
 
 }
 
@@ -48,8 +47,8 @@ object EraRuntime {
       Era(
         keyBlockHash = genesis.blockHash,
         bookingBlockHash = genesis.blockHash,
-        startTick = conf.toTicks(conf.genesisEraStartTick),
-        endTick = conf.toTicks(conf.genesisEraEndTick),
+        startTick = conf.toTicks(conf.genesisEraStart),
+        endTick = conf.toTicks(conf.genesisEraEnd),
         bonds = genesis.getHeader.getState.bonds
       )
     )

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -8,21 +8,21 @@ final case class HighwayConf(
     /** Real-world time unit for one tick. */
     tickUnit: TimeUnit,
     /** Starting tick for the genesis era. */
-    genesisEraStartTick: Instant,
+    genesisEraStart: Instant,
     /** Method for calculating the end of the era based on the start tick. */
     eraDuration: HighwayConf.EraDuration,
     /** Amount of time to go back before the start of the era for picking the booking block. */
-    bookingTicks: FiniteDuration,
+    bookingDuration: FiniteDuration,
     /** Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way. */
-    entropyTicks: FiniteDuration,
+    entropyDuration: FiniteDuration,
     /** Stopping condition for producing ballots after the end of the era. */
     postEraVotingDuration: HighwayConf.VotingDuration
 ) {
   import HighwayConf._
 
   /** Time to go back before the start of the era for picking the key block. */
-  def keyTicks: FiniteDuration =
-    bookingTicks minus entropyTicks
+  def keyDuration: FiniteDuration =
+    bookingDuration minus entropyDuration
 
   /** Convert a `timeUnit` specific (it's up to the caller to make sure this is compatible)
     * number of ticks since the Unix epch to an instant in time.
@@ -41,16 +41,16 @@ final case class HighwayConf(
     Ticks(s + n)
   }
 
-  private def eraEndTick(startTick: Instant, duration: EraDuration): Instant = {
+  private def eraEnd(start: Instant, duration: EraDuration): Instant = {
     import EraDuration.CalendarUnit._
     val UTC = ZoneId.of("UTC")
 
     duration match {
       case EraDuration.FixedLength(ticks) =>
-        startTick plus ticks
+        start plus ticks
 
       case EraDuration.Calendar(length, unit) =>
-        val s = LocalDateTime.ofInstant(startTick, UTC)
+        val s = LocalDateTime.ofInstant(start, UTC)
         val e = unit match {
           case SECONDS => s.plusSeconds(length)
           case MINUTES => s.plusMinutes(length)
@@ -65,8 +65,8 @@ final case class HighwayConf(
   }
 
   /** Calculate the era end tick based on a start tick. */
-  def eraEndTick(startTick: Instant): Instant =
-    eraEndTick(startTick, eraDuration)
+  def eraEnd(start: Instant): Instant =
+    eraEnd(start, eraDuration)
 
   /** The booking block is picked from a previous era, e.g. with 7 day eras
     * we look for the booking block 10 days before the era start, so there's
@@ -78,11 +78,11 @@ final case class HighwayConf(
     * genesis to look at, so the genesis era has to be longer to produce many
     * booking blocks, one for era 2, and one for era 3.
     */
-  def genesisEraEndTick: Instant = {
-    val endTick    = eraEndTick(genesisEraStartTick)
-    val length     = endTick.toEpochMilli - genesisEraStartTick.toEpochMilli
-    val multiplier = 1 + bookingTicks.toMillis / length
-    (1 until multiplier.toInt).foldLeft(endTick)((t, _) => eraEndTick(t))
+  def genesisEraEnd: Instant = {
+    val endTick    = eraEnd(genesisEraStart)
+    val length     = endTick.toEpochMilli - genesisEraStart.toEpochMilli
+    val multiplier = 1 + bookingDuration.toMillis / length
+    (1 until multiplier.toInt).foldLeft(endTick)((t, _) => eraEnd(t))
   }
 
   /** Any time we create a block it may have to be a booking block,
@@ -97,17 +97,17 @@ final case class HighwayConf(
     * back from the start of a upcoming era.
     */
   def criticalBoundaries(
-      startTick: Instant,
-      endTick: Instant,
-      delayTicks: FiniteDuration
+      start: Instant,
+      end: Instant,
+      delayDuration: FiniteDuration
   ): List[Instant] = {
-    def loop(acc: List[Instant], nextStartTick: Instant): List[Instant] = {
-      val boundary = nextStartTick minus delayTicks
-      if (boundary isBefore startTick) loop(acc, eraEndTick(nextStartTick))
-      else if (boundary isBefore endTick) loop(boundary :: acc, eraEndTick(nextStartTick))
+    def loop(acc: List[Instant], nextStart: Instant): List[Instant] = {
+      val boundary = nextStart minus delayDuration
+      if (boundary isBefore start) loop(acc, eraEnd(nextStart))
+      else if (boundary isBefore end) loop(boundary :: acc, eraEnd(nextStart))
       else acc
     }
-    loop(Nil, endTick).reverse
+    loop(Nil, end).reverse
   }
 }
 
@@ -124,7 +124,7 @@ object HighwayConf {
       * In practice this shouldn't be a problem with the Java time library because it spreads
       * leap seconds throughout the day so that they appear to be exactly 86400 seconds.
       */
-    case class FixedLength(ticks: FiniteDuration) extends EraDuration
+    case class FixedLength(duration: FiniteDuration) extends EraDuration
 
     /** Fixed endings can be calculated with the calendar, to make eras take exactly one week (or a month),
       * but it means eras might have different lengths. Using this might mean that a different platform
@@ -149,7 +149,7 @@ object HighwayConf {
   object VotingDuration {
 
     /** Produce ballots according to the leader schedule for up to a certain number of ticks, e.g. 2 days. */
-    case class FixedLength(ticks: FiniteDuration) extends VotingDuration
+    case class FixedLength(duration: FiniteDuration) extends VotingDuration
 
     /** Produce ballots until a certain level of summits are achieved on top of the switch blocks. */
     case class SummitLevel(k: Int) extends VotingDuration

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -90,11 +90,21 @@ final case class HighwayConf(
     * exactly one booking boundary per era, except in the genesis
     * which has more, so that multiple following eras can find
     * booking blocks in it.
-    * For example era 2 will use 1a, and era 3 will use 1b:
-    *   1a     1b     2      3
-    * | .      .   |  .   |  .   |
-    * The function returns the list of ticks that are a certain delay
-    * back from the start of a upcoming era.
+    *
+    * Given a start and end tick for any particular era E,
+    * the function returns the list of ticks that are at a
+    * certain delay before the start of another era coming after E.
+    *
+    * This handles eras of different lengths: it filters out the upcoming
+    * boundaries so that they fall between start and end.
+    *
+    * For example, if the Genesis era was chosen to be 3 weeks long,
+    * we'd see the following booking blocks (B) appear; so Genesis would have 2,
+    * and E1 would have just 1, used by E3.
+    *  G : |....................|
+    *  E1:            B         |......|
+    *  E2:                   B         |......|
+    *  E3:                          B         |......|
     */
   def criticalBoundaries(
       start: Instant,

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -7,32 +7,41 @@ import scala.concurrent.duration._
 final case class HighwayConf(
     /** Real-world time unit for one tick. */
     tickUnit: TimeUnit,
-    /** Starting tick for the genesis era, measured in ticks since the Unix epoch. */
-    genesisEraStartTick: Ticks,
+    /** Starting tick for the genesis era. */
+    genesisEraStartTick: Instant,
     /** Method for calculating the end of the era based on the start tick. */
     eraDuration: HighwayConf.EraDuration,
-    /** Number of ticks to go back before the start of the era for picking the booking block. */
-    bookingTicks: Ticks,
-    /** Number of ticks after the booking before we pick the key block, collecting the magic bits along the way. */
-    entropyTicks: Ticks,
+    /** Amount of time to go back before the start of the era for picking the booking block. */
+    bookingTicks: FiniteDuration,
+    /** Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way. */
+    entropyTicks: FiniteDuration,
     /** Stopping condition for producing ballots after the end of the era. */
     postEraVotingDuration: HighwayConf.VotingDuration
 ) {
   import HighwayConf._
 
-  /** Number of ticks to go back before the start of the era for picking the key block. */
-  def keyTicks: Ticks =
+  private val NanosPerSec = 1000000000L
+
+  /** Time to go back before the start of the era for picking the key block. */
+  def keyTicks: FiniteDuration =
     bookingTicks minus entropyTicks
 
-  /** Convert a tick based time to Unix timestamp. */
-  def toTimestamp(t: Ticks): Timestamp =
-    Timestamp(tickUnit.toMillis(t))
+  /** Convert a `timeUnit` specific (it's up to the caller to make sure this is compatible)
+    * number of ticks since the Unix epch to an instant in time.
+    */
+  def toInstant(t: Ticks): Instant = {
+    val n = tickUnit.toNanos(t)
+    val s = tickUnit.toSeconds(t)
+    Instant.ofEpochSecond(s, n - s * NanosPerSec)
+  }
 
-  /** Convert a Unix timestamp to ticks. */
-  def toTicks(t: Timestamp): Ticks =
-    Ticks(tickUnit.convert(t, TimeUnit.MILLISECONDS))
+  /** Convert an instant in time to the number of ticks we can store in the era model,
+    * or assign to a round ID in a block.
+    */
+  def toTicks(t: Instant): Ticks =
+    Ticks(tickUnit.convert(t.getEpochSecond * NanosPerSec + t.getNano.toLong, TimeUnit.NANOSECONDS))
 
-  private def eraEndTick(startTick: Ticks, duration: EraDuration): Ticks = {
+  private def eraEndTick(startTick: Instant, duration: EraDuration): Instant = {
     import EraDuration.CalendarUnit._
     val UTC = ZoneId.of("UTC")
 
@@ -41,7 +50,7 @@ final case class HighwayConf(
         startTick plus ticks
 
       case EraDuration.Calendar(length, unit) =>
-        val s = LocalDateTime.ofInstant(Instant.ofEpochMilli(toTimestamp(startTick)), UTC)
+        val s = LocalDateTime.ofInstant(startTick, UTC)
         val e = unit match {
           case SECONDS => s.plusSeconds(length)
           case MINUTES => s.plusMinutes(length)
@@ -51,13 +60,12 @@ final case class HighwayConf(
           case MONTHS  => s.plusMonths(length)
           case YEARS   => s.plusYears(length)
         }
-        val t = e.atZone(UTC).toInstant.toEpochMilli
-        toTicks(Timestamp(t))
+        e.atZone(UTC).toInstant
     }
   }
 
   /** Calculate the era end tick based on a start tick. */
-  def eraEndTick(startTick: Ticks): Ticks =
+  def eraEndTick(startTick: Instant): Instant =
     eraEndTick(startTick, eraDuration)
 
   /** The booking block is picked from a previous era, e.g. with 7 day eras
@@ -70,10 +78,10 @@ final case class HighwayConf(
     * genesis to look at, so the genesis era has to be longer to produce many
     * booking blocks, one for era 2, and one for era 3.
     */
-  def genesisEraEndTick: Ticks = {
+  def genesisEraEndTick: Instant = {
     val endTick    = eraEndTick(genesisEraStartTick)
-    val length     = endTick - genesisEraStartTick
-    val multiplier = 1 + bookingTicks / length
+    val length     = endTick.toEpochMilli - genesisEraStartTick.toEpochMilli
+    val multiplier = 1 + bookingTicks.toMillis / length
     (1 until multiplier.toInt).foldLeft(endTick)((t, _) => eraEndTick(t))
   }
 
@@ -88,11 +96,15 @@ final case class HighwayConf(
     * The function returns the list of ticks that are a certain delay
     * back from the start of a upcoming era.
     */
-  def criticalBoundaries(startTick: Ticks, endTick: Ticks, delayTicks: Ticks): List[Ticks] = {
-    def loop(acc: List[Ticks], nextStartTick: Ticks): List[Ticks] = {
+  def criticalBoundaries(
+      startTick: Instant,
+      endTick: Instant,
+      delayTicks: FiniteDuration
+  ): List[Instant] = {
+    def loop(acc: List[Instant], nextStartTick: Instant): List[Instant] = {
       val boundary = nextStartTick minus delayTicks
-      if (boundary < startTick) loop(acc, eraEndTick(nextStartTick))
-      else if (boundary < endTick) loop(boundary :: acc, eraEndTick(nextStartTick))
+      if (boundary isBefore startTick) loop(acc, eraEndTick(nextStartTick))
+      else if (boundary isBefore endTick) loop(boundary :: acc, eraEndTick(nextStartTick))
       else acc
     }
     loop(Nil, endTick).reverse
@@ -112,7 +124,7 @@ object HighwayConf {
       * In practice this shouldn't be a problem with the Java time library because it spreads
       * leap seconds throughout the day so that they appear to be exactly 86400 seconds.
       */
-    case class FixedLength(ticks: Ticks) extends EraDuration
+    case class FixedLength(ticks: FiniteDuration) extends EraDuration
 
     /** Fixed endings can be calculated with the calendar, to make eras take exactly one week (or a month),
       * but it means eras might have different lengths. Using this might mean that a different platform
@@ -137,7 +149,7 @@ object HighwayConf {
   object VotingDuration {
 
     /** Produce ballots according to the leader schedule for up to a certain number of ticks, e.g. 2 days. */
-    case class FixedLength(ticks: Ticks) extends VotingDuration
+    case class FixedLength(ticks: FiniteDuration) extends VotingDuration
 
     /** Produce ballots until a certain level of summits are achieved on top of the switch blocks. */
     case class SummitLevel(k: Int) extends VotingDuration

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -1,5 +1,7 @@
 package io.casperlabs.casper
 
+import java.time.Instant
+import scala.concurrent.duration.FiniteDuration
 import shapeless.tag.@@
 
 package highway {
@@ -13,11 +15,13 @@ package object highway {
   type Timestamp = Long @@ TimestampTag
   def Timestamp(t: Long) = t.asInstanceOf[Timestamp]
 
-  /** Ticks (a point in time or a duration) in an arbitrary time unit. */
+  /** Ticks since Unix epoch in the Highway specific time unit. */
   type Ticks = Long @@ TicksTag
   def Ticks(t: Long) = t.asInstanceOf[Ticks]
-  implicit class TicksOps(val a: Ticks) extends AnyVal {
-    def plus(b: Ticks)  = Ticks(a + b)
-    def minus(b: Ticks) = Ticks(a - b)
+
+  implicit class InstantOps(val a: Instant) extends AnyVal {
+    def plus(b: FiniteDuration)  = a.plusNanos(b.toNanos)
+    def minus(b: FiniteDuration) = a.minusNanos(b.toNanos)
   }
+
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -20,8 +20,11 @@ package object highway {
   def Ticks(t: Long) = t.asInstanceOf[Ticks]
 
   implicit class InstantOps(val a: Instant) extends AnyVal {
-    def plus(b: FiniteDuration)  = a.plusNanos(b.toNanos)
-    def minus(b: FiniteDuration) = a.minusNanos(b.toNanos)
+    def plus(b: FiniteDuration) =
+      a.plus(b.length, b.unit.toChronoUnit)
+
+    def minus(b: FiniteDuration) =
+      a.minus(b.length, b.unit.toChronoUnit)
   }
 
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -11,10 +11,10 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
 
   val conf = HighwayConf(
     tickUnit = TimeUnit.MILLISECONDS,
-    genesisEraStartTick = date(2019, 12, 9),
+    genesisEraStart = date(2019, 12, 9),
     eraDuration = EraDuration.FixedLength(days(7)),
-    bookingTicks = days(10),
-    entropyTicks = hours(3),
+    bookingDuration = days(10),
+    entropyDuration = hours(3),
     postEraVotingDuration = VotingDuration.FixedLength(days(2))
   )
 
@@ -25,8 +25,8 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
       val runtime = EraRuntime.fromGenesis[Id](conf, genesis)
 
       "use the genesis ticks for the era" in {
-        conf.toInstant(Ticks(runtime.era.startTick)) shouldBe conf.genesisEraStartTick
-        conf.toInstant(Ticks(runtime.era.endTick)) shouldBe conf.genesisEraEndTick
+        conf.toInstant(Ticks(runtime.era.startTick)) shouldBe conf.genesisEraStart
+        conf.toInstant(Ticks(runtime.era.endTick)) shouldBe conf.genesisEraEnd
       }
 
       "use the genesis block as key and booking block" in {
@@ -76,7 +76,7 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
       }
 
       "recognize the switch block boundary" in {
-        val end  = conf.genesisEraEndTick
+        val end  = conf.genesisEraEnd
         val `1h` = hours(1)
         runtime.isSwitchBoundary(end minus `1h`, end plus `1h`) shouldBe true
         runtime.isSwitchBoundary(end minus `1h`, end) shouldBe true

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -8,7 +8,6 @@ import org.scalatest._
 
 class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
-  import MilliTicks._
 
   val conf = HighwayConf(
     tickUnit = TimeUnit.MILLISECONDS,
@@ -16,7 +15,7 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
     eraDuration = EraDuration.FixedLength(days(7)),
     bookingTicks = days(10),
     entropyTicks = hours(3),
-    postEraVotingDuration = VotingDuration.FixedLength(Ticks(0))
+    postEraVotingDuration = VotingDuration.FixedLength(days(2))
   )
 
   val genesis = BlockSummary().withBlockHash(ByteString.copyFromUtf8("genesis"))
@@ -26,8 +25,8 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
       val runtime = EraRuntime.fromGenesis[Id](conf, genesis)
 
       "use the genesis ticks for the era" in {
-        runtime.era.startTick shouldBe conf.genesisEraStartTick
-        runtime.era.endTick shouldBe conf.genesisEraEndTick
+        conf.toInstant(Ticks(runtime.era.startTick)) shouldBe conf.genesisEraStartTick
+        conf.toInstant(Ticks(runtime.era.endTick)) shouldBe conf.genesisEraEndTick
       }
 
       "use the genesis block as key and booking block" in {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -1,19 +1,37 @@
 package io.casperlabs.casper.highway
 
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 import org.scalatest._
 
 class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
 
+  val Zero = hours(0)
+
   val init = HighwayConf(
-    genesisEraStartTick = Ticks(0),
+    genesisEraStartTick = date(2000, 1, 3),
     tickUnit = TimeUnit.MILLISECONDS,
-    eraDuration = EraDuration.FixedLength(Ticks(0)),
-    bookingTicks = Ticks(0),
-    entropyTicks = Ticks(0),
-    postEraVotingDuration = VotingDuration.FixedLength(Ticks(0))
+    eraDuration = EraDuration.FixedLength(Zero),
+    bookingTicks = Zero,
+    entropyTicks = Zero,
+    postEraVotingDuration = VotingDuration.FixedLength(Zero)
   )
+
+  "toTicks" should {
+    "convert to the number of ticks since epoch" in {
+      init.toTicks(init.genesisEraStartTick) shouldBe Ticks(dateTimestamp(2000, 1, 3))
+    }
+  }
+
+  "toInstant" should {
+    "convert ticks to insants" in {
+      val a = Instant.ofEpochMilli(System.currentTimeMillis)
+      val b = init.toTicks(a)
+      val c = init.toInstant(b)
+      c shouldBe a
+    }
+  }
 
   "eraEndTick" when {
     // There was a leap second announced for 2008 Dec 31; that's surely included in JDK8.
@@ -22,17 +40,19 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
       "add the specified number of ticks" in {
         val conf = init.copy(
           tickUnit = TimeUnit.SECONDS,
-          eraDuration = EraDuration.FixedLength(Ticks(7 * 24 * 60 * 60))
+          eraDuration = EraDuration.FixedLength(days(7))
         )
 
         // Start from the previous Monday midnight.
-        val startTick = conf.toTicks(dateTimestamp(2008, 12, 29))
+        val startTick = date(2008, 12, 29)
         val endTick   = conf.eraEndTick(startTick)
 
         // The GregorianCalendar doesn't deal with leap seconds,
         // while the LocalDateTime spreads it around; we should
         // not see any discrepancy.
-        endTick shouldBe dateTimestamp(2009, 1, 5) / 1000
+        endTick shouldBe date(2009, 1, 5)
+
+        conf.toTicks(endTick) shouldBe dateTimestamp(2009, 1, 5) / 1000
       }
     }
 
@@ -41,9 +61,9 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
         val conf = init.copy(
           eraDuration = EraDuration.Calendar(3, EraDuration.CalendarUnit.MONTHS)
         )
-        val startTick = conf.toTicks(dateTimestamp(2008, 12, 1))
+        val startTick = date(2008, 12, 1)
         val endTick   = conf.eraEndTick(startTick)
-        endTick shouldBe MilliTicks.date(2009, 3, 1)
+        endTick shouldBe date(2009, 3, 1)
       }
     }
   }
@@ -51,20 +71,20 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
   "genesisEraEndTick" should {
     "expand the genesis era to produce multiple booking blocks" in {
       val conf = init.copy(
-        genesisEraStartTick = MilliTicks.date(2019, 12, 16),
-        bookingTicks = MilliTicks.days(10),
-        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+        genesisEraStartTick = date(2019, 12, 16),
+        bookingTicks = days(10),
+        eraDuration = EraDuration.FixedLength(days(7))
       )
-      conf.genesisEraEndTick shouldBe MilliTicks.date(2019, 12, 30)
+      conf.genesisEraEndTick shouldBe date(2019, 12, 30)
     }
   }
 
   "criticalBoundaries" should {
     "collect all booking block ticks for the genesis era" in {
       val conf = init.copy(
-        genesisEraStartTick = MilliTicks.date(2019, 12, 2),
-        bookingTicks = MilliTicks.days(18),
-        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+        genesisEraStartTick = date(2019, 12, 2),
+        bookingTicks = days(18),
+        eraDuration = EraDuration.FixedLength(days(7))
       )
       val boundaries = conf.criticalBoundaries(
         conf.genesisEraStartTick,
@@ -73,26 +93,26 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
       )
 
       boundaries should contain theSameElementsInOrderAs List(
-        MilliTicks.date(2019, 12, 5),
-        MilliTicks.date(2019, 12, 12),
-        MilliTicks.date(2019, 12, 19)
+        date(2019, 12, 5),
+        date(2019, 12, 12),
+        date(2019, 12, 19)
       )
     }
 
     "collect just the single key tick for a normal era" in {
       val conf = init.copy(
-        bookingTicks = MilliTicks.days(10),
-        entropyTicks = MilliTicks.hours(2),
-        eraDuration = EraDuration.FixedLength(MilliTicks.days(7))
+        bookingTicks = days(10),
+        entropyTicks = hours(2),
+        eraDuration = EraDuration.FixedLength(days(7))
       )
       val boundaries = conf.criticalBoundaries(
-        MilliTicks.date(2019, 12, 23),
-        MilliTicks.date(2019, 12, 30),
+        date(2019, 12, 23),
+        date(2019, 12, 30),
         conf.keyTicks
       )
 
       boundaries should contain only (
-        MilliTicks.date(2019, 12, 27) + MilliTicks.hours(2)
+        date(2019, 12, 27) plus hours(2)
       )
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
@@ -1,6 +1,8 @@
 package io.casperlabs.casper.highway
 
 import java.util.Calendar
+import java.time.Instant
+import scala.concurrent.duration._
 
 trait TickUtils {
   def dateTimestamp(y: Int, m: Int, d: Int): Timestamp = {
@@ -10,9 +12,7 @@ trait TickUtils {
     Timestamp(c.getTimeInMillis)
   }
 
-  object MilliTicks {
-    def days(d: Long)                = hours(d * 24)
-    def hours(h: Long)               = Ticks(h * 60 * 60 * 1000)
-    def date(y: Int, m: Int, d: Int) = Ticks(dateTimestamp(y, m, d))
-  }
+  def days(d: Long)                = d.days
+  def hours(h: Long)               = h.hours
+  def date(y: Int, m: Int, d: Int) = Instant.ofEpochMilli(dateTimestamp(y, m, d))
 }


### PR DESCRIPTION
### Overview
As @goral09 pointed out in #1474 the Ticks data type mixes point in time and duration, and could carry a unit as well so different resolutions can't be added or compared.

Since fitting data types are available in Scala and Java, here's an alternative that uses Instant and FiniteDuration instead of the single Long.

Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1082

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

