### PR TITLE
NODE-1129: Fix some 'hack/build/Makefile' issues

### DIFF
--- a/hack/build/Makefile
+++ b/hack/build/Makefile
@@ -1,3 +1,7 @@
+# Easier to use and less error-prone in some places where we need to 'cd'
+$(eval PROJECT = $(shell echo $$(pwd)/../..))
+$(eval MAKE_DIR = $(shell echo $$(pwd)/.make/run))
+
 # Runs the engine and node in the background using incremental compilation.
 # 'make start-background-scala-compiler' must be run explicitly before.
 start: .make/run/start
@@ -20,10 +24,10 @@ start: .make/run/start
 # To stop background SBT and Bloop server run `make stop-background-scala-compiler`.
 start-background-scala-compiler: .make/run/background-scala-compiler
 
-.make/run/background-scala-compiler: ../../project/reload.sbt
+.make/run/background-scala-compiler: $(PROJECT)/project/reload.sbt
 	@mkdir -p .make/run/data-dir
 	@echo "Starting background sbt..."
-	@cd ../.. && sbt -mem 1024 '~bloopInstall' &> hack/build/.make/run/sbt.log &
+	@cd $(PROJECT) && sbt -mem 1024 '~bloopInstall' &> $(MAKE_DIR)/sbt.log &
 	@sleep 1; while ! grep --silent "Monitoring source files for casperlabs" .make/run/sbt.log; do sleep 1; done
 	@echo "Starting bloop server..."
 	@bloop server &> .make/run/bloop.log &
@@ -31,10 +35,10 @@ start-background-scala-compiler: .make/run/background-scala-compiler
 	@echo Done
 	@mkdir -p $(dir $@) && touch $@
 
-../../project/reload.sbt:
-	@echo "// Automatically reloads sbt on build files changes" > ../../project/reload.sbt
-	@echo "// Created by the 'make start'" >> ../../project/reload.sbt
-	@echo "Global / onChangedBuildSource := ReloadOnSourceChanges" >> ../../project/reload.sbt
+$(PROJECT)/project/reload.sbt:
+	@echo "// Automatically reloads sbt on build files changes" > $(PROJECT)/project/reload.sbt
+	@echo "// Created by the 'make start'" >> $(PROJECT)/project/reload.sbt
+	@echo "Global / onChangedBuildSource := ReloadOnSourceChanges" >> $(PROJECT)/project/reload.sbt
 
 stop-background-scala-compiler:
 	@echo "Stopping backgroung sbt..."
@@ -44,14 +48,14 @@ stop-background-scala-compiler:
 	@bloop ng-stop &> /dev/null || true
 	@rm -rf .make/run/bloop.log
 	@rm -rf .make/run/background-scala-compiler
-	@rm -rf ../../project/reload.sbt
+	@rm -rf $(PROJECT)/project/reload.sbt
 	@echo Done
 
 .make/run/generate-keys:
 	@mkdir -p .make/run/data-dir
 	@echo "Data directory is .make/run/data-dir"
 	@echo "Generating keys..."
-	@../key-management/docker-gen-keys.sh .make/run/data-dir
+	@$(PROJECT)/hack/key-management/docker-gen-keys.sh .make/run/data-dir
 	@mkdir -p $(dir $@) && touch $@
 
 
@@ -64,24 +68,28 @@ stop-background-scala-compiler:
 # at the right of the comma of the 'ifneq' (if not equal) conditional.
 # https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html
 # https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html
+
+# Why not 'if [[ -f .make/run/background-scala-compiler]]'?
+# Since in Makefile each line is a new shell invocation,
+# it requires using multiline escaping which doesn't work well here.
 ifneq ($(wildcard .make/run/background-scala-compiler),)
 	@mkdir -p .make/run/data-dir
 	@echo "Running engine..."
 	@echo "" > .make/run/engine.log
-	@cd ../../execution-engine/engine-grpc-server && \
-		cargo run -- .make/run/data-dir/.casper-node.sock &> hack/build/.make/run/engine.log &
+	@cd $(PROJECT)/execution-engine/engine-grpc-server && \
+		cargo run -- $(MAKE_DIR)/data-dir/.casper-node.sock &> $(MAKE_DIR)/engine.log &
 	@sleep 1; while ! grep --silent "listening on socket" .make/run/engine.log; do sleep 1; done
 	@echo "Running node..."
-	@cd ../.. && bloop run node \
+	@cd $(PROJECT) && $(MAKE) build-node-contracts && bloop run node \
 		--args run \
 		--args "--casper-standalone" \
 		--args "--server-host=0.0.0.0" \
 		--args "--server-no-upnp" \
-		--args "--server-data-dir=.make/run/data-dir" \
+		--args "--server-data-dir=$(MAKE_DIR)/data-dir" \
 		--args "--casper-validator-sig-algorithm=ed25519" \
-		--args "--casper-validator-public-key-path=.make/run/data-dir/validator-public.pem" \
-		--args "--casper-validator-private-key-path=.make/run/data-dir/validator-private.pem" &> hack/build/.make/run/node.log &
-	@sleep 1; while ! grep --silent -i "listening for traffic on" .make/run/node.log; do sleep 1; done
+		--args "--casper-validator-public-key-path=$(MAKE_DIR)/data-dir/validator-public.pem" \
+		--args "--casper-validator-private-key-path=$(MAKE_DIR)/data-dir/validator-private.pem" &> $(MAKE_DIR)/node.log &
+	@sleep 1; while ! grep --silent -i "listening for traffic on" .make/run/node.log &> /dev/null; do sleep 1; done
 	@echo Done
 	@mkdir -p $(dir $@) && touch $@
 else


### PR DESCRIPTION
### Overview
Fixes issues of the https://github.com/CasperLabs/CasperLabs/pull/1532 which were found after the PR merged.

* Explain existence of 'ifneq'
* Revert 'PROJECT' and 'MAKE_DIR' Makefile vars
* Depend on the top-level Makefile's task 'build-node-contracts'

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1129

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
