### PR TITLE
NODE-1144: Order deploys' groups during replay by stage.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -390,7 +390,7 @@ object ExecEngineUtil {
       for {
         protocolVersion <- CasperLabsProtocol[F].protocolFromBlock(block)
         effectsRef      <- Ref[F].of(Map.empty[Int, Seq[TransformEntry]])
-        _ <- deploysGrouped.toList.foldLeftM(prestate) {
+        _ <- deploysGrouped.toList.sortBy(_._1).foldLeftM(prestate) {
               case (preStateHash, (stage, deploys)) =>
                 val eeCommitCaptureEffects: EECommitFun[F] =
                   (preState, transforms, protocol) =>


### PR DESCRIPTION
### Overview
As in the title.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
