### PR TITLE
OP-1079: add dependency to prevent npm race condition

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -817,6 +817,8 @@ steps:
   when:
     ref:
     - refs/tags/v*
+  depends_on:
+  - package-sbt-artifacts-tag
 
 - name: mac-ee-tarball-tag
   image: appleboy/drone-ssh:latest


### PR DESCRIPTION
### Overview
Steps in the tag pipeline were running in parallel and causing npm to step on each other. Adding this dependency prevents this.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1079

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
tested here: https://github.com/TomVasile/CasperLabs/releases/tag/v0.test.fix.1079

