### PR TITLE
Stored increment function in counter contract example

### DIFF
--- a/execution-engine/contracts/examples/counter-define/README.md
+++ b/execution-engine/contracts/examples/counter-define/README.md
@@ -25,6 +25,14 @@ $ casperlabs-client --host $HOST deploy \
     --session $COUNTER_DEFINE_WASM
 ```
 
+Increment the counter.
+```
+$ casperlabs-client --host $HOST deploy \
+    --private-key $PRIVATE_KEY_PATH \
+    --payment-amount 10000000 \
+    --session-name counter_inc
+```
+
 ## Check counter's value
 
 Query global state to check counter's value.

--- a/execution-engine/contracts/examples/counter-define/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-define/src/lib.rs
@@ -13,7 +13,9 @@ use contract_ffi::{
 
 const COUNT_KEY: &str = "count";
 const COUNTER_EXT: &str = "counter_ext";
+const COUNTER_INCREMENT: &str = "counter_increment";
 const COUNTER_KEY: &str = "counter";
+const COUNTER_INC_KEY: &str = "counter_inc";
 const GET_METHOD: &str = "get";
 const INC_METHOD: &str = "inc";
 
@@ -57,6 +59,20 @@ pub extern "C" fn counter_ext() {
 }
 
 #[no_mangle]
+pub extern "C" fn counter_increment() {
+    // This function will call the stored counter contract (defined above) and increment it.
+    // It is stored in `call` below so that it can be called directly by the client
+    // (without needing to send any further wasm).
+    let counter_key = runtime::get_key(COUNTER_KEY).unwrap_or_revert_with(ApiError::GetKey);
+    let contract_ref = counter_key
+        .to_contract_ref()
+        .unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);
+
+    let args = (INC_METHOD,);
+    runtime::call_contract(contract_ref, args)
+}
+
+#[no_mangle]
 pub extern "C" fn call() {
     let counter_local_key = storage::new_turef(0); //initialize counter
 
@@ -67,4 +83,7 @@ pub extern "C" fn call() {
 
     let pointer = storage::store_function_at_hash(COUNTER_EXT, counter_urefs);
     runtime::put_key(COUNTER_KEY, pointer.into());
+
+    let inc_pointer = storage::store_function_at_hash(COUNTER_INCREMENT, Default::default());
+    runtime::put_key(COUNTER_INC_KEY, inc_pointer.into());
 }


### PR DESCRIPTION
### Overview
This PR makes the counter contract example store an additional function for incrementing the counter. This function can be called directly by name in order to increment the counter without sending additional wasm. This is useful because it means we can greatly reduce the amount of wasm we send in the current LRT workflow.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1084

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
