### PR TITLE
EE-805/EE-806: validate URefs

### DIFF
--- a/execution-engine/contract-ffi-as/assembly/externals.ts
+++ b/execution-engine/contract-ffi-as/assembly/externals.ts
@@ -22,7 +22,7 @@ export declare function get_main_purse(dest_ptr: usize): void;
 export declare function get_system_contract(system_contract_index: u32, dest_ptr: usize, dest_size: u32): i32;
 
 @external("env", "call_contract")
-export declare function call_contract(key_ptr: usize, key_size: u32, args_ptr: usize, args_size: u32, extra_urefs_ptr: usize, extra_urefs_size: usize, result_size: usize): i32;
+export declare function call_contract(key_ptr: usize, key_size: u32, args_ptr: usize, args_size: u32, result_size: usize): i32;
 
 @external("env", "read_host_buffer")
 export declare function read_host_buffer(dest_ptr: usize, dest_size: u32, bytes_written: usize): i32;

--- a/execution-engine/contract-ffi-as/assembly/index.ts
+++ b/execution-engine/contract-ffi-as/assembly/index.ts
@@ -234,7 +234,6 @@ export function serializeArguments(values: CLValue[]): Array<u8> {
 export function callContract(key: Key, args: CLValue[]): Uint8Array | null {
   let keyBytes = key.toBytes();
   let argBytes = serializeArguments(args);
-  let extraURefs = serializeArguments([]);
 
   let resultSize = new Uint32Array(1);
   resultSize.fill(0);
@@ -244,8 +243,6 @@ export function callContract(key: Key, args: CLValue[]): Uint8Array | null {
     keyBytes.length,
     argBytes.dataStart,
     argBytes.length,
-    extraURefs.dataStart,
-    extraURefs.length,
     resultSize.dataStart,
   );
   if (ret > 0) {

--- a/execution-engine/contract-ffi/src/ext_ffi.rs
+++ b/execution-engine/contract-ffi/src/ext_ffi.rs
@@ -32,21 +32,12 @@ extern "C" {
     pub fn load_named_keys(total_keys: *mut usize, result_size: *mut usize) -> i32;
     pub fn get_arg(index: usize, dest_ptr: *mut u8, dest_size: usize) -> i32;
     pub fn get_arg_size(index: usize, dest_size: *mut usize) -> i32;
-    pub fn ret(
-        value_ptr: *const u8,
-        value_size: usize,
-        // extra urefs known by the current contract to make available to the caller
-        extra_urefs_ptr: *const u8,
-        extra_urefs_size: usize,
-    ) -> !;
+    pub fn ret(value_ptr: *const u8, value_size: usize) -> !;
     pub fn call_contract(
         key_ptr: *const u8,
         key_size: usize,
         args_ptr: *const u8,
         args_size: usize,
-        // extra urefs known by the caller to make available to the callee
-        extra_urefs_ptr: *const u8,
-        extra_urefs_size: usize,
         result_size: *mut usize,
     ) -> i32;
     pub fn get_key(

--- a/execution-engine/contract-ffi/src/key.rs
+++ b/execution-engine/contract-ffi/src/key.rs
@@ -199,6 +199,13 @@ impl Key {
         }
     }
 
+    pub fn into_uref(self) -> Option<URef> {
+        match self {
+            Key::URef(uref) => Some(uref),
+            _ => None,
+        }
+    }
+
     pub fn as_hash(&self) -> Option<[u8; KEY_HASH_LENGTH]> {
         match self {
             Key::Hash(hash) => Some(*hash),

--- a/execution-engine/contracts/client/bonding/src/lib.rs
+++ b/execution-engine/contracts/client/bonding/src/lib.rs
@@ -1,12 +1,7 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, Error},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::U512,
 };
@@ -29,9 +24,5 @@ pub extern "C" fn call() {
 
     system::transfer_from_purse_to_purse(source_purse, bonding_purse, bond_amount)
         .unwrap_or_revert();
-    runtime::call_contract(
-        pos_pointer,
-        (BOND_METHOD_NAME, bond_amount, bonding_purse),
-        vec![Key::URef(bonding_purse.value())],
-    )
+    runtime::call_contract(pos_pointer, (BOND_METHOD_NAME, bond_amount, bonding_purse))
 }

--- a/execution-engine/contracts/client/named-purse-payment/src/lib.rs
+++ b/execution-engine/contracts/client/named-purse-payment/src/lib.rs
@@ -2,11 +2,10 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, system, Error},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::{account::PurseId, U512},
 };
@@ -37,14 +36,9 @@ pub extern "C" fn call() {
 
     let pos_pointer = system::get_proof_of_stake();
 
-    let payment_purse: PurseId =
-        runtime::call_contract(pos_pointer.clone(), (GET_PAYMENT_PURSE,), vec![]);
+    let payment_purse: PurseId = runtime::call_contract(pos_pointer.clone(), (GET_PAYMENT_PURSE,));
 
-    runtime::call_contract::<_, ()>(
-        pos_pointer,
-        (SET_REFUND_PURSE, purse),
-        vec![Key::URef(purse.value())],
-    );
+    runtime::call_contract::<_, ()>(pos_pointer, (SET_REFUND_PURSE, purse));
 
     system::transfer_from_purse_to_purse(purse, payment_purse, amount).unwrap_or_revert();
 }

--- a/execution-engine/contracts/client/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/client/standard-payment/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, Error},
     unwrap_or_revert::UnwrapOrRevert,
@@ -25,7 +21,7 @@ pub fn delegate() {
 
     let pos_pointer = system::get_proof_of_stake();
 
-    let payment_purse: PurseId = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,), vec![]);
+    let payment_purse: PurseId = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,));
 
     system::transfer_from_purse_to_purse(main_purse, payment_purse, amount).unwrap_or_revert();
 }

--- a/execution-engine/contracts/client/unbonding/src/lib.rs
+++ b/execution-engine/contracts/client/unbonding/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{runtime, system, Error},
     unwrap_or_revert::UnwrapOrRevert,
@@ -26,5 +22,5 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(Error::InvalidArgument);
     let unbond_amount: Option<U512> = arg_0.map(Into::into);
 
-    runtime::call_contract(pos_pointer, (UNBOND_METHOD_NAME, unbond_amount), vec![])
+    runtime::call_contract(pos_pointer, (UNBOND_METHOD_NAME, unbond_amount))
 }

--- a/execution-engine/contracts/examples/bonding-call/src/lib.rs
+++ b/execution-engine/contracts/examples/bonding-call/src/lib.rs
@@ -1,12 +1,7 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, Error},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::U512,
 };
@@ -33,9 +28,5 @@ pub extern "C" fn call() {
     system::transfer_from_purse_to_purse(source_purse, bonding_purse, bond_amount)
         .unwrap_or_revert();
 
-    runtime::call_contract::<_, ()>(
-        pos_pointer,
-        (BOND_METHOD_NAME, bond_amount, bonding_purse),
-        vec![Key::URef(bonding_purse.value())],
-    );
+    runtime::call_contract(pos_pointer, (BOND_METHOD_NAME, bond_amount, bonding_purse))
 }

--- a/execution-engine/contracts/examples/counter-call/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-call/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{runtime, Error},
     unwrap_or_revert::UnwrapOrRevert,
@@ -22,11 +18,11 @@ pub extern "C" fn call() {
 
     {
         let args = (INC_METHOD,);
-        runtime::call_contract::<_, ()>(contract_ref.clone(), args, Vec::new());
+        runtime::call_contract::<_, ()>(contract_ref.clone(), args);
     }
 
     let _result: i32 = {
         let args = (GET_METHOD,);
-        runtime::call_contract(contract_ref, args, Vec::new())
+        runtime::call_contract(contract_ref, args)
     };
 }

--- a/execution-engine/contracts/examples/counter-define/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-define/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error as ApiError, TURef},
@@ -50,7 +50,7 @@ pub extern "C" fn counter_ext() {
                 .unwrap_or_revert_with(ApiError::Read)
                 .unwrap_or_revert_with(ApiError::ValueNotFound);
             let return_value = CLValue::from_t(result).unwrap_or_revert();
-            runtime::ret(return_value, Vec::new());
+            runtime::ret(return_value);
         }
         _ => runtime::revert(Error::UnknownMethodName),
     }

--- a/execution-engine/contracts/examples/erc20-smart-contract/src/deployer.rs
+++ b/execution-engine/contracts/examples/erc20-smart-contract/src/deployer.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, string::String, vec};
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::{
     contract_api::{runtime, storage, system, ContractRef, TURef},
@@ -42,11 +42,7 @@ fn deploy_token(name: &str, initial_balance: U512) {
     let token_ref: ContractRef = storage::store_function_at_hash(ERC20_CONTRACT_NAME, token_urefs);
 
     // Initialize erc20 contract.
-    runtime::call_contract::<_, ()>(
-        token_ref.clone(),
-        (api::INIT_ERC20, initial_balance),
-        vec![],
-    );
+    runtime::call_contract::<_, ()>(token_ref.clone(), (api::INIT_ERC20, initial_balance));
 
     // Save it under a new TURef.
     let token_turef: TURef<Key> = storage::new_turef(token_ref.into());

--- a/execution-engine/contracts/examples/erc20-smart-contract/src/erc20.rs
+++ b/execution-engine/contracts/examples/erc20-smart-contract/src/erc20.rs
@@ -83,18 +83,13 @@ fn entry_point() {
             };
         }
         Api::Approve(spender, amount) => token.approve(&runtime::get_caller(), &spender, amount),
-        Api::BalanceOf(address) => runtime::ret(
-            CLValue::from_t(token.balance_of(&address)).unwrap_or_revert(),
-            Vec::new(),
-        ),
-        Api::TotalSupply => runtime::ret(
-            CLValue::from_t(token.total_supply()).unwrap_or_revert(),
-            Vec::new(),
-        ),
-        Api::Allowance(owner, spender) => runtime::ret(
-            CLValue::from_t(token.allowance(&owner, &spender)).unwrap_or_revert(),
-            Vec::new(),
-        ),
+        Api::BalanceOf(address) => {
+            runtime::ret(CLValue::from_t(token.balance_of(&address)).unwrap_or_revert())
+        }
+        Api::TotalSupply => runtime::ret(CLValue::from_t(token.total_supply()).unwrap_or_revert()),
+        Api::Allowance(owner, spender) => {
+            runtime::ret(CLValue::from_t(token.allowance(&owner, &spender)).unwrap_or_revert())
+        }
         Api::Buy(purse) => {
             let transfered_amount = transfer_in_clx_from_purse(purse);
             token.mint(&runtime::get_caller(), transfered_amount);

--- a/execution-engine/contracts/examples/erc20-smart-contract/src/proxy.rs
+++ b/execution-engine/contracts/examples/erc20-smart-contract/src/proxy.rs
@@ -1,13 +1,12 @@
-use alloc::vec;
-
-use crate::{
-    api::{self, Api},
-    error::Error,
-};
 use contract_ffi::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
     value::U512,
+};
+
+use crate::{
+    api::{self, Api},
+    error::Error,
 };
 
 #[no_mangle]
@@ -15,39 +14,27 @@ pub extern "C" fn erc20_proxy() {
     let token_ref = Api::destination_contract();
     match Api::from_args_in_proxy() {
         Api::Transfer(recipient, amount) => {
-            runtime::call_contract::<_, ()>(
-                token_ref.clone(),
-                (api::TRANSFER, recipient, amount),
-                vec![],
-            );
+            runtime::call_contract::<_, ()>(token_ref.clone(), (api::TRANSFER, recipient, amount));
         }
         Api::TransferFrom(owner, recipient, amount) => {
             runtime::call_contract::<_, ()>(
                 token_ref.clone(),
                 (api::TRANSFER_FROM, owner, recipient, amount),
-                vec![],
             );
         }
         Api::Approve(spender, amount) => {
-            runtime::call_contract::<_, ()>(
-                token_ref.clone(),
-                (api::APPROVE, spender, amount),
-                vec![],
-            );
+            runtime::call_contract::<_, ()>(token_ref.clone(), (api::APPROVE, spender, amount));
         }
         Api::AssertBalance(address, expected_amount) => {
-            let balance = runtime::call_contract::<_, U512>(
-                token_ref.clone(),
-                (api::BALANCE_OF, address),
-                vec![],
-            );
+            let balance =
+                runtime::call_contract::<_, U512>(token_ref.clone(), (api::BALANCE_OF, address));
             if expected_amount != balance {
                 runtime::revert(Error::BalanceAssertionFailure)
             }
         }
         Api::AssertTotalSupply(expected_total_supply) => {
             let total_supply =
-                runtime::call_contract::<_, U512>(token_ref.clone(), (api::TOTAL_SUPPLY,), vec![]);
+                runtime::call_contract::<_, U512>(token_ref.clone(), (api::TOTAL_SUPPLY,));
             if expected_total_supply != total_supply {
                 runtime::revert(Error::TotalSupplyAssertionFailure)
             }
@@ -56,7 +43,6 @@ pub extern "C" fn erc20_proxy() {
             let allowance = runtime::call_contract::<_, U512>(
                 token_ref.clone(),
                 (api::ALLOWANCE, owner, spender),
-                vec![],
             );
             if expected_amount != allowance {
                 runtime::revert(Error::AllowanceAssertionFailure)
@@ -67,18 +53,13 @@ pub extern "C" fn erc20_proxy() {
             let new_purse = system::create_purse();
             system::transfer_from_purse_to_purse(main_purse, new_purse, clx_amount)
                 .unwrap_or_revert_with(Error::PurseTransferError);
-            runtime::call_contract::<_, ()>(
-                token_ref.clone(),
-                (api::BUY, new_purse),
-                vec![new_purse.value().into()],
-            );
+            runtime::call_contract::<_, ()>(token_ref.clone(), (api::BUY, new_purse));
         }
         Api::SellProxy(tokens_amount) => {
             let new_purse = system::create_purse();
             runtime::call_contract::<_, ()>(
                 token_ref.clone(),
                 (api::SELL, new_purse, tokens_amount),
-                vec![new_purse.value().into()],
             );
             let main_purse = account::get_main_purse();
             system::transfer_from_purse_to_purse(new_purse, main_purse, tokens_amount)

--- a/execution-engine/contracts/examples/hello-name-call/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-call/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error},
@@ -20,7 +20,7 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(Error::UnexpectedKeyVariant);
 
     let args = ("World",);
-    let result: String = runtime::call_contract(contract_ref, args, Vec::new());
+    let result: String = runtime::call_contract(contract_ref, args);
     assert_eq!("Hello, World", result);
 
     // Store the result at a uref so it can be seen as an effect on the global state

--- a/execution-engine/contracts/examples/hello-name-define/src/lib.rs
+++ b/execution-engine/contracts/examples/hello-name-define/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error},
@@ -29,7 +29,7 @@ pub extern "C" fn hello_name_ext() {
         .unwrap_or_revert_with(Error::MissingArgument)
         .unwrap_or_revert_with(Error::InvalidArgument);
     let return_value = CLValue::from_t(hello_name(&name)).unwrap_or_revert();
-    runtime::ret(return_value, Vec::new());
+    runtime::ret(return_value);
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-call/src/lib.rs
@@ -41,7 +41,7 @@ pub extern "C" fn call() {
 
     let name = "CasperLabs";
     let args = (SUB_METHOD, name);
-    let sub_key = runtime::call_contract::<_, Option<Key>>(contract_ref.clone(), args, Vec::new())
+    let sub_key = runtime::call_contract::<_, Option<Key>>(contract_ref.clone(), args)
         .unwrap_or_revert_with(Error::NoSubKey);
 
     runtime::put_key(MAIL_FEED_KEY, sub_key);
@@ -54,7 +54,7 @@ pub extern "C" fn call() {
 
     let message = "Hello, World!";
     let args = (PUB_METHOD, message);
-    runtime::call_contract::<_, ()>(contract_ref, args, Vec::new());
+    runtime::call_contract::<_, ()>(contract_ref, args);
 
     let list_key: TURef<Vec<String>> = sub_key
         .to_turef()

--- a/execution-engine/contracts/examples/mailing-list-define/src/lib.rs
+++ b/execution-engine/contracts/examples/mailing-list-define/src/lib.rs
@@ -11,7 +11,6 @@ use contract_ffi::{
     contract_api::{runtime, storage, Error as ApiError, TURef},
     key::Key,
     unwrap_or_revert::UnwrapOrRevert,
-    uref::URef,
     value::CLValue,
 };
 
@@ -88,14 +87,12 @@ pub extern "C" fn mailing_list_ext() {
     match method_name.as_str() {
         "sub" => match sub(arg1) {
             Some(turef) => {
-                let extra_uref = URef::new(turef.addr(), turef.access_rights());
-                let extra_urefs = vec![extra_uref];
                 let return_value = CLValue::from_t(Some(Key::from(turef))).unwrap_or_revert();
-                runtime::ret(return_value, extra_urefs);
+                runtime::ret(return_value);
             }
             _ => {
                 let return_value = CLValue::from_t(Option::<Key>::None).unwrap_or_revert();
-                runtime::ret(return_value, Vec::new())
+                runtime::ret(return_value)
             }
         },
         //Note that this is totally insecure. In reality

--- a/execution-engine/contracts/examples/unbonding-call/src/lib.rs
+++ b/execution-engine/contracts/examples/unbonding-call/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{runtime, system, Error},
     unwrap_or_revert::UnwrapOrRevert,
@@ -28,5 +24,5 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(Error::MissingArgument)
         .unwrap_or_revert_with(Error::InvalidArgument);
 
-    runtime::call_contract(pos_pointer, (UNBOND_METHOD_NAME, unbond_amount), vec![])
+    runtime::call_contract(pos_pointer, (UNBOND_METHOD_NAME, unbond_amount))
 }

--- a/execution-engine/contracts/integration/get-caller-call/src/lib.rs
+++ b/execution-engine/contracts/integration/get-caller-call/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{runtime, ContractRef, Error},
     key::Key,
@@ -21,5 +17,5 @@ pub extern "C" fn call() {
     };
 
     // Call `define` part of the contract.
-    runtime::call_contract(contract_ref, (), Vec::new())
+    runtime::call_contract(contract_ref, ())
 }

--- a/execution-engine/contracts/integration/list-known-urefs-call/src/lib.rs
+++ b/execution-engine/contracts/integration/list-known-urefs-call/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{runtime, ContractRef, Error},
     key::Key,
@@ -22,5 +18,5 @@ pub extern "C" fn call() {
     };
 
     // Call `define` part of the contract.
-    runtime::call_contract(contract_ref, (), Vec::new())
+    runtime::call_contract(contract_ref, ())
 }

--- a/execution-engine/contracts/integration/payment-from-named-purse/src/lib.rs
+++ b/execution-engine/contracts/integration/payment-from-named-purse/src/lib.rs
@@ -2,11 +2,10 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, system, Error as ApiError},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::{account::PurseId, U512},
 };
@@ -42,14 +41,9 @@ pub extern "C" fn call() {
     let purse: PurseId = get_named_purse(&name).unwrap_or_revert_with(Error::PosNotFound);
 
     let pos_pointer = system::get_proof_of_stake();
-    let payment_purse: PurseId =
-        runtime::call_contract(pos_pointer.clone(), (GET_PAYMENT_PURSE,), vec![]);
+    let payment_purse: PurseId = runtime::call_contract(pos_pointer.clone(), (GET_PAYMENT_PURSE,));
 
-    runtime::call_contract::<_, ()>(
-        pos_pointer,
-        (SET_REFUND_PURSE, purse),
-        vec![Key::URef(purse.value())],
-    );
+    runtime::call_contract::<_, ()>(pos_pointer, (SET_REFUND_PURSE, purse));
 
     system::transfer_from_purse_to_purse(purse, payment_purse, amount).unwrap_or_revert();
 }

--- a/execution-engine/contracts/integration/subcall-revert-call/src/lib.rs
+++ b/execution-engine/contracts/integration/subcall-revert-call/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{runtime, ContractRef, Error},
     key::Key,
@@ -21,5 +17,5 @@ pub extern "C" fn call() {
         _ => runtime::revert(Error::UnexpectedKeyVariant),
     };
 
-    runtime::call_contract::<_, ()>(contract_ref, (), Vec::new());
+    runtime::call_contract(contract_ref, ())
 }

--- a/execution-engine/contracts/system/mint-install/src/lib.rs
+++ b/execution-engine/contracts/system/mint-install/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{runtime, storage, Error},
     unwrap_or_revert::UnwrapOrRevert,
@@ -26,5 +22,5 @@ pub extern "C" fn call() {
 
     let return_value = CLValue::from_t(uref).unwrap_or_revert();
 
-    runtime::ret(return_value, vec![uref]);
+    runtime::ret(return_value);
 }

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -12,7 +12,7 @@ mod capabilities;
 pub mod internal_purse_id;
 pub mod mint;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 use core::convert::TryInto;
 
 use contract_ffi::{
@@ -97,19 +97,14 @@ pub fn delegate() {
                 .mint(amount)
                 .map(|purse_id| URef::new(purse_id.raw_id(), AccessRights::READ_ADD_WRITE));
             let return_value = CLValue::from_t(maybe_purse_key).unwrap_or_revert();
-
-            if let Ok(purse_key) = maybe_purse_key {
-                runtime::ret(return_value, vec![purse_key])
-            } else {
-                runtime::ret(return_value, vec![])
-            }
+            runtime::ret(return_value)
         }
 
         "create" => {
             let purse_id = mint.create();
             let purse_key = URef::new(purse_id.raw_id(), AccessRights::READ_ADD_WRITE);
             let return_value = CLValue::from_t(purse_key).unwrap_or_revert();
-            runtime::ret(return_value, vec![purse_key])
+            runtime::ret(return_value)
         }
 
         "balance" => {
@@ -121,7 +116,7 @@ pub fn delegate() {
             let balance: Option<U512> =
                 balance_uref.and_then(|uref| storage::read(uref.into()).unwrap_or_default());
             let return_value = CLValue::from_t(balance).unwrap_or_revert();
-            runtime::ret(return_value, vec![])
+            runtime::ret(return_value)
         }
 
         "transfer" => {
@@ -138,7 +133,7 @@ pub fn delegate() {
             let return_error = |error: PurseIdError| -> ! {
                 let transfer_result: Result<(), Error> = Err(error.into());
                 let return_value = CLValue::from_t(transfer_result).unwrap_or_revert();
-                runtime::ret(return_value, vec![])
+                runtime::ret(return_value)
             };
 
             let source: WithdrawId = match WithdrawId::from_uref(source) {
@@ -153,7 +148,7 @@ pub fn delegate() {
 
             let transfer_result = mint.transfer(source, target, amount);
             let return_value = CLValue::from_t(transfer_result).unwrap_or_revert();
-            runtime::ret(return_value, vec![]);
+            runtime::ret(return_value);
         }
         _ => panic!("Unknown method name!"),
     }

--- a/execution-engine/contracts/system/pos-install/src/lib.rs
+++ b/execution-engine/contracts/system/pos-install/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec};
+use alloc::{collections::BTreeMap, string::String};
 use core::fmt::Write;
 
 use contract_ffi::{
@@ -87,12 +87,11 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(Error::UnexpectedContractRefVariant);
     let return_value = CLValue::from_t(uref).unwrap_or_revert();
 
-    runtime::ret(return_value, vec![uref]);
+    runtime::ret(return_value);
 }
 
 fn mint_purse(mint: &ContractRef, amount: U512) -> PurseId {
-    let result: Result<URef, mint::Error> =
-        runtime::call_contract(mint.clone(), ("mint", amount), vec![]);
+    let result: Result<URef, mint::Error> = runtime::call_contract(mint.clone(), ("mint", amount));
 
     result.map(PurseId::new).unwrap_or_revert()
 }

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -5,9 +5,6 @@ extern crate alloc;
 mod queue;
 mod stakes;
 
-// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
-#[rustfmt::skip]
-use alloc::vec;
 use alloc::{string::String, vec::Vec};
 
 use contract_ffi::{
@@ -320,7 +317,7 @@ pub fn delegate() {
             let rights_controlled_purse =
                 PurseId::new(URef::new(purse.value().addr(), AccessRights::READ_ADD));
             let return_value = CLValue::from_t(rights_controlled_purse).unwrap_or_revert();
-            runtime::ret(return_value, vec![rights_controlled_purse.value()]);
+            runtime::ret(return_value);
         }
         "set_refund_purse" => {
             let purse_id: PurseId = runtime::get_arg(1)
@@ -332,14 +329,10 @@ pub fn delegate() {
             // We purposely choose to remove the access rights so that we do not
             // accidentally give rights for a purse to some contract that is not
             // supposed to have it.
-            let maybe_purse_uref = get_refund_purse().map(|p| p.value().remove_access_rights());
-            if let Some(uref) = maybe_purse_uref {
-                let return_value = CLValue::from_t(Some(PurseId::new(uref))).unwrap_or_revert();
-                runtime::ret(return_value, vec![uref]);
-            } else {
-                let return_value = CLValue::from_t::<Option<URef>>(None).unwrap_or_revert();
-                runtime::ret(return_value, Vec::new());
-            }
+            let maybe_purse_uref =
+                get_refund_purse().map(|p| PurseId::new(p.value().remove_access_rights()));
+            let return_value = CLValue::from_t(maybe_purse_uref).unwrap_or_revert();
+            runtime::ret(return_value);
         }
         "finalize_payment" => {
             let amount_spent: U512 = runtime::get_arg(1)

--- a/execution-engine/contracts/system/test-mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/test-mint-token/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{contract_api::runtime, key::Key, value::U512};
 
@@ -17,23 +17,18 @@ pub extern "C" fn call() {
     //let x = contract_api::get_uref("mint");
 
     let amount1 = U512::from(100);
-    let purse1: Key = runtime::call_contract(mint.clone(), ("create", amount1), vec![]);
+    let purse1: Key = runtime::call_contract(mint.clone(), ("create", amount1));
 
     let amount2 = U512::from(300);
-    let purse2: Key = runtime::call_contract(mint.clone(), ("create", amount2), vec![]);
+    let purse2: Key = runtime::call_contract(mint.clone(), ("create", amount2));
 
-    let result: String = runtime::call_contract(
-        mint.clone(),
-        ("transfer", purse1, purse2, U512::from(70)),
-        vec![purse1],
-    );
+    let result: String =
+        runtime::call_contract(mint.clone(), ("transfer", purse1, purse2, U512::from(70)));
 
     assert!(&result == "Success!");
 
-    let new_amount1: Option<U512> =
-        runtime::call_contract(mint.clone(), ("balance", purse1), vec![purse1]);
-    let new_amount2: Option<U512> =
-        runtime::call_contract(mint.clone(), ("balance", purse2), vec![purse2]);
+    let new_amount1: Option<U512> = runtime::call_contract(mint.clone(), ("balance", purse1));
+    let new_amount2: Option<U512> = runtime::call_contract(mint.clone(), ("balance", purse2));
 
     assert!(new_amount1.unwrap() == U512::from(30));
     assert!(new_amount2.unwrap() == U512::from(370));

--- a/execution-engine/contracts/test/add-gas-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/add-gas-subcall/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error},
@@ -52,7 +52,7 @@ pub extern "C" fn call() {
         },
         ADD_GAS_VIA_SUBCALL => {
             let reference = storage::store_function_at_hash(SUBCALL_NAME, BTreeMap::new());
-            runtime::call_contract::<_, ()>(reference, (amount,), Vec::new());
+            runtime::call_contract::<_, ()>(reference, (amount,));
         }
         _ => runtime::revert(Error::InvalidArgument),
     }

--- a/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-caller/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, ContractRef, Error},
@@ -33,5 +33,5 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(Error::InvalidArgument);
     let do_nothing = ContractRef::URef(URef::new(arg.addr(), AccessRights::READ));
 
-    runtime::call_contract::<_, ()>(do_nothing, (new_purse_name,), vec![]);
+    runtime::call_contract(do_nothing, (new_purse_name,))
 }

--- a/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression-call/src/lib.rs
@@ -19,9 +19,7 @@ pub extern "C" fn call() {
         _ => runtime::revert(Error::UnexpectedKeyVariant),
     };
 
-    let extra_urefs = [].to_vec();
-
-    let result: URef = runtime::call_contract(contract_pointer, (), extra_urefs);
+    let result: URef = runtime::call_contract(contract_pointer, ());
 
     let value = storage::read(TURef::from_uref(result).unwrap());
 

--- a/execution-engine/contracts/test/ee-401-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-401-regression/src/lib.rs
@@ -16,8 +16,7 @@ pub extern "C" fn hello_ext() {
     let test_string = String::from("Hello, world!");
     let test_uref: URef = storage::new_turef(test_string).into();
     let return_value = CLValue::from_t(test_uref).unwrap_or_revert();
-    let extra_urefs = [test_uref].to_vec();
-    runtime::ret(return_value, extra_urefs)
+    runtime::ret(return_value)
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
+++ b/execution-engine/contracts/test/ee-441-rng-state/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec};
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::{
     contract_api::{runtime, storage, ContractRef, Error},
@@ -15,7 +15,7 @@ use contract_ffi::{
 #[no_mangle]
 pub extern "C" fn do_nothing() {
     // Doesn't advance RNG of the runtime
-    runtime::ret(CLValue::from_t("Hello, world!").unwrap_or_revert(), vec![])
+    runtime::ret(CLValue::from_t("Hello, world!").unwrap_or_revert())
 }
 
 #[no_mangle]
@@ -23,9 +23,9 @@ pub extern "C" fn do_something() {
     // Advances RNG of the runtime
     let test_string = String::from("Hello, world!");
 
-    let test_uref = storage::new_turef(test_string).into();
+    let test_uref = URef::from(storage::new_turef(test_string));
     let return_value = CLValue::from_t(test_uref).unwrap_or_revert();
-    runtime::ret(return_value, vec![test_uref])
+    runtime::ret(return_value)
 }
 
 #[no_mangle]
@@ -46,7 +46,7 @@ pub extern "C" fn call() {
         let uref1: URef = storage::new_turef(U512::from(0)).into();
         runtime::put_key("uref1", Key::URef(uref1));
         // do_nothing doesn't do anything. It SHOULD not forward the internal RNG.
-        let result: String = runtime::call_contract(do_nothing.clone(), (), vec![]);
+        let result: String = runtime::call_contract(do_nothing.clone(), ());
         assert_eq!(result, "Hello, world!");
         let uref2: URef = storage::new_turef(U512::from(1)).into();
         runtime::put_key("uref2", Key::URef(uref2));
@@ -54,7 +54,7 @@ pub extern "C" fn call() {
         let uref1: URef = storage::new_turef(U512::from(0)).into();
         runtime::put_key("uref1", Key::URef(uref1));
         // do_something returns a new uref, and it should forward the internal RNG.
-        let uref2: URef = runtime::call_contract(do_something.clone(), (), vec![]);
+        let uref2: URef = runtime::call_contract(do_something.clone(), ());
         runtime::put_key("uref2", Key::URef(uref2));
     }
 }

--- a/execution-engine/contracts/test/ee-549-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-549-regression/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::contract_api::{runtime, system};
 
 const SET_REFUND_PURSE: &str = "set_refund_purse";
@@ -12,11 +8,7 @@ fn malicious_revenue_stealing_contract() {
     let purse = system::create_purse();
     let pos_pointer = system::get_proof_of_stake();
 
-    runtime::call_contract::<_, ()>(
-        pos_pointer,
-        (SET_REFUND_PURSE, purse),
-        vec![purse.value().into()],
-    );
+    runtime::call_contract::<_, ()>(pos_pointer, (SET_REFUND_PURSE, purse));
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-create/src/lib.rs
@@ -1,8 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
 use core::convert::Into;
 
 use contract_ffi::{
@@ -26,10 +23,7 @@ pub extern "C" fn create() {
         ret.into()
     };
     let return_value = CLValue::from_t(read_only_reference).unwrap_or_revert();
-
-    let extra_urefs = vec![read_only_reference];
-
-    runtime::ret(return_value, extra_urefs)
+    runtime::ret(return_value)
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
+++ b/execution-engine/contracts/test/ee-572-regression-escalate/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{runtime, storage, Error as ApiError, TURef},
     key::Key,
@@ -30,7 +26,7 @@ pub extern "C" fn call() {
         .to_contract_ref()
         .unwrap_or_revert_with(ApiError::User(Error::GetArgument as u16));
 
-    let reference: URef = runtime::call_contract(contract_pointer, (), Vec::new());
+    let reference: URef = runtime::call_contract(contract_pointer, ());
 
     let forged_reference: TURef<&str> = {
         let ret = URef::new(reference.addr(), AccessRights::READ_ADD_WRITE);

--- a/execution-engine/contracts/test/ee-597-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-597-regression/src/lib.rs
@@ -1,23 +1,14 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, ContractRef},
-    key::Key,
     value::{account::PurseId, U512},
 };
-
-fn purse_to_key(p: PurseId) -> Key {
-    Key::URef(p.value())
-}
 
 const POS_BOND: &str = "bond";
 
 fn bond(pos: ContractRef, amount: &U512, source: PurseId) {
-    runtime::call_contract::<_, ()>(pos, (POS_BOND, *amount, source), vec![purse_to_key(source)]);
+    runtime::call_contract::<_, ()>(pos, (POS_BOND, *amount, source));
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/ee-598-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-598-regression/src/lib.rs
@@ -1,29 +1,20 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, ContractRef, Error},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::{account::PurseId, U512},
 };
-
-fn purse_to_key(p: PurseId) -> Key {
-    Key::URef(p.value())
-}
 
 const POS_BOND: &str = "bond";
 const POS_UNBOND: &str = "unbond";
 
 fn bond(pos: ContractRef, amount: U512, source: PurseId) {
-    runtime::call_contract::<_, ()>(pos, (POS_BOND, amount, source), vec![purse_to_key(source)]);
+    runtime::call_contract::<_, ()>(pos, (POS_BOND, amount, source));
 }
 
 fn unbond(pos: ContractRef, amount: Option<U512>) {
-    runtime::call_contract::<_, ()>(pos, (POS_UNBOND, amount), vec![]);
+    runtime::call_contract::<_, ()>(pos, (POS_UNBOND, amount));
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/ee-599-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-599-regression/src/lib.rs
@@ -1,9 +1,8 @@
 #![no_std]
 
 extern crate alloc;
-extern crate contract_ffi;
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String};
 use contract_ffi::{
     contract_api::{account, runtime, storage, system, Error},
     key::Key,
@@ -159,7 +158,7 @@ fn delegate() -> Result<(), Error> {
                     .map_err(|_| Error::InvalidArgument)?;
 
             let subcontract_args = (subcontract_method,);
-            runtime::call_contract::<_, ()>(contract_ref, subcontract_args, Vec::new());
+            runtime::call_contract::<_, ()>(contract_ref, subcontract_args);
         }
         _ => return Err(ContractError::InvalidDelegateMethod.into()),
     }

--- a/execution-engine/contracts/test/ee-601-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-601-regression/src/lib.rs
@@ -2,10 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{
-    string::{String, ToString},
-    vec,
-};
+use alloc::string::{String, ToString};
 
 use contract_ffi::{
     contract_api::{account, runtime, storage, system, Error as ApiError},
@@ -37,8 +34,7 @@ pub extern "C" fn call() {
 
         let pos_pointer = system::get_proof_of_stake();
 
-        let payment_purse: PurseId =
-            runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,), vec![]);
+        let payment_purse: PurseId = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,));
 
         system::transfer_from_purse_to_purse(main_purse, payment_purse, amount).unwrap_or_revert()
     }

--- a/execution-engine/contracts/test/ee-803-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-803-regression/src/lib.rs
@@ -2,14 +2,10 @@
 
 extern crate alloc;
 
-// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
-#[rustfmt::skip]
-use alloc::vec;
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, system, ContractRef, Error as ApiError},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::{account::PurseId, U512},
 };
@@ -21,11 +17,11 @@ const COMMAND_BOND: &str = "bond";
 const COMMAND_UNBOND: &str = "unbond";
 
 fn bond(pos: &ContractRef, amount: &U512, source: PurseId) {
-    runtime::call_contract::<_, ()>(pos.clone(), (POS_BOND, *amount, source), vec![]);
+    runtime::call_contract::<_, ()>(pos.clone(), (POS_BOND, *amount, source));
 }
 
 fn unbond(pos: &ContractRef, amount: Option<U512>) {
-    runtime::call_contract::<_, ()>(pos.clone(), (POS_UNBOND, amount), Vec::<Key>::new());
+    runtime::call_contract::<_, ()>(pos.clone(), (POS_UNBOND, amount));
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/get-caller-subcall/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use alloc::collections::BTreeMap;
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error},
@@ -14,7 +14,7 @@ use contract_ffi::{
 pub extern "C" fn check_caller_ext() {
     let caller_public_key: PublicKey = runtime::get_caller();
     let return_value = CLValue::from_t(caller_public_key).unwrap_or_revert();
-    runtime::ret(return_value, Vec::new())
+    runtime::ret(return_value)
 }
 
 #[no_mangle]
@@ -29,7 +29,7 @@ pub extern "C" fn call() {
     );
 
     let pointer = storage::store_function_at_hash("check_caller_ext", BTreeMap::new());
-    let subcall_public_key: PublicKey = runtime::call_contract(pointer, (), Vec::new());
+    let subcall_public_key: PublicKey = runtime::call_contract(pointer, ());
     assert_eq!(
         subcall_public_key, known_public_key,
         "subcall public key was not known public key"

--- a/execution-engine/contracts/test/get-phase-payment/src/lib.rs
+++ b/execution-engine/contracts/test/get-phase-payment/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, Error},
     execution::Phase,
@@ -18,7 +14,7 @@ fn standard_payment(amount: U512) {
 
     let pos_pointer = system::get_proof_of_stake();
 
-    let payment_purse: PurseId = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,), vec![]);
+    let payment_purse: PurseId = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,));
 
     system::transfer_from_purse_to_purse(main_purse, payment_purse, amount).unwrap_or_revert()
 }

--- a/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/local-state-stored-caller/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{runtime, ContractRef, Error},
     unwrap_or_revert::UnwrapOrRevert,
@@ -30,5 +26,5 @@ pub extern "C" fn call() {
         ContractRef::URef(URef::new(local_state_uref.addr(), AccessRights::READ));
 
     // call do_nothing_stored
-    runtime::call_contract::<_, ()>(local_state_contract_pointer, (), vec![]);
+    runtime::call_contract(local_state_contract_pointer, ())
 }

--- a/execution-engine/contracts/test/measure-gas-subcall/src/lib.rs
+++ b/execution-engine/contracts/test/measure-gas-subcall/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{collections::BTreeMap, string::String};
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error},
@@ -20,12 +20,12 @@ enum CustomError {
 #[no_mangle]
 pub extern "C" fn get_phase_ext() {
     let phase = runtime::get_phase();
-    runtime::ret(CLValue::from_t(phase).unwrap_or_revert(), Vec::new())
+    runtime::ret(CLValue::from_t(phase).unwrap_or_revert())
 }
 
 #[no_mangle]
 pub extern "C" fn noop_ext() {
-    runtime::ret(CLValue::from_t(()).unwrap_or_revert(), Vec::new())
+    runtime::ret(CLValue::from_t(()).unwrap_or_revert())
 }
 
 #[no_mangle]
@@ -45,11 +45,11 @@ pub extern "C" fn call() {
         }
         "do-nothing" => {
             let reference = storage::store_function_at_hash(NOOP_EXT, BTreeMap::new());
-            runtime::call_contract::<_, ()>(reference, (), Vec::new());
+            runtime::call_contract::<_, ()>(reference, ());
         }
         "do-something" => {
             let reference = storage::store_function_at_hash(GET_PHASE_EXT, BTreeMap::new());
-            let phase: Phase = runtime::call_contract(reference, (), Vec::new());
+            let phase: Phase = runtime::call_contract(reference, ());
             if phase != Phase::Session {
                 runtime::revert(Error::User(CustomError::UnexpectedPhaseSub as u16))
             }

--- a/execution-engine/contracts/test/mint-purse/src/lib.rs
+++ b/execution-engine/contracts/test/mint-purse/src/lib.rs
@@ -1,12 +1,7 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec;
-
 use contract_ffi::{
     contract_api::{runtime, system, Error as ApiError},
-    key::Key,
     system_contracts::mint,
     unwrap_or_revert::UnwrapOrRevert,
     uref::URef,
@@ -22,7 +17,7 @@ enum Error {
 fn mint_purse(amount: U512) -> Result<PurseId, mint::Error> {
     let mint = system::get_mint();
 
-    let result: Result<URef, mint::Error> = runtime::call_contract(mint, ("mint", amount), vec![]);
+    let result: Result<URef, mint::Error> = runtime::call_contract(mint, ("mint", amount));
 
     result.map(PurseId::new)
 }
@@ -34,11 +29,7 @@ pub extern "C" fn call() {
 
     let mint = system::get_mint();
 
-    let balance: Option<U512> = runtime::call_contract(
-        mint,
-        ("balance", new_purse),
-        vec![Key::URef(new_purse.value())],
-    );
+    let balance: Option<U512> = runtime::call_contract(mint, ("balance", new_purse));
 
     match balance {
         None => runtime::revert(ApiError::User(Error::BalanceNotFound as u16)),

--- a/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint-caller/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, storage, system},
@@ -15,7 +15,7 @@ const RESULT_TUREF_NAME: &str = "output_version";
 #[no_mangle]
 pub extern "C" fn call() {
     let mint_pointer = system::get_mint();
-    let value: String = runtime::call_contract(mint_pointer, (NEW_ENDPOINT_NAME,), vec![]);
+    let value: String = runtime::call_contract(mint_pointer, (NEW_ENDPOINT_NAME,));
     let value_turef = storage::new_turef(value);
     let key = Key::URef(value_turef.into());
     runtime::put_key(RESULT_TUREF_NAME, key);

--- a/execution-engine/contracts/test/modified-mint/src/lib.rs
+++ b/execution-engine/contracts/test/modified-mint/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, storage, Error as ApiError},
@@ -38,18 +38,14 @@ pub fn delegate() {
                 .map(|purse_id| URef::new(purse_id.raw_id(), AccessRights::READ_ADD_WRITE));
             let return_value = CLValue::from_t(maybe_purse_key).unwrap_or_revert();
 
-            if let Ok(purse_key) = maybe_purse_key {
-                runtime::ret(return_value, vec![purse_key])
-            } else {
-                runtime::ret(return_value, vec![])
-            }
+            runtime::ret(return_value)
         }
 
         "create" => {
             let purse_id = mint.create();
             let purse_key = URef::new(purse_id.raw_id(), AccessRights::READ_ADD_WRITE);
             let return_value = CLValue::from_t(purse_key).unwrap_or_revert();
-            runtime::ret(return_value, vec![purse_key])
+            runtime::ret(return_value)
         }
 
         "balance" => {
@@ -61,7 +57,7 @@ pub fn delegate() {
             let balance: Option<U512> =
                 balance_uref.and_then(|uref| storage::read(uref.into()).unwrap_or_default());
             let return_value = CLValue::from_t(balance).unwrap_or_revert();
-            runtime::ret(return_value, vec![])
+            runtime::ret(return_value)
         }
 
         "transfer" => {
@@ -78,7 +74,7 @@ pub fn delegate() {
             let return_error = |error: PurseIdError| -> ! {
                 let transfer_result: Result<(), Error> = Err(error.into());
                 let return_value = CLValue::from_t(transfer_result).unwrap_or_revert();
-                runtime::ret(return_value, vec![])
+                runtime::ret(return_value)
             };
 
             let source: WithdrawId = match WithdrawId::from_uref(source) {
@@ -93,10 +89,10 @@ pub fn delegate() {
 
             let transfer_result = mint.transfer(source, target, amount);
             let return_value = CLValue::from_t(transfer_result).unwrap_or_revert();
-            runtime::ret(return_value, vec![]);
+            runtime::ret(return_value);
         }
         "version" => {
-            runtime::ret(CLValue::from_t(VERSION).unwrap_or_revert(), vec![]);
+            runtime::ret(CLValue::from_t(VERSION).unwrap_or_revert());
         }
 
         _ => panic!("Unknown method name!"),

--- a/execution-engine/contracts/test/pos-bonding/src/lib.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/lib.rs
@@ -2,14 +2,10 @@
 
 extern crate alloc;
 
-// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
-#[rustfmt::skip]
-use alloc::vec;
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{account, runtime, system, ContractRef, Error as ApiError},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::{
         account::{PublicKey, PurseId},
@@ -23,20 +19,12 @@ enum Error {
     UnknownCommand,
 }
 
-fn purse_to_key(p: PurseId) -> Key {
-    Key::URef(p.value())
-}
-
 fn bond(pos: &ContractRef, amount: &U512, source: PurseId) {
-    runtime::call_contract::<_, ()>(
-        pos.clone(),
-        (POS_BOND, *amount, source),
-        vec![purse_to_key(source)],
-    );
+    runtime::call_contract::<_, ()>(pos.clone(), (POS_BOND, *amount, source));
 }
 
 fn unbond(pos: &ContractRef, amount: Option<U512>) {
-    runtime::call_contract::<_, ()>(pos.clone(), (POS_UNBOND, amount), Vec::<Key>::new());
+    runtime::call_contract::<_, ()>(pos.clone(), (POS_UNBOND, amount));
 }
 
 const POS_BOND: &str = "bond";

--- a/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/lib.rs
@@ -1,12 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
-#[rustfmt::skip]
-use alloc::vec;
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, ContractRef, Error},
     key::Key,
@@ -17,16 +10,12 @@ use contract_ffi::{
     },
 };
 
-fn purse_to_key(p: &PurseId) -> Key {
-    Key::URef(p.value())
-}
-
 fn set_refund_purse(pos: &ContractRef, p: &PurseId) {
-    runtime::call_contract(pos.clone(), ("set_refund_purse", *p), vec![purse_to_key(p)])
+    runtime::call_contract(pos.clone(), ("set_refund_purse", *p))
 }
 
 fn get_payment_purse(pos: &ContractRef) -> PurseId {
-    runtime::call_contract(pos.clone(), ("get_payment_purse",), Vec::new())
+    runtime::call_contract(pos.clone(), ("get_payment_purse",))
 }
 
 fn submit_payment(pos: &ContractRef, amount: U512) {
@@ -36,11 +25,7 @@ fn submit_payment(pos: &ContractRef, amount: U512) {
 }
 
 fn finalize_payment(pos: &ContractRef, amount_spent: U512, account: PublicKey) {
-    runtime::call_contract(
-        pos.clone(),
-        ("finalize_payment", amount_spent, account),
-        Vec::new(),
-    )
+    runtime::call_contract(pos.clone(), ("finalize_payment", amount_spent, account))
 }
 
 #[no_mangle]

--- a/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-get-payment-purse/src/lib.rs
@@ -1,9 +1,5 @@
 #![no_std]
 
-extern crate alloc;
-
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, Error as ApiError},
     unwrap_or_revert::UnwrapOrRevert,
@@ -27,8 +23,7 @@ pub extern "C" fn call() {
     let payment_fund: U512 = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let payment_purse: PurseId =
-        runtime::call_contract(pos_pointer, ("get_payment_purse",), Vec::new());
+    let payment_purse: PurseId = runtime::call_contract(pos_pointer, ("get_payment_purse",));
 
     // can deposit
     system::transfer_from_purse_to_purse(source_purse, payment_purse, payment_amount)

--- a/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
+++ b/execution-engine/contracts/test/pos-refund-purse/src/lib.rs
@@ -1,15 +1,7 @@
 #![no_std]
 
-extern crate alloc;
-
-// Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
-#[rustfmt::skip]
-use alloc::vec;
-use alloc::vec::Vec;
-
 use contract_ffi::{
     contract_api::{account, runtime, system, ContractRef, Error as ApiError},
-    key::Key,
     unwrap_or_revert::UnwrapOrRevert,
     value::{account::PurseId, U512},
 };
@@ -22,20 +14,16 @@ enum Error {
     IncorrectAccessRights,
 }
 
-fn purse_to_key(p: &PurseId) -> Key {
-    Key::URef(p.value())
-}
-
 fn set_refund_purse(pos: &ContractRef, p: &PurseId) {
-    runtime::call_contract(pos.clone(), ("set_refund_purse", *p), vec![purse_to_key(p)])
+    runtime::call_contract(pos.clone(), ("set_refund_purse", *p))
 }
 
 fn get_refund_purse(pos: &ContractRef) -> Option<PurseId> {
-    runtime::call_contract(pos.clone(), ("get_refund_purse",), Vec::new())
+    runtime::call_contract(pos.clone(), ("get_refund_purse",))
 }
 
 fn get_payment_purse(pos: &ContractRef) -> PurseId {
-    runtime::call_contract(pos.clone(), ("get_payment_purse",), Vec::new())
+    runtime::call_contract(pos.clone(), ("get_payment_purse",))
 }
 
 fn submit_payment(pos: &ContractRef, amount: U512) {

--- a/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-caller/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, storage, ContractRef, Error},
@@ -44,11 +44,8 @@ pub extern "C" fn call() {
 
     match method_name.as_str() {
         METHOD_VERSION => {
-            let version: String = runtime::call_contract(
-                purse_holder_contract_pointer.clone(),
-                (method_name,),
-                vec![],
-            );
+            let version: String =
+                runtime::call_contract(purse_holder_contract_pointer.clone(), (method_name,));
             let version_key = storage::new_turef(version).into();
             runtime::put_key(METHOD_VERSION, version_key);
         }
@@ -60,7 +57,6 @@ pub extern "C" fn call() {
             runtime::call_contract::<_, ()>(
                 purse_holder_contract_pointer.clone(),
                 (method_name, purse_name),
-                vec![],
             );
         }
     };

--- a/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored-upgrader/src/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, storage, system, Error},
@@ -66,7 +66,7 @@ pub extern "C" fn apply_method() {
             let purse_name = purse_name();
             runtime::remove_key(&purse_name);
         }
-        METHOD_VERSION => runtime::ret(CLValue::from_t(VERSION).unwrap_or_revert(), vec![]),
+        METHOD_VERSION => runtime::ret(CLValue::from_t(VERSION).unwrap_or_revert()),
         _ => runtime::revert(CustomError::UnknownMethodName),
     }
 }

--- a/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
+++ b/execution-engine/contracts/test/purse-holder-stored/src/lib.rs
@@ -4,7 +4,7 @@ extern crate alloc;
 
 #[cfg(not(feature = "lib"))]
 use alloc::collections::BTreeMap;
-use alloc::{string::String, vec};
+use alloc::string::String;
 
 use contract_ffi::{
     contract_api::{runtime, storage, system, Error},
@@ -50,7 +50,7 @@ pub extern "C" fn apply_method() {
             let purse_id = system::create_purse();
             runtime::put_key(&purse_name, purse_id.value().into());
         }
-        METHOD_VERSION => runtime::ret(CLValue::from_t(VERSION).unwrap_or_revert(), vec![]),
+        METHOD_VERSION => runtime::ret(CLValue::from_t(VERSION).unwrap_or_revert()),
         _ => runtime::revert(Error::User(CustomError::UnknownMethodName as u16)),
     }
 }

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -2507,3 +2507,162 @@ where
         Ok(Ok(()))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::extract_urefs;
+    use contract_ffi::{
+        gens::*,
+        key::Key,
+        uref::URef,
+        value::{CLType, CLValue},
+    };
+    use proptest::{
+        array,
+        collection::{btree_map, vec},
+        option,
+        prelude::*,
+        result,
+    };
+
+    fn cl_value_with_urefs_arb() -> impl Strategy<Value = (CLValue, Vec<URef>)> {
+        // If compiler brings you here it most probably means you've added a variant to `CLType`
+        // enum but forgot to add generator for it.
+        let stub: Option<CLType> = None;
+        if let Some(cl_type) = stub {
+            match cl_type {
+                CLType::Bool
+                | CLType::I32
+                | CLType::I64
+                | CLType::U8
+                | CLType::U32
+                | CLType::U64
+                | CLType::U128
+                | CLType::U256
+                | CLType::U512
+                | CLType::Unit
+                | CLType::String
+                | CLType::Key
+                | CLType::URef
+                | CLType::Option(_)
+                | CLType::List(_)
+                | CLType::FixedList(..)
+                | CLType::Result { .. }
+                | CLType::Map { .. }
+                | CLType::Tuple1(_)
+                | CLType::Tuple2(_)
+                | CLType::Tuple3(_)
+                | CLType::Any => (),
+            }
+        };
+
+        prop_oneof![
+            Just((CLValue::from_t(()).expect("should create CLValue"), vec![])),
+            any::<bool>()
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            any::<i32>().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            any::<i64>().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            any::<u8>().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            any::<u32>().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            any::<u64>().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            u128_arb().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            u256_arb().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            u512_arb().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            key_arb().prop_map(|x| {
+                let urefs = x.as_uref().into_iter().cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            uref_arb().prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![x])),
+            ".*".prop_map(|x: String| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            option::of(any::<u64>())
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            option::of(uref_arb()).prop_map(|x| {
+                let urefs = x.iter().cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            option::of(key_arb()).prop_map(|x| {
+                let urefs = x.iter().filter_map(Key::as_uref).cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            vec(any::<i32>(), 0..100)
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            vec(uref_arb(), 0..100).prop_map(|x| (
+                CLValue::from_t(x.clone()).expect("should create CLValue"),
+                x
+            )),
+            vec(key_arb(), 0..100).prop_map(|x| (
+                CLValue::from_t(x.clone()).expect("should create CLValue"),
+                x.into_iter().filter_map(Key::into_uref).collect()
+            )),
+            [any::<u64>(); 32]
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            array::uniform8(uref_arb()).prop_map(|x| {
+                let urefs = x.to_vec();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            array::uniform8(key_arb()).prop_map(|x| {
+                let urefs = x.iter().filter_map(Key::as_uref).cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            result::maybe_err(key_arb(), ".*").prop_map(|x| {
+                let urefs = match &x {
+                    Ok(key) => key.as_uref().into_iter().cloned().collect(),
+                    Err(_) => vec![],
+                };
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            result::maybe_ok(".*", uref_arb()).prop_map(|x| {
+                let urefs = match &x {
+                    Ok(_) => vec![],
+                    Err(uref) => vec![*uref],
+                };
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            btree_map(".*", u512_arb(), 0..100)
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            btree_map(uref_arb(), u512_arb(), 0..100).prop_map(|x| {
+                let urefs = x.keys().cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            btree_map(".*", uref_arb(), 0..100).prop_map(|x| {
+                let urefs = x.values().cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            btree_map(uref_arb(), key_arb(), 0..100).prop_map(|x| {
+                let mut urefs: Vec<URef> = x.keys().cloned().collect();
+                urefs.extend(x.values().filter_map(Key::as_uref).cloned());
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            (any::<bool>())
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            (uref_arb())
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![x])),
+            (any::<bool>(), any::<i32>())
+                .prop_map(|x| (CLValue::from_t(x).expect("should create CLValue"), vec![])),
+            (uref_arb(), any::<i32>()).prop_map(|x| {
+                let uref = x.0;
+                (
+                    CLValue::from_t(x).expect("should create CLValue"),
+                    vec![uref],
+                )
+            }),
+            (any::<i32>(), key_arb()).prop_map(|x| {
+                let urefs = x.1.as_uref().into_iter().cloned().collect();
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+            (uref_arb(), key_arb()).prop_map(|x| {
+                let mut urefs = vec![x.0];
+                urefs.extend(x.1.as_uref().into_iter().cloned());
+                (CLValue::from_t(x).expect("should create CLValue"), urefs)
+            }),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn should_extract_urefs((cl_value, urefs) in cl_value_with_urefs_arb()) {
+            let extracted_urefs = extract_urefs(&cl_value).unwrap();
+            assert_eq!(extracted_urefs, urefs);
+        }
+    }
+}

--- a/execution-engine/engine-core/src/execution/runtime/mod.rs
+++ b/execution-engine/engine-core/src/execution/runtime/mod.rs
@@ -24,7 +24,7 @@ use contract_ffi::{
     uref::{AccessRights, URef},
     value::{
         account::{ActionType, PublicKey, PurseId, Weight, PUBLIC_KEY_SERIALIZED_LENGTH},
-        CLType, CLValue, ProtocolVersion, U512,
+        CLType, CLValue, ProtocolVersion, U128, U256, U512,
     },
 };
 use engine_shared::{account::Account, contract::Contract, gas::Gas, stored_value::StoredValue};
@@ -130,6 +130,1213 @@ pub fn extract_access_rights_from_keys<I: IntoIterator<Item = Key>>(
             )
         })
         .collect()
+}
+
+#[allow(clippy::cognitive_complexity)]
+fn extract_urefs(cl_value: &CLValue) -> Result<Vec<URef>, Error> {
+    match cl_value.cl_type() {
+        CLType::Bool
+        | CLType::I32
+        | CLType::I64
+        | CLType::U8
+        | CLType::U32
+        | CLType::U64
+        | CLType::U128
+        | CLType::U256
+        | CLType::U512
+        | CLType::Unit
+        | CLType::String
+        | CLType::Any => Ok(vec![]),
+        CLType::Option(ty) => match **ty {
+            CLType::URef => {
+                let opt: Option<URef> = cl_value.to_owned().into_t()?;
+                Ok(opt.into_iter().collect())
+            }
+            CLType::Key => {
+                let opt: Option<Key> = cl_value.to_owned().into_t()?;
+                Ok(opt.into_iter().flat_map(Key::into_uref).collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::List(ty) => match **ty {
+            CLType::URef => Ok(cl_value.to_owned().into_t()?),
+            CLType::Key => {
+                let keys: Vec<Key> = cl_value.to_owned().into_t()?;
+                Ok(keys.into_iter().filter_map(Key::into_uref).collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 1) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 1] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 1] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 2) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 2] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 2] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 3) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 3] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 3] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 4) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 4] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 4] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 5) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 5] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 5] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 6) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 6] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 6] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 7) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 7] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 7] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 8) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 8] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 8] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 9) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 9] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 9] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 10) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 10] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 10] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 11) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 11] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 11] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 12) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 12] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 12] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 13) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 13] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 13] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 14) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 14] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 14] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 15) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 15] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 15] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 16) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 16] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 16] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 17) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 17] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 17] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 18) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 18] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 18] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 19) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 19] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 19] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 20) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 20] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 20] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 21) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 21] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 21] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 22) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 22] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 22] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 23) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 23] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 23] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 24) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 24] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 24] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 25) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 25] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 25] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 26) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 26] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 26] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 27) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 27] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 27] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 28) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 28] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 28] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 29) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 29] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 29] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 30) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 30] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 30] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 31) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 31] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 31] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 32) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 32] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 32] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 64) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 64] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 64] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 128) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 128] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 128] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 256) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 256] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 256] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(ty, 512) => match **ty {
+            CLType::URef => {
+                let arr: [URef; 512] = cl_value.to_owned().into_t()?;
+                Ok(arr.to_vec())
+            }
+            CLType::Key => {
+                let arr: [Key; 512] = cl_value.to_owned().into_t()?;
+                Ok(arr.iter().filter_map(Key::as_uref).cloned().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::FixedList(_ty, _) => Ok(vec![]),
+        CLType::Result { ok, err } => match (&**ok, &**err) {
+            (CLType::URef, CLType::Bool) => {
+                let res: Result<URef, bool> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::I32) => {
+                let res: Result<URef, i32> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::I64) => {
+                let res: Result<URef, i64> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::U8) => {
+                let res: Result<URef, u8> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::U32) => {
+                let res: Result<URef, u32> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::U64) => {
+                let res: Result<URef, u64> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::U128) => {
+                let res: Result<URef, U128> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::U256) => {
+                let res: Result<URef, U256> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::U512) => {
+                let res: Result<URef, U512> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::Unit) => {
+                let res: Result<URef, ()> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::String) => {
+                let res: Result<URef, String> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::URef, CLType::Key) => {
+                let res: Result<URef, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::URef, CLType::URef) => {
+                let res: Result<URef, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(uref) => Ok(vec![uref]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::Key, CLType::Bool) => {
+                let res: Result<Key, bool> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::I32) => {
+                let res: Result<Key, i32> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::I64) => {
+                let res: Result<Key, i64> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::U8) => {
+                let res: Result<Key, u8> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::U32) => {
+                let res: Result<Key, u32> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::U64) => {
+                let res: Result<Key, u64> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::U128) => {
+                let res: Result<Key, U128> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::U256) => {
+                let res: Result<Key, U256> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::U512) => {
+                let res: Result<Key, U512> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::Unit) => {
+                let res: Result<Key, ()> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::String) => {
+                let res: Result<Key, String> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(_) => Ok(vec![]),
+                }
+            }
+            (CLType::Key, CLType::URef) => {
+                let res: Result<Key, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::Key, CLType::Key) => {
+                let res: Result<Key, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(key) => Ok(key.into_uref().into_iter().collect()),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::Bool, CLType::URef) => {
+                let res: Result<bool, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::I32, CLType::URef) => {
+                let res: Result<i32, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::I64, CLType::URef) => {
+                let res: Result<i64, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::U8, CLType::URef) => {
+                let res: Result<u8, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::U32, CLType::URef) => {
+                let res: Result<u32, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::U64, CLType::URef) => {
+                let res: Result<u64, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::U128, CLType::URef) => {
+                let res: Result<U128, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::U256, CLType::URef) => {
+                let res: Result<U256, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::U512, CLType::URef) => {
+                let res: Result<U512, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::Unit, CLType::URef) => {
+                let res: Result<(), URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::String, CLType::URef) => {
+                let res: Result<String, URef> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(uref) => Ok(vec![uref]),
+                }
+            }
+            (CLType::Bool, CLType::Key) => {
+                let res: Result<bool, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::I32, CLType::Key) => {
+                let res: Result<i32, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::I64, CLType::Key) => {
+                let res: Result<i64, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::U8, CLType::Key) => {
+                let res: Result<u8, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::U32, CLType::Key) => {
+                let res: Result<u32, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::U64, CLType::Key) => {
+                let res: Result<u64, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::U128, CLType::Key) => {
+                let res: Result<U128, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::U256, CLType::Key) => {
+                let res: Result<U256, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::U512, CLType::Key) => {
+                let res: Result<U512, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::Unit, CLType::Key) => {
+                let res: Result<(), Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (CLType::String, CLType::Key) => {
+                let res: Result<String, Key> = cl_value.to_owned().into_t()?;
+                match res {
+                    Ok(_) => Ok(vec![]),
+                    Err(key) => Ok(key.into_uref().into_iter().collect()),
+                }
+            }
+            (_, _) => Ok(vec![]),
+        },
+        CLType::Map { key, value } => match (&**key, &**value) {
+            (CLType::URef, CLType::Bool) => {
+                let map: BTreeMap<URef, bool> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::I32) => {
+                let map: BTreeMap<URef, i32> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::I64) => {
+                let map: BTreeMap<URef, i64> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::U8) => {
+                let map: BTreeMap<URef, u8> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::U32) => {
+                let map: BTreeMap<URef, u32> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::U64) => {
+                let map: BTreeMap<URef, u64> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::U128) => {
+                let map: BTreeMap<URef, U128> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::U256) => {
+                let map: BTreeMap<URef, U256> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::U512) => {
+                let map: BTreeMap<URef, U512> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::Unit) => {
+                let map: BTreeMap<URef, ()> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::String) => {
+                let map: BTreeMap<URef, String> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().collect())
+            }
+            (CLType::URef, CLType::Key) => {
+                let map: BTreeMap<URef, Key> = cl_value.to_owned().into_t()?;
+                Ok(map
+                    .keys()
+                    .cloned()
+                    .chain(map.values().cloned().filter_map(Key::into_uref))
+                    .collect())
+            }
+            (CLType::URef, CLType::URef) => {
+                let map: BTreeMap<URef, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().chain(map.values().cloned()).collect())
+            }
+            (CLType::Key, CLType::Bool) => {
+                let map: BTreeMap<Key, bool> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::I32) => {
+                let map: BTreeMap<Key, i32> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::I64) => {
+                let map: BTreeMap<Key, i64> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::U8) => {
+                let map: BTreeMap<Key, u8> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::U32) => {
+                let map: BTreeMap<Key, u32> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::U64) => {
+                let map: BTreeMap<Key, u64> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::U128) => {
+                let map: BTreeMap<Key, U128> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::U256) => {
+                let map: BTreeMap<Key, U256> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::U512) => {
+                let map: BTreeMap<Key, U512> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::Unit) => {
+                let map: BTreeMap<Key, ()> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::String) => {
+                let map: BTreeMap<Key, String> = cl_value.to_owned().into_t()?;
+                Ok(map.keys().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Key, CLType::URef) => {
+                let map: BTreeMap<Key, URef> = cl_value.to_owned().into_t()?;
+                Ok(map
+                    .keys()
+                    .cloned()
+                    .filter_map(Key::into_uref)
+                    .chain(map.values().cloned())
+                    .collect())
+            }
+            (CLType::Key, CLType::Key) => {
+                let map: BTreeMap<Key, Key> = cl_value.to_owned().into_t()?;
+                Ok(map
+                    .keys()
+                    .cloned()
+                    .filter_map(Key::into_uref)
+                    .chain(map.values().cloned().filter_map(Key::into_uref))
+                    .collect())
+            }
+            (CLType::Bool, CLType::URef) => {
+                let map: BTreeMap<bool, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::I32, CLType::URef) => {
+                let map: BTreeMap<i32, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::I64, CLType::URef) => {
+                let map: BTreeMap<i64, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::U8, CLType::URef) => {
+                let map: BTreeMap<u8, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::U32, CLType::URef) => {
+                let map: BTreeMap<u32, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::U64, CLType::URef) => {
+                let map: BTreeMap<u64, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::U128, CLType::URef) => {
+                let map: BTreeMap<U128, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::U256, CLType::URef) => {
+                let map: BTreeMap<U256, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::U512, CLType::URef) => {
+                let map: BTreeMap<U512, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::Unit, CLType::URef) => {
+                let map: BTreeMap<(), URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::String, CLType::URef) => {
+                let map: BTreeMap<String, URef> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().collect())
+            }
+            (CLType::Bool, CLType::Key) => {
+                let map: BTreeMap<bool, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::I32, CLType::Key) => {
+                let map: BTreeMap<i32, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::I64, CLType::Key) => {
+                let map: BTreeMap<i64, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::U8, CLType::Key) => {
+                let map: BTreeMap<u8, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::U32, CLType::Key) => {
+                let map: BTreeMap<u32, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::U64, CLType::Key) => {
+                let map: BTreeMap<u64, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::U128, CLType::Key) => {
+                let map: BTreeMap<U128, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::U256, CLType::Key) => {
+                let map: BTreeMap<U256, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::U512, CLType::Key) => {
+                let map: BTreeMap<U512, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::Unit, CLType::Key) => {
+                let map: BTreeMap<(), Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (CLType::String, CLType::Key) => {
+                let map: BTreeMap<String, Key> = cl_value.to_owned().into_t()?;
+                Ok(map.values().cloned().filter_map(Key::into_uref).collect())
+            }
+            (_, _) => Ok(vec![]),
+        },
+        CLType::Tuple1([ty]) => match **ty {
+            CLType::URef => {
+                let val: (URef,) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            CLType::Key => {
+                let val: (Key,) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            _ => Ok(vec![]),
+        },
+        CLType::Tuple2([ty1, ty2]) => match (&**ty1, &**ty2) {
+            (CLType::URef, CLType::Bool) => {
+                let val: (URef, bool) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::I32) => {
+                let val: (URef, i32) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::I64) => {
+                let val: (URef, i64) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::U8) => {
+                let val: (URef, u8) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::U32) => {
+                let val: (URef, u32) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::U64) => {
+                let val: (URef, u64) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::U128) => {
+                let val: (URef, U128) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::U256) => {
+                let val: (URef, U256) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::U512) => {
+                let val: (URef, U512) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::Unit) => {
+                let val: (URef, ()) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::String) => {
+                let val: (URef, String) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0])
+            }
+            (CLType::URef, CLType::Key) => {
+                let val: (URef, Key) = cl_value.to_owned().into_t()?;
+                let mut res = vec![val.0];
+                res.extend(val.1.into_uref().into_iter());
+                Ok(res)
+            }
+            (CLType::URef, CLType::URef) => {
+                let val: (URef, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.0, val.1])
+            }
+            (CLType::Key, CLType::Bool) => {
+                let val: (Key, bool) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::I32) => {
+                let val: (Key, i32) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::I64) => {
+                let val: (Key, i64) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::U8) => {
+                let val: (Key, u8) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::U32) => {
+                let val: (Key, u32) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::U64) => {
+                let val: (Key, u64) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::U128) => {
+                let val: (Key, U128) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::U256) => {
+                let val: (Key, U256) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::U512) => {
+                let val: (Key, U512) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::Unit) => {
+                let val: (Key, ()) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::String) => {
+                let val: (Key, String) = cl_value.to_owned().into_t()?;
+                Ok(val.0.into_uref().into_iter().collect())
+            }
+            (CLType::Key, CLType::URef) => {
+                let val: (Key, URef) = cl_value.to_owned().into_t()?;
+                let mut res: Vec<URef> = val.0.into_uref().into_iter().collect();
+                res.push(val.1);
+                Ok(res)
+            }
+            (CLType::Key, CLType::Key) => {
+                let val: (Key, Key) = cl_value.to_owned().into_t()?;
+                Ok(val
+                    .0
+                    .into_uref()
+                    .into_iter()
+                    .chain(val.1.into_uref().into_iter())
+                    .collect())
+            }
+            (CLType::Bool, CLType::URef) => {
+                let val: (bool, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::I32, CLType::URef) => {
+                let val: (i32, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::I64, CLType::URef) => {
+                let val: (i64, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::U8, CLType::URef) => {
+                let val: (u8, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::U32, CLType::URef) => {
+                let val: (u32, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::U64, CLType::URef) => {
+                let val: (u64, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::U128, CLType::URef) => {
+                let val: (U128, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::U256, CLType::URef) => {
+                let val: (U256, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::U512, CLType::URef) => {
+                let val: (U512, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::Unit, CLType::URef) => {
+                let val: ((), URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::String, CLType::URef) => {
+                let val: (String, URef) = cl_value.to_owned().into_t()?;
+                Ok(vec![val.1])
+            }
+            (CLType::Bool, CLType::Key) => {
+                let val: (bool, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::I32, CLType::Key) => {
+                let val: (i32, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::I64, CLType::Key) => {
+                let val: (i64, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::U8, CLType::Key) => {
+                let val: (u8, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::U32, CLType::Key) => {
+                let val: (u32, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::U64, CLType::Key) => {
+                let val: (u64, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::U128, CLType::Key) => {
+                let val: (U128, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::U256, CLType::Key) => {
+                let val: (U256, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::U512, CLType::Key) => {
+                let val: (U512, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::Unit, CLType::Key) => {
+                let val: ((), Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (CLType::String, CLType::Key) => {
+                let val: (String, Key) = cl_value.to_owned().into_t()?;
+                Ok(val.1.into_uref().into_iter().collect())
+            }
+            (_, _) => Ok(vec![]),
+        },
+        // TODO: nested matches for Tuple3?
+        CLType::Tuple3(_) => Ok(vec![]),
+        CLType::Key => {
+            let key: Key = cl_value.to_owned().into_t()?; // TODO: optimize?
+            Ok(key.into_uref().into_iter().collect())
+        }
+        CLType::URef => {
+            let uref: URef = cl_value.to_owned().into_t()?; // TODO: optimize?
+            Ok(vec![uref])
+        }
+    }
 }
 
 fn sub_call<R>(
@@ -504,10 +1711,14 @@ where
                 // enum indicating that the reason for exiting the module was a call to ret.
                 self.host_buf = bytesrepr::deserialize(buf).ok();
 
-                // TODO(Fraser): extract all URefs now held in `self.host_buf`.
-                let urefs = vec![];
-
-                Error::Ret(urefs).into()
+                let urefs = match &self.host_buf {
+                    Some(buf) => extract_urefs(buf),
+                    None => Ok(vec![]),
+                };
+                match urefs {
+                    Ok(urefs) => Error::Ret(urefs).into(),
+                    Err(e) => e.into(),
+                }
             }
             Err(e) => e.into(),
         }
@@ -548,8 +1759,18 @@ where
             None => parity_wasm::deserialize_buffer(contract.bytes())?,
         };
 
-        // TODO(Fraser): extract and validate all URefs provided in `args`.
-        let extra_urefs = vec![];
+        let mut extra_urefs = vec![];
+        // A loop is needed to be able to use the '?' operator
+        for arg in &args {
+            extra_urefs.extend(
+                extract_urefs(arg)?
+                    .into_iter()
+                    .map(<Key as From<URef>>::from),
+            );
+        }
+        for key in &extra_urefs {
+            self.context.validate_key(key)?;
+        }
 
         let mut refs = contract.take_named_keys();
 

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -81,11 +81,11 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 FunctionIndex::GetArgFuncIndex.into(),
             ),
             "ret" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 4][..], None),
+                Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::RetFuncIndex.into(),
             ),
             "call_contract" => FuncInstance::alloc_host(
-                Signature::new(&[ValueType::I32; 7][..], Some(ValueType::I32)),
+                Signature::new(&[ValueType::I32; 5][..], Some(ValueType::I32)),
                 FunctionIndex::CallContractFuncIndex.into(),
             ),
             "get_key" => FuncInstance::alloc_host(

--- a/execution-engine/engine-tests/src/test/regression/ee_803.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_803.rs
@@ -56,8 +56,7 @@ fn get_cost(response: &ExecuteResponse) -> U512 {
 // bonding step and we should be asserting that
 #[test]
 #[ignore]
-// TODO: uncomment this when the issue is fixed
-// #[should_panic]
+#[should_panic]
 fn should_not_be_able_to_unbond_reward() {
     let mut builder = InMemoryWasmTestBuilder::default();
 


### PR DESCRIPTION
### Overview
This removes `extra_urefs` from `contract_api` functions and instead extracts these from `CLValue`s passed into the runtime.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-805
https://casperlabs.atlassian.net/browse/EE-806

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
We haven't implemented handling for `Tuple3` type in the new `runtime::extract_urefs()` function since it'll significantly increase the length of this 1200-line function.  If the approach to extracting `URef`s taken in this PR is approved, then we can extend the function and its unit test accordingly.

Running benchmarks against current dev at commit 8f8a77556, we're seeing an improvement:
```
Benchmarking tps/transfer_to_existing_account_multiple_execs/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.1s or reduce sample count to 10
tps/transfer_to_existing_account_multiple_execs/3                                                                          
                        time:   [107.11 ms 108.11 ms 109.34 ms]
                        thrpt:  [27.436  elem/s 27.751  elem/s 28.008  elem/s]
                 change:
                        time:   [-9.4037% -7.6483% -5.8503%] (p = 0.00 < 0.05)
                        thrpt:  [+6.2139% +8.2817% +10.380%]
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
Benchmarking tps/transfer_to_existing_account_multiple_deploys_per_exec/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.7s or reduce sample count to 10
tps/transfer_to_existing_account_multiple_deploys_per_exec/3                                                                          
                        time:   [100.71 ms 101.32 ms 102.35 ms]
                        thrpt:  [29.310  elem/s 29.609  elem/s 29.788  elem/s]
                 change:
                        time:   [-7.6786% -6.4001% -5.1742%] (p = 0.00 < 0.05)
                        thrpt:  [+5.4565% +6.8377% +8.3173%]
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking tps/transfer_to_purse_multiple_execs/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.1s or reduce sample count to 10
tps/transfer_to_purse_multiple_execs/3                                                                          
                        time:   [114.49 ms 115.94 ms 116.84 ms]
                        thrpt:  [25.675  elem/s 25.876  elem/s 26.202  elem/s]
                 change:
                        time:   [-3.3788% -1.6643% -0.0310%] (p = 0.09 > 0.05)
                        thrpt:  [+0.0310% +1.6924% +3.4970%]
                        No change in performance detected.
Benchmarking tps/transfer_to_purse_multiple_deploys_per_exec/3: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.5s or reduce sample count to 10
tps/transfer_to_purse_multiple_deploys_per_exec/3                                                                          
                        time:   [101.08 ms 102.41 ms 104.11 ms]
                        thrpt:  [28.815  elem/s 29.294  elem/s 29.678  elem/s]
                 change:
                        time:   [-8.7495% -7.4192% -6.0808%] (p = 0.00 < 0.05)
                        thrpt:  [+6.4745% +8.0137% +9.5885%]
                        Performance has improved.
```