### PR TITLE
CON-619: Message producer

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -77,10 +77,12 @@ object Estimator {
     implicit val ord = DagOperations.blockTopoOrderingDesc
     for {
       latestMessagesMeta <- latestMessages.traverse(dag.lookupUnsafe(_))
+      minRank            = latestMessagesMeta.map(_.rank).toList.min
       tips <- DagOperations
                .bfToposortTraverseF[F](latestMessagesMeta.toList)(
                  _.parents.toList.traverse(dag.lookupUnsafe(_))
                )
+               .takeWhile(_.rank > minRank)
                .takeUntil(_.messageHash == stopHash)
                // We start with the tips and remove any message
                // that is reachable through the parent-child link from other tips.

--- a/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Estimator.scala
@@ -82,7 +82,7 @@ object Estimator {
                .bfToposortTraverseF[F](latestMessagesMeta.toList)(
                  _.parents.toList.traverse(dag.lookupUnsafe(_))
                )
-               .takeWhile(_.rank > minRank)
+               .takeWhile(_.rank >= minRank)
                .takeUntil(_.messageHash == stopHash)
                // We start with the tips and remove any message
                // that is reachable through the parent-child link from other tips.

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -409,7 +409,8 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
                          validatorId,
                          privateKey,
                          sigAlgorithm,
-                         lfbHash
+                         lfbHash,
+                         roundId = 0
                        )
                        CreateBlockStatus.created(block)
                      }
@@ -457,7 +458,8 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
         validatorId,
         privateKey,
         sigAlgorithm,
-        keyBlockHash
+        keyBlockHash,
+        roundId = 0
       )
     } yield CreateBlockStatus.created(block)
 

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -200,7 +200,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
                 // In the voting period the lambda message is a ballot, so can't be a target,
                 // but in any case our own latest message might point at something with more weight already.
                 choice <- ForkChoice[F].fromJustifications(
-                           lambdaMessage.keyBlockHash,
+                           lambdaMessage.eraId,
                            justifications.values.flatten.toSet
                          )
                 message <- messageProducer.ballot(
@@ -449,7 +449,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
 
     for {
       _ <- check(
-            message.keyBlockHash == era.keyBlockHash,
+            message.eraId == era.keyBlockHash,
             "Shouldn't receive messages from other eras!"
           )
       _ <- maybeMessageProducer.fold(noop) { mp =>
@@ -640,7 +640,7 @@ object EraRuntime {
     * can share a round ID, but they are still different rounds.
     */
   def isSameRoundAs(a: Message)(b: Message): Boolean =
-    a.keyBlockHash == b.keyBlockHash && a.roundId == b.roundId
+    a.eraId == b.eraId && a.roundId == b.roundId
 
   /** Check if a message from a validator cites their own message in the same round as the message itself.
     * If it does, that would mean that this message was not the first in that round. In the voting period,

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -197,7 +197,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
                          justifications.values.flatten.toSet
                        )
               message <- messageProducer.ballot(
-                          eraId = era.keyBlockHash,
+                          keyBlockHash = era.keyBlockHash,
                           roundId = Ticks(lambdaMessage.roundId),
                           target = choice.block.messageHash,
                           justifications = justifications
@@ -220,7 +220,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
       // it can only be a ballot, after the switch block has been created.
       block = messageProducer
         .block(
-          eraId = era.keyBlockHash,
+          keyBlockHash = era.keyBlockHash,
           roundId = roundId,
           mainParent = choice.block.messageHash,
           justifications = choice.justificationsMap,
@@ -233,7 +233,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
 
       ballot = messageProducer
         .ballot(
-          eraId = era.keyBlockHash,
+          keyBlockHash = era.keyBlockHash,
           roundId = roundId,
           target = choice.block.messageHash,
           justifications = choice.justificationsMap
@@ -263,7 +263,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
             for {
               choice <- ForkChoice[F].fromKeyBlock(era.keyBlockHash)
               message <- messageProducer.ballot(
-                          eraId = era.keyBlockHash,
+                          keyBlockHash = era.keyBlockHash,
                           roundId = roundId,
                           target = choice.block.messageHash,
                           justifications = choice.justificationsMap

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -215,7 +215,7 @@ object MessageProducer {
           // This, currently, is catered for by a Semaphore in the EraRuntime, which
           // spans the fork choice as well as the block production.
           ownLatests = justificationMessages.filter { j =>
-            j.validatorId == validatorId && j.keyBlockHash == keyBlockHash
+            j.validatorId == validatorId && j.eraId == keyBlockHash
           }
           maybeOwnLatest = Option(ownLatests)
             .filterNot(_.isEmpty)
@@ -282,7 +282,7 @@ object MessageProducer {
                          .bfTraverseF(List(keyBlockHash)) { h =>
                            EraStorage[F].getEraUnsafe(h).map(e => List(e.parentKeyBlockHash))
                          }
-                         .takeUntil(_ == keyBlock.keyBlockHash)
+                         .takeUntil(_ == keyBlock.eraId)
                          .toList
 
       equivocatorsPerEra <- keyBlockHashes.traverse { h =>

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -281,7 +281,7 @@ object MessageProducer {
       keyBlockHashes <- DagOperations
                          .bfTraverseF(List(keyBlockHash)) { h =>
                            EraStorage[F].getEraUnsafe(h).map { e =>
-                             List(e.parentKeyBlockHash)
+                             List(e.parentKeyBlockHash).filterNot(_.isEmpty)
                            }
                          }
                          .takeUntil(_ == keyBlock.eraId)

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -1,10 +1,34 @@
 package io.casperlabs.casper.highway
 
+import cats._
+import cats.data.NonEmptyList
+import cats.implicits._
+import cats.effect.{Clock, Concurrent}
+import cats.effect.concurrent.Semaphore
 import com.google.protobuf.ByteString
+import io.casperlabs.casper.{DeployFilters, Estimator, ValidatorIdentity}
+import io.casperlabs.casper.DeploySelection.DeploySelection
+import io.casperlabs.casper.consensus.Block
 import io.casperlabs.casper.consensus.Block.Justification
-import io.casperlabs.crypto.Keys.PublicKeyBS
+import io.casperlabs.casper.consensus.state.ProtocolVersion
+import io.casperlabs.catscontrib.{MonadThrowable}
+import io.casperlabs.catscontrib.effect.implicits.fiberSyntax
+import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.models.Message
-import io.casperlabs.storage.BlockHash
+import io.casperlabs.metrics.Metrics
+import io.casperlabs.storage.{BlockHash, BlockMsgWithTransform}
+import io.casperlabs.storage.dag.{DagRepresentation, DagStorage}
+import io.casperlabs.storage.block.BlockStorage
+import io.casperlabs.storage.deploy.{DeployStorage, DeployStorageReader}
+import io.casperlabs.casper.util.execengine.ExecEngineUtil
+import io.casperlabs.casper.util.execengine.ExecEngineUtil.{MergeResult, TransformMap}
+import io.casperlabs.casper.util.{CasperLabsProtocol, ProtoUtil}
+import io.casperlabs.casper.util.ProtocolVersions.Config
+import io.casperlabs.shared.Log
+import io.casperlabs.shared.Sorting.byteStringOrdering
+import io.casperlabs.mempool.DeployBuffer
+import io.casperlabs.smartcontracts.ExecutionEngineService
+import io.casperlabs.ipc
 
 /** Produce a signed message, persisted message.
   * The producer should the thread safe, so that when it's
@@ -15,7 +39,7 @@ trait MessageProducer[F[_]] {
   def validatorId: PublicKeyBS
 
   def ballot(
-      eraId: BlockHash,
+      keyBlockHash: BlockHash,
       roundId: Ticks,
       target: BlockHash,
       // For lambda responses we want to limit the justifications to just direct ones.
@@ -28,10 +52,219 @@ trait MessageProducer[F[_]] {
     * persisting it to the block store.
     */
   def block(
-      eraId: BlockHash,
+      keyBlockHash: BlockHash,
       roundId: Ticks,
       mainParent: BlockHash,
       justifications: Map[PublicKeyBS, Set[BlockHash]],
       isBookingBlock: Boolean
   ): F[Message.Block]
+}
+
+object MessageProducer {
+  def apply[F[_]: Concurrent: Clock: Log: Metrics: DagStorage: BlockStorage: DeployBuffer: DeployStorage: CasperLabsProtocol: ExecutionEngineService: DeploySelection](
+      validatorIdentity: ValidatorIdentity,
+      chainName: String,
+      upgrades: Seq[ipc.ChainSpec.UpgradePoint]
+  ): F[MessageProducer[F]] =
+    for {
+      // Make sure we don't mess up the storages and the sequence numbers.
+      semaphore <- Semaphore[F](1)
+    } yield new MessageProducer[F] {
+      override val validatorId =
+        PublicKey(ByteString.copyFrom(validatorIdentity.publicKey))
+
+      override def ballot(
+          keyBlockHash: BlockHash,
+          roundId: Ticks,
+          target: BlockHash,
+          justifications: Map[PublicKeyBS, Set[BlockHash]]
+      ): F[Message.Ballot] = semaphore.withPermit {
+        for {
+          parent        <- BlockStorage[F].getBlockSummaryUnsafe(target)
+          parentMessage <- MonadThrowable[F].fromTry(Message.fromBlockSummary(parent))
+          props         <- messageProps(keyBlockHash, List(parentMessage), justifications)
+          timestamp     <- Clock[F].currentTimeMillis
+
+          signed = ProtoUtil.ballot(
+            props.justifications,
+            parent.getHeader.getState.postStateHash,
+            parent.getHeader.getState.bonds,
+            props.protocolVersion,
+            parent.blockHash,
+            props.validatorSeqNum,
+            props.validatorPrevBlockHash,
+            chainName,
+            timestamp,
+            props.rank,
+            validatorIdentity.publicKey,
+            validatorIdentity.privateKey,
+            validatorIdentity.signatureAlgorithm,
+            keyBlockHash
+          )
+
+          message <- MonadThrowable[F].fromTry(Message.fromBlock(signed))
+
+          record = BlockMsgWithTransform()
+            .withBlockMessage(signed)
+
+          _ <- BlockStorage[F].put(record)
+
+        } yield message.asInstanceOf[Message.Ballot]
+      }
+
+      override def block(
+          keyBlockHash: BlockHash,
+          roundId: Ticks,
+          mainParent: BlockHash,
+          justifications: Map[PublicKeyBS, Set[BlockHash]],
+          isBookingBlock: Boolean
+      ): F[Message.Block] = semaphore.withPermit {
+        for {
+          dag          <- DagStorage[F].getRepresentation
+          merged       <- selectParents(dag, keyBlockHash, mainParent, justifications)
+          parentHashes = merged.parents.map(_.blockHash).toSet
+          _            <- startRequeueingOrphanedDeploys(parentHashes)
+          parentMessages <- MonadThrowable[F].fromTry {
+                             merged.parents.toList.traverse(Message.fromBlock(_))
+                           }
+          props     <- messageProps(keyBlockHash, parentMessages, justifications)
+          timestamp <- Clock[F].currentTimeMillis
+
+          remainingHashes <- DeployBuffer.remainingDeploys[F](
+                              dag,
+                              parentHashes,
+                              timestamp,
+                              props.configuration.deployConfig
+                            )
+
+          deployStream = DeployStorageReader[F]
+            .getByHashes(remainingHashes)
+            .through(
+              DeployFilters.Pipes.dependenciesMet[F](dag, parentHashes)
+            )
+
+          checkpoint <- ExecEngineUtil
+                         .computeDeploysCheckpoint[F](
+                           merged,
+                           deployStream,
+                           timestamp,
+                           props.protocolVersion,
+                           props.rank,
+                           upgrades
+                         )
+
+          signed = ProtoUtil.block(
+            props.justifications,
+            checkpoint.preStateHash,
+            checkpoint.postStateHash,
+            checkpoint.bondedValidators,
+            checkpoint.deploysForBlock,
+            props.protocolVersion,
+            merged.parents.map(_.blockHash),
+            props.validatorSeqNum,
+            props.validatorPrevBlockHash,
+            chainName,
+            timestamp,
+            props.rank,
+            validatorIdentity.publicKey,
+            validatorIdentity.privateKey,
+            validatorIdentity.signatureAlgorithm,
+            keyBlockHash
+          )
+
+          message <- MonadThrowable[F].fromTry(Message.fromBlock(signed))
+
+          record = BlockMsgWithTransform()
+            .withBlockMessage(signed)
+            .withTransformEntry(checkpoint.transformMap)
+
+          _ <- BlockStorage[F].put(record)
+
+        } yield message.asInstanceOf[Message.Block]
+      }
+
+      // NOTE: Currently this will requeue deploys in the background, some will make it, some won't.
+      // This made sense with the AutoProposer, since a new block could be proposed any time;
+      // in Highway that's going to the next round, whenever that is.
+      private def startRequeueingOrphanedDeploys(parentHashes: Set[BlockHash]): F[Unit] = {
+        DeployBuffer.requeueOrphanedDeploys[F](parentHashes) >>= { requeued =>
+          Log[F].info(s"Re-queued $requeued orphaned deploys.").whenA(requeued > 0)
+        }
+      }.forkAndLog
+
+      private def messageProps(
+          keyBlockHash: BlockHash,
+          parents: Seq[Message],
+          justifications: Map[PublicKeyBS, Set[BlockHash]]
+      ): F[MessageProps] =
+        // NCB used to filter justifications to be only the bonded ones.
+        // In Highway, we must include the justifications of the parent era _when_ there's a
+        // new message that that we haven't included before. Transitive elimination should
+        // take care of it, eventually, when it's implemented.
+        for {
+          // NOTE: The validator sequence number restarts in each era, and `justifications`
+          // can contain entries for the parent era as well as the child.
+          justificationMessages <- justifications.values.flatten.toList.traverse { h =>
+                                    BlockStorage[F]
+                                      .getBlockSummaryUnsafe(h)
+                                      .flatMap { s =>
+                                        MonadThrowable[F].fromTry(Message.fromBlockSummary(s))
+                                      }
+                                  }
+          // Find the latest justification we picked (it could have changed since then due to concurrency).
+          // in this era.
+          ownLatests = justificationMessages.filter { j =>
+            j.validatorId == validatorId && j.keyBlockHash == keyBlockHash
+          }
+          maybeOwnLatest = Option(ownLatests)
+            .filterNot(_.isEmpty)
+            .map(_.maxBy(_.validatorMsgSeqNum))
+
+          validatorSeqNum        = maybeOwnLatest.fold(1)(_.validatorMsgSeqNum + 1)
+          validatorPrevBlockHash = maybeOwnLatest.fold(ByteString.EMPTY)(_.messageHash)
+
+          // Genesis is for example not part of the justifications, so to be safe include parents too.
+          rank            = ProtoUtil.nextRank(parents ++ justificationMessages)
+          config          <- CasperLabsProtocol[F].configAt(rank)
+          protocolVersion <- CasperLabsProtocol[F].versionAt(rank)
+        } yield MessageProps(
+          validatorSeqNum,
+          validatorPrevBlockHash,
+          rank,
+          config,
+          protocolVersion,
+          ProtoUtil.toJustification(justificationMessages)
+        )
+    }
+
+  case class MessageProps(
+      validatorSeqNum: Int,
+      validatorPrevBlockHash: BlockHash,
+      rank: Long,
+      configuration: Config,
+      protocolVersion: ProtocolVersion,
+      justifications: Seq[Justification]
+  )
+
+  /** Pick secondary parents that don't conflict with the already chosen fork choice. */
+  def selectParents[F[_]: MonadThrowable: Metrics: BlockStorage](
+      dag: DagRepresentation[F],
+      keyBlockHash: BlockHash,
+      mainParent: BlockHash,
+      justifications: Map[PublicKeyBS, Set[BlockHash]]
+  ): F[MergeResult[TransformMap, Block]] =
+    for {
+      latestMessages <- NonEmptyList(mainParent, justifications.values.flatten.toList).pure[F]
+      tips           <- Estimator.tipsOfLatestMessages[F](dag, latestMessages, stopHash = keyBlockHash)
+      // TODO: Get equivocators based on the eras.
+      equivocators = Set.empty[ByteString]
+      // TODO: There are no scores here for ordering secondary parents.
+      secondaries = tips
+        .filterNot(m => equivocators(m.validatorId) || m.messageHash == mainParent)
+        .map(_.messageHash)
+        .sorted
+      candidates = NonEmptyList(mainParent, secondaries)
+      blocks     <- candidates.traverse(BlockStorage[F].getBlockUnsafe)
+      merged     <- ExecEngineUtil.merge[F](blocks, dag)
+    } yield merged
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -209,8 +209,11 @@ object MessageProducer {
                                         MonadThrowable[F].fromTry(Message.fromBlockSummary(s))
                                       }
                                   }
-          // Find the latest justification we picked (it could have changed since then due to concurrency).
-          // in this era.
+          // Find the latest justification we picked. We must make sure they don't change
+          // due to concurrency between the time the justifications are collected and
+          // the sequence number is calculated, otherwise we could be equivocating.
+          // This, currently, is catered for by a Semaphore in the EraRuntime, which
+          // spans the fork choice as well as the block production.
           ownLatests = justificationMessages.filter { j =>
             j.validatorId == validatorId && j.keyBlockHash == keyBlockHash
           }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -100,7 +100,8 @@ object MessageProducer {
             validatorIdentity.publicKey,
             validatorIdentity.privateKey,
             validatorIdentity.signatureAlgorithm,
-            keyBlockHash
+            keyBlockHash,
+            roundId
           )
 
           message <- MonadThrowable[F].fromTry(Message.fromBlock(signed))
@@ -170,7 +171,8 @@ object MessageProducer {
             validatorIdentity.publicKey,
             validatorIdentity.privateKey,
             validatorIdentity.signatureAlgorithm,
-            keyBlockHash
+            keyBlockHash,
+            roundId
           )
 
           message <- MonadThrowable[F].fromTry(Message.fromBlock(signed))

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -3,6 +3,7 @@ package io.casperlabs.casper
 import cats._
 import cats.implicits._
 import cats.data.WriterT
+import cats.effect.Clock
 import io.casperlabs.crypto.Keys.PublicKeyBS
 import io.casperlabs.storage.BlockHash
 import java.time.Instant
@@ -52,6 +53,11 @@ package object highway {
 
     def minus(b: FiniteDuration) =
       a.minus(b.length, b.unit.toChronoUnit)
+  }
+
+  implicit class ClockOps[F[_]: Applicative](clock: Clock[F]) {
+    def currentTimeMillis: F[Long] =
+      clock.realTime(TimeUnit.MILLISECONDS)
   }
 
   /** Models a state transition of an era, returning the domain events that

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -416,7 +416,8 @@ object ProtoUtil {
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
       sigAlgorithm: SignatureAlgorithm,
-      keyBlockHash: ByteString
+      keyBlockHash: ByteString,
+      roundId: Long
   ): Block = {
     val body = Block.Body().withDeploys(deploys)
     val postState = Block
@@ -437,7 +438,8 @@ object ProtoUtil {
       creator = publicKey,
       validatorSeqNum = validatorSeqNum,
       validatorPrevBlockHash = validatorPrevBlockHash,
-      keyBlockHash = keyBlockHash
+      keyBlockHash = keyBlockHash,
+      roundId = roundId
     )
 
     val unsigned = unsignedBlockProto(body, header)
@@ -463,7 +465,8 @@ object ProtoUtil {
       publicKey: Keys.PublicKey,
       privateKey: Keys.PrivateKey,
       sigAlgorithm: SignatureAlgorithm,
-      keyBlockHash: ByteString
+      keyBlockHash: ByteString,
+      roundId: Long
   ): Block = {
     val body = Block.Body()
 
@@ -485,7 +488,8 @@ object ProtoUtil {
       creator = publicKey,
       validatorSeqNum = validatorSeqNum,
       validatorPrevBlockHash = validatorPrevBlockHash,
-      keyBlockHash = keyBlockHash
+      keyBlockHash = keyBlockHash,
+      roundId = roundId
     ).withMessageType(Block.MessageType.BALLOT)
 
     val unsigned = unsignedBlockProto(body, header)
@@ -509,11 +513,13 @@ object ProtoUtil {
       protocolVersion: ProtocolVersion,
       timestamp: Long,
       chainName: String,
-      keyBlockHash: ByteString = ByteString.EMPTY // For Genesis it will be empty.
+      keyBlockHash: ByteString = ByteString.EMPTY, // For Genesis it will be empty.
+      roundId: Long = 0
   ): Block.Header =
     Block
       .Header()
       .withKeyBlockHash(keyBlockHash)
+      .withRoundId(roundId)
       .withParentHashes(parentHashes)
       .withJustifications(justifications)
       .withDeployCount(body.deploys.size)

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -145,32 +145,10 @@ object ProtoUtil {
   }
 
   def unsafeGetBlockSummary[F[_]: MonadThrowable: BlockStorage](hash: BlockHash): F[BlockSummary] =
-    for {
-      maybeBlock <- BlockStorage[F].getBlockSummary(hash)
-      block <- maybeBlock match {
-                case Some(b) => b.pure[F]
-                case None =>
-                  MonadThrowable[F].raiseError(
-                    new NoSuchElementException(
-                      s"BlockStorage is missing hash ${PrettyPrinter.buildString(hash)}"
-                    )
-                  )
-              }
-    } yield block
+    BlockStorage[F].getBlockSummaryUnsafe(hash)
 
   def unsafeGetBlock[F[_]: MonadThrowable: BlockStorage](hash: BlockHash): F[Block] =
-    for {
-      maybeBlock <- BlockStorage[F].getBlockMessage(hash)
-      block <- maybeBlock match {
-                case Some(b) => b.pure[F]
-                case None =>
-                  MonadThrowable[F].raiseError(
-                    new NoSuchElementException(
-                      s"BlockStorage is missing hash ${PrettyPrinter.buildString(hash)}"
-                    )
-                  )
-              }
-    } yield block
+    BlockStorage[F].getBlockUnsafe(hash)
 
   def nextRank(justificationMsgs: Seq[Message]): Long =
     if (justificationMsgs.isEmpty) 0 // Genesis has rank=0

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -32,7 +32,8 @@ case class DeploysCheckpoint(
     postStateHash: StateHash,
     bondedValidators: Seq[io.casperlabs.casper.consensus.Bond],
     deploysForBlock: Seq[Block.ProcessedDeploy],
-    protocolVersion: state.ProtocolVersion
+    protocolVersion: state.ProtocolVersion,
+    transformMap: ExecEngineUtil.TransformMap
 )
 
 object ExecEngineUtil {
@@ -60,8 +61,9 @@ object ExecEngineUtil {
       (invalidDeploys, deployEffects) = ProcessedDeployResult.split(pdr)
       _                               <- handleInvalidDeploys[F](invalidDeploys)
       (deploysForBlock, transforms)   = ExecEngineUtil.unzipEffectsAndDeploys(deployEffects).unzip
+      transformMap                    = transforms.flatten
       commitResult <- ExecutionEngineService[F]
-                       .commit(preStateHash, transforms.flatten, protocolVersion)
+                       .commit(preStateHash, transformMap, protocolVersion)
                        .rethrow
       //TODO: Remove this logging at some point
       msgBody = transforms.flatten
@@ -78,7 +80,8 @@ object ExecEngineUtil {
       commitResult.postStateHash,
       commitResult.bondedValidators,
       deploysForBlock,
-      protocolVersion
+      protocolVersion,
+      transformMap
     )
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -1305,6 +1305,7 @@ class ValidationTest
           computedPostStateHash,
           bondedValidators,
           processedDeploys,
+          _,
           _
         ) = deploysCheckpoint
         block <- createAndStoreMessage[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -255,7 +255,8 @@ class ValidationTest
       pk,
       sk,
       Ed25519,
-      ByteString.EMPTY
+      ByteString.EMPTY,
+      0
     )
     Validation.blockSignature[Task](block) shouldBeF true
   }

--- a/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/BlockQueryResponseAPITest.scala
@@ -99,7 +99,8 @@ class BlockQueryResponseAPITest extends FlatSpec with Matchers with StorageFixtu
     Keys.PublicKey(secondBlockSender.toByteArray),
     Keys.PrivateKey(secondBlockSender.toByteArray),
     Ed25519,
-    ByteString.EMPTY
+    ByteString.EMPTY,
+    0
   )
   val secondHashString     = Base16.encode(secondBlock.blockHash.toByteArray)
   val blockHash: BlockHash = secondBlock.blockHash

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -831,7 +831,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
             assertEvent(events) {
               case HighwayEvent.CreatedLambdaMessage(b: Message.Block) =>
                 b.roundId shouldBe roundId
-                b.keyBlockHash shouldBe runtime.era.keyBlockHash
+                b.eraId shouldBe runtime.era.keyBlockHash
             }
           }
         }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -8,10 +8,8 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, BlockSummary, Bond, Era}
 import io.casperlabs.casper.consensus.state
 import io.casperlabs.casper.helper.StorageFixture
-import io.casperlabs.casper.highway.mocks.{MockForkChoice, MockMessageProducer}
 import io.casperlabs.comm.gossiping.{Relaying, WaitHandle}
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
-import io.casperlabs.models.ArbitraryConsensus
 import io.casperlabs.shared.{Log, LogStub}
 import io.casperlabs.storage.BlockMsgWithTransform
 import io.casperlabs.storage.block.BlockStorageWriter
@@ -21,42 +19,13 @@ import io.casperlabs.storage.{BlockHash, SQLiteStorage}
 import io.casperlabs.models.Message
 import java.time.Instant
 import java.util.concurrent.TimeUnit
-import monix.catnap.SchedulerEffect
 import monix.eval.Task
 import monix.execution.Scheduler
-import monix.execution.schedulers.TestScheduler
 import org.scalatest._
 import scala.concurrent.duration._
 import io.casperlabs.casper.PrettyPrinter
 
-class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with StorageFixture {
-  import EraSupervisorSpec._
-
-  def testFixtures(numStorages: Int)(
-      f: Timer[Task] => List[SQLiteStorage.CombinedStorage[Task]] => FixtureLike
-  ): Unit = {
-    val ctx   = TestScheduler()
-    val timer = SchedulerEffect.timer[Task](ctx)
-    withCombinedStorages(ctx, numStorages = numStorages) { dbs =>
-      Task.async[Unit] { cb =>
-        val fix = f(timer)(dbs)
-        // TestScheduler allows us to manually forward time.
-        // To get meaningful round IDs, we must start from the genesis.
-        ctx.forwardTo(fix.start)
-        // Without an extra delay the TestScheduler executes tasks immediately.
-        fix.test.delayExecution(0.seconds).runAsync(cb)(ctx)
-        // Now allow the tests to run forward until the end.
-        ctx.forwardTo(fix.start plus fix.length)
-        // There shouldn't be any uncaught exceptions.
-        ctx.state.lastReportedError shouldBe null
-      }
-    }
-  }
-
-  def testFixture(f: Timer[Task] => SQLiteStorage.CombinedStorage[Task] => FixtureLike): Unit =
-    testFixtures(numStorages = 1) { timer => dbs =>
-      f(timer)(dbs.head)
-    }
+class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with HighwayFixture {
 
   behavior of "collectActiveEras"
 
@@ -184,149 +153,4 @@ class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with Stor
         network(List("Alice", "Bob", "Charlie")).use(_.traverse(_.test).void)
     }
   }
-}
-
-object EraSupervisorSpec extends TickUtils with ArbitraryConsensus {
-
-  import HighwayConf.{EraDuration, VotingDuration}
-
-  val genesisEraStart       = date(2019, 12, 30)
-  val eraDuration           = days(10)
-  val postEraVotingDuration = days(2)
-
-  val defaultConf = HighwayConf(
-    tickUnit = TimeUnit.SECONDS,
-    genesisEraStart = genesisEraStart,
-    eraDuration = EraDuration.FixedLength(days(7)),
-    bookingDuration = eraDuration,
-    entropyDuration = hours(3),
-    postEraVotingDuration = VotingDuration.FixedLength(postEraVotingDuration),
-    omegaMessageTimeStart = 0.5,
-    omegaMessageTimeEnd = 0.75
-  )
-
-  trait FixtureLike {
-    // Where to set the TestScheduler to go from.
-    def start: Instant
-    // How long a time to simulate in the TestScheduler.
-    def length: FiniteDuration
-    // Override this value to make sure the assertions are executed.
-    def test: Task[Unit]
-  }
-
-  abstract class Fixture(
-      override val length: FiniteDuration,
-      val conf: HighwayConf = defaultConf,
-      val validator: String = "Alice",
-      val initRoundExponent: Int = 0,
-      val isSyncedRef: Ref[Task, Boolean] = Ref.unsafe(true),
-      printLevel: Log.Level = Log.Level.Error
-  )(
-      implicit
-      timer: Timer[Task],
-      db: SQLiteStorage.CombinedStorage[Task]
-  ) extends FixtureLike {
-
-    override val start = conf.genesisEraStart
-
-    implicit def `String => PublicKeyBS`(s: String): PublicKeyBS =
-      PublicKey(ByteString.copyFromUtf8(s))
-
-    val genesis = Message
-      .fromBlockSummary(
-        BlockSummary()
-          .withBlockHash(ByteString.copyFromUtf8("genesis"))
-          .withHeader(
-            Block
-              .Header()
-              .withState(
-                Block
-                  .GlobalState()
-                  .withBonds(
-                    List(
-                      Bond("Alice").withStake(state.BigInt("3000")),
-                      Bond("Bob").withStake(state.BigInt("4000")),
-                      Bond("Charlie").withStake(state.BigInt("5000"))
-                    )
-                  )
-              )
-          )
-      )
-      .get
-      .asInstanceOf[Message.Block]
-
-    implicit val log: Log[Task] with LogStub =
-      LogStub[Task](
-        prefix = validator.padTo(10, " ").mkString(""),
-        printEnabled = true,
-        printLevel = printLevel
-      )
-
-    implicit val forkchoice  = MockForkChoice.unsafe[Task](genesis)
-    val maybeMessageProducer = new MockMessageProducer[Task](validator).some
-
-    implicit val relaying = new Relaying[Task] {
-      override def relay(hashes: List[BlockHash]): Task[WaitHandle[Task]] = ().pure[Task].pure[Task]
-    }
-
-    def addGenesisEra(): Task[Era] = {
-      val era = EraRuntime.genesisEra(conf, genesis.blockSummary)
-      db.addEra(era).as(era)
-    }
-
-    implicit class EraOps(era: Era) {
-      def addChildEra(): Task[Era] = {
-        val nextEndTick = conf.toTicks(conf.eraEnd(conf.toInstant(Ticks(era.endTick))))
-        val child = sample[Era]
-          .withParentKeyBlockHash(era.keyBlockHash)
-          .withStartTick(era.endTick)
-          .withEndTick(nextEndTick)
-          .withBonds(era.bonds)
-        db.addEra(child).as(child)
-      }
-    }
-
-    def makeRuntime(era: Era): Task[EraRuntime[Task]] =
-      EraRuntime.fromEra[Task](
-        conf,
-        era,
-        maybeMessageProducer,
-        initRoundExponent,
-        isSyncedRef.get
-      )
-
-    def makeSupervisor(): Resource[Task, EraSupervisor[Task]] =
-      for {
-        _ <- Resource.liftF {
-              val genesisSummary = genesis.blockSummary
-              val genesisBlock = Block(
-                blockHash = genesisSummary.blockHash,
-                header = genesisSummary.header,
-                signature = genesisSummary.signature
-              )
-              db.put(BlockMsgWithTransform().withBlockMessage(genesisBlock))
-            }
-        supervisor <- EraSupervisor[Task](
-                       conf,
-                       genesis.blockSummary,
-                       maybeMessageProducer,
-                       initRoundExponent,
-                       isSyncedRef.get
-                     )
-      } yield supervisor
-
-    /** Use this to wait for future conditions in the test, don't try to use `.tick()`
-      * because that can only be called outside the test's for comprehension and it's
-      * done at the top. But sleeps will schedule the tasks that tell the TestScheduler
-      * when the next job is due.
-      */
-    def sleepUntil(t: Instant): Task[Unit] =
-      for {
-        now   <- Timer[Task].clock.realTime(conf.tickUnit)
-        later = conf.toTicks(t)
-        delay = math.max(later - now, 0L)
-        _     <- Timer[Task].sleep(FiniteDuration(delay, conf.tickUnit))
-      } yield ()
-  }
-
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -1,0 +1,196 @@
+package io.casperlabs.casper.highway
+
+import cats._
+import cats.implicits._
+import cats.effect.{ContextShift, Resource, Sync, Timer}
+import cats.effect.concurrent.Ref
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.helper.StorageFixture
+import io.casperlabs.storage.{BlockHash, SQLiteStorage}
+import io.casperlabs.casper.consensus.{Block, BlockSummary, Bond, Era}
+import io.casperlabs.casper.consensus.state
+import io.casperlabs.casper.highway.mocks.{MockForkChoice, MockMessageProducer}
+import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
+import io.casperlabs.comm.gossiping.{Relaying, WaitHandle}
+import io.casperlabs.models.ArbitraryConsensus
+import io.casperlabs.models.Message
+import io.casperlabs.shared.{Log, LogStub}
+import io.casperlabs.storage.BlockMsgWithTransform
+import java.time.Instant
+import java.util.concurrent.TimeUnit
+import monix.catnap.SchedulerEffect
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.execution.schedulers.TestScheduler
+import scala.concurrent.duration._
+import org.scalatest.Suite
+
+trait HighwayFixture extends StorageFixture with TickUtils with ArbitraryConsensus { self: Suite =>
+
+  def testFixtures(numStorages: Int)(
+      f: Timer[Task] => List[SQLiteStorage.CombinedStorage[Task]] => FixtureLike
+  ): Unit = {
+    val ctx   = TestScheduler()
+    val timer = SchedulerEffect.timer[Task](ctx)
+    withCombinedStorages(ctx, numStorages = numStorages) { dbs =>
+      Task.async[Unit] { cb =>
+        val fix = f(timer)(dbs)
+        // TestScheduler allows us to manually forward time.
+        // To get meaningful round IDs, we must start from the genesis.
+        ctx.forwardTo(fix.start)
+        // Without an extra delay the TestScheduler executes tasks immediately.
+        fix.test.delayExecution(0.seconds).runAsync(cb)(ctx)
+        // Now allow the tests to run forward until the end.
+        ctx.forwardTo(fix.start plus fix.length)
+        // There shouldn't be any uncaught exceptions.
+        assert(ctx.state.lastReportedError == null)
+      }
+    }
+  }
+
+  def testFixture(f: Timer[Task] => SQLiteStorage.CombinedStorage[Task] => FixtureLike): Unit =
+    testFixtures(numStorages = 1) { timer => dbs =>
+      f(timer)(dbs.head)
+    }
+
+  import HighwayConf.{EraDuration, VotingDuration}
+
+  val genesisEraStart       = date(2019, 12, 30)
+  val eraDuration           = days(10)
+  val postEraVotingDuration = days(2)
+
+  val defaultConf = HighwayConf(
+    tickUnit = TimeUnit.SECONDS,
+    genesisEraStart = genesisEraStart,
+    eraDuration = EraDuration.FixedLength(days(7)),
+    bookingDuration = eraDuration,
+    entropyDuration = hours(3),
+    postEraVotingDuration = VotingDuration.FixedLength(postEraVotingDuration),
+    omegaMessageTimeStart = 0.5,
+    omegaMessageTimeEnd = 0.75
+  )
+
+  trait FixtureLike {
+    // Where to set the TestScheduler to go from.
+    def start: Instant
+    // How long a time to simulate in the TestScheduler.
+    def length: FiniteDuration
+    // Override this value to make sure the assertions are executed.
+    def test: Task[Unit]
+  }
+
+  abstract class Fixture(
+      override val length: FiniteDuration,
+      val conf: HighwayConf = defaultConf,
+      val validator: String = "Alice",
+      val initRoundExponent: Int = 0,
+      val isSyncedRef: Ref[Task, Boolean] = Ref.unsafe(true),
+      printLevel: Log.Level = Log.Level.Error
+  )(
+      implicit
+      timer: Timer[Task],
+      db: SQLiteStorage.CombinedStorage[Task]
+  ) extends FixtureLike {
+
+    override val start = conf.genesisEraStart
+
+    implicit def `String => PublicKeyBS`(s: String): PublicKeyBS =
+      PublicKey(ByteString.copyFromUtf8(s))
+
+    val genesis = Message
+      .fromBlockSummary(
+        BlockSummary()
+          .withBlockHash(ByteString.copyFromUtf8("genesis"))
+          .withHeader(
+            Block
+              .Header()
+              .withState(
+                Block
+                  .GlobalState()
+                  .withBonds(
+                    List(
+                      Bond("Alice").withStake(state.BigInt("3000")),
+                      Bond("Bob").withStake(state.BigInt("4000")),
+                      Bond("Charlie").withStake(state.BigInt("5000"))
+                    )
+                  )
+              )
+          )
+      )
+      .get
+      .asInstanceOf[Message.Block]
+
+    implicit val log: Log[Task] with LogStub =
+      LogStub[Task](
+        prefix = validator.padTo(10, " ").mkString(""),
+        printEnabled = true,
+        printLevel = printLevel
+      )
+
+    implicit val forkchoice  = MockForkChoice.unsafe[Task](genesis)
+    val maybeMessageProducer = new MockMessageProducer[Task](validator).some
+
+    implicit val relaying = new Relaying[Task] {
+      override def relay(hashes: List[BlockHash]): Task[WaitHandle[Task]] = ().pure[Task].pure[Task]
+    }
+
+    def addGenesisEra(): Task[Era] = {
+      val era = EraRuntime.genesisEra(conf, genesis.blockSummary)
+      db.addEra(era).as(era)
+    }
+
+    implicit class EraOps(era: Era) {
+      def addChildEra(): Task[Era] = {
+        val nextEndTick = conf.toTicks(conf.eraEnd(conf.toInstant(Ticks(era.endTick))))
+        val child = sample[Era]
+          .withParentKeyBlockHash(era.keyBlockHash)
+          .withStartTick(era.endTick)
+          .withEndTick(nextEndTick)
+          .withBonds(era.bonds)
+        db.addEra(child).as(child)
+      }
+    }
+
+    def makeRuntime(era: Era): Task[EraRuntime[Task]] =
+      EraRuntime.fromEra[Task](
+        conf,
+        era,
+        maybeMessageProducer,
+        initRoundExponent,
+        isSyncedRef.get
+      )
+
+    def makeSupervisor(): Resource[Task, EraSupervisor[Task]] =
+      for {
+        _ <- Resource.liftF {
+              val genesisSummary = genesis.blockSummary
+              val genesisBlock = Block(
+                blockHash = genesisSummary.blockHash,
+                header = genesisSummary.header,
+                signature = genesisSummary.signature
+              )
+              db.put(BlockMsgWithTransform().withBlockMessage(genesisBlock))
+            }
+        supervisor <- EraSupervisor[Task](
+                       conf,
+                       genesis.blockSummary,
+                       maybeMessageProducer,
+                       initRoundExponent,
+                       isSyncedRef.get
+                     )
+      } yield supervisor
+
+    /** Use this to wait for future conditions in the test, don't try to use `.tick()`
+      * because that can only be called outside the test's for comprehension and it's
+      * done at the top. But sleeps will schedule the tasks that tell the TestScheduler
+      * when the next job is due.
+      */
+    def sleepUntil(t: Instant): Task[Unit] =
+      for {
+        now   <- Timer[Task].clock.realTime(conf.tickUnit)
+        later = conf.toTicks(t)
+        delay = math.max(later - now, 0L)
+        _     <- Timer[Task].sleep(FiniteDuration(delay, conf.tickUnit))
+      } yield ()
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -129,7 +129,7 @@ trait HighwayFixture extends StorageFixture with TickUtils with ArbitraryConsens
 
     implicit lazy val forkchoice = MockForkChoice.unsafe[Task](genesis)
 
-    lazy val messageProducer = new MockMessageProducer[Task](validator)
+    lazy val messageProducer: MessageProducer[Task] = new MockMessageProducer[Task](validator)
 
     implicit val relaying = new Relaying[Task] {
       override def relay(hashes: List[BlockHash]): Task[WaitHandle[Task]] = ().pure[Task].pure[Task]

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
@@ -1,0 +1,98 @@
+package io.casperlabs.casper.highway
+
+import cats._
+import cats.implicits._
+import io.casperlabs.crypto.Keys.PublicKey
+import io.casperlabs.casper.consensus.{Bond, Era}
+import io.casperlabs.casper.consensus.state
+import io.casperlabs.casper.highway.mocks.MockMessageProducer
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.storage.dag.DagStorage
+import monix.eval.Task
+import org.scalatest._
+
+class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with HighwayFixture {
+
+  behavior of "collectEquivocators"
+
+  it should "gather equivocators from the grandparent, parent and child eras" in testFixture {
+    implicit timer => implicit db =>
+      new Fixture(length = 4 * eraDuration) {
+
+        // Create an equivocation in an era by storing two messages that don't quote each other.
+        // Return the block hash we can use as key block for the next era.
+        def equivocate(validator: String, era: Era): Task[BlockHash] = {
+          val mp = new MockMessageProducer[Task](validator)
+          for {
+            dag    <- DagStorage[Task].getRepresentation
+            tips   <- dag.latestInEra(era.keyBlockHash)
+            latest <- tips.latestMessages
+            justifications = latest.map {
+              case (v, ms) => PublicKey(v) -> ms.map(_.messageHash)
+            }
+            b <- mp.block(
+                  era.keyBlockHash,
+                  roundId = Ticks(era.startTick),
+                  mainParent = genesis.messageHash,
+                  justifications = justifications,
+                  isBookingBlock = false
+                )
+            _ <- mp.ballot(
+                  era.keyBlockHash,
+                  roundId = Ticks(era.endTick),
+                  target = genesis.messageHash,
+                  justifications = justifications
+                )
+          } yield b.messageHash
+        }
+
+        override lazy val bonds = List(
+          Bond("Alice").withStake(state.BigInt("1000")),
+          Bond("Bob").withStake(state.BigInt("2000")),
+          Bond("Charlie").withStake(state.BigInt("3000")),
+          Bond("Dave").withStake(state.BigInt("4000")),
+          Bond("Eve").withStake(state.BigInt("5000")),
+          Bond("Fred").withStake(state.BigInt("6000"))
+        )
+
+        // Make an era tree where we'll put some equivocations into various ones
+        // in the hierarchy and check that the right ones are gathered.
+        // eA - eB
+        //    \ eC - eD
+        //         \ eE - eF
+
+        override def test =
+          for {
+            _ <- insertGenesis()
+
+            eA  <- addGenesisEra()
+            bAB <- equivocate("Alice", eA)
+            bAC <- equivocate("Alice", eA)
+            bAD <- equivocate("Alice", eA)
+            bAE <- equivocate("Alice", eA)
+
+            eB <- eA.addChildEra(bAB)
+            _  <- equivocate("Bob", eB)
+
+            eC  <- eA.addChildEra(bAC)
+            bCF <- equivocate("Charlie", eC)
+
+            eD <- eC.addChildEra(bAD)
+            _  <- equivocate("Dave", eD)
+
+            eE <- eC.addChildEra(bAE)
+            _  <- equivocate("Eve", eE)
+
+            eF <- eE.addChildEra(bCF)
+            _  <- equivocate("Fred", eF)
+
+            unforgiven <- MessageProducer.collectEquivocators[Task](eF.keyBlockHash)
+          } yield {
+            unforgiven("Charlie") shouldBe true
+            unforgiven("Eve") shouldBe true
+            unforgiven("Fred") shouldBe true
+            unforgiven.map(x => new String(x.toByteArray)) should have size 3
+          }
+      }
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
@@ -27,7 +27,17 @@ class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with Hi
 
   it should "gather equivocators from the grandparent, parent and child eras" in testFixture {
     implicit timer => implicit db =>
-      new Fixture(length = 5 * eraDuration) {
+      new Fixture(
+        length = 5 * eraDuration,
+        bonds = List(
+          Bond("Alice").withStake(state.BigInt("1000")),
+          Bond("Bob").withStake(state.BigInt("2000")),
+          Bond("Charlie").withStake(state.BigInt("3000")),
+          Bond("Dave").withStake(state.BigInt("4000")),
+          Bond("Eve").withStake(state.BigInt("5000")),
+          Bond("Fred").withStake(state.BigInt("6000"))
+        )
+      ) {
 
         // Create an equivocation in an era by storing two messages that don't quote each other.
         // Return the block hash we can use as key block for the next era.
@@ -55,15 +65,6 @@ class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with Hi
                 )
           } yield b.messageHash
         }
-
-        override lazy val bonds = List(
-          Bond("Alice").withStake(state.BigInt("1000")),
-          Bond("Bob").withStake(state.BigInt("2000")),
-          Bond("Charlie").withStake(state.BigInt("3000")),
-          Bond("Dave").withStake(state.BigInt("4000")),
-          Bond("Eve").withStake(state.BigInt("5000")),
-          Bond("Fred").withStake(state.BigInt("6000"))
-        )
 
         // Make an era tree where we'll put some equivocations into various ones
         // in the hierarchy and check that the right ones are gathered.
@@ -115,7 +116,7 @@ class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with Hi
         val (privateKey, publicKey) = Ed25519.newKeyPair
         val validatorId             = PublicKey(ByteString.copyFrom(publicKey))
 
-        override lazy val messageProducer: MessageProducer[Task] = {
+        override val messageProducer: MessageProducer[Task] = {
           implicit val deployBuffer = DeployBuffer.create[Task](chainName, minTtl = Duration.Zero)
           implicit val protocol = CasperLabsProtocol.unsafe[Task](
             (0L, ProtocolVersion(0, 1, 0), none)

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockBlockDagStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockBlockDagStorage.scala
@@ -29,7 +29,7 @@ class MockBlockDagStorage[F[_]: Monad](
     val message = Message.fromBlock(block).get
     messagesRef.update(_.updated(message.messageHash, message)) >>
       latestRef.update { m =>
-        val k = message.keyBlockHash
+        val k = message.eraId
         val v = message.validatorId
         m.updated(k, m(k).updated(v, message))
       } >>

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
@@ -61,7 +61,7 @@ class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
     } yield child
 
   override def ballot(
-      eraId: BlockHash,
+      keyBlockHash: BlockHash,
       roundId: Ticks,
       target: ByteString,
       justifications: Map[PublicKeyBS, Set[BlockHash]]
@@ -80,7 +80,7 @@ class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
             } yield Block.Justification(kv._1, h)
           )
           .withRoundId(roundId)
-          .withKeyBlockHash(eraId)
+          .withKeyBlockHash(keyBlockHash)
           .withState(
             Block.GlobalState().withBonds(parent.blockSummary.getHeader.getState.bonds)
           )
@@ -94,7 +94,7 @@ class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
   }
 
   override def block(
-      eraId: ByteString,
+      keyBlockHash: ByteString,
       roundId: Ticks,
       mainParent: ByteString,
       justifications: Map[PublicKeyBS, Set[BlockHash]],
@@ -114,7 +114,7 @@ class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
               } yield Block.Justification(kv._1, h)
             )
             .withRoundId(roundId)
-            .withKeyBlockHash(eraId)
+            .withKeyBlockHash(keyBlockHash)
             .withState(
               Block.GlobalState().withBonds(parent.blockSummary.getHeader.getState.bonds)
             )

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -129,7 +129,7 @@ class ExecEngineUtilTest extends FlatSpec with Matchers with BlockGenerator with
                           rank = 0,
                           upgrades = Nil
                         )
-      DeploysCheckpoint(_, _, _, result, _) = computeResult
+      DeploysCheckpoint(_, _, _, result, _, _) = computeResult
     } yield result
 
   "computeDeploysCheckpoint" should "aggregate the result of deploying multiple programs within the block" in withStorage {

--- a/models/src/main/scala/io/casperlabs/models/Message.scala
+++ b/models/src/main/scala/io/casperlabs/models/Message.scala
@@ -28,7 +28,9 @@ sealed trait Message {
   val validatorMsgSeqNum: Int
   val signature: consensus.Signature
   val roundId: Long
-  val keyBlockHash: Id
+
+  // Returns the `keyBlockHash`, but it was considered unintuitive after a while.
+  val eraId: Id
 
   val parents: Seq[Id]
   val blockSummary: BlockSummary
@@ -47,7 +49,7 @@ object Message {
       validatorId: ByteString,
       timestamp: Long,
       roundId: Long,
-      keyBlockHash: Message#Id,
+      eraId: Message#Id,
       parentBlock: Message#Id,
       justifications: Seq[consensus.Block.Justification],
       rank: Long,
@@ -75,7 +77,7 @@ object Message {
       validatorId: ByteString,
       timestamp: Long,
       roundId: Long,
-      keyBlockHash: Message#Id,
+      eraId: Message#Id,
       parentBlock: Message#Id,
       justifications: Seq[consensus.Block.Justification],
       rank: Long,

--- a/shared/src/main/scala/io/casperlabs/catscontrib/MakeSemaphore.scala
+++ b/shared/src/main/scala/io/casperlabs/catscontrib/MakeSemaphore.scala
@@ -1,0 +1,21 @@
+package io.casperlabs.catscontrib
+
+import cats.effect.Concurrent
+import cats.effect.concurrent.Semaphore
+import simulacrum.typeclass
+
+/** Requiring `Concurrent` just to be able to create a `Semaphore` is too powerful. */
+@typeclass
+trait MakeSemaphore[F[_]] {
+  def apply(n: Long): F[Semaphore[F]]
+}
+
+object MakeSemaphore {
+  implicit def fromConcurrent[F[_]: Concurrent]: MakeSemaphore[F] =
+    new MakeSemaphore[F] {
+      override def apply(n: Long): F[Semaphore[F]] =
+        Semaphore(n)
+    }
+
+  def apply[F[_]](n: Long)(implicit ev: MakeSemaphore[F]) = ev(n)
+}

--- a/shared/src/main/scala/io/casperlabs/catscontrib/effect/implicits/package.scala
+++ b/shared/src/main/scala/io/casperlabs/catscontrib/effect/implicits/package.scala
@@ -16,6 +16,9 @@ package object implicits {
   implicit def fiberSyntax[A, F[_]: Concurrent: Log: MonadThrowable](fa: F[A]): FiberSyntax[F, A] =
     new FiberSyntax(fa)
 
+  // We should only really use this in tests, if possible, since Sync for Id is not lawful.
+  // For example `MonadThrowable[Id].raiseError(...).whenA(x < 0)` would throw before it got to `whenA`,
+  // and it obviously can't suspend any computation (which we may not mind in tests).
   implicit val syncId: Sync[Id] =
     new Sync[Id] {
       def pure[A](x: A): cats.Id[A] = x

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -1,6 +1,6 @@
 package io.casperlabs.storage.dag
 
-import cats.Monad
+import cats.{Applicative, Monad}
 import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.{Block, BlockSummary}
@@ -117,8 +117,11 @@ trait EraTipRepresentation[F[_]] extends TipRepresentation[F] {
   // * the parent block candidate hashes, and
   // * the justifications of the parent block candidates.
 
-  // def getEquivocators: F[Set[Validator]] = ???
-  // def getEquivocations: F[Map[Validator, Set[Message]]] = ???
+  def getEquivocations(implicit A: Applicative[F]): F[Map[Validator, Set[Message]]] =
+    latestMessages.map(_.filter(_._2.size > 1))
+
+  def getEquivocators(implicit A: Applicative[F]): F[Set[Validator]] =
+    getEquivocations.map(_.keySet)
 }
 
 trait DagRepresentation[F[_]] {


### PR DESCRIPTION
### Overview
Implemented the `MessageProducer` based on the `MultiParentCasperImpl` class' `createMessage` method, but with persistence. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-619

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Haven't tested the `makeBlock` method because it depends so much on (unspecified) secondary parent selection, execution engine, merge conflicts, etc. The bits which are common with `makeBallot` are tested. I think when we have the fork choice, we can port over tests from HashSetCasperTest and test them all together.
