### PR TITLE
NODE-1104: Era storage

### DIFF
--- a/storage/src/main/resources/db/migration/V20200103_1104__Create_eras_table.sql
+++ b/storage/src/main/resources/db/migration/V20200103_1104__Create_eras_table.sql
@@ -1,0 +1,18 @@
+-- Related to the io.casperlabs.casper.deploybuffer.DeployBufferImpl
+
+CREATE TABLE eras
+(
+    -- Key block hash or Era ID
+    hash                BLOB PRIMARY KEY NOT NULL,
+    parent_hash         BLOB,
+    -- Since Unix epoch
+    start_millis        INTEGER          NOT NULL,
+    end_millis          INTEGER          NOT NULL,
+    -- The whole era, including the bonds.
+    data                BLOB             NOT NULL,
+    FOREIGN KEY (hash) REFERENCES block_metadata (block_hash),
+    FOREIGN KEY (parent_hash) REFERENCES eras (hash)
+);
+
+CREATE INDEX idx_eras_parent_hash ON eras (parent_hash);
+CREATE INDEX idx_eras_start_end_millis ON eras (start_millis, end_millis);

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -15,7 +15,6 @@ import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Message
 import io.casperlabs.shared.Time
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
 import io.casperlabs.storage.block.{BlockStorage, SQLiteBlockStorage}
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.storage.dag.{DagRepresentation, DagStorage, SQLiteDagStorage}

--- a/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
@@ -7,13 +7,12 @@ import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.metrics.Metered
-import io.casperlabs.storage.BlockMsgWithTransform
-import io.casperlabs.storage.block.BlockStorage.DeployHash
+import io.casperlabs.storage.{BlockHash, BlockMsgWithTransform, DeployHash}
 
 import scala.language.higherKinds
 
 trait BlockStorage[F[_]] {
-  import BlockStorage.{BlockHash, BlockMessage}
+  import BlockStorage.BlockMessage
 
   def put(
       blockMsgWithTransform: BlockMsgWithTransform
@@ -128,7 +127,4 @@ object BlockStorage {
       blockStorage.get(blockHash).map(_.map(_.transformEntry))
   }
   def apply[F[_]](implicit ev: BlockStorage[F]): BlockStorage[F] = ev
-
-  type BlockHash  = ByteString
-  type DeployHash = ByteString
 }

--- a/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
@@ -9,7 +9,8 @@ import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash, MeteredBlockStorage}
+import io.casperlabs.storage.{BlockHash, DeployHash}
+import io.casperlabs.storage.block.BlockStorage.MeteredBlockStorage
 import io.casperlabs.storage.{BlockMsgWithTransform, BlockStorageMetricsSource}
 
 import scala.collection.JavaConverters._

--- a/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
@@ -17,7 +17,8 @@ import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.ipc.TransformEntry
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.metrics.Metrics.Source
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash, MeteredBlockStorage}
+import io.casperlabs.storage.{BlockHash, DeployHash}
+import io.casperlabs.storage.block.BlockStorage.MeteredBlockStorage
 import io.casperlabs.storage.util.DoobieCodecs
 import io.casperlabs.storage.{BlockMsgWithTransform, BlockStorageMetricsSource}
 

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -10,7 +10,7 @@ import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Message
 import io.casperlabs.storage.DagStorageMetricsSource
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.CachingDagStorage.Rank
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.storage.dag.DagStorage.{MeteredDagRepresentation, MeteredDagStorage}

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -7,7 +7,7 @@ import io.casperlabs.casper.consensus.{Block, BlockSummary}
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.metrics.Metered
 import io.casperlabs.models.Message
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.codec.Base16

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -15,7 +15,7 @@ import io.casperlabs.metrics.Metrics.Source
 import io.casperlabs.models.BlockImplicits._
 import io.casperlabs.models.Message
 import io.casperlabs.storage.DagStorageMetricsSource
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.block.SQLiteBlockStorage.blockInfoCols
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.storage.dag.DagStorage.{MeteredDagRepresentation, MeteredDagStorage}

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
@@ -6,7 +6,7 @@ import io.casperlabs.casper.consensus.{Block, Deploy}
 import io.casperlabs.casper.consensus.info.DeployInfo
 import io.casperlabs.crypto.Keys.PublicKeyBS
 import io.casperlabs.metrics.Metered
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
+import io.casperlabs.storage.{BlockHash, DeployHash}
 import simulacrum.typeclass
 
 import scala.concurrent.duration._

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -16,7 +16,7 @@ import io.casperlabs.metrics.Metrics
 import io.casperlabs.metrics.Metrics.Source
 import io.casperlabs.shared.Time
 import io.casperlabs.storage.DeployStorageMetricsSource
-import io.casperlabs.storage.block.BlockStorage.DeployHash
+import io.casperlabs.storage.DeployHash
 import io.casperlabs.storage.block.SQLiteBlockStorage.blockInfoCols
 import io.casperlabs.storage.util.DoobieCodecs
 

--- a/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
@@ -1,0 +1,27 @@
+package io.casperlabs.storage.era
+
+import cats._
+import cats.implicits._
+import io.casperlabs.catscontrib.MonadThrowable
+import io.casperlabs.casper.consensus.Era
+import io.casperlabs.crypto.codec.Base16
+import io.casperlabs.storage.BlockHash
+
+trait EraStorage[F[_]] {
+  def addEra(era: Era): F[Unit]
+
+  /** Retrieve the era, if it exists, by its key block hash. */
+  def getEra(eraId: BlockHash): F[Option[Era]]
+
+  /** Retrieve the era, or raise an error if it's not found. */
+  def getEraUnsafe(eraId: BlockHash)(implicit E: MonadThrowable[F]): F[Era] =
+    getEra(eraId) flatMap {
+      MonadThrowable[F].fromOption(
+        _,
+        new NoSuchElementException(s"Era ${Base16.encode(eraId.toByteArray)} could not be found.")
+      )
+    }
+
+  /** Retrieve the child eras from the era tree. */
+  def getChildEras(eraId: BlockHash): F[Set[Era]]
+}

--- a/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
@@ -11,17 +11,19 @@ trait EraStorage[F[_]] {
   def addEra(era: Era): F[Unit]
 
   /** Retrieve the era, if it exists, by its key block hash. */
-  def getEra(eraId: BlockHash): F[Option[Era]]
+  def getEra(keyBlockHash: BlockHash): F[Option[Era]]
 
   /** Retrieve the era, or raise an error if it's not found. */
-  def getEraUnsafe(eraId: BlockHash)(implicit E: MonadThrowable[F]): F[Era] =
-    getEra(eraId) flatMap {
+  def getEraUnsafe(keyBlockHash: BlockHash)(implicit E: MonadThrowable[F]): F[Era] =
+    getEra(keyBlockHash) flatMap {
       MonadThrowable[F].fromOption(
         _,
-        new NoSuchElementException(s"Era ${Base16.encode(eraId.toByteArray)} could not be found.")
+        new NoSuchElementException(
+          s"Era ${Base16.encode(keyBlockHash.toByteArray)} could not be found."
+        )
       )
     }
 
   /** Retrieve the child eras from the era tree. */
-  def getChildEras(eraId: BlockHash): F[Set[Era]]
+  def getChildEras(keyBlockHash: BlockHash): F[Set[Era]]
 }

--- a/storage/src/main/scala/io/casperlabs/storage/package.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/package.scala
@@ -2,6 +2,7 @@ package io.casperlabs
 
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.metrics.Metrics
+import com.google.protobuf.ByteString
 
 package object storage {
   val BlockStorageMetricsSource: Metrics.Source =
@@ -21,4 +22,7 @@ package object storage {
         signature = b.getBlockMessage.signature
       )
   }
+
+  type BlockHash  = ByteString
+  type DeployHash = ByteString
 }

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -3,7 +3,7 @@ package io.casperlabs.storage.util
 import com.google.protobuf.ByteString
 import doobie._
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
-import io.casperlabs.casper.consensus.{BlockSummary, Deploy}
+import io.casperlabs.casper.consensus.{BlockSummary, Deploy, Era}
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
@@ -92,4 +92,7 @@ trait DoobieCodecs {
 
   protected implicit val metaTransformEntry: Meta[TransformEntry] =
     Meta[Array[Byte]].imap(TransformEntry.parseFrom)(_.toByteString.toByteArray)
+
+  protected implicit val metaEra: Meta[Era] =
+    Meta[Array[Byte]].imap(Era.parseFrom)(_.toByteString.toByteArray)
 }

--- a/storage/src/main/scala/io/casperlabs/storage/util/TopologicalSortUtil.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/TopologicalSortUtil.scala
@@ -3,7 +3,7 @@ package io.casperlabs.storage.util
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.Block
 import io.casperlabs.crypto.codec.Base16
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 
 object TopologicalSortUtil {
   type BlockSort = Vector[Vector[BlockHash]]

--- a/storage/src/main/scala/io/casperlabs/storage/util/byteOps.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/byteOps.scala
@@ -2,7 +2,7 @@ package io.casperlabs.storage.util
 import java.nio.ByteBuffer
 
 import com.google.protobuf.ByteString
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 
 object byteOps {

--- a/storage/src/test/scala/io/casperlabs/storage/benchmarks/BlockStorageBench.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/benchmarks/BlockStorageBench.scala
@@ -1,7 +1,7 @@
 package io.casperlabs.storage.benchmarks
 
 import io.casperlabs.storage.benchmarks.StorageBenchSuite._
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.block._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global

--- a/storage/src/test/scala/io/casperlabs/storage/benchmarks/StorageBenchSuite.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/benchmarks/StorageBenchSuite.scala
@@ -11,7 +11,7 @@ import io.casperlabs.ipc._
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockMsgWithTransform
-import io.casperlabs.storage.block.BlockStorage.BlockHash
+import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.{DagStorage, IndexedDagStorage}
 import io.casperlabs.{metrics, shared}
 import monix.eval.Task

--- a/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
 import io.casperlabs.crypto.codec.Base16
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
+import io.casperlabs.storage.{BlockHash, DeployHash}
 import io.casperlabs.storage.{
   ArbitraryStorageData,
   BlockMsgWithTransform,

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -7,7 +7,7 @@ import doobie.util.transactor.Transactor
 import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.metrics.Metrics
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
+import io.casperlabs.storage.{BlockHash, DeployHash}
 import io.casperlabs.storage.block.CachingBlockStorageTest.{
   createSQLiteBlockStorage,
   CachingBlockStorageTestData,
@@ -26,7 +26,6 @@ class CachingBlockStorageTest
     with Matchers
     with ArbitraryStorageData
     with SQLiteFixture[CachingBlockStorageTestData] {
-  import BlockStorage.BlockHash
 
   override def db: String = "/tmp/caching_block_storage_test.db"
 

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/MockDeployStorage.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/MockDeployStorage.scala
@@ -9,7 +9,7 @@ import io.casperlabs.casper.consensus.info.DeployInfo
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.shared.Log
-import io.casperlabs.storage.block.BlockStorage.{BlockHash, DeployHash}
+import io.casperlabs.storage.{BlockHash, DeployHash}
 import io.casperlabs.storage.deploy.MockDeployStorage.Metadata
 import io.casperlabs.shared.Sorting.byteStringOrdering
 

--- a/storage/src/test/scala/io/casperlabs/storage/era/EraStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/era/EraStorageTest.scala
@@ -1,0 +1,64 @@
+package io.casperlabs.storage.era
+
+import cats._
+import cats.implicits._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.Era
+import io.casperlabs.models.ArbitraryConsensus
+import io.casperlabs.storage.SQLiteFixture
+import io.casperlabs.storage.{SQLiteFixture, SQLiteStorage}
+import monix.eval.Task
+import org.scalatest._
+
+trait EraStorageTest extends FlatSpecLike with Matchers with ArbitraryConsensus {
+
+  def withStorage[R](f: EraStorage[Task] => Task[R]): R
+
+  behavior of "EraStorage"
+
+  it should "return None for non-existing" in withStorage { db =>
+    db.getEra(ByteString.copyFromUtf8("non-existent-era")) map {
+      _ shouldBe empty
+    }
+  }
+
+  it should "raise NoSuchElementException for non-existing with" in withStorage { db =>
+    db.getEraUnsafe(ByteString.copyFromUtf8("non-existent-era")).attempt map {
+      case Left(ex) => ex shouldBe a[NoSuchElementException]
+      case Right(_) => fail("Not expected to find the era.")
+    }
+  }
+
+  it should "add and get an era" in withStorage { db =>
+    val era = sample[Era]
+    for {
+      _ <- db.addEra(era)
+      a <- db.getEra(era.keyBlockHash)
+      _ = a shouldBe Some(era)
+      b <- db.getEraUnsafe(era.keyBlockHash)
+      _ = b shouldBe era
+    } yield ()
+  }
+
+  it should "find the children of an era" in withStorage { db =>
+    val e0 = sample[Era]
+    val e1 = sample[Era].withParentKeyBlockHash(e0.keyBlockHash)
+    val e2 = sample[Era].withParentKeyBlockHash(e0.keyBlockHash)
+    for {
+      _  <- db.addEra(e0)
+      _  <- db.addEra(e1)
+      _  <- db.addEra(e2)
+      es <- db.getChildEras(e0.keyBlockHash)
+      _  = es should contain theSameElementsAs List(e1, e2)
+    } yield ()
+  }
+}
+
+class SQLiteEraStorageTest extends EraStorageTest with SQLiteFixture[EraStorage[Task]] {
+  override def withStorage[R](f: EraStorage[Task] => Task[R]): R = runSQLiteTest[R](f)
+
+  override def db: String = "/tmp/era_storage.db"
+
+  override def createTestResource: Task[EraStorage[Task]] =
+    SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
+}


### PR DESCRIPTION
### Overview
Adds a simple SQL storage for eras. The storage is going to be needed by the era aware DAG story to propagate latest messages to child eras.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1104

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Timestamp ranges were added to the table so later I can select active eras to resume, and so that the API can list eras in order.
