### PR TITLE
RES-151: Minor rustdoc fixes and nit-picks.

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -965,7 +965,7 @@ where
             Default::default(),
         );
 
-        // `[ExecutionResultBuilder]` handles merging of multiple execution results
+        // [`ExecutionResultBuilder`] handles merging of multiple execution results
         let mut execution_result_builder = execution_result::ExecutionResultBuilder::new();
 
         // Execute provided payment code

--- a/execution-engine/engine-shared/src/account/associated_keys.rs
+++ b/execution-engine/engine-shared/src/account/associated_keys.rs
@@ -76,8 +76,8 @@ impl AssociatedKeys {
     ///
     /// This method is not concerned about uniqueness of the passed iterable.
     /// Uniqueness is determined based on the input collection properties,
-    /// which is either BTreeSet (in `[AssociatedKeys::calculate_keys_weight]`)
-    /// or BTreeMap (in `[AssociatedKeys::total_keys_weight]`).
+    /// which is either BTreeSet (in [`AssociatedKeys::calculate_keys_weight`])
+    /// or BTreeMap (in [`AssociatedKeys::total_keys_weight`]).
     fn calculate_any_keys_weight<'a>(&self, keys: impl Iterator<Item = &'a PublicKey>) -> Weight {
         let total = keys
             .filter_map(|key| self.0.get(key))

--- a/execution-engine/engine-shared/src/additive_map.rs
+++ b/execution-engine/engine-shared/src/additive_map.rs
@@ -23,7 +23,7 @@ impl<K: Eq + Hash, V: AddAssign + Default, S: BuildHasher> AdditiveMap<K, V, S> 
     /// Modifies the existing value stored under `key`, or the default value for `V` if none, by
     /// adding `value_to_add`.
     pub fn insert_add(&mut self, key: K, value_to_add: V) {
-        let current_value = self.0.entry(key).or_insert_with(Default::default);
+        let current_value = self.0.entry(key).or_default();
         *current_value += value_to_add;
     }
 }

--- a/execution-engine/engine-shared/src/socket.rs
+++ b/execution-engine/engine-shared/src/socket.rs
@@ -21,7 +21,7 @@ impl Socket {
 
     /// Safely removes file pointed out by a path.
     ///
-    /// In practice this file tries to remove file, and if
+    /// In practice this tries to remove the file, and if
     /// the file does not exist, it ignores it, and propagates
     /// any other error.
     pub fn remove_file(&self) -> io::Result<()> {

--- a/execution-engine/types/src/account.rs
+++ b/execution-engine/types/src/account.rs
@@ -66,7 +66,7 @@ pub enum ActionType {
     KeyManagement = 1,
 }
 
-/// convert from u32 representation of `[ActionType]`
+/// convert from u32 representation of [`ActionType`]
 impl TryFrom<u32> for ActionType {
     type Error = TryFromIntError;
 
@@ -110,7 +110,7 @@ pub enum SetThresholdFailure {
     InsufficientTotalWeight = 4,
 }
 
-/// convert from i32 representation of `[SetThresholdFailure]`
+/// convert from i32 representation of [`SetThresholdFailure`]
 impl TryFrom<i32> for SetThresholdFailure {
     type Error = TryFromIntError;
 
@@ -272,7 +272,7 @@ pub enum AddKeyFailure {
     PermissionDenied = 3,
 }
 
-/// convert from i32 representation of `[AddKeyFailure]`
+/// convert from i32 representation of [`AddKeyFailure`]
 impl TryFrom<i32> for AddKeyFailure {
     type Error = TryFromIntError;
 
@@ -311,7 +311,7 @@ pub enum RemoveKeyFailure {
     ThresholdViolation = 3,
 }
 
-/// convert from i32 representation of `[RemoveKeyFailure]`
+/// convert from i32 representation of [`RemoveKeyFailure`]
 impl TryFrom<i32> for RemoveKeyFailure {
     type Error = TryFromIntError;
 
@@ -351,7 +351,7 @@ pub enum UpdateKeyFailure {
     ThresholdViolation = 3,
 }
 
-/// convert from i32 representation of `[UpdateKeyFailure]`
+/// convert from i32 representation of [`UpdateKeyFailure`]
 impl TryFrom<i32> for UpdateKeyFailure {
     type Error = TryFromIntError;
 


### PR DESCRIPTION
### Overview
Rustdoc displays "`` `[foo]` ``" as "`[foo]`". Only "`` [`foo`] ``" is turned into the correct link.

### Which JIRA ticket does this PR relate to?
These are just minor things I noticed while reading the code for [RES-151](https://casperlabs.atlassian.net/browse/RES-151).

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] ~If this PR adds a new feature, it includes tests related to this feature.~
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
