### PR TITLE
NODE-1101: Era aware DAG

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -12,7 +12,7 @@ import monix.eval.Task
 import org.scalatest.FlatSpec
 import io.casperlabs.casper.scalatestcontrib._
 import io.casperlabs.models.Message
-import io.casperlabs.storage.dag.{DagRepresentation, TipRepresentation}
+import io.casperlabs.storage.dag.{DagRepresentation, EraTipRepresentation, TipRepresentation}
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 
 class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with StorageFixture {
@@ -160,7 +160,8 @@ object FinalityDetectorUtilTest {
         ???
       override def latestInEra(
           keyBlockHash: BlockHash
-      ): StateT[F, Map[BlockHash, Int], TipRepresentation[StateT[F, Map[BlockHash, Int], *]]] = ???
+      ): StateT[F, Map[BlockHash, Int], EraTipRepresentation[StateT[F, Map[BlockHash, Int], *]]] =
+        ???
 
     }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -12,7 +12,7 @@ import monix.eval.Task
 import org.scalatest.FlatSpec
 import io.casperlabs.casper.scalatestcontrib._
 import io.casperlabs.models.Message
-import io.casperlabs.storage.dag.DagRepresentation
+import io.casperlabs.storage.dag.{DagRepresentation, TipRepresentation}
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 
 class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with StorageFixture {
@@ -155,18 +155,12 @@ object FinalityDetectorUtilTest {
           tailLength: Int
       ): fs2.Stream[StateT[F, Map[BlockHash, Int], *], Vector[BlockInfo]] = ???
 
-      override def latestMessageHash(
-          validator: Validator
-      ): StateT[F, Map[BlockHash, Int], Set[BlockHash]] = ???
-
-      override def latestMessage(
-          validator: Validator
-      ): StateT[F, Map[BlockHash, Int], Set[Message]] = ???
-
-      override def latestMessageHashes
-          : StateT[F, Map[BlockHash, Int], Map[Validator, Set[BlockHash]]] = ???
-
-      override def latestMessages: StateT[F, Map[BlockHash, Int], Map[Validator, Set[Message]]] =
+      override def latestGlobal
+          : StateT[F, Map[BlockHash, Int], TipRepresentation[StateT[F, Map[BlockHash, Int], *]]] =
         ???
+      override def latestInEra(
+          keyBlockHash: BlockHash
+      ): StateT[F, Map[BlockHash, Int], TipRepresentation[StateT[F, Map[BlockHash, Int], *]]] = ???
+
     }
 }

--- a/storage/src/main/resources/db/migration/V20200106_1101__Add_era_to_validator_latest_messages.sql
+++ b/storage/src/main/resources/db/migration/V20200106_1101__Add_era_to_validator_latest_messages.sql
@@ -1,0 +1,15 @@
+CREATE TABLE latest_messages
+(
+    key_block_hash BLOB NOT NULL,
+    validator  BLOB     NOT NULL,
+    block_hash BLOB     NOT NULL,
+    PRIMARY KEY (key_block_hash, validator, block_hash),
+    FOREIGN KEY (block_hash) REFERENCES block_metadata (block_hash)
+) WITHOUT ROWID;
+
+INSERT INTO latest_messages (key_block_hash, validator, block_hash)
+SELECT x'', validator, block_hash FROM validator_latest_messages;
+
+DROP TABLE validator_latest_messages;
+
+ALTER TABLE latest_messages RENAME TO validator_latest_messages;

--- a/storage/src/main/resources/db/migration/V20200106_1101__Add_era_to_validator_latest_messages.sql
+++ b/storage/src/main/resources/db/migration/V20200106_1101__Add_era_to_validator_latest_messages.sql
@@ -13,3 +13,10 @@ SELECT x'', validator, block_hash FROM validator_latest_messages;
 DROP TABLE validator_latest_messages;
 
 ALTER TABLE latest_messages RENAME TO validator_latest_messages;
+
+-- Add ticks to the eras to be able to tell when a message is after the end
+-- without having to retrieve the full era record.
+ALTER TABLE eras ADD start_tick INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE eras ADD end_tick INTEGER NOT NULL DEFAULT 0;
+
+UPDATE eras SET start_tick = start_millis, end_tick = end_millis;

--- a/storage/src/main/resources/db/migration/V20200106_1101__Add_ticks_to_eras.sql
+++ b/storage/src/main/resources/db/migration/V20200106_1101__Add_ticks_to_eras.sql
@@ -1,7 +1,0 @@
-
--- Add ticks to the eras to be able to tell when a message is after the end
--- without having to retrieve the full era record.
-ALTER TABLE eras ADD start_tick INTEGER NOT NULL DEFAULT 0;
-ALTER TABLE eras ADD end_tick INTEGER NOT NULL DEFAULT 0;
-
-UPDATE eras SET start_tick = start_millis, end_tick = end_millis;

--- a/storage/src/main/resources/db/migration/V20200106_1101__Add_ticks_to_eras.sql
+++ b/storage/src/main/resources/db/migration/V20200106_1101__Add_ticks_to_eras.sql
@@ -1,0 +1,7 @@
+
+-- Add ticks to the eras to be able to tell when a message is after the end
+-- without having to retrieve the full era record.
+ALTER TABLE eras ADD start_tick INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE eras ADD end_tick INTEGER NOT NULL DEFAULT 0;
+
+UPDATE eras SET start_tick = start_millis, end_tick = end_millis;

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -150,17 +150,11 @@ object SQLiteStorage {
       override def topoSortTail(tailLength: Int): Stream[F, Vector[BlockInfo]] =
         dagStorage.topoSortTail(tailLength)
 
-      override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
-        dagStorage.latestMessageHash(validator)
+      override def latestGlobal =
+        dagStorage.getRepresentation.flatMap(_.latestGlobal)
 
-      override def latestMessage(validator: Validator): F[Set[Message]] =
-        dagStorage.latestMessage(validator)
-
-      override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
-        dagStorage.latestMessageHashes
-
-      override def latestMessages: F[Map[Validator, Set[Message]]] =
-        dagStorage.latestMessages
+      override def latestInEra(keyBlockHash: BlockHash) =
+        dagStorage.getRepresentation.flatMap(_.latestInEra(keyBlockHash))
 
       override def addEra(era: Era): F[Unit]                   = eraStorage.addEra(era)
       override def getEra(eraId: BlockHash): F[Option[Era]]    = eraStorage.getEra(eraId)

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -155,16 +155,8 @@ class CachingDagStorage[F[_]: Concurrent](
   override def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockInfo]] =
     underlying.topoSortTail(tailLength)
 
-  override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
-    underlying.latestMessageHash(validator)
-
-  override def latestMessage(validator: Validator): F[Set[Message]] =
-    underlying.latestMessage(validator)
-
-  override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
-    underlying.latestMessageHashes
-
-  override def latestMessages: F[Map[Validator, Set[Message]]] = underlying.latestMessages
+  override def latestGlobal                         = underlying.latestGlobal
+  override def latestInEra(keyBlockHash: BlockHash) = underlying.latestInEra(keyBlockHash)
 
   override def markAsFinalized(
       mainParent: BlockHash,

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -13,10 +13,18 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.codec.Base16
 
 trait DagStorage[F[_]] {
-  //TODO: Get rid of DagRepresentation if SQLite works out
-  /* Doesn't guarantee to return immutable representation */
+
+  /** Doesn't guarantee to return immutable representation. */
   def getRepresentation: F[DagRepresentation[F]]
+
+  /** Insert a block into the DAG and update the latest messages.
+    *
+    * If the key block hash corresponds to an era, then update descendant eras as well,
+    * so that they can pick up blocks that arrived late and incorporate them into their DAG.
+    * Ballots that only arrive to finalize switch blocks are not propagated to child eras.
+    */
   private[storage] def insert(block: Block): F[DagRepresentation[F]]
+
   def checkpoint(): F[Unit]
   def clear(): F[Unit]
   def close(): F[Unit]
@@ -36,7 +44,6 @@ object DagStorage {
   }
 
   trait MeteredDagRepresentation[F[_]] extends DagRepresentation[F] with Metered[F] {
-    // Not measuring 'latestMessage*' because they return fs2.Stream which doesn't work with 'incAndMeasure'
 
     abstract override def children(blockHash: BlockHash): F[Set[BlockHash]] =
       incAndMeasure("children", super.children(blockHash))
@@ -49,18 +56,6 @@ object DagStorage {
 
     abstract override def contains(blockHash: BlockHash): F[Boolean] =
       incAndMeasure("contains", super.contains(blockHash))
-
-    abstract override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
-      incAndMeasure("latestMessageHash", super.latestMessageHash(validator))
-
-    abstract override def latestMessage(validator: Validator): F[Set[Message]] =
-      incAndMeasure("latestMessage", super.latestMessage(validator))
-
-    abstract override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
-      incAndMeasure("latestMessageHashes", super.latestMessageHashes)
-
-    abstract override def latestMessages: F[Map[Validator, Set[Message]]] =
-      incAndMeasure("latestMessages", super.latestMessages)
 
     abstract override def topoSort(
         startBlockNumber: Long,
@@ -79,7 +74,28 @@ object DagStorage {
       super.incAndMeasure("topoSortTail", super.topoSortTail(tailLength))
   }
 
+  trait MeteredTipRepresentation[F[_]] extends TipRepresentation[F] with Metered[F] {
+    abstract override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
+      incAndMeasure("latestMessageHash", super.latestMessageHash(validator))
+
+    abstract override def latestMessage(validator: Validator): F[Set[Message]] =
+      incAndMeasure("latestMessage", super.latestMessage(validator))
+
+    abstract override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
+      incAndMeasure("latestMessageHashes", super.latestMessageHashes)
+
+    abstract override def latestMessages: F[Map[Validator, Set[Message]]] =
+      incAndMeasure("latestMessages", super.latestMessages)
+  }
+
   def apply[F[_]](implicit B: DagStorage[F]): DagStorage[F] = B
+}
+
+trait TipRepresentation[F[_]] {
+  def latestMessageHash(validator: Validator): F[Set[BlockHash]]
+  def latestMessage(validator: Validator): F[Set[Message]]
+  def latestMessageHashes: F[Map[Validator, Set[BlockHash]]]
+  def latestMessages: F[Map[Validator, Set[Message]]]
 }
 
 trait DagRepresentation[F[_]] {
@@ -111,21 +127,37 @@ trait DagRepresentation[F[_]] {
 
   def topoSortTail(tailLength: Int): fs2.Stream[F, Vector[BlockInfo]]
 
-  def latestMessageHash(validator: Validator): F[Set[BlockHash]]
-  def latestMessage(validator: Validator): F[Set[Message]]
-  def latestMessageHashes: F[Map[Validator, Set[BlockHash]]]
-  def latestMessages: F[Map[Validator, Set[Message]]]
+  /** Get a global representation, which can be used in:
+    * 1) naive casper mode, without eras
+    * 2) in the gossiping, when nodes ask each other for their latest blocks
+    *
+    * Latest messages would be that of any era which is considered active,
+    * so that pull based gossiping can pull ballots of eras still being finalized
+    * as well as the child era which is already started, but we stop returning
+    * records for eras that have already finished (their last ballots are no longer
+    * relevant tips).
+    *
+    * Doesn't guarantee to return immutable representation.
+    */
+  def latestGlobal: F[TipRepresentation[F]]
+
+  /** Get a representation restricted to a given era, which means the latest messages
+    * of the ancestor eras affect the child eras, but not vice versa. Latest messages
+    * in sibling eras are also invisible to each other. The DAG itself, i.e. the parent
+    * child relationships are unaffected.
+    */
+  def latestInEra(keyBlockHash: BlockHash): F[TipRepresentation[F]]
 }
 
 object DagRepresentation {
   type Validator = ByteString
 
-  implicit class DagRepresentationRich[F[_]](
+  implicit class DagRepresentationRich[F[_]: Monad](
       dagRepresentation: DagRepresentation[F]
   ) {
     def getMainChildren(
         blockHash: BlockHash
-    )(implicit monad: Monad[F]): F[List[BlockHash]] =
+    ): F[List[BlockHash]] =
       dagRepresentation
         .children(blockHash)
         .flatMap(
@@ -141,16 +173,31 @@ object DagRepresentation {
         )
 
     // Returns a set of validators that this node has seen equivocating.
-    def getEquivocators(implicit M: Monad[F]): F[Set[Validator]] =
+    def getEquivocators: F[Set[Validator]] =
       getEquivocations.map(_.keySet)
 
+    // NOTE: These extension methods are here so the Naive-Casper codebase doesn't have to do another
+    // step (i.e. `.latestGlobal.flatMap { tip => ... }`)  but in Highway we should first specify the era.
+
+    def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
+      dagRepresentation.latestGlobal.flatMap(_.latestMessageHash(validator))
+
+    def latestMessage(validator: Validator): F[Set[Message]] =
+      dagRepresentation.latestGlobal.flatMap(_.latestMessage(validator))
+
+    def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
+      dagRepresentation.latestGlobal.flatMap(_.latestMessageHashes)
+
+    def latestMessages: F[Map[Validator, Set[Message]]] =
+      dagRepresentation.latestGlobal.flatMap(_.latestMessages)
+
     // Returns a mapping between equivocators and their messages.
-    def getEquivocations(implicit M: Monad[F]): F[Map[Validator, Set[Message]]] =
-      dagRepresentation.latestMessages.map(_.filter(_._2.size > 1))
+    def getEquivocations: F[Map[Validator, Set[Message]]] =
+      latestMessages.map(_.filter(_._2.size > 1))
 
     // Returns latest messages from honest validators
-    def latestMessagesHonestValidators(implicit M: Monad[F]): F[Map[Validator, Message]] =
-      dagRepresentation.latestMessages.map { latestMessages =>
+    def latestMessagesHonestValidators: F[Map[Validator, Message]] =
+      latestMessages.map { latestMessages =>
         latestMessages.collect {
           case (v, messages) if messages.size == 1 =>
             (v, messages.head)

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -98,6 +98,16 @@ trait TipRepresentation[F[_]] {
   def latestMessages: F[Map[Validator, Set[Message]]]
 }
 
+trait EraTipRepresentation[F[_]] extends TipRepresentation[F] {
+  // TODO: These methods should move here from DagRepresentationRich,
+  // to make sure we never try to detect equivocators on the global
+  // representation, however for that we need lots of updates in
+  // the casper codebase.
+
+  // def getEquivocators: F[Set[Validator]] = ???
+  // def getEquivocations: F[Map[Validator, Set[Message]]] = ???
+}
+
 trait DagRepresentation[F[_]] {
   def children(blockHash: BlockHash): F[Set[BlockHash]]
 
@@ -137,6 +147,8 @@ trait DagRepresentation[F[_]] {
     * records for eras that have already finished (their last ballots are no longer
     * relevant tips).
     *
+    * This will not reflect equivocations in the presence of parallel eras.
+    *
     * Doesn't guarantee to return immutable representation.
     */
   def latestGlobal: F[TipRepresentation[F]]
@@ -146,7 +158,7 @@ trait DagRepresentation[F[_]] {
     * in sibling eras are also invisible to each other. The DAG itself, i.e. the parent
     * child relationships are unaffected.
     */
-  def latestInEra(keyBlockHash: BlockHash): F[TipRepresentation[F]]
+  def latestInEra(keyBlockHash: BlockHash): F[EraTipRepresentation[F]]
 }
 
 object DagRepresentation {

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -4,6 +4,7 @@ import cats._
 import cats.data._
 import cats.effect._
 import cats.implicits._
+import com.google.protobuf.ByteString
 import doobie._
 import doobie.implicits._
 import io.casperlabs.casper.consensus.info.BlockInfo
@@ -49,13 +50,14 @@ class SQLiteDagStorage[F[_]: Sync](
         deploys
           .map(d => d.cost * d.getDeploy.getHeader.gasPrice)
           .sum / deployCostTotal
-    val blockMetadataQuery =
+
+    val insertBlockMetadata =
       (fr"""INSERT OR IGNORE INTO block_metadata
             (block_hash, validator, rank, """ ++ blockInfoCols() ++ fr""")
             VALUES (${block.blockHash}, ${block.validatorPublicKey}, ${block.rank}, ${blockSummary.toByteString}, ${block.serializedSize}, $deployErrorCount, $deployCostTotal, $deployGasPriceAvg)
             """).update.run
 
-    val justificationsQuery =
+    val insertJustifications =
       Update[(BlockHash, BlockHash)](
         """|INSERT OR IGNORE INTO block_justifications
            |(justification_block_hash, block_hash)
@@ -66,7 +68,27 @@ class SQLiteDagStorage[F[_]: Sync](
           .toList
       )
 
-    val latestMessagesQuery =
+    // The key block may or may not be an actual era ID, depending on whether
+    // we're using Highway or NCB. We can find out if we select all the eras
+    // that need updating. This requires that the era already exists, but
+    // that should be fine, because the switch block that triggers the creation
+    // of the era is processed before any block in the child era is downloaded.
+    val keyBlockHash = block.getHeader.keyBlockHash
+
+    val selectEras =
+      sql"""WITH RECURSIVE
+            descendant_eras(hash) AS (
+              SELECT hash FROM eras WHERE hash = $keyBlockHash
+              UNION
+              SELECT e.hash
+              FROM   eras e
+              JOIN   descendant_eras d ON e.parent_hash = d.hash
+            )
+            SELECT hash FROM descendant_eras"""
+        .query[BlockHash]
+        .to[List]
+
+    def upsertLatestMessages(keyBlockHash: BlockHash): ConnectionIO[Unit] =
       if (!block.isGenesisLike) {
         // CON-557 will add a validity condition that a block cannot cite multiple latest messages
         // from its creator, i.e. merging of swimlane is not allowed.
@@ -74,40 +96,45 @@ class SQLiteDagStorage[F[_]: Sync](
           Option(blockSummary.getHeader.validatorPrevBlockHash).filterNot(_.isEmpty)
 
         val insertQuery =
-          sql""" INSERT OR IGNORE INTO validator_latest_messages (validator, block_hash)
-                 VALUES (${blockSummary.validatorPublicKey}, ${blockSummary.blockHash})""".stripMargin
+          sql""" INSERT OR IGNORE INTO validator_latest_messages (key_block_hash, validator, block_hash)
+                 VALUES ($keyBlockHash, ${blockSummary.validatorPublicKey}, ${blockSummary.blockHash})""".stripMargin
 
         validatorPreviousMessage
           .fold {
             // No previous message visible from the justifications.
             // This is the first block from this validator (at least according to the creator of the message).
-            insertQuery.update.run
+            insertQuery.update.run.void
           } { lastMessageHash =>
             // Delete previous entry if the new block cites it.
             // Insert new one.
-            sql"""|DELETE FROM validator_latest_messages
-                  |WHERE validator = ${blockSummary.validatorPublicKey}
-                  |AND block_hash = $lastMessageHash""".stripMargin.update.run >>
-              insertQuery.update.run
+            sql"""DELETE FROM validator_latest_messages
+                  WHERE key_block_hash = $keyBlockHash
+                  AND validator = ${blockSummary.validatorPublicKey}
+                  AND block_hash = $lastMessageHash""".update.run >>
+              insertQuery.update.run.void
           }
       } else ().pure[ConnectionIO]
 
-    val topologicalSortingQuery =
+    val insertTopologicalSorting =
       if (block.isGenesisLike) {
         ().pure[ConnectionIO]
       } else {
         Update[(BlockHash, BlockHash)](
-          """|INSERT OR IGNORE INTO block_parents
-             |(parent_block_hash, child_block_hash)
-             |VALUES (?, ?)""".stripMargin
+          """INSERT OR IGNORE INTO block_parents
+             (parent_block_hash, child_block_hash)
+             VALUES (?, ?)"""
         ).updateMany(blockSummary.parentHashes.map((_, blockSummary.blockHash)).toList).void
       }
 
     val transaction = for {
-      _ <- blockMetadataQuery
-      _ <- justificationsQuery
-      _ <- latestMessagesQuery
-      _ <- topologicalSortingQuery
+      _ <- insertBlockMetadata
+      _ <- insertJustifications
+      _ <- insertTopologicalSorting
+      // Maintain a version of latest messages across the whole DAG, independent of eras.
+      _ <- upsertLatestMessages(ByteString.EMPTY)
+      // Update era-specific latest messages in this and all descendant eras.
+      eras <- selectEras
+      _    <- eras.traverse(upsertLatestMessages)
     } yield ()
 
     for {
@@ -200,34 +227,35 @@ class SQLiteDagStorage[F[_]: Sync](
       .transact(readXa)
       .groupByRank
 
-  override def latestInEra(keyBlockHash: BlockHash): F[TipRepresentation[F]] = ???
+  override def latestInEra(keyBlockHash: BlockHash): F[EraTipRepresentation[F]] = Sync[F].delay {
+    SQLiteTipRepresentation(keyBlockHash): EraTipRepresentation[F]
+  }
 
   override def latestGlobal: F[TipRepresentation[F]] =
     globalTipRepresentation.value.pure[F]
 
   private val globalTipRepresentation = Eval.later {
-    new SQLiteTipRepresentation() with MeteredTipRepresentation[F] {
-      override implicit val m: Metrics[F] = met
-      override implicit val ms: Source    = SQLiteDagStorage.MetricsSource
-      override implicit val a: Apply[F]   = Sync[F]
-    }: TipRepresentation[F]
+    SQLiteTipRepresentation(keyBlockHash = ByteString.EMPTY): TipRepresentation[F]
   }
 
-  class SQLiteTipRepresentation() extends TipRepresentation[F] {
+  // There will be a global representation with an empty key block hash,
+  // and the era-specific versions. We can use the global for gossiping,
+  // without having to worry about filtering for which era is active.
+  class SQLiteTipRepresentation(keyBlockHash: BlockHash) extends EraTipRepresentation[F] {
 
     override def latestMessageHash(validator: Validator): F[Set[BlockHash]] =
-      sql"""|SELECT block_hash
-          |FROM validator_latest_messages
-          |WHERE validator=$validator""".stripMargin
+      sql"""SELECT block_hash
+            FROM validator_latest_messages
+            WHERE key_block_hash = $keyBlockHash AND validator = $validator"""
         .query[BlockHash]
         .to[Set]
         .transact(readXa)
 
     override def latestMessage(validator: Validator): F[Set[Message]] =
-      sql"""|SELECT m.data
-          |FROM validator_latest_messages v
-          |INNER JOIN block_metadata m
-          |ON v.validator=$validator AND v.block_hash=m.block_hash""".stripMargin
+      sql"""SELECT m.data
+            FROM validator_latest_messages v
+            INNER JOIN block_metadata m ON v.block_hash=m.block_hash
+            WHERE v.key_block_hash = $keyBlockHash AND v.validator = $validator"""
         .query[BlockSummary]
         .to[List]
         .transact(readXa)
@@ -235,23 +263,32 @@ class SQLiteDagStorage[F[_]: Sync](
         .map(_.toSet)
 
     override def latestMessageHashes: F[Map[Validator, Set[BlockHash]]] =
-      sql"""|SELECT *
-          |FROM validator_latest_messages""".stripMargin
+      sql"""SELECT validator, block_hash
+            FROM validator_latest_messages
+            WHERE key_block_hash = $keyBlockHash"""
         .query[(Validator, BlockHash)]
         .to[List]
         .transact(readXa)
         .map(_.groupBy(_._1).mapValues(_.map(_._2).toSet))
 
     override def latestMessages: F[Map[Validator, Set[Message]]] =
-      sql"""|SELECT v.validator, m.data
-          |FROM validator_latest_messages v
-          |INNER JOIN block_metadata m
-          |ON m.block_hash=v.block_hash""".stripMargin
+      sql"""SELECT v.validator, m.data
+            FROM validator_latest_messages v
+            INNER JOIN block_metadata m ON m.block_hash = v.block_hash
+            WHERE v.key_block_hash = $keyBlockHash"""
         .query[(Validator, BlockSummary)]
         .to[List]
         .transact(readXa)
         .flatMap(_.traverse { case (v, bs) => toMessageSummaryF(bs).map(v -> _) })
         .map(_.groupBy(_._1).mapValues(_.map(_._2).toSet))
+  }
+  object SQLiteTipRepresentation {
+    def apply(keyBlockHash: BlockHash) =
+      new SQLiteTipRepresentation(keyBlockHash) with MeteredTipRepresentation[F] {
+        override implicit val m: Metrics[F] = met
+        override implicit val ms: Source    = SQLiteDagStorage.MetricsSource
+        override implicit val a: Apply[F]   = Sync[F]
+      }
   }
 
   override def markAsFinalized(

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -74,36 +74,15 @@ class SQLiteDagStorage[F[_]: Sync](
     // that should be fine, because the switch block that triggers the creation
     // of the era is processed before any block in the child era is downloaded.
     val keyBlockHash = block.getHeader.keyBlockHash
-    val roundId      = block.getHeader.roundId
 
-    // Ballots that only vote on switch block don't need to be propagated
-    // to child eras because they would appear as equivocations.
-    // Only the messages that lead up to the switch block should be visible.
-    val selectIsVisible: ConnectionIO[Option[Boolean]] = {
-      sql"""SELECT CASE WHEN $roundId < end_tick THEN true ELSE false END
+    val selectEraExists: ConnectionIO[Boolean] = {
+      sql"""SELECT true
             FROM   eras
             WHERE  hash = $keyBlockHash"""
         .query[Boolean]
         .option
-        .map {
-          case Some(false) => block.getHeader.messageType.isBlock.some
-          case other       => other
-        }
+        .map(_ getOrElse false)
     }
-
-    def selectEras(isVisible: Boolean): ConnectionIO[List[BlockHash]] =
-      sql"""WITH RECURSIVE
-            descendant_eras(hash) AS (
-              SELECT hash FROM eras WHERE hash = $keyBlockHash
-              UNION
-              SELECT e.hash
-              FROM   eras e
-              JOIN   descendant_eras d ON e.parent_hash = d.hash
-              WHERE  $isVisible = true
-            )
-            SELECT hash FROM descendant_eras"""
-        .query[BlockHash]
-        .to[List]
 
     def upsertLatestMessages(keyBlockHash: BlockHash): ConnectionIO[Unit] =
       if (!block.isGenesisLike) {
@@ -147,15 +126,15 @@ class SQLiteDagStorage[F[_]: Sync](
       _ <- insertBlockMetadata
       _ <- insertJustifications
       _ <- insertTopologicalSorting
-      // Maintain a version of latest messages across the whole DAG, independent of eras.
+      // Maintain a version of latest messages across the whole DAG, independent of eras,
+      // for pull based gossiping, until era statuses are added which allows us to find active ones easily.
       _ <- upsertLatestMessages(ByteString.EMPTY)
-      // Update era-specific latest messages in this and all descendant eras.
-      maybeIsVisible <- selectIsVisible
-      _ <- maybeIsVisible.fold(().pure[ConnectionIO]) { isVisible =>
-            selectEras(isVisible) flatMap { eras =>
-              eras.traverse(upsertLatestMessages).void
-            }
-          }
+      // Update era-specific latest messages in this era. Child eras don't need to be updated because the
+      // application layer can track and cache it on its own.
+      _ <- selectEraExists.ifM(
+            upsertLatestMessages(keyBlockHash),
+            ().pure[ConnectionIO]
+          )
     } yield ()
 
     for {

--- a/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
@@ -25,8 +25,10 @@ class SQLiteEraStorage[F[_]: Sync](
     val endMillis   = TimeUnit.MILLISECONDS.convert(era.endTick, tickUnit)
 
     val insert =
-      sql"""INSERT OR IGNORE INTO eras (hash, parent_hash, start_millis, end_millis, data)
-            VALUES ($hash, $parentHash, $startMillis, $endMillis, $era)""".update.run
+      sql"""INSERT OR IGNORE INTO eras
+            (hash, parent_hash, start_millis, end_millis, start_tick, end_tick, data)
+            VALUES ($hash, $parentHash, $startMillis, $endMillis, ${era.startTick}, ${era.endTick}, $era)
+            """.update.run
 
     insert.transact(writeXa).void
   }

--- a/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
@@ -30,20 +30,7 @@ class SQLiteEraStorage[F[_]: Sync](
             VALUES ($hash, $parentHash, $startMillis, $endMillis, ${era.startTick}, ${era.endTick}, $era)
             """.update.run
 
-    val insertLatestMessages =
-      sql"""INSERT OR IGNORE INTO validator_latest_messages
-            (key_block_hash, validator, block_hash)
-            SELECT $hash, validator, block_hash
-            FROM   validator_latest_messages
-            WHERE  key_block_hash = $parentHash
-            """.update.run
-
-    val transaction = for {
-      _ <- insertEra
-      _ <- insertLatestMessages
-    } yield ()
-
-    transaction.transact(writeXa).void
+    insertEra.transact(writeXa).void
   }
 
   override def getEra(keyBlockHash: BlockHash): F[Option[Era]] =

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -145,7 +145,7 @@ trait DagStorageTest
     }
   }
 
-  "DAG Storage" should "be able to properly (de)serialize data" in {
+  it should "be able to properly (de)serialize data" in {
     forAll { b: Block =>
       withDagStorage { storage =>
         val before = BlockSummary.fromBlock(b).toByteArray
@@ -162,17 +162,8 @@ trait DagStorageTest
       }
     }
   }
-}
 
-class SQLiteDagStorageTest extends DagStorageTest with SQLiteFixture[DagStorage[Task]] {
-  override def withDagStorage[R](f: DagStorage[Task] => Task[R]): R = runSQLiteTest[R](f)
-
-  override def db: String = "/tmp/dag_storage.db"
-
-  override def createTestResource: Task[DagStorage[Task]] =
-    SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
-
-  "SQLite DAG Storage" should "override validator's latest block hash only if new messages quotes the previous one" in {
+  it should "override validator's latest block hash only if new messages quotes the previous one" in {
     forAll { (initial: Block, a: Block, c: Block) =>
       withDagStorage { storage =>
         def update(b: Block, validator: ByteString, prevHash: ByteString): Block =
@@ -242,4 +233,13 @@ class SQLiteDagStorageTest extends DagStorageTest with SQLiteFixture[DagStorage[
       }
     }
   }
+}
+
+class SQLiteDagStorageTest extends DagStorageTest with SQLiteFixture[DagStorage[Task]] {
+  override def withDagStorage[R](f: DagStorage[Task] => Task[R]): R = runSQLiteTest[R](f)
+
+  override def db: String = "/tmp/dag_storage.db"
+
+  override def createTestResource: Task[DagStorage[Task]] =
+    SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
 }


### PR DESCRIPTION
### Overview
Eras need to be able to pick the tips of the DAG and detect equivocations independently from each other. Since these were both based on the `validator_latest_messages` table, this PR extends that to have an era ID in it. 

I created a new `TipRepresentation` trait to hold the `latestMessage*` methods which has a specialization for `EraTipRepresentation` which we can use later to restrict methods we use currently to detect equivocations to only work in the context of a specific era. The other, global version will in the future only be used in pull based gossiping. 

The `DagStorage.DagRepresentation` trait gets two new methods: `latestGlobal` and `latestInEra(keyBlockHash)` which we can use to get those two traits. For now there will be a global instance with an empty era if we use NCB and even with Highway, so that for pull based gossiping we can just return those, but really what should happen is that in the global one we only return the tips of eras which are still active. This will need some extra status fields in the `eras` table, for easy filtering.

During `insert` the `SQLiteDagStorage` will do the usual delete+insert of latest messages, but on a per-era basis. This allows simple detection of equivocators, but it doesn't have any support for picking the parent candidates for example; that will be done in the application layer. Messages in the child eras will have to cite all messages from the parent era, but for now those are not propagated on the database level. It's been said we'll only have to consider latest messages up the grandparent era; looking them up should be quick enough, and then eliminating transitive justifications is to be done later.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1101

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Created https://casperlabs.atlassian.net/browse/NODE-1106 to add era status, at which point the `latestGlobal` can be changed to do a join with the `eras` to return only active ones, or maybe old records can be cleared out.
