### PR TITLE
NODE-1116: Validate begin end boundaries

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -52,6 +52,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
     rng: Random = new Random()
 ) {
   import EraRuntime._, Agenda._
+  import HighwayConf.VotingDuration
 
   type HWL[A] = HighwayLog[F, A]
   private val noop = HighwayLog.unit[F]
@@ -120,11 +121,11 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
   /** Check if the era is finished at a given tick, including the post-era voting period. */
   private val isEraOverAt: Ticks => F[Boolean] =
     conf.postEraVotingDuration match {
-      case HighwayConf.VotingDuration.FixedLength(duration) =>
+      case VotingDuration.FixedLength(duration) =>
         val votingEndTick = conf.toTicks(end plus duration)
         tick => (tick >= votingEndTick).pure[F]
 
-      case HighwayConf.VotingDuration.SummitLevel(1) =>
+      case VotingDuration.SummitLevel(1) =>
         // We have to keep voting until the switch block given by the fork choice
         // in *this* era is finalized.
         tick =>
@@ -138,7 +139,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
             }
           }
 
-      case HighwayConf.VotingDuration.SummitLevel(_) =>
+      case VotingDuration.SummitLevel(_) =>
         // Don't know how to do this for higher levels of k, we'll have to figure it out,
         // run multiple instances of higher level finalizers or something.
         ???
@@ -360,7 +361,18 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
     check(
       "The block is coming from a doppelganger.",
       maybeMessageProducer.map(_.validatorId).contains(message.validatorId)
-    ) >> {
+    ) >>
+      check(
+        "The round ID is before the start of the era.",
+        message.roundId < startTick
+      ) >>
+      check(
+        "The round ID is after the end of the voting period.",
+        conf.postEraVotingDuration match {
+          case VotingDuration.FixedLength(d) => conf.toTicks(end plus d) < message.roundId
+          case _                             => false
+        }
+      ) >> {
       message match {
         case b: Message.Block =>
           check(
@@ -456,21 +468,19 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
           for {
             now                           <- currentTick
             (currentRoundId, nextRoundId) <- roundBoundariesAt(now)
-            isOverAtNext                  <- isEraOverAt(nextRoundId)
+            // NOTE: These will potentially ask for the fork choice in this era;
+            // it would be good if it was cached and updated only when new messages are added.
+            isOverAtCurrent <- isEraOverAt(currentRoundId)
+            isOverAtNext    <- isEraOverAt(nextRoundId)
           } yield {
-            val next = if (!isOverAtNext) {
-              Agenda(nextRoundId -> Agenda.StartRound(nextRoundId))
-            } else Agenda.empty
-
             // Schedule the omega for whatever the current round is, don't bother
             // with the old one if the block production was so slow that it pushed
             // us into the next round already. We can still participate in this one.
-            val omega = {
-              val omegaTick = chooseOmegaTick(currentRoundId, nextRoundId)
-              Agenda(omegaTick -> Agenda.CreateOmegaMessage(currentRoundId))
-            }
+            val omegaTick = chooseOmegaTick(currentRoundId, nextRoundId)
+            val omega     = Agenda(omegaTick -> Agenda.CreateOmegaMessage(currentRoundId))
+            val next      = Agenda(nextRoundId -> Agenda.StartRound(nextRoundId))
 
-            omega ++ next
+            omega.filterNot(_ => isOverAtCurrent) ++ next.filterNot(_ => isOverAtNext)
           }
 
         maybeMessageProducer

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -372,6 +372,10 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
           case VotingDuration.FixedLength(d) => conf.toTicks(end plus d) < message.roundId
           case _                             => false
         }
+      ) >>
+      check(
+        "The validator is not bonded in the era.",
+        era.bonds.find(_.validatorPublicKey == message.validatorId).isEmpty
       ) >> {
       message match {
         case b: Message.Block =>

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -269,7 +269,16 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
   }
 
   "validate" should {
-    "reject a block before the era starts" in {
+    "reject a message from an unbonded validator" in {
+      val runtime = genesisEraRuntime()
+      val message =
+        makeBlock("Anonymous", runtime.era, roundId = runtime.startTick)
+      runtime.validate(message).value shouldBe Left(
+        "The validator is not bonded in the era."
+      )
+    }
+
+    "reject a message before the era starts" in {
       val runtime = genesisEraRuntime()
       val message =
         makeBlock("Alice", runtime.era, roundId = Ticks(runtime.startTick - 1))
@@ -278,7 +287,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       )
     }
 
-    "reject a block after the era ends" in {
+    "reject a message after the era ends" in {
       val runtime = genesisEraRuntime()
       val message =
         makeBlock(

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -41,13 +41,15 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
 
   implicit def defaultClock: Clock[Id] = TestClock.frozen[Id](date(2019, 12, 9))
 
+  val postEraVotingDuration = days(2)
+
   val conf = HighwayConf(
     tickUnit = TimeUnit.MILLISECONDS,
     genesisEraStart = date(2019, 12, 9),
     eraDuration = EraDuration.FixedLength(days(7)),
     bookingDuration = days(10),
     entropyDuration = hours(3),
-    postEraVotingDuration = VotingDuration.FixedLength(days(2)),
+    postEraVotingDuration = VotingDuration.FixedLength(postEraVotingDuration),
     omegaMessageTimeStart = 0.5,
     omegaMessageTimeEnd = 0.75
   )
@@ -267,6 +269,28 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
   }
 
   "validate" should {
+    "reject a block before the era starts" in {
+      val runtime = genesisEraRuntime()
+      val message =
+        makeBlock("Alice", runtime.era, roundId = Ticks(runtime.startTick - 1))
+      runtime.validate(message).value shouldBe Left(
+        "The round ID is before the start of the era."
+      )
+    }
+
+    "reject a block after the era ends" in {
+      val runtime = genesisEraRuntime()
+      val message =
+        makeBlock(
+          "Alice",
+          runtime.era,
+          roundId = conf.toTicks(conf.genesisEraEnd plus postEraVotingDuration plus 1.hour)
+        )
+      runtime.validate(message).value shouldBe Left(
+        "The round ID is after the end of the voting period."
+      )
+    }
+
     "reject a block received from a doppelganger" in {
       val runtime = genesisEraRuntime("Alice".some)
       val message =
@@ -876,10 +900,6 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
           }
         }
         "the fixed voting period is almost over" should {
-          val postEraVotingDuration = conf.postEraVotingDuration match {
-            case VotingDuration.FixedLength(d) => d
-            case _                             => fail("Expected fixed duration.")
-          }
           "not schedule a next round after the end" in {
             new PostEraFixture(postEraElapsed = postEraVotingDuration minus 1.second) {
               handle.value.map(_.action).collect {
@@ -947,7 +967,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       }
 
       "creating the lambda message takes longer than a round" should {
-        "skip to the next active round" in {
+        "skip to the lambda in the next active round but schedule an omega for it" in {
           val exponent       = 15 // ~30s
           val roundLength    = Ticks.roundLength(exponent).millis
           val roundStart     = conf.genesisEraStart plus 60 * roundLength
@@ -955,7 +975,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
           val currentTick    = conf.toTicks(now)
           implicit val clock = TestClock.frozen[Id](now)
 
-          val runtime = genesisEraRuntime(none, roundExponent = exponent)
+          val runtime = genesisEraRuntime("Alice".some, roundExponent = exponent)
 
           // Executing this round that was supposed to have been done a while ago.
           val roundId = conf.toTicks(roundStart)
@@ -976,6 +996,16 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
               currentRoundId should be <= currentTick.toLong
               conf.toInstant(currentRoundId) should be >= (now minus roundLength)
           }
+        }
+
+        "not schedule an omega if it's after the end of the voting period" in {
+          val now            = conf.genesisEraEnd plus postEraVotingDuration plus 1.hour
+          implicit val clock = TestClock.frozen[Id](now)
+          val roundId        = conf.toTicks(now)
+          val runtime        = genesisEraRuntime("Alice".some)
+          val agenda         = runtime.handleAgenda(Agenda.StartRound(roundId)).value
+
+          agenda shouldBe empty
         }
       }
 


### PR DESCRIPTION
### Overview
Validates incoming messages that they aren't strictly before or after the era. 
Avoids producing an omega message after the voting period ends.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1116

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
