### PR TITLE
NODE-1065: Bump `GrpcGossipServiceSpec#GetBlocksChunked` test timeout by 3 seconds.

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -243,7 +243,7 @@ class GrpcGossipServiceSpec
               val queueSize     = 10
               val minSuccessful = 2
 
-              implicit val patienceConfig = PatienceConfig(7.second, 500.millis)
+              implicit val patienceConfig = PatienceConfig(10.seconds, 500.millis)
 
               test(block, queueSize) { stub =>
                 val success = Atomic(0)


### PR DESCRIPTION
### Overview
As in the title. Jumping into code, trying to rewrite it so that we don't have to make use of `eventually { … }` seems like bad "bang for the buck".

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1065

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
