### PR TITLE
EE-882: fix the build script for cargo-casperlabs package

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -60,6 +60,8 @@ INTEGRATION_CONTRACTS := $(patsubst %, build-integration-contract/%, $(INTEGRATI
 CONTRACT_TARGET_DIR       = target/wasm32-unknown-unknown/release
 CONTRACT_TARGET_DIR_AS    = target-as
 PACKAGED_SYSTEM_CONTRACTS = mint_install.wasm pos_install.wasm
+TOOL_TARGET_DIR           = cargo-casperlabs/target
+TOOL_WASM_DIR             = cargo-casperlabs/wasm
 
 .PHONY: all
 all: build build-contracts
@@ -112,14 +114,8 @@ build-integration-contracts: $(INTEGRATION_CONTRACTS)
 .PHONY: build-example-contracts
 build-example-contracts: $(EXAMPLE_CONTRACTS)
 
-.PHONY: build-tool-contracts
-build-tool-contracts: \
-	build-contract-rs/mint-install \
-	build-contract-rs/pos-install \
-	build-contract-rs/standard-payment
-
 .PHONY: test-rs
-test-rs: build-tool-contracts
+test-rs:
 	$(CARGO) test $(CARGO_FLAGS) --all -- --nocapture
 
 .PHONY: test-as
@@ -150,7 +146,7 @@ format:
 	$(CARGO) fmt --all
 
 .PHONY: lint
-lint: build-tool-contracts
+lint:
 	$(CARGO) clippy --all-targets --all -- -D warnings -A renamed_and_removed_lints
 
 .PHONY: check
@@ -165,6 +161,8 @@ check: \
 clean:
 	rm -f comm/.rpm
 	rm -rf $(CONTRACT_TARGET_DIR_AS)
+	rm -rf $(TOOL_TARGET_DIR)
+	rm -rf $(TOOL_WASM_DIR)
 	$(CARGO) clean
 
 .PHONY: deb

--- a/execution-engine/cargo-casperlabs/build.rs
+++ b/execution-engine/cargo-casperlabs/build.rs
@@ -38,7 +38,8 @@ impl Package for StandardPayment {
     const WASM_FILENAME: &'static str = "standard_payment.wasm";
 }
 
-const ORIGINAL_WASM_DIR: &str = "../target/wasm32-unknown-unknown/release";
+const TARGET_DIR_FOR_WASM: &str = "target/built-contracts";
+const ORIGINAL_WASM_DIR: &str = "wasm32-unknown-unknown/release";
 const NEW_WASM_DIR: &str = "wasm";
 
 fn build_package<T: Package>() {
@@ -60,7 +61,7 @@ fn build_package<T: Package>() {
     // '.../cargo-casperlabs/target/built-contracts' and then copy the resulting Wasm file from
     // there to '.../cargo-casperlabs/wasm'.
 
-    let target_dir = root_dir.join("target").join("built-contracts");
+    let target_dir = root_dir.join(TARGET_DIR_FOR_WASM);
     build_args.push(format!(
         "--target-dir={}",
         target_dir.to_str().expect("Expected valid unicode")
@@ -83,7 +84,7 @@ fn build_package<T: Package>() {
     let new_wasm_dir = env::current_dir().unwrap().join(NEW_WASM_DIR);
     let _ = fs::create_dir(&new_wasm_dir);
 
-    let original_wasm_file = PathBuf::from(ORIGINAL_WASM_DIR).join(T::WASM_FILENAME);
+    let original_wasm_file = target_dir.join(ORIGINAL_WASM_DIR).join(T::WASM_FILENAME);
     let copied_wasm_file = new_wasm_dir.join(T::WASM_FILENAME);
     fs::copy(original_wasm_file, copied_wasm_file).unwrap();
 }


### PR DESCRIPTION
### Overview
This fixes a bug in the build script of the `cargo-casperlabs` package.  The script was trying to copy the required compiled Wasm files from the wrong location.  This location would contain the required files if e.g. `make build-contracts` or `make build-tool-contracts` had been previously executed.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-882

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
