### PR TITLE
NODE-1106: Collect active eras

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -1,0 +1,59 @@
+package io.casperlabs.casper.highway
+
+import cats._
+import cats.implicits._
+import cats.effect.{Clock, Sync}
+import io.casperlabs.casper.consensus.Era
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.storage.dag.{DagRepresentation, DagStorage, FinalityStorageReader}
+import io.casperlabs.storage.era.EraStorage
+import io.casperlabs.casper.util.DagOperations, DagOperations.Key
+
+object EraSupervisor {
+
+  // Return type for the initialization of active eras along the era tree.
+  type EraWithAgenda[F[_]] = (EraRuntime[F], EraRuntime.Agenda)
+
+  // Helper for traversing the era tree.
+  implicit def `Key[EraWithAgenda]`[F[_]] = Key.instance[EraWithAgenda[F], BlockHash] {
+    case (runtime, _) => runtime.era.keyBlockHash
+  }
+
+  /** Walk up the era tree, starting from the tips, and collect any era that's
+    * not finished yet. We know they are not finished because they have something
+    * they want to do. If there's nothing, we'll have to rely on incoming messages
+    * to establish the missing links for us.
+    */
+  def collectActiveEras[F[_]: Sync: EraStorage](
+      makeRuntime: Era => F[EraRuntime[F]]
+  ): F[List[EraWithAgenda[F]]] = {
+    // Eras without agendas are finished.
+    def selectActives(eras: List[EraWithAgenda[F]]) =
+      eras.filterNot(_._2.isEmpty)
+
+    for {
+      tips <- EraStorage[F].getChildlessEras
+
+      activeTips <- tips.toList.traverse { era =>
+                     for {
+                       runtime <- makeRuntime(era)
+                       agenda  <- runtime.initAgenda
+                     } yield runtime -> agenda
+                   } map { selectActives }
+
+      active <- DagOperations
+                 .bfTraverseF[F, EraWithAgenda[F]](activeTips) {
+                   case (runtime, _) if !runtime.era.parentKeyBlockHash.isEmpty =>
+                     for {
+                       parentEra     <- EraStorage[F].getEraUnsafe(runtime.era.parentKeyBlockHash)
+                       parentRuntime <- makeRuntime(parentEra)
+                       parentAgenda  <- parentRuntime.initAgenda
+                     } yield selectActives(List(parentRuntime -> parentAgenda))
+
+                   case _ =>
+                     List.empty.pure[F]
+                 }
+                 .toList
+    } yield active
+  }
+}

--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -61,7 +61,7 @@ object LeaderSequencer extends LeaderSequencer {
             val stake = BigInt(bond.getStake.value)
             // This should be trivial; the auction should not allow 0 bids,
             // but if it did, there would be no way to pick between them.
-            require(stake > 0, "Bonds must be positive.")
+            require(stake > 0, s"Bonds must be positive: $stake")
             val from = total
             val to   = total + stake
             ((key, from, to) :: ranges) -> to

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1467,8 +1467,8 @@ object HashSetCasperTest {
       })
 
     StorageFixture
-      .createStorages[Task]()
-      .flatMap {
+      .createMemoryStorages[Task]()
+      .use {
         case (
             implicit0(blockStorage: BlockStorage[Task]),
             _,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -1,7 +1,7 @@
 package io.casperlabs.casper.helper
 
 import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift, Timer}
+import cats.effect.{Concurrent, ContextShift, Resource, Timer}
 import cats.implicits._
 import cats.{~>, Applicative, Defer, Parallel}
 import com.google.protobuf.ByteString
@@ -205,7 +205,7 @@ trait HashSetCasperTestNodeFactory {
 
   protected def initStorage[F[_]: Concurrent: Log: Metrics: ContextShift: Time]()
       : F[(BlockStorage[F], IndexedDagStorage[F], DeployStorage[F], FinalityStorage[F])] =
-    StorageFixture.createStorages[F]()
+    StorageFixture.createFileStorages[F]()
 }
 
 object HashSetCasperTestNode {

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -1,7 +1,7 @@
 package io.casperlabs.casper.helper
 
 import cats.effect.concurrent.Ref
-import cats.effect.{Concurrent, ContextShift, Resource, Timer}
+import cats.effect.{Concurrent, ContextShift, Timer}
 import cats.implicits._
 import cats.{~>, Applicative, Defer, Parallel}
 import com.google.protobuf.ByteString

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -491,7 +491,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
                 }.toMap
                 jmap("Alice") shouldBe msgA.messageHash
                 jmap("Charlie") shouldBe msgC.messageHash
-                jmap.keys should not contain ("Bob")
+                jmap.get("Bob") shouldBe empty
             }
           }
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -1,0 +1,145 @@
+package io.casperlabs.casper.highway
+
+import cats._
+import cats.implicits._
+import cats.effect.Sync
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.{Block, BlockSummary, Bond, Era}
+import io.casperlabs.casper.consensus.state
+import io.casperlabs.casper.helper.StorageFixture
+import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
+import io.casperlabs.models.ArbitraryConsensus
+import io.casperlabs.storage.era.EraStorage
+import io.casperlabs.storage.SQLiteStorage
+import io.casperlabs.models.Message
+import io.casperlabs.casper.highway.mocks.{MockForkChoice, MockMessageProducer}
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.scalatest._
+import scala.concurrent.duration._
+
+class EraSupervisorSpec extends FlatSpec with Matchers with StorageFixture {
+  import EraSupervisorSpec._
+  import Scheduler.Implicits.global
+
+  def testFixture(f: SQLiteStorage.CombinedStorage[Task] => Fixture) =
+    withCombinedStorage { db =>
+      f(db).test
+    }
+
+  behavior of "collectActiveEras"
+
+  it should "collect voting and active eras" in testFixture { implicit db =>
+    new Fixture() {
+      // 2 weeks for genesis, then 1 week for each descendant.
+      // e0 - e1
+      //    \ e2 - e3
+      //         \ e4 - e5
+      override def test =
+        for {
+          e0 <- addGenesisEra()
+          _  <- e0.addChildEra()
+          e2 <- e0.addChildEra()
+          e3 <- e2.addChildEra()
+          e4 <- e2.addChildEra()
+          e5 <- e4.addChildEra()
+          // Set the clock forward to where e3 and e4 is voting.
+          // Their parent eras will have their voting over, and
+          // their children should be active.
+          _      <- clock.set(conf.toInstant(Ticks(e3.endTick)) plus 1.hour)
+          active <- EraSupervisor.collectActiveEras[Task](makeRuntime)
+        } yield {
+          active.map(_._1.era) should contain theSameElementsAs List(e3, e4, e5)
+        }
+    }
+  }
+}
+
+object EraSupervisorSpec extends TickUtils with ArbitraryConsensus {
+
+  import HighwayConf.{EraDuration, VotingDuration}
+
+  val defaultConf = HighwayConf(
+    tickUnit = TimeUnit.SECONDS,
+    genesisEraStart = date(2019, 12, 30),
+    eraDuration = EraDuration.FixedLength(days(7)),
+    bookingDuration = days(10),
+    entropyDuration = hours(3),
+    postEraVotingDuration = VotingDuration.FixedLength(days(2)),
+    omegaMessageTimeStart = 0.5,
+    omegaMessageTimeEnd = 0.75
+  )
+
+  abstract class Fixture(val conf: HighwayConf = defaultConf)(
+      implicit db: SQLiteStorage.CombinedStorage[Task],
+      scheduler: Scheduler
+  ) {
+    // Override this value to make sure the assertions are executed.
+    def test: Task[Unit]
+
+    implicit def `String => PublicKeyBS`(s: String) = PublicKey(ByteString.copyFromUtf8(s))
+
+    val genesis = Message
+      .fromBlockSummary(
+        BlockSummary()
+          .withBlockHash(ByteString.copyFromUtf8("genesis"))
+          .withHeader(
+            Block
+              .Header()
+              .withState(
+                Block
+                  .GlobalState()
+                  .withBonds(
+                    List(
+                      Bond("Alice").withStake(state.BigInt("3000")),
+                      Bond("Bob").withStake(state.BigInt("4000")),
+                      Bond("Charlie").withStake(state.BigInt("5000"))
+                    )
+                  )
+              )
+          )
+      )
+      .get
+      .asInstanceOf[Message.Block]
+
+    val validator = "Alice"
+
+    implicit val clock      = TestClock.adjustable[Task](conf.genesisEraStart)
+    implicit val forkchoice = MockForkChoice[Task](genesis).runSyncUnsafe(5.seconds)
+
+    def addGenesisEra(): Task[Era] = {
+      val era = Era(
+        keyBlockHash = genesis.messageHash,
+        bookingBlockHash = genesis.messageHash,
+        startTick = conf.toTicks(conf.genesisEraStart),
+        endTick = conf.toTicks(conf.genesisEraEnd),
+        bonds = genesis.blockSummary.getHeader.getState.bonds
+      )
+      db.addEra(era).as(era)
+    }
+
+    implicit class EraOps(era: Era) {
+      def addChildEra(): Task[Era] = {
+        val nextEnd = conf.toTicks(conf.eraEnd(conf.toInstant(Ticks(era.endTick))))
+        val child = sample[Era]
+          .withParentKeyBlockHash(era.keyBlockHash)
+          .withStartTick(era.endTick)
+          .withEndTick(nextEnd)
+          .withBonds(era.bonds)
+        db.addEra(child).as(child)
+      }
+    }
+
+    def makeRuntime(era: Era): Task[EraRuntime[Task]] =
+      EraRuntime.fromEra[Task](
+        conf,
+        era,
+        maybeMessageProducer = new MockMessageProducer[Task](validator).some,
+        initRoundExponent = 0,
+        isSynced = true.pure[Task]
+      )
+
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -48,7 +48,7 @@ class EraSupervisorSpec extends FlatSpec with Matchers with StorageFixture {
           // Set the clock forward to where e3 and e4 is voting.
           // Their parent eras will have their voting over, and
           // their children should be active.
-          _      <- clock.set(conf.toInstant(Ticks(e3.endTick)) plus 1.hour)
+          _      <- clock.set(conf.toInstant(Ticks(e3.endTick)) plus postEraVotingDuration / 2)
           active <- EraSupervisor.collectActiveEras[Task](makeRuntime)
         } yield {
           active.map(_._1.era) should contain theSameElementsAs List(e3, e4, e5)
@@ -61,13 +61,15 @@ object EraSupervisorSpec extends TickUtils with ArbitraryConsensus {
 
   import HighwayConf.{EraDuration, VotingDuration}
 
+  val postEraVotingDuration = days(2)
+
   val defaultConf = HighwayConf(
     tickUnit = TimeUnit.SECONDS,
     genesisEraStart = date(2019, 12, 30),
     eraDuration = EraDuration.FixedLength(days(7)),
     bookingDuration = days(10),
     entropyDuration = hours(3),
-    postEraVotingDuration = VotingDuration.FixedLength(days(2)),
+    postEraVotingDuration = VotingDuration.FixedLength(postEraVotingDuration),
     omegaMessageTimeStart = 0.5,
     omegaMessageTimeEnd = 0.75
   )

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockEraStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockEraStorage.scala
@@ -20,6 +20,7 @@ class MockEraStorage[F[_]: Applicative](
     erasRef.get.map(_.get(keyBlockHash))
 
   def getChildEras(keyBlockHash: BlockHash): F[Set[Era]] = ???
+  def getChildlessEras: F[Set[Era]]                      = ???
 }
 
 object MockEraStorage {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
@@ -1,0 +1,65 @@
+package io.casperlabs.casper.highway.mocks
+
+import cats._
+import cats.implicits._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.{Block, BlockSummary, Bond}
+import io.casperlabs.casper.highway.{MessageProducer, Ticks}
+import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.models.Message
+
+class MockMessageProducer[F[_]: Applicative](
+    val validatorId: PublicKeyBS
+) extends MessageProducer[F] {
+
+  override def ballot(
+      eraId: BlockHash,
+      roundId: Ticks,
+      target: ByteString,
+      justifications: Map[PublicKeyBS, Set[BlockHash]]
+  ): F[Message.Ballot] =
+    BlockSummary()
+      .withHeader(
+        Block
+          .Header()
+          .withMessageType(Block.MessageType.BALLOT)
+          .withValidatorPublicKey(validatorId)
+          .withParentHashes(List(target))
+          .withJustifications(
+            for {
+              kv <- justifications.toList
+              h  <- kv._2.toList
+            } yield Block.Justification(kv._1, h)
+          )
+          .withRoundId(roundId)
+          .withKeyBlockHash(eraId)
+      )
+      .pure[F]
+      .map(Message.fromBlockSummary(_).get.asInstanceOf[Message.Ballot])
+
+  override def block(
+      eraId: ByteString,
+      roundId: Ticks,
+      mainParent: ByteString,
+      justifications: Map[PublicKeyBS, Set[BlockHash]],
+      isBookingBlock: Boolean
+  ): F[Message.Block] =
+    BlockSummary()
+      .withHeader(
+        Block
+          .Header()
+          .withValidatorPublicKey(validatorId)
+          .withParentHashes(List(mainParent))
+          .withJustifications(
+            for {
+              kv <- justifications.toList
+              h  <- kv._2.toList
+            } yield Block.Justification(kv._1, h)
+          )
+          .withRoundId(roundId)
+          .withKeyBlockHash(eraId)
+      )
+      .pure[F]
+      .map(Message.fromBlockSummary(_).get.asInstanceOf[Message.Block])
+}

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -159,6 +159,7 @@ object SQLiteStorage {
       override def addEra(era: Era)               = eraStorage.addEra(era)
       override def getEra(eraId: BlockHash)       = eraStorage.getEra(eraId)
       override def getChildEras(eraId: BlockHash) = eraStorage.getChildEras(eraId)
+      override def getChildlessEras               = eraStorage.getChildlessEras
 
       override def markAsFinalized(
           mainParent: BlockHash,

--- a/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
@@ -35,4 +35,6 @@ trait EraStorage[F[_]] {
   /** Retrieve the child eras from the era tree. */
   def getChildEras(keyBlockHash: BlockHash): F[Set[Era]]
 
+  /** Retrieve childless eras, which are the leaves of the era tree. */
+  def getChildlessEras: F[Set[Era]]
 }

--- a/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/SQLiteEraStorage.scala
@@ -41,6 +41,15 @@ class SQLiteEraStorage[F[_]: Sync](
       .query[Era]
       .to[Set]
       .transact(readXa)
+
+  override def getChildlessEras: F[Set[Era]] =
+    sql"""SELECT data
+          FROM   eras e
+          WHERE  NOT EXISTS (
+            SELECT 1 FROM eras c
+            WHERE  c.parent_hash = e.hash
+          )
+      """.query[Era].to[Set].transact(readXa)
 }
 
 object SQLiteEraStorage {

--- a/storage/src/test/scala/io/casperlabs/storage/era/EraStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/era/EraStorageTest.scala
@@ -67,6 +67,22 @@ trait EraStorageTest extends FlatSpecLike with Matchers with ArbitraryConsensus 
       _  = es should contain theSameElementsAs List(e1, e2)
     } yield ()
   }
+
+  it should "find childless eras" in withStorage { db =>
+    // e0 - e1
+    //    \ e2 - e3
+    //         \ e4
+    val e0 = sample[Era]
+    val e1 = sample[Era].withParentKeyBlockHash(e0.keyBlockHash)
+    val e2 = sample[Era].withParentKeyBlockHash(e0.keyBlockHash)
+    val e3 = sample[Era].withParentKeyBlockHash(e2.keyBlockHash)
+    val e4 = sample[Era].withParentKeyBlockHash(e2.keyBlockHash)
+    for {
+      _  <- List(e0, e1, e2, e3, e4).traverse(db.addEra)
+      es <- db.getChildlessEras
+      _  = es should contain theSameElementsAs List(e1, e3, e4)
+    } yield ()
+  }
 }
 
 class SQLiteEraStorageTest extends EraStorageTest with SQLiteFixture[EraStorage[Task]] {


### PR DESCRIPTION
### Overview
Instead of adding a status field to eras, the PR adds methods to collect active eras, defined as eras that have some agenda. The collection starts from the leaf eras and goes upwards until an ancestor era considers itself over (either because the voting period is over, or the switch blocks are finalized, depends on configuration). 

This will be used to resume the era scheduling in the supervisor. Note that because the measure of "active" here is that it has an agenda, eras where the validator is not bonded are not going to be active. Instead, these will react to incoming messages. Since we can receive a stray block any time, the supervisor will always have to be ready to instantiate an era anyway.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1106

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Tweaked the `StorageFixture` to work with in-memory SQLite, except for the `HashSetCapserTests` which are not following scoping rules at the moment. I thought it could be a PR against dev, but there's not much going on there. Could be cherry picked if necessary.

Similar tests in `storage` could be refactored independently. I tried the `ForkChoiceTests` and instead of 600-700ms per test it was more around 200ms.