### PR TITLE
NO-TICKET: Optimize FromBytes for Vec<u8> case.

### DIFF
--- a/execution-engine/contract-ffi/src/bytesrepr.rs
+++ b/execution-engine/contract-ffi/src/bytesrepr.rs
@@ -181,9 +181,9 @@ impl FromBytes for i64 {
 
 impl FromBytes for Vec<u8> {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (size, rest) = u32::from_bytes(bytes)?;
-        let (vec_data, rest) = safe_split_at(&rest, size as usize)?;
-        Ok((vec_data.to_vec(), rest))
+        let (size, rem) = u32::from_bytes(bytes)?;
+        let (vec_data, rem) = safe_split_at(&rem, size as usize)?;
+        Ok((vec_data.to_vec(), rem))
     }
 }
 


### PR DESCRIPTION
### Overview

This will use one memory copy, as opposed to `FromBytes` called n times,
which branches out every iteration which supposedly isn't optimized out
by the compiler.

```
tps/transfer_to_existing_account_multiple_execs/3
                        time:   [144.78 ms 146.72 ms 148.96 ms]
                        thrpt:  [20.140  elem/s 20.448  elem/s 20.720  elem/s]
                 change:
                        time:   [-13.322% -11.027% -9.0764%] (p = 0.00 < 0.05)
                        thrpt:  [+9.9825% +12.393% +15.369%]
                        Performance has improved.
Benchmarking tps/transfer_to_existing_account_multiple_deploys_per_exec/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.6s or reduce sample count to 10
tps/transfer_to_existing_account_multiple_deploys_per_exec/3
                        time:   [136.67 ms 137.57 ms 138.66 ms]
                        thrpt:  [21.636  elem/s 21.807  elem/s 21.951  elem/s]
                 change:
                        time:   [-11.222% -9.5489% -7.9746%] (p = 0.00 < 0.05)
                        thrpt:  [+8.6657% +10.557% +12.640%]
                        Performance has improved.
Benchmarking tps/transfer_to_purse_multiple_execs/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.8s or reduce sample count to 10
tps/transfer_to_purse_multiple_execs/3
                        time:   [139.19 ms 140.79 ms 142.38 ms]
                        thrpt:  [21.071  elem/s 21.308  elem/s 21.553  elem/s]
                 change:
                        time:   [-29.866% -21.616% -14.257%] (p = 0.00 < 0.05)
                        thrpt:  [+16.627% +27.577% +42.583%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking tps/transfer_to_purse_multiple_deploys_per_exec/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.7s or reduce sample count to 10
tps/transfer_to_purse_multiple_deploys_per_exec/3
                        time:   [140.26 ms 141.43 ms 143.31 ms]
                        thrpt:  [20.934  elem/s 21.212  elem/s 21.389  elem/s]
                 change:
                        time:   [-22.141% -16.093% -11.470%] (p = 0.00 < 0.05)
                        thrpt:  [+12.957% +19.179% +28.438%]
                        Performance has improved.

```

### Which JIRA ticket does this PR relate to?

Adhoc

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
