### PR TITLE
[ECO-{173,90}]: Preserve size during zoom in Clarity and enable sharing the page of Explorer and Blocks

### DIFF
--- a/explorer/ui/src/components/App.tsx
+++ b/explorer/ui/src/components/App.tsx
@@ -50,7 +50,7 @@ const SideMenuItems: MenuItem[] = [
   new MenuItem(Pages.Blocks, 'Blocks', 'th-large'),
   new MenuItem(Pages.Deploys, 'Deploys', 'tasks'),
   new MenuItem(Pages.Search, 'Search', 'search'),
-  new MenuItem(Pages.ConnectedPeers, "Connected Peers", 'network-wired'),
+  new MenuItem(Pages.ConnectedPeers, 'Connected Peers', 'network-wired')
 ];
 
 export interface AppProps {
@@ -284,13 +284,28 @@ const Content = (props: AppProps) => {
             />
             <Route
               path={Pages.Explorer}
-              render={_ => <Explorer {...props} />}
+              render={_ => (
+                <Explorer
+                  maxRank={query.get('maxRank')}
+                  depth={query.get('depth')}
+                  {...props}
+                />
+              )}
             />
             <Route
               path={Pages.Block}
               render={_ => <BlockDetails {...props} />}
             />
-            <Route path={Pages.Blocks} render={_ => <BlockList {...props} />} />
+            <Route
+              path={Pages.Blocks}
+              render={_ => (
+                <BlockList
+                  maxRank={query.get('maxRank')}
+                  depth={query.get('depth')}
+                  {...props}
+                />
+              )}
+            />
             <Route
               path={Pages.Deploy}
               render={_ => <DeployDetails {...props} />}

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -142,7 +142,7 @@ export class BlockDAG extends React.Component<Props, {}> {
         .scaleExtent([0.1, 4])
         .on('zoom', () => {
           this.xTrans = d3.event.transform.rescaleX(initXTrans);
-          this.yTrans = d3.event.transform.rescaleY(initXTrans);
+          this.yTrans = d3.event.transform.rescaleY(initYTrans);
           updatePositions();
         });
 
@@ -259,7 +259,7 @@ export class BlockDAG extends React.Component<Props, {}> {
     node.on('click', select);
 
     const updatePositions = () => {
-      const x = this.xTrans ?? initYTrans;
+      const x = this.xTrans ?? initXTrans;
       const y = this.yTrans ?? initYTrans;
       // update position of node
       container

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react';
 import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
-import { RefreshButton, Loading, ListInline } from './Utils';
+import { ListInline, Loading, RefreshButton, shortHash } from './Utils';
 import * as d3 from 'd3';
-import $ from 'jquery';
-import { shortHash } from './Utils';
 import { encodeBase16 } from 'casperlabs-sdk';
 import { ToggleButton, ToggleStore } from './ToggleButton';
 
@@ -112,23 +110,41 @@ export class BlockDAG extends React.Component<Props, {}> {
       this.initialized = false;
       return;
     }
-
     const svg = d3.select(this.svg);
     const hint = d3.select(this.hint);
     const color = consistentColor();
+    // See what the actual width and height is.
+    const width = $(this.svg!).width()!;
+    const height = $(this.svg!).height()!;
+
+    // see https://www.d3-graph-gallery.com/graph/interactivity_zoom.html#axisZoom
+    // using axis transform function to simplify transform
+    const xTrans: d3.ScaleLinear<number, number> = d3
+      .scaleLinear()
+      .domain([0, width])
+      .range([0, width]);
+    const yTrans: d3.ScaleLinear<number, number> = d3
+      .scaleLinear()
+      .domain([0, height])
+      .range([0, height]);
 
     // Append items that will not change.
     if (!this.initialized) {
       // Add the zoomable container.
-      const container = svg.append('g');
+      svg.append('g').attr('class', 'container');
 
       const zoom: any = d3
         .zoom()
         .scaleExtent([0.1, 4])
-        .on('zoom', () => container.attr('transform', d3.event.transform));
+        .on('zoom', () => {
+          const newXTrana = d3.event.transform.rescaleX(xTrans);
+          const newYTrans = d3.event.transform.rescaleY(yTrans);
+          updatePositions(newXTrana, newYTrans);
+        });
+
       svg.call(zoom);
 
-      // Draw an arrow at the end of the lines to point at parents.
+      // add the defs of arrow which can be used to draw an arrow at the end of the lines to point at parents later
       svg
         .append('svg:defs')
         .append('svg:marker')
@@ -145,14 +161,11 @@ export class BlockDAG extends React.Component<Props, {}> {
       this.initialized = true;
     }
 
-    const container = svg.select('g');
+    // The container are the root layer to draw all node/label/line components
+    const container = svg.select('.container');
 
     // Clear previous contents.
     container.selectAll('g').remove();
-
-    // See what the actual width and height is.
-    const width = $(this.svg!).width()!;
-    const height = $(this.svg!).height()!;
 
     let graph: Graph = toGraph(this.props.blocks);
     graph = calculateCoordinates(graph, width, height);
@@ -168,7 +181,7 @@ export class BlockDAG extends React.Component<Props, {}> {
       .append('line')
       .attr('stroke', LineColor)
       .attr('stroke-width', (d: d3Link) => (d.isMainParent ? 3 : 1))
-      .attr('marker-end', 'url(#arrow)')
+      .attr('marker-end', 'url(#arrow)') // use the Arrow created above
       .attr('stroke-dasharray', (d: d3Link) =>
         d.isJustification ? '3, 3' : null
       )
@@ -184,6 +197,7 @@ export class BlockDAG extends React.Component<Props, {}> {
 
     node
       .append('circle')
+      .attr('class', 'node')
       .attr('r', CircleRadius)
       .attr('stroke', (d: d3Node) =>
         selectedId && d.id === selectedId ? '#E00' : '#fff'
@@ -193,11 +207,11 @@ export class BlockDAG extends React.Component<Props, {}> {
       )
       .attr('fill', (d: d3Node) => color(d.validator));
 
+    // Append a node-label to each node
     const label = node
       .append('text')
+      .attr('class', 'node-label')
       .text((d: d3Node) => d.title)
-      .attr('x', 9)
-      .attr('y', 12)
       .style('font-family', 'Arial')
       .style('font-size', 12)
       .style('pointer-events', 'none') // to prevent mouseover/drag capture
@@ -240,26 +254,45 @@ export class BlockDAG extends React.Component<Props, {}> {
     node.on('mouseover', focus).on('mouseout', unfocus);
     node.on('click', select);
 
-    const updatePositions = () => {
-      link
-        .attr('x1', (d: any) => d.source.x)
-        .attr('y1', (d: any) => d.source.y)
-        .attr(
-          'x2',
-          (d: any) =>
-            d.source.x +
-            (d.target.x - d.source.x) * shorten(d, CircleRadius + 2)
-        )
-        .attr(
-          'y2',
-          (d: any) =>
-            d.source.y +
-            (d.target.y - d.source.y) * shorten(d, CircleRadius + 2)
-        );
-      node.attr('transform', (d: any) => 'translate(' + d.x + ',' + d.y + ')');
+    const updatePositions = (
+      x: d3.ScaleLinear<number, number>,
+      y: d3.ScaleLinear<number, number>
+    ) => {
+      // update position of node
+      container
+        .selectAll('circle.node')
+        .attr('cx', (d: any) => x(d.x))
+        .attr('cy', (d: any) => y(d.y));
+
+      // update position of label
+      container
+        .selectAll('text.node-label')
+        .attr('x', (d: any) => x(d.x) + 9)
+        .attr('y', (d: any) => y(d.y) + 12)
+        .style('transform-origin', (d: any) => `${x(d.x)}px ${y(d.y)}px`);
+
+      // update positions of line
+      container
+        .selectAll('line')
+        .attr('x1', (d: any) => x(d.source.x))
+        .attr('y1', (d: any) => y(d.source.y))
+        .attr('x2', (d: any) => {
+          // We want the radius of Node keep the same after scaling, so we need use invert function to calculate that before scaling.
+          const newRInX= x.invert(CircleRadius + 2) - x.invert(0);
+          return x(
+            d.source.x + (d.target.x - d.source.x) * shorten(d, newRInX)
+          );
+        })
+        .attr('y2', (d: any) => {
+          // We want the radius of Node keep the same after scaling, so we need use invert function to calculate that before scaling.
+          const newRInY = y.invert(CircleRadius + 2) - y.invert(0);
+          return y(
+            d.source.y + (d.target.y - d.source.y) * shorten(d, newRInY)
+          );
+        });
     };
 
-    updatePositions();
+    updatePositions(xTrans, yTrans);
   }
 }
 
@@ -405,6 +438,7 @@ const calculateCoordinates = (graph: Graph, width: number, height: number) => {
     // (validators.indexOf(node.validator) + 0.5) * verticalStep is the y of the baseline of swimlane of node.validator
     node.y = (validators.indexOf(node.validator) + 0.5 + step) * verticalStep;
     node.x = (node.rank - minRank + 1) * horizontalStep;
+    console.log(node.x, node.y);
   });
 
   return graph;

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -2,24 +2,35 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import DagContainer, { DagStep } from '../containers/DagContainer';
 import {
-  RefreshableComponent,
-  ListInline,
   IconButton,
+  ListInline,
+  RefreshableComponent,
   shortHash
 } from './Utils';
 import DataTable from './DataTable';
 import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
 import Timestamp from './TimeStamp';
+import * as H from 'history';
 
-interface Props {
+export interface Props extends RouteComponentProps<{}> {
   dag: DagContainer;
+  maxRank: string | null;
+  depth: string | null;
 }
 
 @observer
-export default class BlockList extends RefreshableComponent<Props, {}> {
+class _BlockList extends RefreshableComponent<Props, {}> {
+  constructor(props:Props) {
+    super(props);
+    let maxRank = parseInt(props.maxRank || '') || 0;
+    let depth = parseInt(props.depth || '') || 10;
+    this.props.dag.updateMaxRankAndDepth(maxRank, depth);
+    this.props.dag.refreshBlockDagAndSetupSubscriber();
+  }
+
   async refresh() {
     await this.props.dag.refreshBlockDagAndSetupSubscriber();
   }
@@ -59,33 +70,52 @@ export default class BlockList extends RefreshableComponent<Props, {}> {
             </tr>
           );
         }}
-        footerMessage={<DagStepButtons step={dag.step} />}
+        footerMessage={
+          <DagStepButtons
+            step={dag.step}
+            history={this.props.history}
+            urlWithRankAndDepth={Pages.blocksWithMaxRankAndDepth}
+          />
+        }
       />
     );
   }
 }
 
-export const DagStepButtons = (props: { step: DagStep }) => {
+const BlockList = withRouter(_BlockList);
+export default BlockList;
+
+export const DagStepButtons = (props: {
+  step: DagStep;
+  history: H.History;
+  urlWithRankAndDepth: (maxRank: number, depth: number) => string;
+}) => {
+  const updateUrlQuery = (stepFunc: () => void) => {
+    stepFunc();
+    props.history.push(
+      props.urlWithRankAndDepth(props.step.maxRank, props.step.depth)
+    );
+  };
   return (
     <ListInline>
       <IconButton
         title="First"
-        onClick={() => props.step.first()}
+        onClick={() => updateUrlQuery(props.step.first)}
         icon="fast-backward"
       />
       <IconButton
         title="Previous"
-        onClick={() => props.step.prev()}
+        onClick={() => updateUrlQuery(props.step.prev)}
         icon="step-backward"
       />
       <IconButton
         title="Next"
-        onClick={() => props.step.next()}
+        onClick={() => updateUrlQuery(props.step.next)}
         icon="step-forward"
       />
       <IconButton
         title="Last"
-        onClick={() => props.step.last()}
+        onClick={() => updateUrlQuery(props.step.last)}
         icon="fast-forward"
       />
     </ListInline>

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { observer } from 'mobx-react';
-import DagContainer from '../containers/DagContainer';
 import {
   LinkButton,
   ListInline,

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -11,20 +11,24 @@ import { BlockDAG } from './BlockDAG';
 import DataTable from './DataTable';
 import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
 import $ from 'jquery';
-import { DagStepButtons } from './BlockList';
-import { Link } from 'react-router-dom';
+import { DagStepButtons, Props } from './BlockList';
+import { Link, withRouter } from 'react-router-dom';
 import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
 import { BondedValidatorsTable } from './BondedValidatorsTable';
 import { ToggleButton } from './ToggleButton';
 
-interface Props {
-  dag: DagContainer;
-}
-
 /** Show the tips of the DAG. */
 @observer
-export default class Explorer extends RefreshableComponent<Props, {}> {
+class _Explorer extends RefreshableComponent<Props, {}> {
+  constructor(props:Props) {
+    super(props);
+    let maxRank = parseInt(props.maxRank || '') || 0;
+    let depth = parseInt(props.depth || '') || 10;
+    this.props.dag.updateMaxRankAndDepth(maxRank, depth);
+    this.props.dag.refreshBlockDagAndSetupSubscriber();
+  }
+
   async refresh() {
     await this.props.dag.refreshBlockDagAndSetupSubscriber();
   }
@@ -52,7 +56,11 @@ export default class Explorer extends RefreshableComponent<Props, {}> {
               subscribeToggleStore={dag.subscribeToggleStore}
               footerMessage={
                 <ListInline>
-                  <DagStepButtons step={dag.step} />
+                  <DagStepButtons
+                    step={dag.step}
+                    history={this.props.history}
+                    urlWithRankAndDepth={Pages.explorerWithMaxRankAndDepth}
+                  />
                   {dag.hasBlocks && (
                     <span>Select a block to see its details.</span>
                   )}
@@ -112,11 +120,17 @@ export default class Explorer extends RefreshableComponent<Props, {}> {
   }
 }
 
-class BlockDetails extends React.Component<{
-  block: BlockInfo;
-  blocks: BlockInfo[];
-  onSelect: (blockHash: string) => void;
-}, {}> {
+const Explorer = withRouter(_Explorer);
+export default Explorer;
+
+class BlockDetails extends React.Component<
+  {
+    block: BlockInfo;
+    blocks: BlockInfo[];
+    onSelect: (blockHash: string) => void;
+  },
+  {}
+> {
   ref: HTMLElement | null = null;
 
   render() {

--- a/explorer/ui/src/components/Pages.ts
+++ b/explorer/ui/src/components/Pages.ts
@@ -26,4 +26,14 @@ export default class Pages {
     const url = `/accounts/${accountHashBase16}/deploys`;
     return pageToken ? `${url}?pageToken=${pageToken}` : url;
   };
+
+  static readonly explorerWithMaxRankAndDepth = (
+    maxRank: number,
+    depth: number
+  ) => `${Pages.Explorer}?maxRank=${maxRank}&depth=${depth}`;
+
+  static readonly blocksWithMaxRankAndDepth = (
+    maxRank: number,
+    depth: number
+  ) => `${Pages.Blocks}?maxRank=${maxRank}&depth=${depth}`;
 }

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -16,15 +16,15 @@ export class DagStep {
     this.container.selectedBlock = undefined;
   };
 
-  private get maxRank() {
+  get maxRank() {
     return this.container.maxRank;
   }
 
-  private get depth() {
+  get depth() {
     return this.container.depth;
   }
 
-  private set maxRank(rank: number) {
+  set maxRank(rank: number) {
     this.container.maxRank = rank;
   }
 
@@ -80,6 +80,11 @@ export class DagContainer {
       fireImmediately: false,
       delay: 100
     });
+  }
+
+  updateMaxRankAndDepth(rank: number, depth: number){
+    this.maxRank = rank;
+    this.depth = depth;
   }
 
   get minRank() {

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -82,6 +82,7 @@ export class DagContainer {
     });
   }
 
+  @action
   updateMaxRankAndDepth(rank: number, depth: number){
     this.maxRank = rank;
     this.depth = depth;
@@ -130,7 +131,7 @@ export class DagContainer {
   step = new DagStep(this);
 
   unsubscribe() {
-    if (this.subscriberState == SubscribeState.ON) {
+    if (this.subscriberState === SubscribeState.ON) {
       this.eventsSubscriber!.unsubscribe();
     }
   }


### PR DESCRIPTION
### Overview
As in the title.

It looks like: 
Preserve size during zoom in Clarity: 
![preservesize](https://user-images.githubusercontent.com/7604540/72534276-7f0ac300-38b1-11ea-95c9-b790fe4ebafe.gif)

Enable sharing the page of Explorer and BlockList(take a look at the URL of the browser): 
![depth](https://user-images.githubusercontent.com/7604540/72534337-9c3f9180-38b1-11ea-95e3-82885d3e352d.gif)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-173
https://casperlabs.atlassian.net/browse/ECO-90

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
