### PR TITLE
EE-748: Propagate payment code errors.

### DIFF
--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -53,7 +53,7 @@ pub enum ExecutionResult {
 pub enum ForcedTransferResult {
     /// Payment code ran out of gas during execution
     InsufficientPayment,
-    /// Payment code executing resulted in an error
+    /// Payment code execution resulted in an error
     PaymentFailure,
 }
 


### PR DESCRIPTION
### Overview

This refactors a bit the `check_forced_transfer` logic to be able to safely "consume" payment's `ExecutionResult` instances to extract `error` out of `ExecutionResult::Failure` variant and create a payment error result with punitive transforms (as done originally). On my first attempt I just tried to clone the payment result's error, although deriving `Clone` for error enums we use touched multiple unintended code sites, and changed logic in numerous place where given error can't be cloned (i.e. for `wasmi::Error` I had to wrap it in `Arc` etc.).

- For actual payment code runtime errors they would be propagated (i.e. Revert, GasLimit, etc)
- For successful executions of payment code, they would be validated
against the required minimum payment cost and appropriate error would be
returned (InsufficientPaymentError)
- For succesesful executions of payment code whose met the payment
requirements, normal session code would be executed.


### Which JIRA ticket does this PR relate to?

https://casperlabs.atlassian.net/browse/EE-748

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
