### PR TITLE
OP-1123: Fix race condition where earlierPendingDeploys might be updated after validDeploys has been computed, causing some deploys to be erroneously marked as discarded

### DIFF
--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -74,7 +74,7 @@ object DeployBuffer {
     }
 
   /** Returns deploys that are not present in the p-past-cone of chosen parents. */
-  def remainingDeploys[F[_]: MonadThrowable: BlockStorage: DeployStorage: Metrics: Fs2Compiler: Log](
+  def remainingDeploys[F[_]: MonadThrowable: BlockStorage: DeployStorage: Metrics: Fs2Compiler](
       dag: DagRepresentation[F],
       parents: Set[BlockHash],
       timestamp: Long,
@@ -105,8 +105,6 @@ object DeployBuffer {
       // anything with timestamp earlier than now and not included in the valid deploys
       // can be discarded as a duplicate and/or expired deploy
       deploysToDiscard = earlierPendingSet diff validDeploys
-      discardStr       = deploysToDiscard.toVector.map(PrettyPrinter.buildString).sorted.mkString(",")
-      _                <- Log[F].info(s"Discarded deploys: $discardStr").whenA(deploysToDiscard.nonEmpty)
       _ <- DeployStorageWriter[F]
             .markAsDiscardedByHashes(deploysToDiscard.toList.map((_, "Duplicate or expired")))
             .whenA(deploysToDiscard.nonEmpty)


### PR DESCRIPTION
### Overview
Fix race condition where earlierPendingDeploys might be updated after validDeploys has been computed, causing some deploys to be erroneously marked as discarded. This bug was found by @TomVasile in an LRT.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1123

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
