### PR TITLE
{EE-819, EE-820}: Create an internal ExecuteRequest type and refactor the code to use it

### DIFF
--- a/execution-engine/engine-core/src/engine_state/deploy_item.rs
+++ b/execution-engine/engine-core/src/engine_state/deploy_item.rs
@@ -7,6 +7,7 @@ use crate::{engine_state::executable_deploy_item::ExecutableDeployItem, DeployHa
 type GasPrice = u64;
 
 /// Represents a deploy to be executed.  Corresponds to the similarly-named ipc protobuf message.
+#[derive(Clone, PartialEq, Eq)]
 pub struct DeployItem {
     pub address: PublicKey,
     pub session: ExecutableDeployItem,

--- a/execution-engine/engine-core/src/engine_state/executable_deploy_item.rs
+++ b/execution-engine/engine-core/src/engine_state/executable_deploy_item.rs
@@ -1,3 +1,4 @@
+#[derive(Clone, PartialEq, Eq)]
 pub enum ExecutableDeployItem {
     ModuleBytes {
         module_bytes: Vec<u8>,

--- a/execution-engine/engine-core/src/engine_state/execute_request.rs
+++ b/execution-engine/engine-core/src/engine_state/execute_request.rs
@@ -1,0 +1,44 @@
+use std::mem;
+
+use engine_shared::newtypes::Blake2bHash;
+use types::ProtocolVersion;
+
+use super::{deploy_item::DeployItem, execution_result::ExecutionResult};
+
+pub struct ExecuteRequest {
+    pub parent_state_hash: Blake2bHash,
+    pub block_time: u64,
+    pub deploys: Vec<Result<DeployItem, ExecutionResult>>,
+    pub protocol_version: ProtocolVersion,
+}
+
+impl ExecuteRequest {
+    pub fn new(
+        parent_state_hash: Blake2bHash,
+        block_time: u64,
+        deploys: Vec<Result<DeployItem, ExecutionResult>>,
+        protocol_version: ProtocolVersion,
+    ) -> Self {
+        Self {
+            parent_state_hash,
+            block_time,
+            deploys,
+            protocol_version,
+        }
+    }
+
+    pub fn take_deploys(&mut self) -> Vec<Result<DeployItem, ExecutionResult>> {
+        mem::replace(&mut self.deploys, vec![])
+    }
+}
+
+impl Default for ExecuteRequest {
+    fn default() -> Self {
+        Self {
+            parent_state_hash: [0u8; 32].into(),
+            block_time: 0,
+            deploys: vec![],
+            protocol_version: Default::default(),
+        }
+    }
+}

--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -83,6 +83,15 @@ impl ExecutionResult {
         }
     }
 
+    pub fn has_precondition_failure(&self) -> bool {
+        match self {
+            ExecutionResult::Failure { cost, effect, .. } => {
+                cost.value() == 0.into() && *effect == Default::default()
+            }
+            ExecutionResult::Success { .. } => false,
+        }
+    }
+
     pub fn cost(&self) -> Gas {
         match self {
             ExecutionResult::Failure { cost, .. } => *cost,
@@ -116,6 +125,13 @@ impl ExecutionResult {
                 cost,
             },
             ExecutionResult::Success { cost, .. } => ExecutionResult::Success { effect, cost },
+        }
+    }
+
+    pub fn error(&self) -> Option<&error::Error> {
+        match self {
+            ExecutionResult::Failure { error, .. } => Some(error),
+            ExecutionResult::Success { .. } => None,
         }
     }
 

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -2,6 +2,7 @@ pub mod deploy_item;
 pub mod engine_config;
 mod error;
 pub mod executable_deploy_item;
+pub mod execute_request;
 pub mod execution_effect;
 pub mod execution_result;
 pub mod genesis;

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/deploy_item.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/deploy_item.rs
@@ -55,3 +55,22 @@ impl TryFrom<ipc::DeployItem> for DeployItem {
         ))
     }
 }
+
+impl From<DeployItem> for ipc::DeployItem {
+    fn from(deploy_item: DeployItem) -> Self {
+        let mut result = ipc::DeployItem::new();
+        result.set_address(deploy_item.address.value().to_vec());
+        result.set_session(deploy_item.session.into());
+        result.set_payment(deploy_item.payment.into());
+        result.set_gas_price(deploy_item.gas_price);
+        result.set_authorization_keys(
+            deploy_item
+                .authorization_keys
+                .into_iter()
+                .map(|key| key.value().to_vec())
+                .collect(),
+        );
+        result.set_deploy_hash(deploy_item.deploy_hash.to_vec());
+        result
+    }
+}

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/executable_deploy_item.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/executable_deploy_item.rs
@@ -1,9 +1,6 @@
 use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
 
-use crate::engine_server::ipc::{
-    DeployCode, DeployPayload, DeployPayload_oneof_payload, StoredContractHash, StoredContractName,
-    StoredContractURef,
-};
+use crate::engine_server::ipc::{DeployPayload, DeployPayload_oneof_payload};
 
 impl From<DeployPayload_oneof_payload> for ExecutableDeployItem {
     fn from(pb_deploy_payload: DeployPayload_oneof_payload) -> Self {
@@ -41,28 +38,24 @@ impl From<ExecutableDeployItem> for DeployPayload {
         let mut result = DeployPayload::new();
         match edi {
             ExecutableDeployItem::ModuleBytes { module_bytes, args } => {
-                let mut code = DeployCode::new();
+                let code = result.mut_deploy_code();
                 code.set_code(module_bytes);
                 code.set_args(args);
-                result.set_deploy_code(code);
             }
             ExecutableDeployItem::StoredContractByHash { hash, args } => {
-                let mut inner = StoredContractHash::new();
+                let inner = result.mut_stored_contract_hash();
                 inner.set_hash(hash);
                 inner.set_args(args);
-                result.set_stored_contract_hash(inner);
             }
             ExecutableDeployItem::StoredContractByName { name, args } => {
-                let mut inner = StoredContractName::new();
+                let inner = result.mut_stored_contract_name();
                 inner.set_stored_contract_name(name);
                 inner.set_args(args);
-                result.set_stored_contract_name(inner);
             }
             ExecutableDeployItem::StoredContractByURef { uref, args } => {
-                let mut inner = StoredContractURef::new();
+                let inner = result.mut_stored_contract_uref();
                 inner.set_uref(uref);
                 inner.set_args(args);
-                result.set_stored_contract_uref(inner);
             }
         }
         result

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/executable_deploy_item.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/executable_deploy_item.rs
@@ -1,6 +1,9 @@
 use engine_core::engine_state::executable_deploy_item::ExecutableDeployItem;
 
-use crate::engine_server::ipc::DeployPayload_oneof_payload;
+use crate::engine_server::ipc::{
+    DeployCode, DeployPayload, DeployPayload_oneof_payload, StoredContractHash, StoredContractName,
+    StoredContractURef,
+};
 
 impl From<DeployPayload_oneof_payload> for ExecutableDeployItem {
     fn from(pb_deploy_payload: DeployPayload_oneof_payload) -> Self {
@@ -30,5 +33,38 @@ impl From<DeployPayload_oneof_payload> for ExecutableDeployItem {
                 }
             }
         }
+    }
+}
+
+impl From<ExecutableDeployItem> for DeployPayload {
+    fn from(edi: ExecutableDeployItem) -> Self {
+        let mut result = DeployPayload::new();
+        match edi {
+            ExecutableDeployItem::ModuleBytes { module_bytes, args } => {
+                let mut code = DeployCode::new();
+                code.set_code(module_bytes);
+                code.set_args(args);
+                result.set_deploy_code(code);
+            }
+            ExecutableDeployItem::StoredContractByHash { hash, args } => {
+                let mut inner = StoredContractHash::new();
+                inner.set_hash(hash);
+                inner.set_args(args);
+                result.set_stored_contract_hash(inner);
+            }
+            ExecutableDeployItem::StoredContractByName { name, args } => {
+                let mut inner = StoredContractName::new();
+                inner.set_stored_contract_name(name);
+                inner.set_args(args);
+                result.set_stored_contract_name(inner);
+            }
+            ExecutableDeployItem::StoredContractByURef { uref, args } => {
+                let mut inner = StoredContractURef::new();
+                inner.set_uref(uref);
+                inner.set_args(args);
+                result.set_stored_contract_uref(inner);
+            }
+        }
+        result
     }
 }

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/execute_request.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/execute_request.rs
@@ -15,17 +15,15 @@ impl TryFrom<ipc::ExecuteRequest> for ExecuteRequest {
             let parent_state_hash = request.take_parent_state_hash();
             let length = parent_state_hash.len();
             if length != BLAKE2B_DIGEST_LENGTH {
-                let mut error = ipc::RootNotFound::new();
-                error.set_hash(parent_state_hash);
                 let mut result = ipc::ExecuteResponse::new();
-                result.set_missing_parent(error);
+                result.mut_missing_parent().set_hash(parent_state_hash);
                 return Err(result);
             }
             parent_state_hash.as_slice().try_into().map_err(|_| {
-                let mut error = ipc::RootNotFound::new();
-                error.set_hash(parent_state_hash.clone());
                 let mut result = ipc::ExecuteResponse::new();
-                result.set_missing_parent(error);
+                result
+                    .mut_missing_parent()
+                    .set_hash(parent_state_hash.clone());
                 result
             })?
         };

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/execute_request.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/execute_request.rs
@@ -1,0 +1,53 @@
+use std::convert::{TryFrom, TryInto};
+
+use engine_core::engine_state::{
+    execute_request::ExecuteRequest, execution_result::ExecutionResult,
+};
+use engine_shared::newtypes::BLAKE2B_DIGEST_LENGTH;
+
+use crate::engine_server::{ipc, mappings::MappingError};
+
+impl TryFrom<ipc::ExecuteRequest> for ExecuteRequest {
+    type Error = ipc::ExecuteResponse;
+
+    fn try_from(mut request: ipc::ExecuteRequest) -> Result<Self, Self::Error> {
+        let parent_state_hash = {
+            let parent_state_hash = request.take_parent_state_hash();
+            let length = parent_state_hash.len();
+            if length != BLAKE2B_DIGEST_LENGTH {
+                let mut error = ipc::RootNotFound::new();
+                error.set_hash(parent_state_hash);
+                let mut result = ipc::ExecuteResponse::new();
+                result.set_missing_parent(error);
+                return Err(result);
+            }
+            parent_state_hash.as_slice().try_into().map_err(|_| {
+                let mut error = ipc::RootNotFound::new();
+                error.set_hash(parent_state_hash.clone());
+                let mut result = ipc::ExecuteResponse::new();
+                result.set_missing_parent(error);
+                result
+            })?
+        };
+
+        let block_time = request.get_block_time();
+
+        let deploys = Into::<Vec<_>>::into(request.take_deploys())
+            .into_iter()
+            .map(|deploy_item| {
+                deploy_item
+                    .try_into()
+                    .map_err(|err: MappingError| ExecutionResult::precondition_failure(err.into()))
+            })
+            .collect();
+
+        let protocol_version = request.take_protocol_version().into();
+
+        Ok(ExecuteRequest::new(
+            parent_state_hash,
+            block_time,
+            deploys,
+            protocol_version,
+        ))
+    }
+}

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/execute_request.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/execute_request.rs
@@ -51,3 +51,22 @@ impl TryFrom<ipc::ExecuteRequest> for ExecuteRequest {
         ))
     }
 }
+
+impl From<ExecuteRequest> for ipc::ExecuteRequest {
+    fn from(req: ExecuteRequest) -> Self {
+        let mut result = ipc::ExecuteRequest::new();
+        result.set_parent_state_hash(req.parent_state_hash.to_vec());
+        result.set_block_time(req.block_time);
+        result.set_deploys(
+            req.deploys
+                .into_iter()
+                .map(|res| match res {
+                    Ok(deploy_item) => deploy_item.into(),
+                    Err(_) => ipc::DeployItem::new(),
+                })
+                .collect(),
+        );
+        result.set_protocol_version(req.protocol_version.into());
+        result
+    }
+}

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/mod.rs
@@ -5,6 +5,7 @@ mod bond;
 mod deploy_item;
 mod deploy_result;
 mod executable_deploy_item;
+mod execute_request;
 mod execution_effect;
 mod genesis_account;
 mod genesis_config;

--- a/execution-engine/engine-test-support/src/low_level/deploy_item_builder.rs
+++ b/execution-engine/engine-test-support/src/low_level/deploy_item_builder.rs
@@ -1,14 +1,26 @@
+use std::collections::BTreeSet;
+
 use contract::args_parser::ArgsParser;
-use engine_grpc_server::engine_server::ipc::{
-    DeployCode, DeployItem, DeployPayload, StoredContractHash, StoredContractName,
-    StoredContractURef,
+use engine_core::{
+    engine_state::{deploy_item::DeployItem, executable_deploy_item::ExecutableDeployItem},
+    DeployHash,
 };
 use types::{account::PublicKey, bytesrepr::ToBytes, URef};
 
 use crate::low_level::utils;
 
+#[derive(Default)]
+struct DeployItemData {
+    pub address: Option<PublicKey>,
+    pub payment_code: Option<ExecutableDeployItem>,
+    pub session_code: Option<ExecutableDeployItem>,
+    pub gas_price: u64,
+    pub authorization_keys: BTreeSet<PublicKey>,
+    pub deploy_hash: DeployHash,
+}
+
 pub struct DeployItemBuilder {
-    deploy_item: DeployItem,
+    deploy_item: DeployItemData,
 }
 
 impl DeployItemBuilder {
@@ -17,116 +29,99 @@ impl DeployItemBuilder {
     }
 
     pub fn with_address(mut self, address: [u8; 32]) -> Self {
-        self.deploy_item.set_address(address.to_vec());
+        self.deploy_item.address = Some(address.into());
         self
     }
 
     pub fn with_payment_code(mut self, file_name: &str, args: impl ArgsParser) -> Self {
         let wasm_bytes = utils::read_wasm_file_bytes(file_name);
         let args = Self::serialize_args(args);
-        let mut deploy_code = DeployCode::new();
-        deploy_code.set_args(args);
-        deploy_code.set_code(wasm_bytes);
-        let mut payment = DeployPayload::new();
-        payment.set_deploy_code(deploy_code);
-        self.deploy_item.set_payment(payment);
+        self.deploy_item.payment_code = Some(ExecutableDeployItem::ModuleBytes {
+            module_bytes: wasm_bytes,
+            args,
+        });
         self
     }
 
     pub fn with_stored_payment_hash(mut self, hash: Vec<u8>, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        let mut item = StoredContractHash::new();
-        item.set_args(args);
-        item.set_hash(hash);
-        let mut payment = DeployPayload::new();
-        payment.set_stored_contract_hash(item);
-        self.deploy_item.set_payment(payment);
+        self.deploy_item.payment_code =
+            Some(ExecutableDeployItem::StoredContractByHash { hash, args });
         self
     }
 
     pub fn with_stored_payment_uref(mut self, uref: URef, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        let mut item = StoredContractURef::new();
-        item.set_args(args);
-        item.set_uref(uref.addr().to_vec());
-        let mut payment = DeployPayload::new();
-        payment.set_stored_contract_uref(item);
-        self.deploy_item.set_payment(payment);
+        self.deploy_item.payment_code = Some(ExecutableDeployItem::StoredContractByURef {
+            uref: uref.addr().to_vec(),
+            args,
+        });
         self
     }
 
     pub fn with_stored_payment_named_key(mut self, uref_name: &str, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        let mut item = StoredContractName::new();
-        item.set_args(args);
-        item.set_stored_contract_name(uref_name.to_owned()); // <-- named uref
-        let mut payment = DeployPayload::new();
-        payment.set_stored_contract_name(item);
-        self.deploy_item.set_payment(payment);
+        self.deploy_item.payment_code = Some(ExecutableDeployItem::StoredContractByName {
+            name: uref_name.to_owned(),
+            args,
+        });
         self
     }
 
     pub fn with_session_code(mut self, file_name: &str, args: impl ArgsParser) -> Self {
         let wasm_bytes = utils::read_wasm_file_bytes(file_name);
         let args = Self::serialize_args(args);
-        let mut deploy_code = DeployCode::new();
-        deploy_code.set_code(wasm_bytes);
-        deploy_code.set_args(args);
-        let mut session = DeployPayload::new();
-        session.set_deploy_code(deploy_code);
-        self.deploy_item.set_session(session);
+        self.deploy_item.session_code = Some(ExecutableDeployItem::ModuleBytes {
+            module_bytes: wasm_bytes,
+            args,
+        });
         self
     }
 
     pub fn with_stored_session_hash(mut self, hash: Vec<u8>, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        let mut item: StoredContractHash = StoredContractHash::new();
-        item.set_args(args);
-        item.set_hash(hash);
-        let mut session = DeployPayload::new();
-        session.set_stored_contract_hash(item);
-        self.deploy_item.set_session(session);
+        self.deploy_item.session_code =
+            Some(ExecutableDeployItem::StoredContractByHash { hash, args });
         self
     }
 
     pub fn with_stored_session_uref(mut self, uref: URef, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        let mut item: StoredContractURef = StoredContractURef::new();
-        item.set_args(args);
-        item.set_uref(uref.addr().to_vec());
-        let mut payment = DeployPayload::new();
-        payment.set_stored_contract_uref(item);
-        self.deploy_item.set_session(payment);
+        self.deploy_item.session_code = Some(ExecutableDeployItem::StoredContractByURef {
+            uref: uref.addr().to_vec(),
+            args,
+        });
         self
     }
 
     pub fn with_stored_session_named_key(mut self, uref_name: &str, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        let mut item = StoredContractName::new();
-        item.set_args(args);
-        item.set_stored_contract_name(uref_name.to_owned()); // <-- named uref
-        let mut session = DeployPayload::new();
-        session.set_stored_contract_name(item);
-        self.deploy_item.set_session(session);
+        self.deploy_item.session_code = Some(ExecutableDeployItem::StoredContractByName {
+            name: uref_name.to_owned(),
+            args,
+        });
         self
     }
 
     pub fn with_authorization_keys(mut self, authorization_keys: &[PublicKey]) -> Self {
-        let authorization_keys = authorization_keys
-            .iter()
-            .map(|public_key| public_key.value().to_vec())
-            .collect();
-        self.deploy_item.set_authorization_keys(authorization_keys);
+        self.deploy_item.authorization_keys = authorization_keys.iter().cloned().collect();
         self
     }
 
     pub fn with_deploy_hash(mut self, hash: [u8; 32]) -> Self {
-        self.deploy_item.set_deploy_hash(hash.to_vec());
+        self.deploy_item.deploy_hash = hash;
         self
     }
 
     pub fn build(self) -> DeployItem {
-        self.deploy_item
+        DeployItem {
+            address: self.deploy_item.address.unwrap_or_else(|| [0u8; 32].into()),
+            session: self.deploy_item.session_code.unwrap(),
+            payment: self.deploy_item.payment_code.unwrap(),
+            gas_price: self.deploy_item.gas_price,
+            authorization_keys: self.deploy_item.authorization_keys,
+            deploy_hash: self.deploy_item.deploy_hash,
+        }
     }
 
     fn serialize_args(args: impl ArgsParser) -> Vec<u8> {
@@ -139,8 +134,8 @@ impl DeployItemBuilder {
 
 impl Default for DeployItemBuilder {
     fn default() -> Self {
-        let mut deploy_item = DeployItem::new();
-        deploy_item.set_gas_price(1);
+        let mut deploy_item: DeployItemData = Default::default();
+        deploy_item.gas_price = 1;
         DeployItemBuilder { deploy_item }
     }
 }

--- a/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
+++ b/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
@@ -341,6 +341,7 @@ fn new_execute_request(args: &Args) -> ExecuteRequest {
     )
     .with_pre_state_hash(&args.pre_state_hash)
     .build()
+    .into()
 }
 
 fn main() {

--- a/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
@@ -55,8 +55,6 @@ fn should_raise_auth_failure_with_invalid_key() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response")
-        .get_success()
-        .get_deploy_results()
         .get(0)
         .expect("should have at least one deploy result");
 
@@ -65,7 +63,7 @@ fn should_raise_auth_failure_with_invalid_key() {
         "{:?}",
         deploy_result
     );
-    let message = deploy_result.get_precondition_failure().get_message();
+    let message = format!("{}", deploy_result.error().unwrap());
 
     assert_eq!(
         message,
@@ -111,13 +109,11 @@ fn should_raise_auth_failure_with_invalid_keys() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response")
-        .get_success()
-        .get_deploy_results()
         .get(0)
         .expect("should have at least one deploy result");
 
     assert!(deploy_result.has_precondition_failure());
-    let message = deploy_result.get_precondition_failure().get_message();
+    let message = format!("{}", deploy_result.error().unwrap());
 
     assert_eq!(
         message,
@@ -204,13 +200,11 @@ fn should_raise_deploy_authorization_failure() {
             .builder()
             .get_exec_response(0)
             .expect("should have exec response")
-            .get_success()
-            .get_deploy_results()
             .get(0)
             .expect("should have at least one deploy result");
 
         assert!(deploy_result.has_precondition_failure());
-        let message = deploy_result.get_precondition_failure().get_message();
+        let message = format!("{}", deploy_result.error().unwrap());
         assert!(message.contains(&format!(
             "{}",
             execution::Error::DeploymentAuthorizationFailure
@@ -258,13 +252,11 @@ fn should_raise_deploy_authorization_failure() {
             .builder()
             .get_exec_response(0)
             .expect("should have exec response")
-            .get_success()
-            .get_deploy_results()
             .get(0)
             .expect("should have at least one deploy result");
 
         assert!(deploy_result.has_precondition_failure());
-        let message = deploy_result.get_precondition_failure().get_message();
+        let message = format!("{}", deploy_result.error().unwrap());
         assert!(message.contains(&format!(
             "{}",
             execution::Error::DeploymentAuthorizationFailure
@@ -413,8 +405,6 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response")
-        .get_success()
-        .get_deploy_results()
         .get(0)
         .expect("should have at least one deploy result");
 
@@ -423,7 +413,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
         "{:?}",
         deploy_result
     );
-    let message = deploy_result.get_precondition_failure().get_message();
+    let message = format!("{}", deploy_result.error().unwrap());
     assert!(message.contains(&format!(
         "{}",
         execution::Error::DeploymentAuthorizationFailure

--- a/execution-engine/engine-tests/src/test/contract_api/get_arg.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_arg.rs
@@ -36,13 +36,9 @@ fn call_get_arg(args: impl ArgsParser) -> Result<(), String> {
     let response = result
         .builder()
         .get_exec_response(0)
-        .expect("should have a response")
-        .to_owned();
+        .expect("should have a response");
 
-    let error_message = {
-        let execution_result = utils::get_success_result(&response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(response);
 
     Err(error_message)
 }
@@ -57,41 +53,36 @@ fn should_use_passed_argument() {
 #[ignore]
 #[test]
 fn should_revert_with_missing_arg() {
-    assert_eq!(
-        call_get_arg(()).expect_err("should fail"),
-        format!(
-            "Exit code: {}",
+    assert!(call_get_arg(())
+        .expect_err("should fail")
+        .contains(&format!(
+            "Revert({})",
             u32::from(ApiError::User(GetArgContractError::MissingArgument0 as u16))
-        )
-    );
-    assert_eq!(
-        call_get_arg((String::from(ARG0_VALUE),)).expect_err("should fail"),
-        format!(
-            "Exit code: {}",
+        )));
+    assert!(call_get_arg((String::from(ARG0_VALUE),))
+        .expect_err("should fail")
+        .contains(&format!(
+            "Revert({})",
             u32::from(ApiError::User(GetArgContractError::MissingArgument1 as u16))
-        )
-    );
+        )));
 }
 
 #[ignore]
 #[test]
 fn should_revert_with_invalid_argument() {
-    assert_eq!(
-        call_get_arg((U512::from(123),)).expect_err("should fail"),
-        format!(
-            "Exit code: {}",
+    assert!(call_get_arg((U512::from(123),))
+        .expect_err("should fail")
+        .contains(&format!(
+            "Revert({})",
             u32::from(ApiError::User(GetArgContractError::InvalidArgument0 as u16))
-        )
-    );
-    assert_eq!(
-        call_get_arg((
-            String::from(ARG0_VALUE),
-            String::from("this is expected to be U512")
-        ))
-        .expect_err("should fail"),
-        format!(
-            "Exit code: {}",
-            u32::from(ApiError::User(GetArgContractError::InvalidArgument1 as u16))
-        )
-    );
+        )));
+    assert!(call_get_arg((
+        String::from(ARG0_VALUE),
+        String::from("this is expected to be U512")
+    ))
+    .expect_err("should fail")
+    .contains(&format!(
+        "Revert({})",
+        u32::from(ApiError::User(GetArgContractError::InvalidArgument1 as u16))
+    )));
 }

--- a/execution-engine/engine-tests/src/test/contract_api/transfer.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer.rs
@@ -120,7 +120,7 @@ fn should_transfer_from_account_to_account() {
 
     let genesis_balance = builder.get_purse_balance(default_account_purse_id);
 
-    let gas_cost = Motes::from_gas(utils::get_exec_costs(&exec_1_response)[0], CONV_RATE)
+    let gas_cost = Motes::from_gas(utils::get_exec_costs(exec_1_response)[0], CONV_RATE)
         .expect("should convert");
 
     assert_eq!(
@@ -162,7 +162,7 @@ fn should_transfer_from_account_to_account() {
 
     let account_1_balance = builder.get_purse_balance(account_1_purse_id);
 
-    let gas_cost = Motes::from_gas(utils::get_exec_costs(&exec_2_response)[0], CONV_RATE)
+    let gas_cost = Motes::from_gas(utils::get_exec_costs(exec_2_response)[0], CONV_RATE)
         .expect("should convert");
 
     assert_eq!(
@@ -311,13 +311,11 @@ fn should_fail_when_insufficient_funds() {
         .commit()
         .finish();
 
-    assert_eq!(
-        "Trap(Trap { kind: Unreachable })",
-        result
-            .builder()
-            .exec_error_message(2)
-            .expect("should have error message"),
-    )
+    assert!(result
+        .builder()
+        .exec_error_message(2)
+        .expect("should have error message")
+        .contains("Trap(Trap { kind: Unreachable })"))
 }
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/deploy/payment_code.rs
+++ b/execution-engine/engine-tests/src/test/deploy/payment_code.rs
@@ -1,7 +1,7 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 use engine_core::engine_state::{genesis::POS_REWARDS_PURSE, CONV_RATE, MAX_PAYMENT};
-use engine_shared::{gas::Gas, motes::Motes, stored_value::StoredValue, transform::Transform};
+use engine_shared::{motes::Motes, stored_value::StoredValue, transform::Transform};
 use engine_test_support::low_level::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_ACCOUNT_INITIAL_BALANCE, DEFAULT_ACCOUNT_KEY, DEFAULT_GENESIS_CONFIG,
@@ -48,17 +48,14 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
         .exec(account_1_request)
         .commit()
         .get_exec_response(1)
-        .expect("there should be a response")
-        .to_owned();
+        .expect("there should be a response");
 
-    let error_message = {
-        let execution_result = utils::get_success_result(&account_1_response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(account_1_response);
 
-    assert_eq!(
-        error_message, "Insufficient payment",
-        "expected insufficient payment"
+    assert!(
+        error_message.contains("InsufficientPaymentError"),
+        "expected insufficient payment, got: {}",
+        error_message
     );
 
     let expected_transfers_count = 0;
@@ -144,11 +141,10 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
 
     let response = builder
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let execution_result = utils::get_success_result(&response);
-    let error_message = utils::get_error_message(execution_result);
+    let execution_result = utils::get_success_result(response);
+    let error_message = format!("{}", execution_result.error().expect("should have error"));
 
     assert_eq!(
         error_message, "Insufficient payment",
@@ -234,11 +230,10 @@ fn should_raise_insufficient_payment_error_when_out_of_gas() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let execution_result = utils::get_success_result(&response);
-    let error_message = utils::get_error_message(execution_result);
+    let execution_result = utils::get_success_result(response);
+    let error_message = format!("{}", execution_result.error().expect("should have error"));
 
     assert_eq!(
         error_message, "Insufficient payment",
@@ -323,13 +318,15 @@ fn should_forward_payment_execution_runtime_error() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let execution_result = utils::get_success_result(&response);
-    let error_message = utils::get_error_message(execution_result);
+    let execution_result = utils::get_success_result(response);
+    let error_message = format!("{}", execution_result.error().expect("should have error"));
 
-    assert_eq!(error_message, "Exit code: 65636", "expected payment error",);
+    assert!(
+        error_message.contains("Revert(65636)"),
+        "expected payment error",
+    );
 }
 
 #[ignore]
@@ -409,13 +406,15 @@ fn should_forward_payment_execution_gas_limit_error() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let execution_result = utils::get_success_result(&response);
-    let error_message = utils::get_error_message(execution_result);
+    let execution_result = utils::get_success_result(response);
+    let error_message = format!("{}", execution_result.error().expect("should have error"));
 
-    assert_eq!(error_message, "GasLimit", "expected gas limit error");
+    assert!(
+        error_message.contains("GasLimit"),
+        "expected gas limit error"
+    );
 }
 
 #[ignore]
@@ -451,13 +450,16 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let execution_result = utils::get_success_result(&response);
-    let error_message = utils::get_error_message(execution_result);
+    let execution_result = utils::get_success_result(response);
+    let error_message = format!("{}", execution_result.error().expect("should have error"));
 
-    assert_eq!(error_message, "GasLimit", "expected gas limit");
+    assert!(
+        error_message.contains("GasLimit"),
+        "expected gas limit, got {}",
+        error_message
+    );
 }
 
 #[ignore]
@@ -502,15 +504,10 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let mut success_result = utils::get_success_result(&response);
-    let cost = success_result
-        .take_cost()
-        .try_into()
-        .expect("should map to U512");
-    let gas = Gas::new(cost);
+    let success_result = utils::get_success_result(&response);
+    let gas = success_result.cost();
     let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let tally = motes.value() + modified_balance;
@@ -520,10 +517,10 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
         "no net resources should be gained or lost post-distribution"
     );
 
-    let execution_result = utils::get_success_result(&response);
-    let error_message = utils::get_error_message(execution_result);
+    let execution_result = utils::get_success_result(response);
+    let error_message = format!("{}", execution_result.error().expect("should have error"));
 
-    assert_eq!(error_message, "GasLimit", "expected gas limit");
+    assert!(error_message.contains("GasLimit"), "expected gas limit");
 }
 
 #[ignore]
@@ -576,12 +573,8 @@ fn should_correctly_charge_when_session_code_fails() {
         .expect("there should be a response")
         .clone();
 
-    let mut success_result = utils::get_success_result(&response);
-    let cost = success_result
-        .take_cost()
-        .try_into()
-        .expect("should map to U512");
-    let gas = Gas::new(cost);
+    let success_result = utils::get_success_result(&response);
+    let gas = success_result.cost();
     let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
     let tally = motes.value() + modified_balance;
 
@@ -642,12 +635,8 @@ fn should_correctly_charge_when_session_code_succeeds() {
         .expect("there should be a response")
         .clone();
 
-    let mut success_result = utils::get_success_result(&response);
-    let cost = success_result
-        .take_cost()
-        .try_into()
-        .expect("should map to U512");
-    let gas = Gas::new(cost);
+    let success_result = utils::get_success_result(&response);
+    let gas = success_result.cost();
     let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
     let total = motes.value() + U512::from(transferred_amount);
     let tally = total + modified_balance;
@@ -919,9 +908,8 @@ fn should_charge_non_main_purse() {
         .expect("there should be a response")
         .clone();
 
-    let mut result = utils::get_success_result(&response);
-    let cost = result.take_cost().try_into().expect("should map to U512");
-    let gas = Gas::new(cost);
+    let result = utils::get_success_result(&response);
+    let gas = result.cost();
     let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
     let expected_resting_balance = account_1_purse_funding_amount - motes.value();

--- a/execution-engine/engine-tests/src/test/deploy/preconditions.rs
+++ b/execution-engine/engine-tests/src/test/deploy/preconditions.rs
@@ -38,13 +38,12 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let precondition_failure = utils::get_precondition_failure(&response);
+    let precondition_failure = utils::get_precondition_failure(response);
 
     assert_eq!(
-        precondition_failure.message, "Authorization failure: not authorized.",
+        precondition_failure, "Authorization failure: not authorized.",
         "expected authorization failure"
     );
 }
@@ -73,13 +72,12 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let precondition_failure = utils::get_precondition_failure(&response);
+    let precondition_failure = utils::get_precondition_failure(response);
 
     assert_eq!(
-        precondition_failure.message, "Authorization failure: not authorized.",
+        precondition_failure, "Authorization failure: not authorized.",
         "expected authorization failure"
     );
 }
@@ -116,13 +114,12 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
     let response = transfer_result
         .builder()
         .get_exec_response(0)
-        .expect("there should be a response")
-        .clone();
+        .expect("there should be a response");
 
-    let precondition_failure = utils::get_precondition_failure(&response);
+    let precondition_failure = utils::get_precondition_failure(response);
 
     assert_eq!(
-        precondition_failure.message, "Authorization failure: not authorized.",
+        precondition_failure, "Authorization failure: not authorized.",
         "expected authorization failure"
     );
 }

--- a/execution-engine/engine-tests/src/test/examples/erc20/erc20_test.rs
+++ b/execution-engine/engine-tests/src/test/examples/erc20/erc20_test.rs
@@ -1,8 +1,7 @@
-use std::convert::{TryFrom, TryInto};
+use std::{convert::TryFrom, rc::Rc};
 
-use engine_core::engine_state::CONV_RATE;
-use engine_grpc_server::engine_server::ipc::ExecuteResponse;
-use engine_shared::{gas::Gas, motes::Motes};
+use engine_core::engine_state::{execution_result::ExecutionResult, CONV_RATE};
+use engine_shared::motes::Motes;
 use engine_test_support::low_level::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder as TestBuilder, DEFAULT_GENESIS_CONFIG,
 };
@@ -226,8 +225,8 @@ impl ERC20Test {
             .builder
             .exec_error_message(last_deploy_index - 1)
             .unwrap();
-        let expected_message = format!("Exit code: {:?}", code);
-        assert_eq!(deploy_error, expected_message);
+        let expected_message = format!("Revert({:?})", code);
+        assert!(deploy_error.contains(&expected_message));
         self
     }
 
@@ -340,13 +339,13 @@ impl ERC20Test {
     }
 }
 
-fn get_cost(response: &ExecuteResponse) -> U512 {
-    let mut success_result = utils::get_success_result(response);
-    let cost = success_result
-        .take_cost()
-        .try_into()
-        .expect("should map to U512");
-    let gas = Gas::new(cost);
-    let motes = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
+fn get_cost(response: &[Rc<ExecutionResult>]) -> U512 {
+    let motes = Motes::from_gas(
+        utils::get_exec_costs(response)
+            .into_iter()
+            .fold(Default::default(), |i, acc| i + acc),
+        CONV_RATE,
+    )
+    .expect("should convert");
     motes.value()
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_532.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_532.rs
@@ -25,8 +25,6 @@ fn should_run_ee_532_get_uref_regression_test() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response")
-        .get_success()
-        .get_deploy_results()
         .get(0)
         .expect("should have at least one deploy result");
 
@@ -35,10 +33,10 @@ fn should_run_ee_532_get_uref_regression_test() {
         "expected precondition failure"
     );
 
-    let message = deploy_result.get_precondition_failure().get_message();
+    let message = deploy_result.error().map(|err| format!("{}", err));
     assert_eq!(
         message,
-        format!("{}", Error::AuthorizationError),
+        Some(format!("{}", Error::AuthorizationError)),
         "expected AuthorizationError"
     )
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_572.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_572.rs
@@ -75,10 +75,7 @@ fn should_run_ee_572_regression() {
         .expect("should have a response")
         .to_owned();
 
-    let error_message = {
-        let execution_result = utils::get_success_result(&response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(response);
 
     assert!(error_message.contains("ForgedReference"));
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_597.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_597.rs
@@ -25,13 +25,7 @@ fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
         .expect("should have a response")
         .to_owned();
 
-    let error_message = {
-        let execution_result = utils::get_success_result(&response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(response);
     // Error::BondTooSmall => 5,
-    assert_eq!(
-        error_message,
-        format!("Exit code: {}", u32::from(ApiError::ProofOfStake(5)))
-    );
+    assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(5)))));
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_598.rs
@@ -69,13 +69,7 @@ fn should_fail_unboding_more_than_it_was_staked_ee_598_regression() {
         .get_exec_response(1)
         .expect("should have a response")
         .to_owned();
-    let error_message = {
-        let execution_result = utils::get_success_result(&response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(response);
     // Error::UnbondTooLarge => 7,
-    assert_eq!(
-        error_message,
-        format!("Exit code: {}", u32::from(ApiError::ProofOfStake(7)))
-    );
+    assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(7)))));
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_599.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_599.rs
@@ -14,7 +14,7 @@ use types::{
 const CONTRACT_EE_599_REGRESSION: &str = "ee_599_regression.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account.wasm";
 const DONATION_BOX_COPY_KEY: &str = "donation_box_copy";
-const EXPECTED_ERROR: &str = "Invalid execution context.";
+const EXPECTED_ERROR: &str = "InvalidContext";
 const TRANSFER_FUNDS_KEY: &str = "transfer_funds";
 const VICTIM_ADDR: [u8; 32] = [42; 32];
 
@@ -91,14 +91,18 @@ fn should_not_be_able_to_transfer_funds_with_transfer_purse_to_purse() {
         .builder()
         .get_exec_response(0)
         .expect("should have response");
-    let gas_cost = Motes::from_gas(utils::get_exec_costs(&exec_3_response)[0], CONV_RATE)
+    let gas_cost = Motes::from_gas(utils::get_exec_costs(exec_3_response)[0], CONV_RATE)
         .expect("should convert");
 
     let error_msg = result_2
         .builder()
         .exec_error_message(0)
         .expect("should have error");
-    assert_eq!(error_msg, EXPECTED_ERROR,);
+    assert!(
+        error_msg.contains(EXPECTED_ERROR),
+        "Got error: {}",
+        error_msg
+    );
 
     let victim_balance_after = result_2
         .builder()
@@ -160,14 +164,18 @@ fn should_not_be_able_to_transfer_funds_with_transfer_from_purse_to_account() {
         .get_exec_response(0)
         .expect("should have response");
 
-    let gas_cost = Motes::from_gas(utils::get_exec_costs(&exec_3_response)[0], CONV_RATE)
+    let gas_cost = Motes::from_gas(utils::get_exec_costs(exec_3_response)[0], CONV_RATE)
         .expect("should convert");
 
     let error_msg = result_2
         .builder()
         .exec_error_message(0)
         .expect("should have error");
-    assert_eq!(error_msg, EXPECTED_ERROR,);
+    assert!(
+        error_msg.contains(EXPECTED_ERROR),
+        "Got error: {}",
+        error_msg
+    );
 
     let victim_balance_after = result_2
         .builder()
@@ -235,14 +243,18 @@ fn should_not_be_able_to_transfer_funds_with_transfer_to_account() {
         .get_exec_response(0)
         .expect("should have response");
 
-    let gas_cost = Motes::from_gas(utils::get_exec_costs(&exec_3_response)[0], CONV_RATE)
+    let gas_cost = Motes::from_gas(utils::get_exec_costs(exec_3_response)[0], CONV_RATE)
         .expect("should convert");
 
     let error_msg = result_2
         .builder()
         .exec_error_message(0)
         .expect("should have error");
-    assert_eq!(error_msg, EXPECTED_ERROR,);
+    assert!(
+        error_msg.contains(EXPECTED_ERROR),
+        "Got error: {}",
+        error_msg
+    );
 
     let victim_balance_after = result_2
         .builder()
@@ -303,14 +315,18 @@ fn should_not_be_able_to_get_main_purse_in_invalid_context() {
         .get_exec_response(0)
         .expect("should have response");
 
-    let gas_cost = Motes::from_gas(utils::get_exec_costs(&exec_3_response)[0], CONV_RATE)
+    let gas_cost = Motes::from_gas(utils::get_exec_costs(exec_3_response)[0], CONV_RATE)
         .expect("should convert");
 
     let error_msg = result_2
         .builder()
         .exec_error_message(0)
         .expect("should have error");
-    assert_eq!(error_msg, EXPECTED_ERROR,);
+    assert!(
+        error_msg.contains(EXPECTED_ERROR),
+        "Got error: {}",
+        error_msg
+    );
 
     let victim_balance_after = result_2
         .builder()

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
@@ -94,7 +94,7 @@ fn should_run_successful_bond_and_unbond() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response");
-    let mut genesis_gas_cost = utils::get_exec_costs(&exec_response)[0];
+    let mut genesis_gas_cost = utils::get_exec_costs(exec_response)[0];
 
     let transforms = &result.builder().get_transforms()[0];
 
@@ -159,7 +159,7 @@ fn should_run_successful_bond_and_unbond() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response");
-    genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(&exec_response)[0];
+    genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(exec_response)[0];
 
     let account_1 = result
         .builder()
@@ -222,7 +222,7 @@ fn should_run_successful_bond_and_unbond() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response");
-    let gas_cost_b = Motes::from_gas(utils::get_exec_costs(&exec_response)[0], CONV_RATE)
+    let gas_cost_b = Motes::from_gas(utils::get_exec_costs(exec_response)[0], CONV_RATE)
         .expect("should convert");
 
     assert_eq!(
@@ -278,7 +278,7 @@ fn should_run_successful_bond_and_unbond() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response");
-    genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(&exec_response)[0];
+    genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(exec_response)[0];
 
     assert_eq!(
         result
@@ -327,7 +327,7 @@ fn should_run_successful_bond_and_unbond() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response");
-    let gas_cost_b = Motes::from_gas(utils::get_exec_costs(&exec_response)[0], CONV_RATE)
+    let gas_cost_b = Motes::from_gas(utils::get_exec_costs(exec_response)[0], CONV_RATE)
         .expect("should convert");
 
     assert_eq!(
@@ -374,7 +374,7 @@ fn should_run_successful_bond_and_unbond() {
         .builder()
         .get_exec_response(0)
         .expect("should have exec response");
-    genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(&exec_response)[0];
+    genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(exec_response)[0];
 
     // Back to original after funding account1's pursee
     assert_eq!(
@@ -495,15 +495,9 @@ fn should_fail_bonding_with_insufficient_funds() {
         .expect("should have a response")
         .to_owned();
 
-    let error_message = {
-        let execution_result = utils::get_success_result(&response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(response);
     // pos::Error::BondTransferFailed => 8
-    assert_eq!(
-        error_message,
-        format!("Exit code: {}", u32::from(ApiError::ProofOfStake(8)))
-    );
+    assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(8)))));
 }
 
 #[ignore]
@@ -541,13 +535,7 @@ fn should_fail_unbonding_validator_without_bonding_first() {
         .expect("should have a response")
         .to_owned();
 
-    let error_message = {
-        let execution_result = utils::get_success_result(&response);
-        utils::get_error_message(execution_result)
-    };
+    let error_message = utils::get_error_message(response);
     // pos::Error::NotBonded => 0
-    assert_eq!(
-        error_message,
-        format!("Exit code: {}", u32::from(ApiError::ProofOfStake(0)))
-    );
+    assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(0)))));
 }

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
@@ -4,7 +4,7 @@ use engine_core::engine_state::{
     genesis::{POS_PAYMENT_PURSE, POS_REWARDS_PURSE},
     CONV_RATE,
 };
-use engine_shared::{account::Account, gas::Gas, motes::Motes};
+use engine_shared::{account::Account, motes::Motes};
 use engine_test_support::low_level::{
     utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR,
     DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
@@ -125,12 +125,8 @@ fn finalize_payment_should_refund_to_specified_purse() {
             .get_exec_response(0)
             .expect("there should be a response");
 
-        let mut success_result = utils::get_success_result(response);
-        let cost = success_result
-            .take_cost()
-            .try_into()
-            .expect("should map to U512");
-        Motes::from_gas(Gas::new(cost), CONV_RATE)
+        let success_result = utils::get_success_result(response);
+        Motes::from_gas(success_result.cost(), CONV_RATE)
             .expect("should have motes")
             .value()
     };

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 
-use engine_core::{engine_state::Error, execution};
+use engine_core::execution;
 use engine_shared::transform::TypeMismatch;
 use engine_test_support::low_level::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNT_ADDR, DEFAULT_GENESIS_CONFIG,
@@ -64,7 +64,7 @@ fn overwrite_as_account(builder: &mut InMemoryWasmTestBuilder, uref: URef, addre
         "{}",
         execution::Error::ForgedReference(uref.into_read_add_write())
     );
-    assert_eq!(error_msg, err);
+    assert!(error_msg.contains(&err));
 }
 
 #[ignore]
@@ -136,7 +136,11 @@ fn should_overwrite_system_contract_uref_as_system() {
         .builder()
         .exec_error_message(0)
         .expect("should execute mint overwrite with error");
-    assert_eq!(error_msg, Error::FinalizationError.to_string());
+    assert!(
+        error_msg.contains("FinalizationError"),
+        "Expected FinalizationError, got {}",
+        error_msg
+    );
 
     let result_2 = new_builder.exec(exec_request_3).commit().finish();
 
@@ -147,5 +151,5 @@ fn should_overwrite_system_contract_uref_as_system() {
 
     let type_mismatch = TypeMismatch::new("Contract".to_string(), "String".to_string());
     let expected_error = execution::Error::TypeMismatch(type_mismatch);
-    assert_eq!(error_msg, expected_error.to_string());
+    assert!(error_msg.contains(&expected_error.to_string()));
 }


### PR DESCRIPTION
### Overview
This PR creates an `ExecuteRequest` for internal usage, in order to decouple the internals from the protobuf types.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-819
https://casperlabs.atlassian.net/browse/EE-820

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
