### PR TITLE
NO-TICKET: Depend on `setup-as` task.

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -111,7 +111,7 @@ test-rs:
 	$(CARGO) test $(CARGO_FLAGS) --all -- --nocapture
 
 .PHONY: test-as
-test-as:
+test-as: setup-as
 	cd contract-ffi-as && npm run asbuild && npm run test
 
 .PHONY: test


### PR DESCRIPTION
### Overview

As noticed by @fizyk20 `make check` was raising errors with missing `ava` command. This PR adds `setup-as` dependency that would do `npm install` first and therefore fix the error. 

Its a follow up PR for #1483 

### Which JIRA ticket does this PR relate to?

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
