### PR TITLE
EE-824: add initial crate root docs for contract-ffi

### DIFF
--- a/execution-engine/contract-ffi/src/args_parser.rs
+++ b/execution-engine/contract-ffi/src/args_parser.rs
@@ -1,3 +1,6 @@
+//! Home of [`ArgsParser`](crate::args_parser::ArgsParser), a trait used for parsing contract
+//! arguments from n-ary tuples.
+
 // Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
 #[rustfmt::skip]
 use alloc::vec;
@@ -8,10 +11,11 @@ use crate::{
     value::{CLTyped, CLValue, CLValueError},
 };
 
-/// Parses `Self` into a byte representation that is ABI compliant.
+/// Types which implement [`ArgsParser`] can be parsed into an ABI-compliant byte representation
+/// suitable for passing as arguments to a contract.
 ///
-/// It means that each type of the tuple has to implement `CLTyped + ToBytes`.  Implemented for
-/// tuples of various sizes.
+/// It is primarily implemented for n-ary tuples of values which themselves implement [`ToBytes`]
+/// and [`CLTyped`].
 pub trait ArgsParser {
     fn parse(self) -> Result<Vec<CLValue>, CLValueError>;
 

--- a/execution-engine/contract-ffi/src/block_time.rs
+++ b/execution-engine/contract-ffi/src/block_time.rs
@@ -1,3 +1,6 @@
+//! Home of [`BlockTime`](crate::block_time::BlockTime), an internal type used in the execution of
+//! contracts.
+
 use alloc::vec::Vec;
 
 use crate::bytesrepr::{Error, FromBytes, ToBytes, U64_SERIALIZED_LENGTH};

--- a/execution-engine/contract-ffi/src/bytesrepr.rs
+++ b/execution-engine/contract-ffi/src/bytesrepr.rs
@@ -1,3 +1,5 @@
+//! Contains serialization and deserialization code for types used throughout the system.
+
 // Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
 #[rustfmt::skip]
 use alloc::vec;

--- a/execution-engine/contract-ffi/src/contract_api/mod.rs
+++ b/execution-engine/contract-ffi/src/contract_api/mod.rs
@@ -1,3 +1,5 @@
+//! Contains support for writing smart contracts.
+
 pub mod account;
 mod contract_ref;
 mod error;

--- a/execution-engine/contract-ffi/src/execution.rs
+++ b/execution-engine/contract-ffi/src/execution.rs
@@ -1,3 +1,6 @@
+//! Home of [`Phase`](crate::execution::Phase), which represents the phase in which a given contract
+//! is executing.
+
 // Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
 #[rustfmt::skip]
 use alloc::vec;

--- a/execution-engine/contract-ffi/src/ext_ffi.rs
+++ b/execution-engine/contract-ffi/src/ext_ffi.rs
@@ -1,3 +1,7 @@
+//! Contains low-level bindings for host-side ("external") functions.
+//!
+//! Generally should not be used directly.  See the [`contract_api`](crate::contract_api) for
+//! high-level bindings suitable for writing smart contracts.
 extern "C" {
     pub fn read_value(key_ptr: *const u8, key_size: usize, output_size: *mut usize) -> i32;
     pub fn read_value_local(key_ptr: *const u8, key_size: usize, output_size: *mut usize) -> i32;

--- a/execution-engine/contract-ffi/src/gens.rs
+++ b/execution-engine/contract-ffi/src/gens.rs
@@ -1,4 +1,4 @@
-//! Contains functions for generating arbitrary values for use by [`proptest`](proptest).
+//! Contains functions for generating arbitrary values for use by [`Proptest`](https://crates.io/crates/proptest).
 
 use alloc::{collections::BTreeMap, string::String, vec};
 

--- a/execution-engine/contract-ffi/src/gens.rs
+++ b/execution-engine/contract-ffi/src/gens.rs
@@ -1,3 +1,5 @@
+//! Contains functions for generating arbitrary values for use by [`proptest`](proptest).
+
 use alloc::{collections::BTreeMap, string::String, vec};
 
 use proptest::{

--- a/execution-engine/contract-ffi/src/handlers.rs
+++ b/execution-engine/contract-ffi/src/handlers.rs
@@ -1,4 +1,4 @@
-//! Contains definitions for panic and allocation error handlers, along with other `#[nostd]`
+//! Contains definitions for panic and allocation error handlers, along with other `#[no_std]`
 //! support code.
 
 #[panic_handler]

--- a/execution-engine/contract-ffi/src/handlers.rs
+++ b/execution-engine/contract-ffi/src/handlers.rs
@@ -1,3 +1,6 @@
+//! Contains definitions for panic and allocation error handlers, along with other `#[nostd]`
+//! support code.
+
 #[panic_handler]
 #[no_mangle]
 pub fn panic(_info: &::core::panic::PanicInfo) -> ! {

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -1,3 +1,6 @@
+//! Home of [`Key`](crate::key::Key), the type for indexing all data stored on the CasperLabs
+//! Platform.
+
 use alloc::{format, vec::Vec};
 
 use base16;

--- a/execution-engine/contract-ffi/src/lib.rs
+++ b/execution-engine/contract-ffi/src/lib.rs
@@ -1,3 +1,48 @@
+//! A Rust library for writing smart contracts on the [CasperLabs Platform](https://techspec.casperlabs.io).
+//!
+//! # Example
+//!
+//! The following example contains session code which persists an integer value under an unforgeable
+//! reference.  It then stores the unforgeable reference under a name in context-local storage.
+//!
+//! ```rust,no_run
+//! use casperlabs_contract_ffi::contract_api::{storage, runtime, Error, TURef};
+//! use casperlabs_contract_ffi::key::Key;
+//! use casperlabs_contract_ffi::unwrap_or_revert::UnwrapOrRevert;
+//! use casperlabs_contract_ffi::uref::URef;
+//!
+//! const KEY: &str = "special_value";
+//!
+//! fn store(value: i32) {
+//!     // Store `value` under a new unforgeable reference.
+//!     let value_ref: TURef<i32> = storage::new_turef(value);
+//!
+//!     // Wrap the unforgeable reference in a value of type `Key`.
+//!     let value_key: Key = value_ref.into();
+//!
+//!     // Store this key under the name "special_value" in context-local storage.
+//!     runtime::put_key(KEY, value_key);
+//! }
+//!
+//! // All session code must have a `call` entrypoint.
+//! #[no_mangle]
+//! pub extern "C" fn call() {
+//!     // Get the optional first argument supplied to the argument.
+//!     let value: i32 = runtime::get_arg(0)
+//!         // Unwrap the `Option`, returning an error if there was no argument supplied.
+//!         .unwrap_or_revert_with(Error::MissingArgument)
+//!         // Unwrap the `Result` containing the deserialized argument or returns an error
+//!         // if there was a deserialization error.
+//!         .unwrap_or_revert_with(Error::InvalidArgument);
+//!
+//!     store(value);
+//! }
+//! ```
+//!
+//! # Writing Smart Contracts
+//! Support for writing smart contracts are contained in the [`contract_api`](crate::contract_api)
+//! module and its submodules.
+
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(
     allocator_api,

--- a/execution-engine/contract-ffi/src/lib.rs
+++ b/execution-engine/contract-ffi/src/lib.rs
@@ -31,7 +31,7 @@
 //!     let value: i32 = runtime::get_arg(0)
 //!         // Unwrap the `Option`, returning an error if there was no argument supplied.
 //!         .unwrap_or_revert_with(Error::MissingArgument)
-//!         // Unwrap the `Result` containing the deserialized argument or returns an error
+//!         // Unwrap the `Result` containing the deserialized argument or return an error
 //!         // if there was a deserialization error.
 //!         .unwrap_or_revert_with(Error::InvalidArgument);
 //!

--- a/execution-engine/contract-ffi/src/system_contracts/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mod.rs
@@ -1,10 +1,7 @@
-//! Supporting code for system contract implementation.
+//! Contains support for implementing system contracts.
 //!
-//! Submodules contains supporting code and logic that is shared between host
-//! and the contract implementation.
-//!
-//! Naming of the modules is related to actual system contract that is user of
-//! the supporting code i.e. mint.
+//! Each submodule contains support code and logic that is shared between host
+//! and the system contract .
 mod error;
 pub mod mint;
 pub mod pos;

--- a/execution-engine/contract-ffi/src/system_contracts/mod.rs
+++ b/execution-engine/contract-ffi/src/system_contracts/mod.rs
@@ -1,7 +1,7 @@
 //! Contains support for implementing system contracts.
 //!
 //! Each submodule contains support code and logic that is shared between host
-//! and the system contract .
+//! and the system contract.
 mod error;
 pub mod mint;
 pub mod pos;

--- a/execution-engine/contract-ffi/src/unwrap_or_revert.rs
+++ b/execution-engine/contract-ffi/src/unwrap_or_revert.rs
@@ -1,3 +1,6 @@
+//! Home of [`UnwrapOrRevert`](crate::unwrap_or_revert::UnwrapOrRevert), a convenience trait for
+//! unwrapping values.
+
 use crate::contract_api::{runtime, Error};
 
 /// A trait which provides syntactic sugar for unwrapping a type or calling

--- a/execution-engine/contract-ffi/src/uref.rs
+++ b/execution-engine/contract-ffi/src/uref.rs
@@ -1,3 +1,5 @@
+//! Home of [`URef`](crate::uref::URef), which represents an unforgeable reference.
+
 use alloc::{format, string::String, vec::Vec};
 
 use base16;

--- a/execution-engine/contract-ffi/src/value/mod.rs
+++ b/execution-engine/contract-ffi/src/value/mod.rs
@@ -1,3 +1,6 @@
+//! Home of [`CLValue`](crate::value::CLValue), the type representing data stored and manipulated on
+//! the CasperLabs Platform.
+
 pub mod account;
 mod cl_type;
 mod cl_value;


### PR DESCRIPTION
### Overview
This PR adds initial crate root docs for `casperlabs-contract-ffi`, including a bit of example code and module descriptions for all of the top-level modules.

To view locally:
```
cargo doc -p casperlabs-contract-ffi --open
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-824

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
