### PR TITLE
EE-823: fix rustdoc warnings

### DIFF
--- a/execution-engine/contract-ffi/src/contract_api/runtime.rs
+++ b/execution-engine/contract-ffi/src/contract_api/runtime.rs
@@ -207,7 +207,7 @@ pub fn put_key(name: &str, key: Key) {
     unsafe { ext_ffi::put_key(name_ptr, name_size, key_ptr, key_size) };
 }
 
-/// Removes Key persisted under [name] in the current context's map.
+/// Removes key persisted under `name` in the current context's map.
 pub fn remove_key(name: &str) {
     let (name_ptr, name_size, _bytes) = contract_api::to_ptr(name);
     unsafe { ext_ffi::remove_key(name_ptr, name_size) }

--- a/execution-engine/engine-core/src/execution/address_generator.rs
+++ b/execution-engine/engine-core/src/execution/address_generator.rs
@@ -11,7 +11,7 @@ use crate::{Address, ADDRESS_LENGTH};
 
 const SEED_LENGTH: usize = 32;
 
-/// An [`AddressGenerator`] generates [`URef`] addresses
+/// An [`AddressGenerator`] generates [`URef`](contract_ffi::uref::URef) addresses
 pub struct AddressGenerator(ChaChaRng);
 
 impl AddressGenerator {

--- a/execution-engine/engine-storage/src/protocol_data_store/mod.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/mod.rs
@@ -1,4 +1,5 @@
-//! A store for persisting [`ProtocolData`] values at their protocol versions.
+//! A store for persisting [`ProtocolData`](contract_ffi::value::ProtocolVersion) values at their
+//! protocol versions.
 use contract_ffi::value::ProtocolVersion;
 
 pub mod in_memory;

--- a/execution-engine/engine-storage/src/trie_store/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/mod.rs
@@ -1,4 +1,4 @@
-//! A store for persisting [`Trie`](crate::history::trie::Trie) values at their hashes.
+//! A store for persisting [`Trie`](crate::trie::Trie) values at their hashes.
 //!
 //! See the [in_memory](in_memory/index.html#usage) and
 //! [lmdb](lmdb/index.html#usage) modules for usage examples.

--- a/execution-engine/engine-tests/src/support/test_support.rs
+++ b/execution-engine/engine-tests/src/support/test_support.rs
@@ -439,15 +439,14 @@ impl Default for UpgradeRequestBuilder {
 
 /// Builder for simple WASM test
 pub struct WasmTestBuilder<S> {
-    /// Engine state is wrapped in Rc<> to workaround missing `impl Clone for
-    /// EngineState`
+    /// [`EngineState`] is wrapped in [`Rc`] to work around a missing [`Clone`] implementation
     engine_state: Rc<EngineState<S>>,
     exec_responses: Vec<ExecuteResponse>,
     upgrade_responses: Vec<UpgradeResponse>,
     genesis_hash: Option<Vec<u8>>,
     post_state_hash: Option<Vec<u8>>,
-    /// Cached transform maps after subsequent successful runs
-    /// i.e. transforms[0] is for first run() call etc.
+    /// Cached transform maps after subsequent successful runs i.e. `transforms[0]` is for first
+    /// exec call etc.
     transforms: Vec<AdditiveMap<Key, Transform>>,
     bonded_validators: Vec<HashMap<PublicKey, U512>>,
     /// Cached genesis transforms


### PR DESCRIPTION
### Overview
This PR addresses some warnings that occur when running `cargo doc`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-823

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A