### PR TITLE
NODE-1082: Rounds

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -191,9 +191,10 @@ class EraRuntime[F[_]: MonadThrowable: Clock](
 
   /** Pick a time during the round to send the omega message. */
   private def chooseOmegaTick(roundStart: Ticks, roundEnd: Ticks): Ticks = {
-    val r = conf.omegaMessageTimeStart + (conf.omegaMessageTimeEnd - conf.omegaMessageTimeEnd) * rng
-      .nextDouble()
-    Ticks(roundStart + ((roundEnd - roundStart) * r).toLong)
+    val r = rng.nextDouble()
+    val o = conf.omegaMessageTimeStart + r * (conf.omegaMessageTimeEnd - conf.omegaMessageTimeStart)
+    val t = roundStart + o * (roundEnd - roundStart)
+    Ticks(t.toLong)
   }
 
   /** Preliminary check before the block is executed. Invalid blocks can be dropped. */

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -7,7 +7,7 @@ import cats.effect.{Clock, Sync}
 import cats.effect.concurrent.Ref
 import com.google.protobuf.ByteString
 import java.time.Instant
-import io.casperlabs.casper.consensus.{BlockSummary, Era}
+import io.casperlabs.casper.consensus.{Block, BlockSummary, Era}
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.models.Message
@@ -167,7 +167,9 @@ class EraRuntime[F[_]: MonadThrowable: Clock](
               // TODO: Execute the fork choice.
               mainParent = ByteString.EMPTY,
               // TODO: Get all justifications
-              justifications = Map.empty
+              justifications = Map.empty,
+              // TODO: Detect boundary based on main parent
+              isBookingBlock = false
             )
           }
       _ <- HighwayLog.tell[F](

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -285,8 +285,11 @@ class EraRuntime[F[_]: MonadThrowable: Clock](
             omega ++ next
           }
 
-        withProducer(noop) {
-          createLambdaMessage(_, roundId)
+        withProducer(noop) { mp =>
+          if (leaderFunction(roundId) == mp.validatorId)
+            createLambdaMessage(mp, roundId)
+          else
+            noop
         } >> HighwayLog.liftF(agenda)
 
       case Agenda.CreateOmegaMessage(roundId) =>

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -130,7 +130,7 @@ object HighwayConf {
   object EraDuration {
 
     /** Fixed length eras are easy to deal with, but over the years can accumulate leap seconds
-      * which menas they will eventually move away from starting at the desired midnight.
+      * which means they will eventually move away from starting at the desired midnight.
       * In practice this shouldn't be a problem with the Java time library because it spreads
       * leap seconds throughout the day so that they appear to be exactly 86400 seconds.
       */

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -16,7 +16,11 @@ final case class HighwayConf(
     /** Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way. */
     entropyDuration: FiniteDuration,
     /** Stopping condition for producing ballots after the end of the era. */
-    postEraVotingDuration: HighwayConf.VotingDuration
+    postEraVotingDuration: HighwayConf.VotingDuration,
+    /** Fraction of time through the round after which we can create an omega message. */
+    omegaMessageTimeStart: Double,
+    /** Fraction of time through the round before which we must have created the omega message. */
+    omegaMessageTimeEnd: Double
 ) {
   import HighwayConf._
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayEvent.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayEvent.scala
@@ -1,0 +1,25 @@
+package io.casperlabs.casper.highway
+
+import io.casperlabs.casper.consensus.Era
+import io.casperlabs.models.Message
+
+/** Domain events raised during the processing of messages and rounds.
+  * Messages in the events will have been created and persisted, but not
+  * yet sent to the peers on the network.
+  */
+sealed trait HighwayEvent
+
+object HighwayEvent {
+
+  /** Created a lambda message; only happens if this validator was leader in the round. Needs to be broadcasted. */
+  case class CreatedLambdaMessage(message: Message.Block) extends HighwayEvent
+
+  /** Created a response to a lambda message received from a leader. Needs to be broadcasted. */
+  case class CreatedLambdaResponse(message: Message.Ballot) extends HighwayEvent
+
+  /** Created an omega message, some time during the round. */
+  case class CreatedOmegaMessage(message: Message.Ballot) extends HighwayEvent
+
+  /** Create a new era based on a previously unused key block. Needs to be started. */
+  case class CreatedEra(era: Era) extends HighwayEvent
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -1,0 +1,22 @@
+package io.casperlabs.casper.highway
+
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.Block.Justification
+import io.casperlabs.crypto.Keys.PublicKeyBS
+import io.casperlabs.models.Message
+import io.casperlabs.storage.block.BlockStorage.BlockHash
+
+/** Produce a signed message, persisted message.
+  * The producer should the thread safe, so that when it's
+  * called from multiple threads to produce ballots in response
+  * to different messages it doesn't create an equivocation.
+  */
+trait MessageProducer[F[_]] {
+  def validatorId: PublicKeyBS
+
+  def ballot(
+      target: BlockHash,
+      justifications: Map[PublicKeyBS, Set[BlockHash]],
+      roundId: Ticks
+  ): F[Message.Ballot]
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -31,6 +31,7 @@ trait MessageProducer[F[_]] {
       eraId: BlockHash,
       roundId: Ticks,
       mainParent: BlockHash,
-      justifications: Map[PublicKeyBS, Set[BlockHash]]
+      justifications: Map[PublicKeyBS, Set[BlockHash]],
+      isBookingBlock: Boolean
   ): F[Message.Block]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -15,8 +15,22 @@ trait MessageProducer[F[_]] {
   def validatorId: PublicKeyBS
 
   def ballot(
+      eraId: BlockHash,
+      roundId: Ticks,
       target: BlockHash,
-      justifications: Map[PublicKeyBS, Set[BlockHash]],
-      roundId: Ticks
+      // For lambda responses we want to limit the justifications to just direct ones.
+      justifications: Map[PublicKeyBS, Set[BlockHash]]
   ): F[Message.Ballot]
+
+  /** Pick whatever secondary parents are compatible with the chosen main parent
+    * and the justifications selected when the caller started their operation,
+    * select deploys from the buffer, and create a (possibly empty) block,
+    * persisting it to the block store.
+    */
+  def block(
+      eraId: BlockHash,
+      roundId: Ticks,
+      mainParent: BlockHash,
+      justifications: Map[PublicKeyBS, Set[BlockHash]]
+  ): F[Message.Block]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -27,7 +27,21 @@ package object highway {
     def apply(t: Long) = t.asInstanceOf[Ticks]
 
     /** Calculate round length as 2^exp */
-    def roundLength(exponent: Int) = Ticks(ArithmeticUtils.pow(2L, exponent))
+    def roundLength(exp: Int): Ticks = Ticks(ArithmeticUtils.pow(2L, exp))
+
+    /** Calculate the next round tick. */
+    def nextRound(epoch: Ticks, exp: Int)(now: Ticks): Ticks =
+      roundBoundaries(epoch, exp)(now)._2
+
+    /** Calculate the round boundaries, given regular round lengths from an epoch. */
+    def roundBoundaries(epoch: Ticks, exp: Int)(now: Ticks): (Ticks, Ticks) = {
+      val length        = roundLength(exp)
+      val elapsed       = now - epoch
+      val relativeStart = elapsed - elapsed % length
+      val absoluteStart = epoch + relativeStart
+      val absoluteEnd   = absoluteStart + length
+      Ticks(absoluteStart) -> Ticks(absoluteEnd)
+    }
   }
 
   implicit class InstantOps(val a: Instant) extends AnyVal {

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import shapeless.tag.@@
 import scala.annotation.tailrec
 import scala.concurrent.duration.FiniteDuration
+import org.apache.commons.math3.util.ArithmeticUtils
 
 package highway {
   sealed trait TimestampTag
@@ -25,8 +26,8 @@ package object highway {
   object Ticks {
     def apply(t: Long) = t.asInstanceOf[Ticks]
 
-    /** Calculate round length. */
-    def roundLength(exponent: Int) = Ticks(pow(2L, exponent))
+    /** Calculate round length as 2^exp */
+    def roundLength(exponent: Int) = Ticks(ArithmeticUtils.pow(2L, exponent))
   }
 
   implicit class InstantOps(val a: Instant) extends AnyVal {
@@ -57,10 +58,4 @@ package object highway {
   }
 
   type LeaderFunction = Ticks => PublicKeyBS
-
-  @tailrec
-  private def pow(base: Long, exp: Int, acc: Long = 1L): Long =
-    if (exp <= 0) acc
-    else if (exp % 2 == 0) pow(base * base, exp / 2, acc)
-    else pow(base, exp - 1, acc * base)
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -1,5 +1,6 @@
 package io.casperlabs.casper
 
+import cats.data.WriterT
 import java.time.Instant
 import scala.concurrent.duration.FiniteDuration
 import shapeless.tag.@@
@@ -27,4 +28,11 @@ package object highway {
       a.minus(b.length, b.unit.toChronoUnit)
   }
 
+  /** Models a state transition of an era, returning the domain events that
+    * were raised during the operation. For example a round, or handling the
+    * a message may have created a new era, which is now persisted in the
+    * database, but scheduling has not been started for it (as we may be in
+    * playback mode).
+    */
+  type HighwayLog[F[_], T] = WriterT[F, Vector[HighwayEvent], T]
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -447,6 +447,10 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
           }
         }
       }
+
+      "crossing a booking block boundary" should {
+        "pass the information to the message producer" in (pending)
+      }
     }
     "given a CreateOmegaMessage action" when {
       "during initial sync" should {
@@ -545,7 +549,8 @@ object EraRuntimeSpec {
         eraId: ByteString,
         roundId: Ticks,
         mainParent: ByteString,
-        justifications: Map[PublicKeyBS, Set[BlockHash]]
+        justifications: Map[PublicKeyBS, Set[BlockHash]],
+        isBookingBlock: Boolean
     ): F[Message.Block] =
       BlockSummary()
         .withHeader(

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -260,10 +260,20 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         }
       }
 
-      "given a ballot" should {
-        "not respond" in {
-          val msg = makeBallot(leader, runtime.era.keyBlockHash, runtime.startTick)
-          runtime.handleMessage(msg).written shouldBe empty
+      "given a ballot" when {
+        "in the normal era period" should {
+          "not respond" in {
+            val msg = makeBallot(leader, runtime.era.keyBlockHash, runtime.startTick)
+            runtime.handleMessage(msg).written shouldBe empty
+          }
+        }
+        "in the post-era voting period" when {
+          "coming from the leader" should {
+            "create a lambda response" in (pending)
+          }
+          "coming from a non-leader" should {
+            "not respond" in (pending)
+          }
         }
       }
     }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -355,9 +355,25 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         }
 
         "the validator is not leading" should {
-          "not create a lambda message" in (pending)
-          "schedule another round" in (pending)
-          "schedule an omega message" in (pending)
+          val runtime = genesisEraRuntime(
+            "Alice".some,
+            leaderSequencer = mockSequencer("Bob")
+          )
+          val (events, agenda) = runtime.handleAgenda(Agenda.StartRound(runtime.startTick)).run
+
+          "not create a lambda message" in {
+            events shouldBe empty
+          }
+          "schedule another round" in {
+            forExactly(1, agenda) { a =>
+              a.action shouldBe an[Agenda.StartRound]
+            }
+          }
+          "schedule an omega message" in {
+            forExactly(1, agenda) { a =>
+              a.action shouldBe an[Agenda.CreateOmegaMessage]
+            }
+          }
         }
       }
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import io.casperlabs.casper.consensus.BlockSummary
 import org.scalatest._
 
-class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
+class EraRuntimeSpec extends WordSpec with Matchers with TickUtils {
   import HighwayConf._
 
   val conf = HighwayConf(
@@ -86,4 +86,80 @@ class EraRuntimeConfSpec extends WordSpec with Matchers with TickUtils {
     }
   }
 
+  "initAgenda" when {
+    "the validator is bonded in the era" should {
+      "schedule the first round" in (pending)
+    }
+    "the validator is not bonded in the era" should {
+      "not schedule anything" in (pending)
+    }
+    "the era is already over" should {
+      "not schedule anything" in (pending)
+    }
+  }
+
+  "handleMessage" when {
+    "the validator is bonded" when {
+      "given a lambda message" when {
+        "it is from the leader" should {
+          "create a lambda response" in (pending)
+          "remember that a lambda message was received in this round" in (pending)
+        }
+        "it is not from the leader" should {
+          "not respond" in (pending)
+        }
+        "it is a switch block" should {
+          "create an era" in (pending)
+        }
+      }
+      "given a ballot" should {
+        "not respond" in (pending)
+      }
+    }
+    "the validator is not bonded" when {
+      "given a lambda message" should {
+        "not respond" in (pending)
+      }
+      "given a switch block" should {
+        "create an era" in (pending)
+      }
+    }
+  }
+
+  "handleAgenda" when {
+    "starting a round" when {
+      "in the active period of the era" when {
+        "the validator is the leader" should {
+          "create a lambda message" in (pending)
+          "schedule another round" in (pending)
+          "schedule an omega message" in (pending)
+        }
+        "the validator is not leading" should {
+          "not create a lambda message" in (pending)
+          "schedule another round" in (pending)
+          "schedule an omega message" in (pending)
+        }
+      }
+      "right after the era-end" when {
+        "no previous switch block has been seen" should {
+          "create a switch block" in (pending)
+        }
+        "already found a switch block" should {
+          "only create ballots" in (pending)
+        }
+      }
+      "in the post-era voting period" when {
+        "the validator is the leader" should {
+          "a ballot instead of a lambda message" in (pending)
+        }
+        "the voting is still going" should {
+          "schedule an omega message" in (pending)
+          "schedule another round" in (pending)
+        }
+        "the voting period is over" should {
+          "not schedule anything" in (pending)
+        }
+      }
+    }
+  }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -157,6 +157,14 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
   }
 
   "validate" should {
+    "reject a block received from a doppelganger" in {
+      val runtime = genesisEraRuntime("Alice".some)
+      val message =
+        makeBlock("Alice", eraId = runtime.era.keyBlockHash, roundId = runtime.startTick)
+      runtime.validate(message).value shouldBe Left(
+        "The block is coming from a doppelganger."
+      )
+    }
     "reject a block received from a non-leader" in {
       val runtime = genesisEraRuntime(
         "Alice".some,

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -24,7 +24,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
   import io.casperlabs.catscontrib.effect.implicits.syncId
 
   // Let's say we are right at the beginning of the era by default.
-  implicit def defaultClock: Clock[Id] = new TestClock[Id](date(2019, 12, 9))
+  implicit def defaultClock: Clock[Id] = TestClock.frozen[Id](date(2019, 12, 9))
 
   val conf = HighwayConf(
     tickUnit = TimeUnit.MILLISECONDS,
@@ -157,7 +157,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
   }
 
   "validate" should {
-    "reject a block is received from a non-leader" in {
+    "reject a block received from a non-leader" in {
       val runtime = genesisEraRuntime(
         "Alice".some,
         leaderSequencer = mockSequencer("Bob")
@@ -190,7 +190,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         val now = conf.genesisEraStart plus 5.hours
         val exp = 10
 
-        implicit val clock = new TestClock[Id](now)
+        implicit val clock = TestClock.frozen[Id](now)
         val runtime        = genesisEraRuntime(validator = "Alice".some, roundExponent = exp)
 
         val millisRound = math.pow(2.0, exp.toDouble).toLong
@@ -213,7 +213,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
 
     "the era is already over" should {
       "not schedule anything" in {
-        implicit val clock = new TestClock[Id](conf.genesisEraStart plus 700.days)
+        implicit val clock = TestClock.frozen[Id](conf.genesisEraStart plus 700.days)
         genesisEraRuntime(validator = "Alice".some).initAgenda shouldBe empty
       }
     }
@@ -345,7 +345,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
           val roundId     = conf.toTicks(now)
           val nextRoundId = Ticks(roundId + roundLength.toMillis)
 
-          implicit val clock = new TestClock[Id](now)
+          implicit val clock = TestClock.frozen[Id](now)
 
           val runtime = genesisEraRuntime(
             "Alice".some,
@@ -460,7 +460,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
           val roundLength    = math.pow(2.0, exponent.toDouble).toLong.millis
           val roundStart     = conf.genesisEraStart plus 60 * roundLength
           val now            = roundStart plus 3 * roundLength
-          implicit val clock = new TestClock[Id](now)
+          implicit val clock = TestClock.frozen[Id](now)
 
           val runtime = genesisEraRuntime(none, roundExponent = exponent)
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayConfSpec.scala
@@ -15,7 +15,9 @@ class HighwayConfSpec extends WordSpec with Matchers with TickUtils {
     eraDuration = EraDuration.FixedLength(Zero),
     bookingDuration = Zero,
     entropyDuration = Zero,
-    postEraVotingDuration = VotingDuration.FixedLength(Zero)
+    postEraVotingDuration = VotingDuration.FixedLength(Zero),
+    omegaMessageTimeStart = 0.0,
+    omegaMessageTimeEnd = 0.0
   )
 
   "toTicks" should {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -39,7 +39,7 @@ class LeaderSequencerSpec extends WordSpec with Matchers with Inspectors {
     }
   }
 
-  "makeSequencer" should {
+  "apply" should {
     val bonds = NonEmptyList.of(
       Bond(ByteString.copyFromUtf8("Alice")).withStake(state.BigInt("1000")),
       Bond(ByteString.copyFromUtf8("Bob")).withStake(state.BigInt("2000")),

--- a/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/LeaderSequencerSpec.scala
@@ -46,7 +46,7 @@ class LeaderSequencerSpec extends WordSpec with Matchers with Inspectors {
       Bond(ByteString.copyFromUtf8("Charlie")).withStake(state.BigInt("3000"))
     )
 
-    val leaderOf = LeaderSequencer.makeSequencer("leader-seed".getBytes, bonds)
+    val leaderOf = LeaderSequencer("leader-seed".getBytes, bonds)
 
     "create a deterministic function" in {
       val tick = Ticks(System.currentTimeMillis)
@@ -73,7 +73,7 @@ class LeaderSequencerSpec extends WordSpec with Matchers with Inspectors {
     }
 
     "work with an empty seed" in {
-      val genesisLeader = LeaderSequencer.makeSequencer(Array.empty[Byte], bonds)
+      val genesisLeader = LeaderSequencer(Array.empty[Byte], bonds)
       genesisLeader(Ticks(System.currentTimeMillis))
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/TickUtils.scala
@@ -1,5 +1,8 @@
 package io.casperlabs.casper.highway
 
+import cats._
+import cats.implicits._
+import cats.effect.Clock
 import java.util.Calendar
 import java.time.Instant
 import scala.concurrent.duration._
@@ -15,4 +18,12 @@ trait TickUtils {
   def days(d: Long)                = d.days
   def hours(h: Long)               = h.hours
   def date(y: Int, m: Int, d: Int) = Instant.ofEpochMilli(dateTimestamp(y, m, d))
+
+  class TestClock[F[_]: Applicative](t: Instant) extends Clock[F] {
+    override def realTime(unit: TimeUnit): F[Long] =
+      unit.convert(t.toEpochMilli, MILLISECONDS).pure[F]
+
+    override def monotonic(unit: TimeUnit): F[Long] =
+      ???
+  }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/TicksSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/TicksSpec.scala
@@ -1,0 +1,28 @@
+package io.casperlabs.casper.highway
+
+import org.scalatest._
+
+class TicksSpec extends FlatSpec with Matchers {
+
+  "roundLength" should "calculate the length as 2^round_exponent" in {
+    Ticks.roundLength(0) shouldBe 1L
+    Ticks.roundLength(1) shouldBe 2L
+    Ticks.roundLength(2) shouldBe 4L
+  }
+
+  "nextRound" should "give the next available round" in {
+    val exp   = 4
+    val epoch = Ticks(0L)
+    val next  = Ticks.nextRound(epoch, exp)(_)
+    next(Ticks(15L)) shouldBe 16L
+    next(Ticks(16L)) shouldBe 32L
+    next(Ticks(17L)) shouldBe 32L
+    next(Ticks(32L)) shouldBe 48L
+  }
+
+  it should "take the epoch into account" in {
+    val exp   = 3
+    val epoch = Ticks(5L)
+    Ticks.nextRound(epoch, exp)(Ticks(7L)) shouldBe 13L
+  }
+}

--- a/models/src/main/scala/io/casperlabs/models/Message.scala
+++ b/models/src/main/scala/io/casperlabs/models/Message.scala
@@ -22,11 +22,13 @@ sealed trait Message {
   val messageHash: Id
   val validatorId: ByteString
   val timestamp: Long
+  val rank: Long
   val parentBlock: Id
   val justifications: Seq[consensus.Block.Justification]
-  val rank: Long
   val validatorMsgSeqNum: Int
   val signature: consensus.Signature
+  val roundId: Long
+  val keyBlockHash: Id
 
   val parents: Seq[Id]
   val blockSummary: BlockSummary
@@ -42,6 +44,8 @@ object Message {
       messageHash: Message#Id,
       validatorId: ByteString,
       timestamp: Long,
+      roundId: Long,
+      keyBlockHash: Message#Id,
       parentBlock: Message#Id,
       justifications: Seq[consensus.Block.Justification],
       rank: Long,
@@ -67,6 +71,8 @@ object Message {
       messageHash: Message#Id,
       validatorId: ByteString,
       timestamp: Long,
+      roundId: Long,
+      keyBlockHash: Message#Id,
       parentBlock: Message#Id,
       justifications: Seq[consensus.Block.Justification],
       rank: Long,
@@ -82,6 +88,8 @@ object Message {
       val messageHash        = b.blockHash
       val header             = b.getHeader
       val timestamp          = header.timestamp
+      val roundId            = header.roundId
+      val keyBlockHash       = header.keyBlockHash
       val parentBlock        = header.parentHashes.headOption.getOrElse(ByteString.EMPTY)
       val validatorId        = header.validatorPublicKey
       val justifications     = header.justifications
@@ -97,6 +105,8 @@ object Message {
               messageHash,
               validatorId,
               timestamp,
+              roundId,
+              keyBlockHash,
               parentBlock,
               justifications,
               rank,
@@ -111,6 +121,8 @@ object Message {
               messageHash,
               validatorId,
               timestamp,
+              roundId,
+              keyBlockHash,
               parentBlock,
               justifications,
               rank,


### PR DESCRIPTION
### Overview
Fills in the round and message handling logic of the era. 
There are three methods:
* `handleMessage` gets the blocks/ballots sent by other validators
* `handleAgenda` gets the events scheduled by the era itself
* `initAgenda` schedules the first events

No actual scheduling takes place in this class, it just returns a list of action items to take, which are easy to write tests for. They also return a list of domain events about what they did (blocks, ballots, eras created), without gossiping anything. The supervisor / manager class will have to do the scheduling; it will be the only place where all the fibers are collected, so they can be canceled if necessary. 

The PR is growing long, and the next steps require DAG lookups, so maybe this is a good place to stop. Some tests are pending, the ones that require:
- Detect booking block boundaries
- Detect switch blocks
- Create eras
- Handle voting only periods (after the switch block)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1082

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I thought about passing in an `(implicit Agenda[F])` to the methods where they can do the scheduling via methods such as `scheduleStartRound(roundId)`, which would have the benefit of not having to finish processing and creating a lambda message before returning the `Agenda`, which is _then_ scheduled. However as discussed with Andreas if it takes longer to create a message than the round length then we can just say the validator should slow down. We could also just return an agenda item which is the `CreateLambdaMessage` itself, and have both worlds.

I think the supervisor will validate and persist the block first, before passing it to the era to handle the schedules and reactions. We can ask the era if the block is a booking block, other than that I don't think it has anything special about validation.