### PR TITLE
NODE-1102: Era switch blocks

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -4,7 +4,7 @@ import cats._
 import cats.data.{EitherT, WriterT}
 import cats.implicits._
 import cats.effect.{Clock, Sync}
-import cats.effect.concurrent.{Ref, Semaphore}
+import cats.effect.concurrent.Ref
 import com.google.protobuf.ByteString
 import java.time.Instant
 import io.casperlabs.casper.consensus.{Block, BlockSummary, Era}
@@ -16,8 +16,6 @@ import io.casperlabs.storage.dag.{DagRepresentation, DagStorage}
 import io.casperlabs.storage.era.EraStorage
 import io.casperlabs.casper.util.DagOperations
 import scala.util.Random
-
-import io.casperlabs.crypto.codec.Base16
 
 /** Class to encapsulate the message handling logic of messages in an era.
   *

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -241,7 +241,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: ForkChoice](
                              isCrossing(bookingBlockBoundary)
                            )
             magicBits <- collectMagicBits(dag, bookingBlock, keyBlock)
-            seed      = LeaderSequencer.seed(era.leaderSeed.toByteArray, magicBits)
+            seed      = LeaderSequencer.seed(bookingBlock.messageHash.toByteArray, magicBits)
             childEra = Era(
               parentKeyBlockHash = era.keyBlockHash,
               keyBlockHash = keyBlock.messageHash,

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -136,7 +136,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: ForkChoice](
 
   private def createLambdaResponse(
       messageProducer: MessageProducer[F],
-      // TODO (NODE-1102): Lambda message will be a ballot during voting.
+      // TODO (NODE-1116): Lambda message will be a ballot during voting.
       lambdaMessage: Message.Block
   ): HWL[Unit] = ifSynced {
     for {
@@ -164,7 +164,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: ForkChoice](
       b <- HighwayLog.liftF {
             for {
               choice <- ForkChoice[F].fromKeyBlock(era.keyBlockHash)
-              // TODO (NODE-1102): Create ballot during voting-only.
+              // TODO (NODE-1116): Create ballot during voting-only.
               message <- messageProducer.block(
                           eraId = era.keyBlockHash,
                           roundId = roundId,
@@ -373,7 +373,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: ForkChoice](
       MonadThrowable[HWL].raiseError[Unit](new IllegalStateException(msg))
 
     message match {
-      // TODO (NODE-1102): Respond to lambda-ballots during voting.
+      // TODO (NODE-1116): Respond to lambda-ballots during voting.
       case _: Message.Ballot =>
         noop
       case b: Message.Block =>

--- a/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
@@ -33,8 +33,19 @@ trait ForkChoice[F[_]] {
     * either to validate the main parent of an incoming block, or to pick a
     * target for a lambda response, given the lambda message and the validator's
     * own latest message as justifications.
+    *
+    * `keyBlockHash` is passed because in order to be able to validate that a
+    * fork choice is correct we need to know what era it started the evaluation
+    * from; for example if we don't have a block in the child era yet, just
+    * the ballots that vote on the switch block in the parent era, we have to
+    * know that the fork choice was run from the grandparent or the great-
+    * grandparent era, and the parent-era justifications on their own don't
+    * indicate this.
     */
-  def fromJustifications(justifications: Set[BlockHash]): F[ForkChoice.Result]
+  def fromJustifications(
+      keyBlockHash: BlockHash,
+      justifications: Set[BlockHash]
+  ): F[ForkChoice.Result]
 }
 object ForkChoice {
   case class Result(

--- a/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
@@ -1,0 +1,42 @@
+package io.casperlabs.casper.highway
+
+import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
+import io.casperlabs.models.Message
+import io.casperlabs.storage.BlockHash
+import simulacrum.typeclass
+
+/** Some sort of stateful, memoizing implementation of a fast fork choice.
+  * Should have access to the era tree to check what are the latest messages
+  * along the path, who are the validators in each era, etc.
+  */
+@typeclass
+trait ForkChoice[F[_]] {
+
+  /** Execute the fork choice based on a key block of an era:
+    * - go from the key block to the switch block of the era, using the validators in that era
+    * - go from the switch block using the next era's validators to the end of the next era
+    * - repeat until the we arrive at the tips
+    * - return the fork choice block along with all the justifications taken into account.
+    */
+  def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result]
+
+  // There will be another method to validate a fork choice of an incoming block,
+  // which will have as input the justifications of the message.
+}
+object ForkChoice {
+  case class Result(
+      mainParent: Message,
+      // The fork choice must take into account messages from the parent
+      // era's voting period as well, in order to be able to tell which
+      // switch block in the end of the era to build on, and so which
+      // blocks in the child era to follow. The new block we build
+      // on top of the main parent can cite all these justifications.
+      justifications: Set[Message]
+  ) {
+    def justificationsMap: Map[PublicKeyBS, Set[BlockHash]] =
+      justifications.toSeq
+        .map(j => PublicKey(j.validatorId) -> j.messageHash)
+        .groupBy(_._1)
+        .mapValues(_.map(_._2).toSet)
+  }
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
@@ -29,8 +29,12 @@ trait ForkChoice[F[_]] {
     */
   def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result]
 
-  // There will be another method to validate a fork choice of an incoming block,
-  // which will have as input the justifications of the message.
+  /** Calculate the fork choice from a set of known blocks. This can be used
+    * either to validate the main parent of an incoming block, or to pick a
+    * target for a lambda response, given the lambda message and the validator's
+    * own latest message as justifications.
+    */
+  def fromJustifications(justifications: Set[BlockHash]): F[ForkChoice.Result]
 }
 object ForkChoice {
   case class Result(

--- a/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
@@ -17,6 +17,15 @@ trait ForkChoice[F[_]] {
     * - go from the switch block using the next era's validators to the end of the next era
     * - repeat until the we arrive at the tips
     * - return the fork choice block along with all the justifications taken into account.
+    *
+    * `keyBlockHash` is the identifier of the era in which we are seeking the
+    * fork choice. The key block itself will have an era ID, which the implementation
+    * can use to consult the `DagStorage` to find out the latest messages in that era.
+    *
+    * All the switch blocks based on the same keyblock lead to the same child era.
+    * At some point the algorithm can find which switch block is the fork choice,
+    * and carry on towards the latest messages in the era corresponding to `keyBlockHash`,
+    * but stop there, without recursing into potential child eras.
     */
   def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result]
 

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -61,14 +61,14 @@ object DagOperations {
 
   /** Traverses j-past-cone of the block and returns messages by specified validator.
     */
-  def swimlaneV[F[_]: Monad](
+  def swimlaneV[F[_]: MonadThrowable](
       validator: ByteString,
       message: Message,
       dag: DagRepresentation[F]
   ): StreamT[F, Message] = {
     // Messages visible in the direct justifications of the block.
     val messagePanorama =
-      message.justifications.toList.traverse(j => dag.lookup(j.latestBlockHash)).map(_.flatten)
+      message.justifications.toList.traverse(j => dag.lookupUnsafe(j.latestBlockHash))
     val tail = StreamT.lift(messagePanorama).flatMap { jTips =>
       toposortJDagDesc[F](dag, jTips).filter(_.validatorId == validator)
     }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -356,7 +356,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
             }
           }
 
-          "only cite the lambda mesage and validators own latest message" in {
+          "only cite the lambda message and validators own latest message" in {
             implicit val ds = defaultDagStorage
             val runtime =
               genesisEraRuntime("Alice".some, leaderSequencer = mockSequencer("Charlie"))

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -279,8 +279,6 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
             // This will be relevant when for round exponent adjustments.
             pending
           }
-
-          "reject further lambda messages in this round" in (pending)
         }
 
         "it is not from the leader" should {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -446,10 +446,13 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
                 era.bookingBlockHash shouldBe blocks(bookingIdx).messageHash
                 era.keyBlockHash shouldBe blocks(keyIdx).messageHash
 
-                era.leaderSeed.toByteArray shouldBe LeaderSequencer.seed(
-                  runtime.era.leaderSeed.toByteArray,
+                val expectedSeed = LeaderSequencer.seed(
+                  // NOTE: The white paper says to use key block, the math paper booking block hash.
+                  blocks(bookingIdx).messageHash.toByteArray,
                   blocks.slice(bookingIdx, keyIdx + 1).map(_.blockSummary.getHeader.magicBit)
                 )
+
+                era.leaderSeed.toByteArray shouldBe expectedSeed
             }
           }
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockDagStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockDagStorage.scala
@@ -38,8 +38,10 @@ class MockDagStorage[F[_]: Monad](
 }
 
 object MockDagStorage {
-  def apply[F[_]: Sync] =
+  def apply[F[_]: Sync](blocks: Block*) =
     for {
-      messagesRef <- Ref.of[F, Map[BlockHash, Message]](Map.empty)
+      messagesRef <- Ref.of[F, Map[BlockHash, Message]](
+                      blocks.map(b => b.blockHash -> Message.fromBlock(b).get).toMap
+                    )
     } yield new MockDagStorage(messagesRef)
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockDagStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockDagStorage.scala
@@ -37,6 +37,7 @@ class MockDagStorage[F[_]: Monad](
   class MockDagRepresentation extends DagRepresentation[F] {
     override def lookup(blockHash: BlockHash) =
       messagesRef.get.map(_.get(blockHash))
+
     override def children(blockHash: BlockHash)                         = ???
     override def justificationToBlocks(blockHash: BlockHash)            = ???
     override def contains(blockHash: BlockHash)                         = ???

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockDagStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockDagStorage.scala
@@ -1,0 +1,45 @@
+package io.casperlabs.casper.highway.mocks
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.Ref
+import io.casperlabs.casper.consensus.Block
+import io.casperlabs.models.Message
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.storage.dag.{DagRepresentation, DagStorage}
+
+class MockDagStorage[F[_]: Monad](
+    messagesRef: Ref[F, Map[BlockHash, Message]]
+) extends DagStorage[F] {
+  override val getRepresentation: F[DagRepresentation[F]] =
+    (new MockDagRepresentation(): DagRepresentation[F]).pure[F]
+
+  def insert(block: Block): F[DagRepresentation[F]] =
+    messagesRef.update(_.updated(block.blockHash, Message.fromBlock(block).get)) >> getRepresentation
+
+  override def checkpoint(): F[Unit] = ???
+  override def clear(): F[Unit]      = ???
+  override def close(): F[Unit]      = ???
+
+  class MockDagRepresentation extends DagRepresentation[F] {
+    override def lookup(blockHash: BlockHash) =
+      messagesRef.get.map(_.get(blockHash))
+    override def children(blockHash: BlockHash)                         = ???
+    override def justificationToBlocks(blockHash: BlockHash)            = ???
+    override def contains(blockHash: BlockHash)                         = ???
+    override def topoSort(startBlockNumber: Long, endBlockNumber: Long) = ???
+    override def topoSort(startBlockNumber: Long)                       = ???
+    override def topoSortTail(tailLength: Int)                          = ???
+    override def latestGlobal                                           = ???
+    override def latestInEra(keyBlockHash: BlockHash)                   = ???
+
+  }
+}
+
+object MockDagStorage {
+  def apply[F[_]: Sync] =
+    for {
+      messagesRef <- Ref.of[F, Map[BlockHash, Message]](Map.empty)
+    } yield new MockDagStorage(messagesRef)
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockEraStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockEraStorage.scala
@@ -11,8 +11,10 @@ import io.casperlabs.storage.era.EraStorage
 class MockEraStorage[F[_]: Applicative](
     erasRef: Ref[F, Map[BlockHash, Era]]
 ) extends EraStorage[F] {
-  def addEra(era: Era): F[Unit] =
-    erasRef.update(_.updated(era.keyBlockHash, era))
+  def addEra(era: Era): F[Boolean] =
+    erasRef.modify { es =>
+      es.updated(era.keyBlockHash, era) -> !es.contains(era.keyBlockHash)
+    }
 
   def getEra(keyBlockHash: BlockHash): F[Option[Era]] =
     erasRef.get.map(_.get(keyBlockHash))

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockEraStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockEraStorage.scala
@@ -1,0 +1,28 @@
+package io.casperlabs.casper.highway.mocks
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.Ref
+import io.casperlabs.casper.consensus.Era
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.storage.era.EraStorage
+
+class MockEraStorage[F[_]: Applicative](
+    erasRef: Ref[F, Map[BlockHash, Era]]
+) extends EraStorage[F] {
+  def addEra(era: Era): F[Unit] =
+    erasRef.update(_.updated(era.keyBlockHash, era))
+
+  def getEra(keyBlockHash: BlockHash): F[Option[Era]] =
+    erasRef.get.map(_.get(keyBlockHash))
+
+  def getChildEras(keyBlockHash: BlockHash): F[Set[Era]] = ???
+}
+
+object MockEraStorage {
+  def apply[F[_]: Sync] =
+    for {
+      erasRef <- Ref.of[F, Map[BlockHash, Era]](Map.empty)
+    } yield new MockEraStorage(erasRef)
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
@@ -16,6 +16,9 @@ class MockForkChoice[F[_]](
 
   def set(result: ForkChoice.Result): F[Unit] =
     resultRef.set(result)
+
+  def set(message: Message): F[Unit] =
+    resultRef.set(ForkChoice.Result(message, Set.empty))
 }
 
 object MockForkChoice {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
@@ -14,7 +14,10 @@ class MockForkChoice[F[_]](
   override def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result] =
     resultRef.get
 
-  override def fromJustifications(justifications: Set[BlockHash]): F[ForkChoice.Result] =
+  override def fromJustifications(
+      keyBlockHash: BlockHash,
+      justifications: Set[BlockHash]
+  ): F[ForkChoice.Result] =
     resultRef.get
 
   def set(result: ForkChoice.Result): F[Unit] =

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
@@ -1,0 +1,26 @@
+package io.casperlabs.casper.highway.mocks
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.Ref
+import io.casperlabs.models.Message
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.casper.highway.ForkChoice
+
+class MockForkChoice[F[_]](
+    resultRef: Ref[F, ForkChoice.Result]
+) extends ForkChoice[F] {
+  override def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result] =
+    resultRef.get
+
+  def set(result: ForkChoice.Result): F[Unit] =
+    resultRef.set(result)
+}
+
+object MockForkChoice {
+  def apply[F[_]: Sync](init: Message) =
+    for {
+      ref <- Ref.of[F, ForkChoice.Result](ForkChoice.Result(init, Set.empty))
+    } yield new MockForkChoice[F](ref)
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
@@ -14,6 +14,9 @@ class MockForkChoice[F[_]](
   override def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result] =
     resultRef.get
 
+  override def fromJustifications(justifications: Set[BlockHash]): F[ForkChoice.Result] =
+    resultRef.get
+
   def set(result: ForkChoice.Result): F[Unit] =
     resultRef.set(result)
 

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -156,9 +156,9 @@ object SQLiteStorage {
       override def latestInEra(keyBlockHash: BlockHash) =
         dagStorage.getRepresentation.flatMap(_.latestInEra(keyBlockHash))
 
-      override def addEra(era: Era): F[Unit]                   = eraStorage.addEra(era)
-      override def getEra(eraId: BlockHash): F[Option[Era]]    = eraStorage.getEra(eraId)
-      override def getChildEras(eraId: BlockHash): F[Set[Era]] = eraStorage.getChildEras(eraId)
+      override def addEra(era: Era)               = eraStorage.addEra(era)
+      override def getEra(eraId: BlockHash)       = eraStorage.getEra(eraId)
+      override def getChildEras(eraId: BlockHash) = eraStorage.getChildEras(eraId)
 
       override def markAsFinalized(
           mainParent: BlockHash,

--- a/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
@@ -10,10 +10,16 @@ import simulacrum.typeclass
 
 @typeclass
 trait EraStorage[F[_]] {
-  def addEra(era: Era): F[Unit]
+
+  /** Persist an era. Return whether it already existed. */
+  def addEra(era: Era): F[Boolean]
 
   /** Retrieve the era, if it exists, by its key block hash. */
   def getEra(keyBlockHash: BlockHash): F[Option[Era]]
+
+  /** Check if an era already exists. */
+  def containsEra(keyBlockHash: BlockHash)(implicit A: Applicative[F]): F[Boolean] =
+    getEra(keyBlockHash).map(_.isDefined)
 
   /** Retrieve the era, or raise an error if it's not found. */
   def getEraUnsafe(keyBlockHash: BlockHash)(implicit E: MonadThrowable[F]): F[Era] =
@@ -28,4 +34,5 @@ trait EraStorage[F[_]] {
 
   /** Retrieve the child eras from the era tree. */
   def getChildEras(keyBlockHash: BlockHash): F[Set[Era]]
+
 }

--- a/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
@@ -6,7 +6,9 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.casper.consensus.Era
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.storage.BlockHash
+import simulacrum.typeclass
 
+@typeclass
 trait EraStorage[F[_]] {
   def addEra(era: Era): F[Unit]
 

--- a/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
@@ -18,7 +18,7 @@ class SQLiteEraStorage[F[_]: Sync](
 ) extends EraStorage[F]
     with DoobieCodecs {
 
-  override def addEra(era: Era): F[Unit] = {
+  override def addEra(era: Era): F[Boolean] = {
     val hash        = era.keyBlockHash
     val parentHash  = Option(era.parentKeyBlockHash).filterNot(_.isEmpty)
     val startMillis = TimeUnit.MILLISECONDS.convert(era.startTick, tickUnit)
@@ -30,7 +30,7 @@ class SQLiteEraStorage[F[_]: Sync](
             VALUES ($hash, $parentHash, $startMillis, $endMillis, ${era.startTick}, ${era.endTick}, $era)
             """.update.run
 
-    insertEra.transact(writeXa).void
+    insertEra.transact(writeXa).map(_ > 0)
   }
 
   override def getEra(keyBlockHash: BlockHash): F[Option[Era]] =

--- a/storage/src/test/scala/io/casperlabs/storage/era/EraStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/era/EraStorageTest.scala
@@ -40,6 +40,21 @@ trait EraStorageTest extends FlatSpecLike with Matchers with ArbitraryConsensus 
     } yield ()
   }
 
+  it should "return whether the era already existed" in withStorage { db =>
+    val era = sample[Era]
+    for {
+      a <- db.containsEra(era.keyBlockHash)
+      b <- db.addEra(era)
+      c <- db.containsEra(era.keyBlockHash)
+      d <- db.addEra(era)
+    } yield {
+      a shouldBe false
+      b shouldBe true
+      c shouldBe true
+      d shouldBe false
+    }
+  }
+
   it should "find the children of an era" in withStorage { db =>
     val e0 = sample[Era]
     val e1 = sample[Era].withParentKeyBlockHash(e0.keyBlockHash)


### PR DESCRIPTION
### Overview
Adds support for:
- [x] Switch block detection and era creation in incoming message
- [x] Switch block detection during own round
- [x] Correctly set justifications based on the DAG
- [x] Pass booking flag to message producer
- [x] Validate repeated lambdas
- [x] Cite own latest message in lambda response

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1102

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Deferred the voting-only period to NODE-1116
