### PR TITLE
NODE-1082: Leader sequence

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper.highway
 
 import io.casperlabs.casper.consensus.{BlockSummary, Era}
+import io.casperlabs.crypto.Keys.PublicKeyBS
 
 class EraRuntime[F[_]](conf: HighwayConf, val era: Era) {
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -62,6 +62,7 @@ object LeaderSequencer {
       val tickSeed = leaderSeed ++ longToBytesLittleEndian(tick)
       random.setSeed(tickSeed)
       // Pick a number between [0, 1) and use it to find a validator.
+      // NODE-1096: If possible generate a random BigInt directly, without involving a Double.
       val r = BigDecimal.valueOf(random.nextDouble())
       // Integer arithmetic is supposed to be safer than Double.
       val t = (total * r).toBigInt

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -1,5 +1,7 @@
 package io.casperlabs.casper.highway
 
+import io.casperlabs.crypto.hash.Blake2b256
+
 object LeaderSequencer {
 
   /** Concatentate all the magic bits into a byte array,
@@ -19,4 +21,7 @@ object LeaderSequencer {
     }
     arr.map(_.toByte)
   }
+
+  def seed(parentSeed: Array[Byte], magicBits: Seq[Boolean]) =
+    Blake2b256.hash(parentSeed ++ toByteArray(magicBits))
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -4,6 +4,7 @@ import io.casperlabs.crypto.hash.Blake2b256
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.casper.consensus.Bond
 import java.security.SecureRandom
+import java.nio.{ByteBuffer, ByteOrder}
 
 object LeaderSequencer {
 
@@ -68,14 +69,9 @@ object LeaderSequencer {
   }
 
   private def longToBytesLittleEndian(i: Long): Array[Byte] =
-    Array(
-      i.toByte,
-      (i >>> 8).toByte,
-      (i >>> 16).toByte,
-      (i >>> 24).toByte,
-      (i >>> 32).toByte,
-      (i >>> 40).toByte,
-      (i >>> 48).toByte,
-      (i >>> 56).toByte
-    )
+    ByteBuffer
+      .allocate(8)
+      .order(ByteOrder.LITTLE_ENDIAN)
+      .putLong(i)
+      .array
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -13,16 +13,14 @@ object LeaderSequencer {
     * padding them with zeroes on the right.
     */
   def toByteArray(bits: Seq[Boolean]): Array[Byte] = {
-    val size   = bits.size
-    val pad    = 8 - size % 8
-    val padded = bits.padTo(size + pad, false)
-    val arr    = Array.fill(padded.size / 8)(0)
-    padded.zipWithIndex.foreach {
+    val arr = Array.fill(math.ceil(bits.size / 8.0).toInt)(0)
+    bits.zipWithIndex.foreach {
       case (bit, i) =>
-        val a = i / 8
-        val b = 7 - i % 8
-        val s = (if (bit) 1 else 0) << b
-        arr(a) = arr(a) | s
+        if (bit) {
+          val a = i / 8
+          val b = 7 - i % 8
+          arr(a) = arr(a) | 1 << b
+        }
     }
     arr.map(_.toByte)
   }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -36,7 +36,8 @@ object LeaderSequencer {
     val validators = bonds.toList.toVector.map { x =>
       PublicKey(x.validatorPublicKey) -> BigInt(x.getStake.value)
     }
-    val total = validators.map(_._2).sum.doubleValue
+    // Using BigDecimal to be able to multiply with a Double later.
+    val total = BigDecimal(validators.map(_._2).sum)
 
     // The auction should not allow 0 bids, but if it was, there would be no way to pick between them.
     require(validators.forall(_._2 > 0), "Bonds must be positive.")
@@ -61,9 +62,9 @@ object LeaderSequencer {
       val tickSeed = leaderSeed ++ longToBytesLittleEndian(tick)
       random.setSeed(tickSeed)
       // Pick a number between [0, 1) and use it to find a validator.
-      val r = random.nextDouble()
-      // Integer arithmetic is supposed to be safer than double.
-      val t = BigDecimal.valueOf(total * r).toBigInt
+      val r = BigDecimal.valueOf(random.nextDouble())
+      // Integer arithmetic is supposed to be safer than Double.
+      val t = (total * r).toBigInt
       // Find the first validator over the target.
       seek(t)
     }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -53,6 +53,7 @@ object LeaderSequencer {
       // On Linux SecureRandom uses NativePRNG, and ignores the seed.
       // Re-seeding also doesn't reset the seed, just augments it, so a new instance is required.
       // https://stackoverflow.com/questions/50107982/rhe-7-not-respecting-java-secure-random-seed
+      // NODE-1095: Find a more secure, cross platform algorithm.
       val random = SecureRandom.getInstance("SHA1PRNG", "SUN")
       // Ticks need to be deterministic, so each time we have to reset the seed.
       val tickSeed = leaderSeed ++ longToBytesLittleEndian(tick)

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -1,0 +1,22 @@
+package io.casperlabs.casper.highway
+
+object LeaderSequencer {
+
+  /** Concatentate all the magic bits into a byte array,
+    * padding them with zeroes on the right.
+    */
+  def toByteArray(bits: Seq[Boolean]): Array[Byte] = {
+    val size   = bits.size
+    val pad    = 8 - size % 8
+    val padded = bits.padTo(size + pad, false)
+    val arr    = Array.fill(padded.size / 8)(0)
+    padded.zipWithIndex.foreach {
+      case (bit, i) =>
+        val a = i / 8
+        val b = 7 - i % 8
+        val s = (if (bit) 1 else 0) << b
+        arr(a) = arr(a) | s
+    }
+    arr.map(_.toByte)
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -33,7 +33,7 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
       "use the genesis block as key and booking block" in {
         runtime.era.keyBlockHash shouldBe genesis.blockHash
         runtime.era.bookingBlockHash shouldBe genesis.blockHash
-        runtime.era.leaderSeed shouldBe 0L
+        runtime.era.leaderSeed shouldBe ByteString.EMPTY
       }
 
       "not assign a parent era" in {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -70,5 +70,10 @@ class LeaderSequencerSpec extends WordSpec with Matchers {
         counts(bond.validatorPublicKey).toDouble / rounds shouldBe (w +- 0.05)
       }
     }
+
+    "work with an empty seed" in {
+      val genesisLeader = LeaderSequencer.makeSequencer(Array.empty[Byte], bonds)
+      genesisLeader(Ticks(System.currentTimeMillis))
+    }
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -1,0 +1,25 @@
+package io.casperlabs.casper.highway
+
+import org.scalatest._
+
+class LeaderSequencerSpec extends WordSpec with Matchers {
+  "toByteArray" should {
+    "concatenate bits to a byte array, padding on the right" in {
+      val bits =
+        List(true, false, false, true, true, false, false, false) ++
+          List(false, true, true, false, true)
+
+      val bytes = LeaderSequencer.toByteArray(bits)
+
+      bytes should have size 2
+
+      // If we just called .toInt on the bytes Java would interpret them as signed
+      // think it's -104 instead of 152.
+      def check(i: Int, b: String) =
+        java.lang.Byte.toUnsignedInt(bytes(i)) shouldBe Integer.parseInt(b, 2)
+
+      check(0, "10011000")
+      check(1, "01101000")
+    }
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.casper.highway
 
 import org.scalatest._
+import io.casperlabs.crypto.hash.Blake2b256
 
 class LeaderSequencerSpec extends WordSpec with Matchers {
   "toByteArray" should {
@@ -22,4 +23,16 @@ class LeaderSequencerSpec extends WordSpec with Matchers {
       check(1, "01101000")
     }
   }
+
+  "seed" should {
+    "concatenate the parent seed with the child magic bits" in {
+      val parentSeed = "parent-seed".getBytes
+      val magicBits  = List(false, true, false, false, true)
+      val magicBytes = LeaderSequencer.toByteArray(magicBits)
+      val seed       = LeaderSequencer.seed(parentSeed, magicBits)
+
+      seed shouldBe Blake2b256.hash(parentSeed ++ magicBytes)
+    }
+  }
+
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -1,12 +1,13 @@
 package io.casperlabs.casper.highway
 
+import cats.data.NonEmptyList
 import com.google.protobuf.ByteString
 import io.casperlabs.crypto.hash.Blake2b256
 import io.casperlabs.casper.consensus.Bond
 import io.casperlabs.casper.consensus.state
 import org.scalatest._
 
-class LeaderSequencerSpec extends WordSpec with Matchers {
+class LeaderSequencerSpec extends WordSpec with Matchers with Inspectors {
   "toByteArray" should {
     "concatenate bits to a byte array, padding on the right" in {
       val bits =
@@ -39,7 +40,7 @@ class LeaderSequencerSpec extends WordSpec with Matchers {
   }
 
   "makeSequencer" should {
-    val bonds = Vector(
+    val bonds = NonEmptyList.of(
       Bond(ByteString.copyFromUtf8("Alice")).withStake(state.BigInt("1000")),
       Bond(ByteString.copyFromUtf8("Bob")).withStake(state.BigInt("2000")),
       Bond(ByteString.copyFromUtf8("Charlie")).withStake(state.BigInt("3000"))
@@ -65,7 +66,7 @@ class LeaderSequencerSpec extends WordSpec with Matchers {
               counts.updated(v, counts(v) + 1)
           }
 
-      bonds.foreach { bond =>
+      forAll(bonds.toList) { bond =>
         val w = bond.getStake.value.toDouble / total
         counts(bond.validatorPublicKey).toDouble / rounds shouldBe (w +- 0.05)
       }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -56,7 +56,7 @@ class LeaderSequencerSpec extends WordSpec with Matchers with Inspectors {
     "pick validators proportionately to their weight" in {
       val rnd    = new scala.util.Random()
       val total  = 1000 + 2000 + 3000
-      val rounds = 1000
+      val rounds = 10000
       val counts =
         List
           .fill(rounds)(Ticks(rnd.nextLong))

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -236,7 +236,11 @@ message Era {
     // this is where the bonds are coming, included in the era for reference.
     bytes booking_block_hash = 5;
     // The random seed compiled from the magic bits between the booking block and the key block.
-    int64 leader_seed = 6;
+    // 1. Concatenate all the magic bits into an array of bytes, padding on the right with 0s to make it divisble by 8.
+    // 2. Concatenate the byte array to the parent leader seed.
+    // 3. Take the blake2b256 hash of the resulting array.
+    // 4. Use it as a seed for a PRNG to randomize the validators in `bonds`.
+    bytes leader_seed = 6;
     // Bonded validator weights from the booking block.
     repeated Bond bonds = 7;
 }

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -238,8 +238,10 @@ message Era {
     // The random seed compiled from the magic bits between the booking block and the key block.
     // 1. Concatenate all the magic bits into an array of bytes, padding on the right with 0s to make it divisble by 8.
     // 2. Concatenate the byte array to the parent leader seed.
-    // 3. Take the blake2b256 hash of the resulting array.
-    // 4. Use it as a seed for a PRNG to randomize the validators in `bonds`.
+    // 3. Let the leader_seed be the blake2b256 hash of the resulting array.
+    // 4. Convert any uint64 tick to bytes in little-endian format.
+    // 5. Concatentate the the bytes of the tick to the leader_seed and use the array as a seed to a SHA1PRNG generator.
+    // 6. Generate a random double r between [0, 1) and seek the first validator in `bonds` where the total cumulative weight exceeds r * total.
     bytes leader_seed = 6;
     // Bonded validator weights from the booking block.
     repeated Bond bonds = 7;


### PR DESCRIPTION
### Overview
Adds a `LeaderSequencer` that can deterministically assign the same validator to the same tick.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1082

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
@birchmd noted that the SHA1PRNG may be breakable if we use a seed. Will have to investigate another cross platform solutions at some point.
