### PR TITLE
EE-840: fix issues in AdditiveMapDiff and add unit tests

### DIFF
--- a/execution-engine/engine-test-support/src/internal/additive_map_diff.rs
+++ b/execution-engine/engine-test-support/src/internal/additive_map_diff.rs
@@ -11,35 +11,26 @@ pub struct AdditiveMapDiff {
 
 impl AdditiveMapDiff {
     /// Creates a diff from two `AdditiveMap`s.
-    pub fn new(left: AdditiveMap<Key, Transform>, right: AdditiveMap<Key, Transform>) -> Self {
-        let both = Default::default();
-        let left_clone = left.clone();
-        let mut ret = AdditiveMapDiff { left, both, right };
-
-        for key in left_clone.keys() {
-            let l = ret.left.remove_entry(key);
-            let r = ret.right.remove_entry(key);
-
-            match (l, r) {
-                (Some(le), Some(re)) => {
-                    if le == re {
-                        ret.both.insert(*key, re.1);
-                    } else {
-                        ret.left.insert(*key, le.1);
-                        ret.right.insert(*key, re.1);
-                    }
+    pub fn new(
+        mut left: AdditiveMap<Key, Transform>,
+        mut right: AdditiveMap<Key, Transform>,
+    ) -> Self {
+        let mut both = AdditiveMap::new();
+        for key in left.keys().copied().collect::<Vec<_>>() {
+            let left_value = left.remove(&key).unwrap();
+            if let Some(right_value) = right.remove(&key) {
+                if left_value == right_value {
+                    both.insert(key, left_value);
+                } else {
+                    left.insert(key, left_value);
+                    right.insert(key, right_value);
                 }
-                (None, Some(re)) => {
-                    ret.right.insert(*key, re.1);
-                }
-                (Some(le), None) => {
-                    ret.left.insert(*key, le.1);
-                }
-                (None, None) => unreachable!(),
+            } else {
+                left.insert(key, left_value);
             }
         }
 
-        ret
+        AdditiveMapDiff { left, both, right }
     }
 
     /// Returns the entries that are unique to the `left` input.
@@ -55,5 +46,129 @@ impl AdditiveMapDiff {
     /// Returns the entries shared by both inputs.
     pub fn both(&self) -> &AdditiveMap<Key, Transform> {
         &self.both
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lazy_static::lazy_static;
+    use rand::{self, Rng};
+
+    use super::*;
+
+    const MIN_ELEMENTS: u8 = 1;
+    const MAX_ELEMENTS: u8 = 10;
+
+    lazy_static! {
+        static ref LEFT_ONLY: AdditiveMap<Key, Transform> = {
+            let mut map = AdditiveMap::new();
+            for i in 0..random_element_count() {
+                map.insert(Key::Local([i; 32]), Transform::AddInt32(i.into()));
+            }
+            map
+        };
+        static ref BOTH: AdditiveMap<Key, Transform> = {
+            let mut map = AdditiveMap::new();
+            for i in 0..random_element_count() {
+                map.insert(Key::Local([i + MAX_ELEMENTS; 32]), Transform::Identity);
+            }
+            map
+        };
+        static ref RIGHT_ONLY: AdditiveMap<Key, Transform> = {
+            let mut map = AdditiveMap::new();
+            for i in 0..random_element_count() {
+                map.insert(Key::Local([i; 32]), Transform::AddUInt512(i.into()));
+            }
+            map
+        };
+    }
+
+    fn random_element_count() -> u8 {
+        rand::thread_rng().gen_range(MIN_ELEMENTS, MAX_ELEMENTS + 1)
+    }
+
+    struct TestFixture {
+        expected: AdditiveMapDiff,
+    }
+
+    impl TestFixture {
+        fn new(
+            left_only: AdditiveMap<Key, Transform>,
+            both: AdditiveMap<Key, Transform>,
+            right_only: AdditiveMap<Key, Transform>,
+        ) -> Self {
+            TestFixture {
+                expected: AdditiveMapDiff {
+                    left: left_only,
+                    both,
+                    right: right_only,
+                },
+            }
+        }
+
+        fn left(&self) -> AdditiveMap<Key, Transform> {
+            self.expected
+                .left
+                .iter()
+                .chain(self.expected.both.iter())
+                .map(|(key, transform)| (*key, transform.clone()))
+                .collect()
+        }
+
+        fn right(&self) -> AdditiveMap<Key, Transform> {
+            self.expected
+                .right
+                .iter()
+                .chain(self.expected.both.iter())
+                .map(|(key, transform)| (*key, transform.clone()))
+                .collect()
+        }
+
+        fn run(&self) {
+            let diff = AdditiveMapDiff::new(self.left(), self.right());
+            assert_eq!(self.expected, diff);
+        }
+    }
+
+    #[test]
+    fn should_create_diff_where_left_is_subset_of_right() {
+        let fixture = TestFixture::new(AdditiveMap::new(), BOTH.clone(), RIGHT_ONLY.clone());
+        fixture.run();
+    }
+
+    #[test]
+    fn should_create_diff_where_right_is_subset_of_left() {
+        let fixture = TestFixture::new(LEFT_ONLY.clone(), BOTH.clone(), AdditiveMap::new());
+        fixture.run();
+    }
+
+    #[test]
+    fn should_create_diff_where_no_intersection() {
+        let fixture = TestFixture::new(LEFT_ONLY.clone(), AdditiveMap::new(), RIGHT_ONLY.clone());
+        fixture.run();
+    }
+
+    #[test]
+    fn should_create_diff_where_both_equal() {
+        let fixture = TestFixture::new(AdditiveMap::new(), BOTH.clone(), AdditiveMap::new());
+        fixture.run();
+    }
+
+    #[test]
+    fn should_create_diff_where_left_is_empty() {
+        let fixture = TestFixture::new(AdditiveMap::new(), AdditiveMap::new(), RIGHT_ONLY.clone());
+        fixture.run();
+    }
+
+    #[test]
+    fn should_create_diff_where_right_is_empty() {
+        let fixture = TestFixture::new(LEFT_ONLY.clone(), AdditiveMap::new(), AdditiveMap::new());
+        fixture.run();
+    }
+
+    #[test]
+    fn should_create_diff_where_both_are_empty() {
+        let fixture = TestFixture::new(AdditiveMap::new(), AdditiveMap::new(), AdditiveMap::new());
+        fixture.run();
     }
 }


### PR DESCRIPTION
### Overview
This addresses some issues raised previously around the `AdditiveMapDiff` struct.  It also adds unit tests for it.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-840

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
