### PR TITLE
EE-829: add test showing gas charges being skipped in subcalls

### DIFF
--- a/execution-engine/Cargo.lock
+++ b/execution-engine/Cargo.lock
@@ -8,6 +8,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "add-gas-subcall"
+version = "0.1.0"
+dependencies = [
+ "casperlabs-contract-ffi 0.21.0",
+]
+
+[[package]]
 name = "add-update-associated-key"
 version = "0.1.0"
 dependencies = [

--- a/execution-engine/contracts/test/add-gas-subcall/Cargo.toml
+++ b/execution-engine/contracts/test/add-gas-subcall/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "add-gas-subcall"
+version = "0.1.0"
+authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
+
+[features]
+default = []
+std = ["contract-ffi/std" ]
+
+[dependencies]
+contract-ffi = { path = "../../../contract-ffi", package = "casperlabs-contract-ffi" }

--- a/execution-engine/contracts/test/add-gas-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/add-gas-subcall/src/lib.rs
@@ -1,0 +1,59 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
+use contract_ffi::{
+    contract_api::{runtime, storage, Error},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+
+// This is making use of the undocumented "FFI" function `gas()` which is used by the Wasm
+// interpreter to charge gas for upcoming interpreted instructions.  For further info on this, see
+// https://docs.rs/pwasm-utils/0.12.0/pwasm_utils/fn.inject_gas_counter.html
+extern "C" {
+    pub fn gas(amount: i32);
+}
+
+const SUBCALL_NAME: &str = "add_gas";
+const ADD_GAS_FROM_SESSION: &str = "add-gas-from-session";
+const ADD_GAS_VIA_SUBCALL: &str = "add-gas-via-subcall";
+
+enum Args {
+    GasAmount = 0,
+    MethodName = 1,
+}
+
+#[no_mangle]
+pub extern "C" fn add_gas() {
+    let amount: i32 = runtime::get_arg(Args::GasAmount as u32)
+        .unwrap_or_revert_with(Error::MissingArgument)
+        .unwrap_or_revert_with(Error::InvalidArgument);
+
+    unsafe {
+        gas(amount);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let amount: i32 = runtime::get_arg(Args::GasAmount as u32)
+        .unwrap_or_revert_with(Error::MissingArgument)
+        .unwrap_or_revert_with(Error::InvalidArgument);
+
+    let method_name: String = runtime::get_arg(Args::MethodName as u32)
+        .unwrap_or_revert_with(Error::MissingArgument)
+        .unwrap_or_revert_with(Error::InvalidArgument);
+
+    match method_name.as_str() {
+        ADD_GAS_FROM_SESSION => unsafe {
+            gas(amount);
+        },
+        ADD_GAS_VIA_SUBCALL => {
+            let reference = storage::store_function_at_hash(SUBCALL_NAME, BTreeMap::new());
+            runtime::call_contract::<_, ()>(reference, (amount,), Vec::new());
+        }
+        _ => runtime::revert(Error::InvalidArgument),
+    }
+}

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -187,6 +187,11 @@ where
 
     let result = instance.invoke_export("call", &[], &mut runtime);
 
+    // TODO: To account for the gas used in a subcall, we should uncomment the following lines
+    // if !current_runtime.charge_gas(runtime.context.gas_counter()) {
+    //     return Err(Error::GasLimit);
+    // }
+
     match result {
         // If `Ok` and the `host_buf` is `None`, the contract's execution succeeded but did not
         // explicitly call `runtime::ret()`.  Treat as though the execution returned the unit type

--- a/execution-engine/engine-tests/src/test/contract_api/subcall.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/subcall.rs
@@ -1,6 +1,11 @@
+use num_traits::cast::AsPrimitive;
+
+use contract_ffi::value::U512;
+use engine_core::engine_state::CONV_RATE;
+
 use crate::{
     support::test_support::{ExecuteRequestBuilder, InMemoryWasmTestBuilder},
-    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG},
+    test::{DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT},
 };
 
 #[ignore]
@@ -60,5 +65,86 @@ fn should_charge_gas_for_subcall() {
     assert!(
         no_subcall_cost < do_nothing_cost,
         "do nothing in a subcall should cost more than no subcall"
+    );
+}
+
+// TODO: remove `#[should_panic]` once subcalls' gas costs are included in total costs.
+#[should_panic]
+#[ignore]
+#[test]
+fn should_add_all_gas_for_subcall() {
+    const CONTRACT_NAME: &str = "add_gas_subcall.wasm";
+    const ADD_GAS_FROM_SESSION: &str = "add-gas-from-session";
+    const ADD_GAS_VIA_SUBCALL: &str = "add-gas-via-subcall";
+
+    // Use 90% of the standard test contract's balance
+    let gas_to_add: U512 = *DEFAULT_PAYMENT / CONV_RATE * 9 / 10;
+
+    assert!(gas_to_add <= U512::from(i32::max_value()));
+    let gas_to_add_as_arg: i32 = gas_to_add.as_();
+
+    let add_zero_gas_from_session_request = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_NAME,
+        (0, ADD_GAS_FROM_SESSION),
+    )
+    .build();
+
+    let add_some_gas_from_session_request = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_NAME,
+        (gas_to_add_as_arg, ADD_GAS_FROM_SESSION),
+    )
+    .build();
+
+    let add_zero_gas_via_subcall_request = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_NAME,
+        (0, ADD_GAS_VIA_SUBCALL),
+    )
+    .build();
+
+    let add_some_gas_via_subcall_request = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_NAME,
+        (gas_to_add_as_arg, ADD_GAS_VIA_SUBCALL),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder
+        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .exec(add_zero_gas_from_session_request)
+        .expect_success()
+        .commit()
+        .exec(add_some_gas_from_session_request)
+        .expect_success()
+        .commit()
+        .exec(add_zero_gas_via_subcall_request)
+        .expect_success()
+        .commit()
+        .exec(add_some_gas_via_subcall_request)
+        .expect_success()
+        .commit()
+        .finish();
+
+    let add_zero_gas_from_session_cost = builder.exec_costs(0)[0];
+    let add_some_gas_from_session_cost = builder.exec_costs(1)[0];
+    let add_zero_gas_via_subcall_cost = builder.exec_costs(2)[0];
+    let add_some_gas_via_subcall_cost = builder.exec_costs(3)[0];
+
+    assert!(add_zero_gas_from_session_cost.value() < gas_to_add);
+    assert!(add_some_gas_from_session_cost.value() > gas_to_add);
+    assert_eq!(
+        add_some_gas_from_session_cost.value(),
+        gas_to_add + add_zero_gas_from_session_cost.value()
+    );
+
+    assert!(add_zero_gas_via_subcall_cost.value() < gas_to_add);
+    assert!(add_some_gas_via_subcall_cost.value() > gas_to_add);
+    assert_eq!(
+        add_some_gas_via_subcall_cost.value(),
+        gas_to_add + add_zero_gas_via_subcall_cost.value()
     );
 }


### PR DESCRIPTION
### Overview
Adds a test showing gas charges being skipped in subcalls.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-811
https://casperlabs.atlassian.net/browse/EE-829

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
