### PR TITLE
ECO-224: Consume stream of finalized blocks in Clarity.

### DIFF
--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -187,7 +187,7 @@ export class DagContainer {
               }
             } else if (event.hasNewFinalizedBlock()) {
               this.errors.capture(
-                this.casperService.getLatestBlockInfo().then(block => {
+                this.casperService.getLastFinalizedBlockInfo().then(block => {
                   this.lastFinalizedBlock = block;
                 })
               );
@@ -217,7 +217,7 @@ export class DagContainer {
     );
 
     await this.errors.capture(
-      this.casperService.getLatestBlockInfo().then(block => {
+      this.casperService.getLastFinalizedBlockInfo().then(block => {
         this.lastFinalizedBlock = block;
       })
     );

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -151,41 +151,50 @@ export class DagContainer {
 
         let subscribeTopics = {
           blockAdded: true,
-          blockFinalized: false
+          blockFinalized: true
         };
         let obs = this.casperService.subscribeEvents(subscribeTopics);
 
         this.eventsSubscriber = obs.subscribe({
           next: (event: Event) => {
-            let block = event.getBlockAdded()?.getBlock();
-            if (block) {
-              let index: number | undefined = this.blocks?.findIndex(
-                b =>
-                  b.getSummary()?.getBlockHash_asB64() ===
-                  block!.getSummary()?.getBlockHash_asB64()
-              );
+            if (event.hasBlockAdded()) {
+              let block = event.getBlockAdded()?.getBlock();
+              if (block) {
+                let index: number | undefined = this.blocks?.findIndex(
+                  b =>
+                    b.getSummary()?.getBlockHash_asB64() ===
+                    block!.getSummary()?.getBlockHash_asB64()
+                );
 
-              if (index === -1) {
-                // blocks with rank < N+1-depth will be culled
-                let culledThreshold = block!.getSummary()!.getHeader()!.getRank() + 1 - this.depth;
-                let remainingBlocks: BlockInfo[] = [];
-                if (this.blocks !== null) {
-                  remainingBlocks = this.blocks.filter(b => {
-                    let rank = b.getSummary()?.getHeader()?.getRank();
-                    if (rank !== undefined) {
-                      return rank >= culledThreshold;
-                    }
-                    return false;
+                if (index === -1) {
+                  // blocks with rank < N+1-depth will be culled
+                  let culledThreshold = block!.getSummary()!.getHeader()!.getRank() + 1 - this.depth;
+                  let remainingBlocks: BlockInfo[] = [];
+                  if (this.blocks !== null) {
+                    remainingBlocks = this.blocks.filter(b => {
+                      let rank = b.getSummary()?.getHeader()?.getRank();
+                      if (rank !== undefined) {
+                        return rank >= culledThreshold;
+                      }
+                      return false;
+                    });
+                  }
+                  remainingBlocks.splice(0, 0, block!);
+                  runInAction(() => {
+                    this.blocks = remainingBlocks;
                   });
                 }
-                remainingBlocks.splice(0, 0, block!);
-                runInAction(() => {
-                  this.blocks = remainingBlocks;
-                });
               }
+            } else if (event.hasNewFinalizedBlock()) {
+              this.errors.capture(
+                this.casperService.getLatestBlockInfo().then(block => {
+                  this.lastFinalizedBlock = block;
+                })
+              );
             }
           }
         });
+
       }
     } else {
       // disable subscriber


### PR DESCRIPTION
### Overview
Consume the stream of finalized blocks in Clarity, so that we can update bonds of validators in real-time. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-247

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
