### PR TITLE
ECO-92: Selecting a block not currently in retrieved should trigger a retrieval of the DAG.

### DIFF
--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -86,11 +86,7 @@ export default class Explorer extends RefreshableComponent<Props, {}> {
                 block={dag.selectedBlock}
                 blocks={dag.blocks!}
                 onSelect={blockHashBase16 => {
-                  dag.selectedBlock = dag.blocks!.find(
-                    x =>
-                      encodeBase16(x.getSummary()!.getBlockHash_asU8()) ===
-                      blockHashBase16
-                  );
+                  dag.selectByBlockHashBase16(blockHashBase16);
                 }}
               />
             </div>
@@ -113,7 +109,7 @@ class BlockDetails extends React.Component<{
   block: BlockInfo;
   blocks: BlockInfo[];
   onSelect: (blockHash: string) => void;
-}> {
+}, {}> {
   ref: HTMLElement | null = null;
 
   render() {

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -1,7 +1,7 @@
 import { observable } from 'mobx';
 
 import ErrorContainer from './ErrorContainer';
-import { CasperService } from 'casperlabs-sdk';
+import { CasperService, encodeBase16 } from 'casperlabs-sdk';
 import {
   BlockInfo,
   Event
@@ -75,6 +75,24 @@ export class DagContainer {
 
   get hasBlocks() {
     return this.blocks ? this.blocks.length > 0 : false;
+  }
+
+  async selectByBlockHashBase16(blockHashBase16: string) {
+    let selectedBlock = this.blocks!.find(
+      x =>
+        encodeBase16(x.getSummary()!.getBlockHash_asU8()) ===
+        blockHashBase16
+    );
+    if (selectedBlock) {
+      this.selectedBlock = selectedBlock;
+    } else {
+      await this.errors.capture(
+        this.casperService.getBlockInfo(blockHashBase16, 0).then(block => {
+          this.selectedBlock = block;
+          this.blocks!.push(block);
+        })
+      );
+    }
   }
 
   step = new DagStep(this);


### PR DESCRIPTION
# Overview
As the title said. It looks like: 
![qetRAJ0Aff](https://user-images.githubusercontent.com/7604540/71899447-b6cd8880-3196-11ea-8fe3-de2aa9bbb3b4.gif)



### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-92

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
