### PR TITLE
NODE-1116: Voting only period

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ integration-testing.log
 *.sublime-workspace
 .metals/
 .vscode/
+project/metals.sbt
 
 # Library Cargo.lock files
 execution-engine/common/*.lock

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -462,11 +462,13 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
               Agenda(nextRoundId -> Agenda.StartRound(nextRoundId))
             } else Agenda.empty
 
-            // Only bother with the omega if we're still in the same round which we started.
-            val omega = if (currentRoundId == roundId) {
-              val omegaTick = chooseOmegaTick(roundId, nextRoundId)
-              Agenda(omegaTick -> Agenda.CreateOmegaMessage(roundId))
-            } else Agenda.empty
+            // Schedule the omega for whatever the current round is, don't bother
+            // with the old one if the block production was so slow that it pushed
+            // us into the next round already. We can still participate in this one.
+            val omega = {
+              val omegaTick = chooseOmegaTick(currentRoundId, nextRoundId)
+              Agenda(omegaTick -> Agenda.CreateOmegaMessage(currentRoundId))
+            }
 
             omega ++ next
           }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -121,8 +121,8 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
           // We have to keep voting until the switch block given by the fork choice
           // in *this* era is finalized.
           ForkChoice[F].fromKeyBlock(era.keyBlockHash).flatMap { choice =>
-            choice.mainParent.isSwitchBlock.ifM(
-              FinalityStorageReader[F].isFinalized(choice.mainParent.messageHash),
+            choice.block.isSwitchBlock.ifM(
+              FinalityStorageReader[F].isFinalized(choice.block.messageHash),
               false.pure[F]
             )
           }
@@ -186,7 +186,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
               message <- messageProducer.ballot(
                           eraId = era.keyBlockHash,
                           roundId = Ticks(lambdaMessage.roundId),
-                          target = choice.mainParent.messageHash,
+                          target = choice.block.messageHash,
                           justifications = justifications
                         )
             } yield message
@@ -209,10 +209,10 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
         .block(
           eraId = era.keyBlockHash,
           roundId = roundId,
-          mainParent = choice.mainParent.messageHash,
+          mainParent = choice.block.messageHash,
           justifications = choice.justificationsMap,
           isBookingBlock = isBookingBoundary(
-            choice.mainParent.roundInstant,
+            choice.block.roundInstant,
             conf.toInstant(roundId)
           )
         )
@@ -222,7 +222,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
         .ballot(
           eraId = era.keyBlockHash,
           roundId = roundId,
-          target = choice.mainParent.messageHash,
+          target = choice.block.messageHash,
           justifications = choice.justificationsMap
         )
         .widen[Message]
@@ -230,7 +230,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
       message <- if (roundId < endTick) {
                   block
                 } else {
-                  choice.mainParent.isSwitchBlock.ifM(ballot, block)
+                  choice.block.isSwitchBlock.ifM(ballot, block)
                 }
     } yield message
 
@@ -252,7 +252,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
               message <- messageProducer.ballot(
                           eraId = era.keyBlockHash,
                           roundId = roundId,
-                          target = choice.mainParent.messageHash,
+                          target = choice.block.messageHash,
                           justifications = choice.justificationsMap
                         )
             } yield message

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -97,7 +97,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
 
     /** Check if this block is the first in its main-chain that crosses the end of the era. */
     def isSwitchBlock: F[Boolean] =
-      if (msg.parentBlock.isEmpty)
+      if (msg.parentBlock.isEmpty || !msg.isInstanceOf[Message.Block])
         false.pure[F]
       else
         dag.lookupUnsafe(msg.parentBlock).map { parent =>

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -348,7 +348,18 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: ForkChoice](
               // can only be an equivocation, otherwise the 2nd one cites the first
               // and that means it's not lambda-like.
               hasOtherLambdaMessageInSameRound[F](dag, b, endTick)
+            ) >>
+            checkF(
+              "The block is built on top of a switch block.",
+              dag.lookupUnsafe(message.parentBlock).flatMap(_.isSwitchBlock)
             )
+
+        case b: Message.Ballot if b.roundId >= endTick =>
+          checkF(
+            "The ballot is not built on top of a switch block.",
+            dag.lookupUnsafe(b.parentBlock).flatMap(_.isSwitchBlock).map(!_)
+          )
+
         case _ =>
           ok
       }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -375,13 +375,13 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
               hasOtherLambdaMessageInSameRound[F](dag, b, endTick)
             ) >>
             checkF(
-              "The block is built on top of a switch block.",
+              "Only ballots should be build on top of a switch block in the current era.",
               dag.lookupUnsafe(message.parentBlock).flatMap(_.isSwitchBlock)
             )
 
         case b: Message.Ballot if b.roundId >= endTick =>
           checkF(
-            "The ballot is not built on top of a switch block.",
+            "A ballot during the voting-only period can only be built on top of a switch block.",
             dag.lookupUnsafe(b.parentBlock).flatMap(_.isSwitchBlock).map(!_)
           )
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
@@ -49,7 +49,7 @@ trait ForkChoice[F[_]] {
 }
 object ForkChoice {
   case class Result(
-      mainParent: Message,
+      block: Message.Block,
       // The fork choice must take into account messages from the parent
       // era's voting period as well, in order to be able to tell which
       // switch block in the end of the era to build on, and so which

--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayEvent.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayEvent.scala
@@ -11,15 +11,15 @@ sealed trait HighwayEvent
 
 object HighwayEvent {
 
-  /** Created a lambda message; only happens if this validator was leader in the round. Needs to be broadcasted. */
-  case class CreatedLambdaMessage(message: Message.Block) extends HighwayEvent
+  /** Created a lambda message; only happens if this validator was leader in the round. */
+  case class CreatedLambdaMessage(message: Message) extends HighwayEvent
 
-  /** Created a response to a lambda message received from a leader. Needs to be broadcasted. */
+  /** Created a response to a lambda message received from a leader. */
   case class CreatedLambdaResponse(message: Message.Ballot) extends HighwayEvent
 
   /** Created an omega message, some time during the round. */
   case class CreatedOmegaMessage(message: Message.Ballot) extends HighwayEvent
 
-  /** Create a new era based on a previously unused key block. Needs to be started. */
+  /** Create a new era based on a previously unused key block. */
   case class CreatedEra(era: Era) extends HighwayEvent
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -16,12 +16,8 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.{DagStorage, FinalityStorage}
 import io.casperlabs.storage.era.EraStorage
-import io.casperlabs.casper.highway.mocks.{
-  MockDagStorage,
-  MockEraStorage,
-  MockFinalityStorage,
-  MockForkChoice
-}
+import io.casperlabs.casper.mocks.{MockFinalityStorage}
+import io.casperlabs.casper.highway.mocks.{MockDagStorage, MockEraStorage, MockForkChoice}
 import org.scalatest._
 import org.scalactic.source
 import org.scalactic.Prettifier

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -245,6 +245,8 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       }
     }
 
+    "reject a block build on a switch block" in (pending) // NODE-1116
+
     "accept a second lambda ballot received from the leader in the same round during the voting-only period" in {
       implicit val ds = defaultDagStorage
       val leader      = "Bob"
@@ -415,11 +417,10 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         }
 
         "it is not from the leader" should {
-          "reject the block" in {
+          "ignore the block" in {
             val msg = makeBlock("Bob", runtime.era, runtime.startTick)
-            an[IllegalStateException] should be thrownBy {
-              runtime.handleMessage(msg)
-            }
+            // These will fail validation but in case they didn't, don't repond.
+            runtime.handleMessage(msg).written shouldBe empty
           }
         }
 
@@ -506,10 +507,10 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         }
         "in the post-era voting period" when {
           "coming from the leader" should {
-            "create a lambda response" in (pending)
+            "create a lambda response" in (pending) // NODE-1116
           }
           "coming from a non-leader" should {
-            "not respond" in (pending)
+            "not respond" in (pending) // NODE-1116
           }
         }
       }
@@ -680,14 +681,14 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
 
       "in the post-era voting period" when {
         "the validator is the leader" should {
-          "a ballot instead of a lambda message" in (pending)
+          "a ballot instead of a lambda message" in (pending) // NODE-1116
         }
         "the voting is still going" should {
-          "schedule an omega message" in (pending)
-          "schedule another round" in (pending)
+          "schedule an omega message" in (pending) // NODE-1116
+          "schedule another round" in (pending)    // NODE-1116
         }
-        "the voting period is over" should {
-          "not schedule anything" in (pending)
+        "voting period is over" should {
+          "not schedule anything " in (pending) // NODE-1116
         }
       }
 
@@ -805,7 +806,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         }
       }
       "in the post-era voting period" should {
-        "create an omega message" in (pending)
+        "create an omega message" in (pending) // NODE-1116
       }
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -322,7 +322,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       val msg2 = insert(build(runtime.endTick, msg1.messageHash))
       val msg3 = build(Ticks(runtime.endTick + 1), msg2.messageHash)
       runtime.validate(msg3).value shouldBe Left(
-        "The block is built on top of a switch block."
+        "Only ballots should be build on top of a switch block in the current era."
       )
     }
 
@@ -333,7 +333,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       val msg1        = insert(makeBlock(leader, runtime.era, runtime.startTick))
       val msg2        = makeBallot(leader, runtime.era, runtime.endTick, target = msg1.messageHash)
       runtime.validate(msg2).value shouldBe Left(
-        "The ballot is not built on top of a switch block."
+        "A ballot during the voting-only period can only be built on top of a switch block."
       )
     }
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -382,7 +382,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       } shouldBe List(false, false, true, false)
 
       ballots map {
-        EraRuntime.hasJustificationInOwnRound[Id](
+        EraRuntime.citesOwnMessageInSameRound[Id](
           ds.getRepresentation,
           _
         )

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockFinalityStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockFinalityStorage.scala
@@ -1,0 +1,30 @@
+package io.casperlabs.casper.highway.mocks
+
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.Ref
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.storage.dag.FinalityStorage
+
+class MockFinalityStorage[F[_]: Monad](
+    lastFinalizedRef: Ref[F, BlockHash],
+    finalizedRef: Ref[F, Set[BlockHash]]
+) extends FinalityStorage[F] {
+  override def getLastFinalizedBlock: F[BlockHash] =
+    lastFinalizedRef.get
+  override def isFinalized(block: BlockHash): F[Boolean] =
+    finalizedRef.get.map(_ contains block)
+  override def markAsFinalized(mainParent: BlockHash, secondary: Set[BlockHash]): F[Unit] =
+    lastFinalizedRef.set(mainParent) >> finalizedRef.update {
+      _ ++ secondary + mainParent
+    }
+}
+
+object MockFinalityStorage {
+  def apply[F[_]: Sync](genesis: BlockHash) =
+    for {
+      lastFinalizedRef <- Ref.of[F, BlockHash](genesis)
+      finalizedRef     <- Ref.of[F, Set[BlockHash]](Set(genesis))
+    } yield new MockFinalityStorage(lastFinalizedRef, finalizedRef)
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
@@ -8,7 +8,7 @@ import io.casperlabs.models.Message
 import io.casperlabs.storage.BlockHash
 import io.casperlabs.casper.highway.ForkChoice
 
-class MockForkChoice[F[_]](
+class MockForkChoice[F[_]: Applicative](
     resultRef: Ref[F, ForkChoice.Result]
 ) extends ForkChoice[F] {
   override def fromKeyBlock(keyBlockHash: BlockHash): F[ForkChoice.Result] =
@@ -23,8 +23,8 @@ class MockForkChoice[F[_]](
   def set(result: ForkChoice.Result): F[Unit] =
     resultRef.set(result)
 
-  def set(message: Message): F[Unit] =
-    resultRef.set(ForkChoice.Result(message, Set.empty))
+  def set(message: Message): F[Message] =
+    resultRef.set(ForkChoice.Result(message, Set.empty)).as(message)
 }
 
 object MockForkChoice {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockForkChoice.scala
@@ -23,12 +23,12 @@ class MockForkChoice[F[_]: Applicative](
   def set(result: ForkChoice.Result): F[Unit] =
     resultRef.set(result)
 
-  def set(message: Message): F[Message] =
-    resultRef.set(ForkChoice.Result(message, Set.empty)).as(message)
+  def set(block: Message.Block): F[Message.Block] =
+    resultRef.set(ForkChoice.Result(block, Set.empty)).as(block)
 }
 
 object MockForkChoice {
-  def apply[F[_]: Sync](init: Message) =
+  def apply[F[_]: Sync](init: Message.Block) =
     for {
       ref <- Ref.of[F, ForkChoice.Result](ForkChoice.Result(init, Set.empty))
     } yield new MockForkChoice[F](ref)

--- a/casper/src/test/scala/io/casperlabs/casper/mocks/MockFinalityStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/mocks/MockFinalityStorage.scala
@@ -1,4 +1,4 @@
-package io.casperlabs.casper.highway.mocks
+package io.casperlabs.casper.mocks
 
 import cats._
 import cats.implicits._

--- a/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
@@ -3,8 +3,7 @@ package io.casperlabs.storage.dag
 import io.casperlabs.storage.BlockHash
 import simulacrum.typeclass
 
-@typeclass trait FinalityStorage[F[_]] {
-  def markAsFinalized(mainParent: BlockHash, secondary: Set[BlockHash]): F[Unit]
+@typeclass trait FinalityStorageReader[F[_]] {
   def isFinalized(block: BlockHash): F[Boolean]
 
   /** Returns last finalized block.
@@ -12,4 +11,8 @@ import simulacrum.typeclass
     * A block with the highest rank from the main chain.
     */
   def getLastFinalizedBlock: F[BlockHash]
+}
+
+@typeclass trait FinalityStorage[F[_]] extends FinalityStorageReader[F] {
+  def markAsFinalized(mainParent: BlockHash, secondary: Set[BlockHash]): F[Unit]
 }


### PR DESCRIPTION
### Overview
Produce ballots instead of blocks as lambda messages during the voting-only period, _iff_ there's already a switch block to build on. Validate that a block is not built on a switch block, and lambda ballots are targeting a switch block (otherwise the leader should have built a switch block instead).

Stop scheduling further rounds if the voting period is over, either because of the fixed time window we want it to run for, or, if it's so configured, if the switch block which is the fork choice in the current era has been finalized.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1116

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
