### PR TITLE
EE-551: Clean up tests to use the query API

### DIFF
--- a/execution-engine/contracts/test/named-keys/src/lib.rs
+++ b/execution-engine/contracts/test/named-keys/src/lib.rs
@@ -9,81 +9,82 @@ use contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{ApiError, Key, U512};
+use types::{bytesrepr::ToBytes, ApiError, CLTyped, Key, U512};
+
+fn create_uref<T: CLTyped + ToBytes>(key_name: &str, value: T) {
+    let key: Key = storage::new_turef(value).into();
+    runtime::put_key(key_name, key);
+}
+
+const COMMAND_CREATE_UREF1: &str = "create-uref1";
+const COMMAND_CREATE_UREF2: &str = "create-uref2";
+const COMMAND_REMOVE_UREF1: &str = "remove-uref1";
+const COMMAND_REMOVE_UREF2: &str = "remove-uref2";
+const COMMAND_TEST_READ_UREF1: &str = "test-read-uref1";
+const COMMAND_TEST_READ_UREF2: &str = "test-read-uref2";
+const COMMAND_INCREASE_UREF2: &str = "increase-uref2";
+const COMMAND_OVERWRITE_UREF2: &str = "overwrite-uref2";
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let initi_uref_num = 2; // TODO: this is very brittle as it breaks whenever we add another default uref
+    let command: String = runtime::get_arg(0)
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
 
-    // Account starts with two known urefs: mint uref & pos uref
-    if runtime::list_named_keys().len() != initi_uref_num {
-        runtime::revert(ApiError::User(201));
+    match command.as_str() {
+        COMMAND_CREATE_UREF1 => create_uref("hello-world", String::from("Hello, world!")),
+        COMMAND_CREATE_UREF2 => create_uref("big-value", U512::max_value()),
+        COMMAND_REMOVE_UREF1 => runtime::remove_key("hello-world"),
+        COMMAND_REMOVE_UREF2 => runtime::remove_key("big-value"),
+        COMMAND_TEST_READ_UREF1 => {
+            // Read data hidden behind `URef1` uref
+            let hello_world: String = storage::read(
+                runtime::list_named_keys()
+                    .get("hello-world")
+                    .expect("Unable to get hello-world")
+                    .clone()
+                    .try_into()
+                    .expect("Unable to convert to turef"),
+            )
+            .expect("Unable to deserialize TURef")
+            .expect("Unable to find value");
+            assert_eq!(hello_world, "Hello, world!");
+
+            // Read data through dedicated FFI function
+            let uref1 = runtime::get_key("hello-world").unwrap_or_revert();
+
+            let turef = uref1.try_into().unwrap_or_revert_with(ApiError::User(101));
+            let hello_world = storage::read(turef);
+            assert_eq!(hello_world, Ok(Some("Hello, world!".to_string())));
+        }
+        COMMAND_TEST_READ_UREF2 => {
+            // Get the big value back
+            let big_value_key =
+                runtime::get_key("big-value").unwrap_or_revert_with(ApiError::User(102));
+            let big_value_ref = big_value_key.try_into().unwrap_or_revert();
+            let big_value = storage::read(big_value_ref);
+            assert_eq!(big_value, Ok(Some(U512::max_value())));
+        }
+        COMMAND_INCREASE_UREF2 => {
+            // Get the big value back
+            let big_value_key =
+                runtime::get_key("big-value").unwrap_or_revert_with(ApiError::User(102));
+            let big_value_ref = big_value_key.try_into().unwrap_or_revert();
+            // Increase by 1
+            storage::add(big_value_ref, U512::one());
+            let new_big_value = storage::read(big_value_ref);
+            assert_eq!(new_big_value, Ok(Some(U512::zero())));
+        }
+        COMMAND_OVERWRITE_UREF2 => {
+            // Get the big value back
+            let big_value_key =
+                runtime::get_key("big-value").unwrap_or_revert_with(ApiError::User(102));
+            let big_value_ref = big_value_key.try_into().unwrap_or_revert();
+            // I can overwrite some data under the pointer
+            storage::write(big_value_ref, U512::from(123_456_789u64));
+            let new_value = storage::read(big_value_ref);
+            assert_eq!(new_value, Ok(Some(U512::from(123_456_789u64))));
+        }
+        _ => runtime::revert(ApiError::InvalidArgument),
     }
-
-    // Add new urefs
-    let hello_world_key: Key = storage::new_turef(String::from("Hello, world!")).into();
-    runtime::put_key("hello-world", hello_world_key);
-    assert_eq!(runtime::list_named_keys().len(), initi_uref_num + 1);
-
-    // Verify if the uref is present
-    assert!(runtime::has_key("hello-world"));
-
-    let big_value_key: Key = storage::new_turef(U512::max_value()).into();
-    runtime::put_key("big-value", big_value_key);
-
-    assert_eq!(runtime::list_named_keys().len(), initi_uref_num + 2);
-
-    // Read data hidden behind `URef1` uref
-    let hello_world: String = storage::read(
-        runtime::list_named_keys()
-            .get("hello-world")
-            .expect("Unable to get hello-world")
-            .clone()
-            .try_into()
-            .expect("Unable to convert to turef"),
-    )
-    .expect("Unable to deserialize TURef")
-    .expect("Unable to find value");
-    assert_eq!(hello_world, "Hello, world!");
-
-    // Read data through dedicated FFI function
-    let uref1 = runtime::get_key("hello-world").unwrap_or_revert();
-
-    let turef = uref1.try_into().unwrap_or_revert_with(ApiError::User(101));
-    let hello_world = storage::read(turef);
-    assert_eq!(hello_world, Ok(Some("Hello, world!".to_string())));
-
-    // Remove uref
-    runtime::remove_key("hello-world");
-    assert!(!runtime::has_key("hello-world"));
-
-    // Confirm URef2 is still there
-    assert!(runtime::has_key("big-value"));
-
-    // Get the big value back
-    let big_value_key = runtime::get_key("big-value").unwrap_or_revert_with(ApiError::User(102));
-    let big_value_ref = big_value_key.try_into().unwrap_or_revert();
-    let big_value = storage::read(big_value_ref);
-    assert_eq!(big_value, Ok(Some(U512::max_value())));
-
-    // Increase by 1
-    storage::add(big_value_ref, U512::one());
-    let new_big_value = storage::read(big_value_ref);
-    assert_eq!(new_big_value, Ok(Some(U512::zero())));
-
-    // I can overwrite some data under the pointer
-    storage::write(big_value_ref, U512::from(123_456_789u64));
-    let new_value = storage::read(big_value_ref);
-    assert_eq!(new_value, Ok(Some(U512::from(123_456_789u64))));
-
-    // Try to remove non existing uref which shouldn't fail
-    runtime::remove_key("hello-world");
-    // Remove a valid uref
-    runtime::remove_key("big-value");
-
-    // Cleaned up state
-    assert!(!runtime::has_key("hello-world"));
-    assert!(!runtime::has_key("big-value"));
-
-    assert_eq!(runtime::list_named_keys().len(), initi_uref_num);
 }

--- a/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
@@ -1,16 +1,14 @@
 use lazy_static::lazy_static;
 
-use engine_shared::account::Account;
 use engine_test_support::{
     internal::{
-        utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG,
-        DEFAULT_PAYMENT,
+        ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG, DEFAULT_PAYMENT,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
 use types::{
     account::{PublicKey, Weight},
-    Key, U512,
+    U512,
 };
 
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
@@ -49,14 +47,11 @@ fn should_manage_associated_key() {
         .expect_success()
         .commit();
 
-    let account_key = Key::Account(ACCOUNT_1_ADDR);
     let genesis_key = PublicKey::new(DEFAULT_ACCOUNT_ADDR);
 
-    let account_1: Account = {
-        let tmp = builder.clone();
-        let transforms = tmp.get_transforms();
-        utils::get_account(&transforms[1], &account_key).expect("should get account")
-    };
+    let account_1 = builder
+        .get_account(ACCOUNT_1_ADDR)
+        .expect("should have account");
 
     let gen_weight = account_1
         .get_associated_key_weight(genesis_key)
@@ -74,17 +69,13 @@ fn should_manage_associated_key() {
 
     builder.exec(exec_request_3).expect_success().commit();
 
-    let account_1: Account = {
-        let tmp = builder.clone();
-        let transforms = tmp.get_transforms();
-        utils::get_account(&transforms[2], &account_key).expect("should get account")
-    };
+    let account_1 = builder
+        .get_account(ACCOUNT_1_ADDR)
+        .expect("should have account");
 
-    assert_eq!(
-        account_1.get_associated_key_weight(genesis_key),
-        None,
-        "key should be removed"
-    );
+    let new_weight = account_1.get_associated_key_weight(genesis_key);
+
+    assert_eq!(new_weight, None, "key should be removed");
 
     let is_error = builder.is_error();
     assert!(!is_error);

--- a/execution-engine/engine-tests/src/test/contract_api/account/named_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/named_keys.rs
@@ -1,72 +1,106 @@
-use engine_shared::{stored_value::StoredValue, transform::Transform};
+use std::convert::TryFrom;
+
 use engine_test_support::{
     internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{Key, U512};
+use types::{bytesrepr::FromBytes, CLTyped, CLValue, Key, U512};
 
 const CONTRACT_NAMED_KEYS: &str = "named_keys.wasm";
 const EXPECTED_UREF_VALUE: u64 = 123_456_789u64;
 
-#[ignore]
-#[test]
-fn should_run_named_keys_contract() {
-    let exec_request =
-        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_NAMED_KEYS, ()).build();
+const KEY1: &str = "hello-world";
+const KEY2: &str = "big-value";
 
-    let result = InMemoryWasmTestBuilder::default()
-        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+const COMMAND_CREATE_UREF1: &str = "create-uref1";
+const COMMAND_CREATE_UREF2: &str = "create-uref2";
+const COMMAND_REMOVE_UREF1: &str = "remove-uref1";
+const COMMAND_REMOVE_UREF2: &str = "remove-uref2";
+const COMMAND_TEST_READ_UREF1: &str = "test-read-uref1";
+const COMMAND_TEST_READ_UREF2: &str = "test-read-uref2";
+const COMMAND_INCREASE_UREF2: &str = "increase-uref2";
+const COMMAND_OVERWRITE_UREF2: &str = "overwrite-uref2";
+
+fn run_command(builder: &mut InMemoryWasmTestBuilder, command: &str) {
+    let exec_request =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_NAMED_KEYS, (command,))
+            .build();
+    builder
         .exec(exec_request)
         .commit()
         .expect_success()
         .finish();
+}
 
-    let transforms = result.builder().get_transforms();
+fn read_value<T: CLTyped + FromBytes>(builder: &mut InMemoryWasmTestBuilder, key: Key) -> T {
+    CLValue::try_from(builder.query(None, key, &[]).expect("should have value"))
+        .expect("should have CLValue")
+        .into_t()
+        .expect("should convert successfully")
+}
 
-    assert_eq!(transforms.len(), 1);
+#[ignore]
+#[test]
+fn should_run_named_keys_contract() {
+    let mut builder = InMemoryWasmTestBuilder::default();
 
-    let transform = transforms
-        .get(0)
-        .expect("Should have at least one transform");
+    builder.run_genesis(&DEFAULT_GENESIS_CONFIG);
 
-    let string_value = transform
-        .iter()
-        .filter_map(|(k, v)| {
-            if let Transform::Write(StoredValue::CLValue(cl_value)) = v {
-                let s = cl_value.to_owned().into_t::<String>().ok()?;
-                if let Key::URef(_) = k {
-                    return Some(s);
-                }
-            }
-            None
-        })
-        .next()
-        .expect("Should have write string");
-    assert_eq!(string_value, "Hello, world!");
-    let u512_value = transform
-        .iter()
-        .filter_map(|(k, v)| {
-            if let Transform::Write(StoredValue::CLValue(cl_value)) = v {
-                let value = cl_value.to_owned().into_t::<U512>().ok()?;
-                if let Key::URef(_) = k {
-                    // Since payment code is enabled by default there are multiple writes of Uint512
-                    // type, so we narrow it down to the expected value.
-                    if value == U512::from(EXPECTED_UREF_VALUE) {
-                        return Some(());
-                    }
-                }
-            }
-            None
-        })
-        .next();
+    run_command(&mut builder, COMMAND_CREATE_UREF1);
 
-    assert!(u512_value.is_some(), "should have write uin512");
-
-    let account = result
-        .builder()
+    let account = builder
         .get_account(DEFAULT_ACCOUNT_ADDR)
-        .expect("Unable to get account transformation");
-    // Those named URefs are created, although removed at the end of the test
-    assert!(account.named_keys().get("URef1").is_none());
-    assert!(account.named_keys().get("URef2").is_none());
+        .expect("should have account");
+    assert!(account.named_keys().contains_key(KEY1));
+    assert!(!account.named_keys().contains_key(KEY2));
+
+    run_command(&mut builder, COMMAND_CREATE_UREF2);
+
+    let account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    let uref1 = *account.named_keys().get(KEY1).expect("should have key");
+    let uref2 = *account.named_keys().get(KEY2).expect("should have key");
+    let value1: String = read_value(&mut builder, uref1);
+    let value2: U512 = read_value(&mut builder, uref2);
+    assert_eq!(value1, "Hello, world!");
+    assert_eq!(value2, U512::max_value());
+
+    run_command(&mut builder, COMMAND_TEST_READ_UREF1);
+
+    run_command(&mut builder, COMMAND_REMOVE_UREF1);
+
+    let account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    assert!(!account.named_keys().contains_key(KEY1));
+    assert!(account.named_keys().contains_key(KEY2));
+
+    run_command(&mut builder, COMMAND_TEST_READ_UREF2);
+
+    run_command(&mut builder, COMMAND_INCREASE_UREF2);
+
+    let account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    let uref2 = *account.named_keys().get(KEY2).expect("should have key");
+    let value2: U512 = read_value(&mut builder, uref2);
+    assert_eq!(value2, U512::zero());
+
+    run_command(&mut builder, COMMAND_OVERWRITE_UREF2);
+
+    let account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    let uref2 = *account.named_keys().get(KEY2).expect("should have key");
+    let value2: U512 = read_value(&mut builder, uref2);
+    assert_eq!(value2, U512::from(EXPECTED_UREF_VALUE));
+
+    run_command(&mut builder, COMMAND_REMOVE_UREF2);
+
+    let account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    assert!(!account.named_keys().contains_key(KEY1));
+    assert!(!account.named_keys().contains_key(KEY2));
 }

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_purse.rs
@@ -1,5 +1,6 @@
-use engine_shared::{stored_value::StoredValue, transform::Transform};
-use types::{ApiError, Key, U512};
+use std::convert::TryFrom;
+
+use types::{ApiError, CLValue, Key, U512};
 
 use engine_test_support::{
     internal::{
@@ -24,53 +25,44 @@ fn should_run_purse_to_purse_transfer() {
     )
     .build();
 
-    let transfer_result = InMemoryWasmTestBuilder::default()
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder
         .run_genesis(&DEFAULT_GENESIS_CONFIG)
         .exec(exec_request_1)
         .expect_success()
         .commit()
         .finish();
 
-    let transforms = transfer_result.builder().get_transforms();
-    let transform = &transforms[0];
-
-    let default_account = transfer_result
-        .builder()
+    let default_account = builder
         .get_account(DEFAULT_ACCOUNT_ADDR)
         .expect("should get genesis account");
 
     // Get the `purse_transfer_result` for a given
-    let purse_transfer_result =
-        &transform[&default_account.named_keys()["purse_transfer_result"].normalize()];
-    let purse_transfer_result =
-        if let Transform::Write(StoredValue::CLValue(cl_value)) = purse_transfer_result {
-            cl_value
-                .to_owned()
-                .into_t::<String>()
-                .expect("should be String")
-        } else {
-            panic!("Purse transfer result is expected to contain Write with String value");
-        };
+    let purse_transfer_result_key =
+        default_account.named_keys()["purse_transfer_result"].normalize();
+    let purse_transfer_result = CLValue::try_from(
+        builder
+            .query(None, purse_transfer_result_key, &[])
+            .expect("should have purse transfer result"),
+    )
+    .expect("should be a CLValue")
+    .into_t::<String>()
+    .expect("should be String");
     // Main assertion for the result of `transfer_from_purse_to_purse`
     assert_eq!(
         purse_transfer_result,
         format!("{:?}", Result::<_, ApiError>::Ok(()),)
     );
 
-    let main_purse_balance =
-        &transform[&default_account.named_keys()["main_purse_balance"].normalize()];
-    let main_purse_balance =
-        if let Transform::Write(StoredValue::CLValue(cl_value)) = main_purse_balance {
-            cl_value
-                .to_owned()
-                .into_t::<U512>()
-                .expect("should be U512")
-        } else {
-            panic!(
-                "Purse transfer result is expected to contain Write with Uint512 value, got {:?}",
-                main_purse_balance
-            );
-        };
+    let main_purse_balance_key = default_account.named_keys()["main_purse_balance"].normalize();
+    let main_purse_balance = CLValue::try_from(
+        builder
+            .query(None, main_purse_balance_key, &[])
+            .expect("should have main purse balance"),
+    )
+    .expect("should be a CLValue")
+    .into_t::<U512>()
+    .expect("should be U512");
 
     // Assert secondary purse value after successful transfer
     let purse_secondary_key = default_account.named_keys()["purse:secondary"];
@@ -84,32 +76,22 @@ fn should_run_purse_to_purse_transfer() {
         .remove_access_rights()
         .as_string();
 
-    let mint_contract_uref = transfer_result.builder().get_mint_contract_uref();
-    // Obtain transforms for a mint account
-    let mint_transforms = transform
-        .get(&Key::from(mint_contract_uref).normalize())
-        .expect("Unable to find transforms for a mint");
-
-    // Inspect AddKeys for that account
-    let mint_addkeys = if let Transform::AddKeys(value) = mint_transforms {
-        value
-    } else {
-        panic!("Transform {:?} is not AddKeys", mint_transforms);
-    };
+    let mint_contract_uref = builder.get_mint_contract_uref().remove_access_rights();
+    let mint_contract = builder
+        .get_contract(mint_contract_uref)
+        .expect("should have mint contract");
 
     // Find `purse:secondary`.
-    let purse_secondary_uref = &mint_addkeys[&purse_secondary_lookup_key];
+    let purse_secondary_uref = mint_contract.named_keys()[&purse_secondary_lookup_key];
     let purse_secondary_key: Key = purse_secondary_uref.normalize();
-    let purse_secondary = &transform[&purse_secondary_key];
-    let purse_secondary_balance =
-        if let Transform::Write(StoredValue::CLValue(cl_value)) = purse_secondary {
-            cl_value
-                .to_owned()
-                .into_t::<U512>()
-                .expect("should be U512")
-        } else {
-            panic!("actual purse uref should be a Write of UInt512 type");
-        };
+    let purse_secondary_balance = CLValue::try_from(
+        builder
+            .query(None, purse_secondary_key, &[])
+            .expect("should have main purse balance"),
+    )
+    .expect("should be a CLValue")
+    .into_t::<U512>()
+    .expect("should be U512");
 
     // Final balance of the destination purse
     assert_eq!(purse_secondary_balance, U512::from(PURSE_TO_PURSE_AMOUNT));
@@ -132,33 +114,29 @@ fn should_run_purse_to_purse_transfer_with_error() {
         (source, target, U512::from(999_999_999_999i64)),
     )
     .build();
-    let transfer_result = InMemoryWasmTestBuilder::default()
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder
         .run_genesis(&DEFAULT_GENESIS_CONFIG)
         .exec(exec_request_1)
         .expect_success()
         .commit()
         .finish();
 
-    let transforms = transfer_result.builder().get_transforms();
-    let transform = &transforms[0];
-
-    let default_account = transfer_result
-        .builder()
+    let default_account = builder
         .get_account(DEFAULT_ACCOUNT_ADDR)
         .expect("should get genesis account");
 
     // Get the `purse_transfer_result` for a given
-    let purse_transfer_result =
-        &transform[&default_account.named_keys()["purse_transfer_result"].normalize()]; //addkeys["purse_transfer_result"].as_uref().unwrap();
-    let purse_transfer_result =
-        if let Transform::Write(StoredValue::CLValue(cl_value)) = purse_transfer_result {
-            cl_value
-                .to_owned()
-                .into_t::<String>()
-                .expect("should be String")
-        } else {
-            panic!("Purse transfer result is expected to contain Write with String value");
-        };
+    let purse_transfer_result_key =
+        default_account.named_keys()["purse_transfer_result"].normalize();
+    let purse_transfer_result = CLValue::try_from(
+        builder
+            .query(None, purse_transfer_result_key, &[])
+            .expect("should have purse transfer result"),
+    )
+    .expect("should be a CLValue")
+    .into_t::<String>()
+    .expect("should be String");
     // Main assertion for the result of `transfer_from_purse_to_purse`
     assert_eq!(
         purse_transfer_result,
@@ -166,34 +144,15 @@ fn should_run_purse_to_purse_transfer_with_error() {
     );
 
     // Obtain main purse's balance
-    let main_purse_balance =
-        &transform[&default_account.named_keys()["main_purse_balance"].normalize()];
-    let main_purse_balance =
-        if let Transform::Write(StoredValue::CLValue(cl_value)) = main_purse_balance {
-            cl_value
-                .to_owned()
-                .into_t::<U512>()
-                .expect("should be U512")
-        } else {
-            panic!(
-                "Purse transfer result is expected to contain Write with Uint512 value, got {:?}",
-                main_purse_balance
-            );
-        };
-
-    let mint_contract_uref = transfer_result.builder().get_mint_contract_uref();
-
-    // Obtain transforms for a mint account
-    let mint_transforms = transform
-        .get(&Key::from(mint_contract_uref).normalize())
-        .expect("Unable to find transforms for a mint");
-
-    // Inspect AddKeys for that account
-    let mint_addkeys = if let Transform::AddKeys(value) = mint_transforms {
-        value
-    } else {
-        panic!("Transform {:?} is not AddKeys", mint_transforms);
-    };
+    let main_purse_balance_key = default_account.named_keys()["main_purse_balance"].normalize();
+    let main_purse_balance = CLValue::try_from(
+        builder
+            .query(None, main_purse_balance_key, &[])
+            .expect("should have main purse balance"),
+    )
+    .expect("should be a CLValue")
+    .into_t::<U512>()
+    .expect("should be U512");
 
     // Assert secondary purse value after successful transfer
     let purse_secondary_key = default_account.named_keys()["purse:secondary"];
@@ -207,19 +166,22 @@ fn should_run_purse_to_purse_transfer_with_error() {
         .remove_access_rights()
         .as_string();
 
+    let mint_contract_uref = builder.get_mint_contract_uref();
+    let mint_contract = builder
+        .get_contract(mint_contract_uref)
+        .expect("should have mint contract");
+
     // Find `purse:secondary` for a balance
-    let purse_secondary_uref = &mint_addkeys[&purse_secondary_lookup_key];
+    let purse_secondary_uref = mint_contract.named_keys()[&purse_secondary_lookup_key];
     let purse_secondary_key: Key = purse_secondary_uref.normalize();
-    let purse_secondary = &transform[&purse_secondary_key];
-    let purse_secondary_balance =
-        if let Transform::Write(StoredValue::CLValue(cl_value)) = purse_secondary {
-            cl_value
-                .to_owned()
-                .into_t::<U512>()
-                .expect("should be U512")
-        } else {
-            panic!("actual purse uref should be a Write of UInt512 type");
-        };
+    let purse_secondary_balance = CLValue::try_from(
+        builder
+            .query(None, purse_secondary_key, &[])
+            .expect("should have main purse balance"),
+    )
+    .expect("should be a CLValue")
+    .into_t::<U512>()
+    .expect("should be U512");
 
     // Final balance of the destination purse equals to 0 as this purse is created
     // as new.

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -1,10 +1,8 @@
-use std::collections::{hash_map::RandomState, BTreeMap};
+use std::collections::BTreeMap;
 
 use engine_core::engine_state::{upgrade::ActivationPoint, CONV_RATE};
 use engine_grpc_server::engine_server::ipc::DeployCode;
-use engine_shared::{
-    additive_map::AdditiveMap, motes::Motes, stored_value::StoredValue, transform::Transform,
-};
+use engine_shared::{motes::Motes, stored_value::StoredValue, transform::Transform};
 use engine_test_support::{
     internal::{
         utils, AdditiveMapDiff, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
@@ -126,42 +124,26 @@ fn should_exec_stored_code_by_hash() {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
-    let test_result = builder.exec_commit_finish(exec_request);
+    builder.exec_commit_finish(exec_request);
 
-    let response = test_result
-        .builder()
+    let default_account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+    let stored_payment_contract_hash = default_account
+        .named_keys()
+        .get(STANDARD_PAYMENT_CONTRACT_NAME)
+        .expect("stored_payment_contract_hash should exist")
+        .as_hash()
+        .expect("should be a hash");
+
+    let response = builder
         .get_exec_response(0)
         .expect("there should be a response")
         .clone();
-
-    let transforms = &test_result.builder().get_transforms()[0];
-
-    // find the contract write transform, then get the hash from its key
-    let stored_payment_contract_hash = {
-        let mut ret = None;
-        for (k, t) in transforms {
-            if let Transform::Write(StoredValue::Contract(_)) = t {
-                if let Key::Hash(hash) = k {
-                    ret = Some(hash);
-                    break;
-                }
-            }
-        }
-        ret
-    };
-
-    assert_ne!(
-        stored_payment_contract_hash, None,
-        "stored_payment_contract_hash should exist"
-    );
-
     let mut result = utils::get_success_result(&response);
     let gas = result.cost();
     let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
-    let default_account = builder
-        .get_account(DEFAULT_ACCOUNT_ADDR)
-        .expect("should get genesis account");
     let modified_balance_alpha: U512 = builder.get_purse_balance(default_account.purse_id());
 
     let account_1_public_key = PublicKey::new(ACCOUNT_1_ADDR);
@@ -176,9 +158,7 @@ fn should_exec_stored_code_by_hash() {
                 (account_1_public_key, U512::from(transferred_amount)),
             )
             .with_stored_payment_hash(
-                stored_payment_contract_hash
-                    .expect("hash should exist")
-                    .to_vec(),
+                stored_payment_contract_hash.to_vec(),
                 (U512::from(payment_purse_amount),),
             )
             .with_authorization_keys(&[*DEFAULT_ACCOUNT_KEY])
@@ -188,14 +168,13 @@ fn should_exec_stored_code_by_hash() {
         ExecuteRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let test_result = builder.exec_commit_finish(exec_request_stored_payment);
+    builder.exec_commit_finish(exec_request_stored_payment);
 
     let modified_balance_bravo: U512 = builder.get_purse_balance(default_account.purse_id());
 
     let initial_balance: U512 = U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE);
 
-    let response = test_result
-        .builder()
+    let response = builder
         .get_exec_response(1)
         .expect("there should be a response")
         .clone();
@@ -567,45 +546,25 @@ fn should_produce_same_transforms_by_uref_or_named_uref() {
     let mut builder_by_uref = InMemoryWasmTestBuilder::default();
     builder_by_uref.run_genesis(&*DEFAULT_GENESIS_CONFIG);
 
-    let test_result = builder_by_uref.exec_commit_finish(exec_request_genesis);
-    let transforms: &AdditiveMap<Key, Transform, RandomState> =
-        &test_result.builder().get_transforms()[0];
+    builder_by_uref.exec_commit_finish(exec_request_genesis);
 
-    let stored_payment_contract_uref = {
-        // get pos contract public key
-        let pos_uref = builder_by_uref.get_pos_contract_uref();
+    let default_account = builder_by_uref
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
 
-        // find the contract write transform, then get the uref from its key
-        // the pos contract gets re-written when the refund purse uref is removed from
-        // it and therefore there are two URef->Contract Writes present in
-        // transforms... we want to ignore the proof of stake URef as it is not
-        // the one we are interested in
-        let stored_payment_contract_uref = transforms
-            .iter()
-            .find_map(|key_transform| match key_transform {
-                (Key::URef(uref), Transform::Write(StoredValue::Contract(_)))
-                    if uref != &pos_uref =>
-                {
-                    Some(uref)
-                }
-                _ => None,
-            })
-            .expect("should have stored_payment_contract_uref");
-
-        assert_ne!(
-            &pos_uref, stored_payment_contract_uref,
-            "should ignore the pos_uref"
-        );
-
-        stored_payment_contract_uref
-    };
+    let stored_payment_contract_uref = default_account
+        .named_keys()
+        .get(TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME)
+        .expect("should have named key")
+        .into_uref()
+        .expect("should be an URef");
 
     // direct uref exec
     let exec_request_by_uref = {
         let deploy = DeployItemBuilder::new()
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_stored_session_uref(
-                *stored_payment_contract_uref,
+                stored_payment_contract_uref,
                 (account_1_public_key, U512::from(transferred_amount)),
             )
             .with_payment_code(
@@ -723,26 +682,25 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 .build()
         };
 
-        let store_transforms = builder
+        builder
             .run_genesis(&*DEFAULT_GENESIS_CONFIG)
             .exec(exec_request_1)
             .expect_success()
             .commit()
             .exec(exec_request_2)
             .expect_success()
-            .commit()
-            .get_transforms()[1]
-            .to_owned();
+            .commit();
 
-        let stored_payment_contract_hash =
-            store_transforms
-                .iter()
-                .find_map(|key_transform| match key_transform {
-                    (Key::Hash(hash), Transform::Write(StoredValue::Contract(_))) => Some(hash),
-                    _ => None,
-                });
+        let default_account = builder
+            .get_account(DEFAULT_ACCOUNT_ADDR)
+            .expect("should have account");
 
-        assert!(stored_payment_contract_hash.is_some());
+        let stored_payment_contract_hash = default_account
+            .named_keys()
+            .get(STANDARD_PAYMENT_CONTRACT_NAME)
+            .expect("should have named key")
+            .as_hash()
+            .expect("should be a hash");
 
         let call_stored_request = {
             let deploy = DeployItemBuilder::new()
@@ -752,9 +710,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                     (account_1_public_key, U512::from(transferred_amount)),
                 )
                 .with_stored_payment_hash(
-                    stored_payment_contract_hash
-                        .expect("hash should exist")
-                        .to_vec(),
+                    stored_payment_contract_hash.to_vec(),
                     (U512::from(payment_purse_amount),),
                 )
                 .with_authorization_keys(&[*DEFAULT_ACCOUNT_KEY])

--- a/execution-engine/engine-tests/src/test/regression/ee_441.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_441.rs
@@ -1,4 +1,3 @@
-use engine_shared::transform::Transform;
 use engine_test_support::{
     internal::{
         DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG,
@@ -29,25 +28,21 @@ fn do_pass(pass: &str) -> (URef, URef) {
         ExecuteRequestBuilder::from_deploy_item(deploy).build()
     };
 
-    let transforms = InMemoryWasmTestBuilder::default()
+    let mut builder = InMemoryWasmTestBuilder::default();
+    builder
         .run_genesis(&DEFAULT_GENESIS_CONFIG)
         .exec(exec_request)
         .expect_success()
-        .commit()
-        .get_transforms();
+        .commit();
 
-    let transform = &transforms[0];
-    let account_transform = &transform[&Key::Account(DEFAULT_ACCOUNT_ADDR)];
-    let keys = if let Transform::AddKeys(keys) = account_transform {
-        keys
-    } else {
-        panic!(
-            "Transform for account is expected to be of type AddKeys(keys) but got {:?}",
-            account_transform
-        );
-    };
+    let account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
 
-    (get_uref(keys["uref1"]), get_uref(keys["uref2"]))
+    (
+        get_uref(account.named_keys()["uref1"]),
+        get_uref(account.named_keys()["uref2"]),
+    )
 }
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use engine_shared::{stored_value::StoredValue, transform::Transform};
 use engine_test_support::{
     internal::{
         exec_with_return, ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_BLOCK_TIME,
@@ -61,20 +60,16 @@ fn should_run_pos_install_contract() {
     .expect("should run successfully");
 
     let prestate = builder.get_post_state_hash();
-    builder.commit_effects(prestate, effect.transforms.clone());
+    builder.commit_effects(prestate, effect.transforms);
 
     // should return a uref
     assert_eq!(ret_value, ret_urefs[0]);
 
     // should have written a contract under that uref
-    let named_keys = match effect
-        .transforms
-        .get(&Key::URef(ret_value.remove_access_rights()))
-    {
-        Some(Transform::Write(StoredValue::Contract(contract))) => contract.named_keys(),
-
-        _ => panic!("Expected contract to be written under the key"),
-    };
+    let contract = builder
+        .get_contract(ret_value.remove_access_rights())
+        .expect("should have a contract");
+    let named_keys = contract.named_keys();
 
     assert_eq!(named_keys.len(), EXPECTED_KNOWN_KEYS_LEN);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
@@ -4,7 +4,7 @@ use engine_core::engine_state::{
     genesis::{GenesisAccount, POS_BONDING_PURSE},
     CONV_RATE,
 };
-use engine_shared::{motes::Motes, stored_value::StoredValue, transform::Transform};
+use engine_shared::motes::Motes;
 use engine_test_support::{
     internal::{
         utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS, DEFAULT_PAYMENT,
@@ -68,16 +68,14 @@ fn should_run_successful_bond_and_unbond() {
 
     let genesis_config = utils::create_genesis_config(accounts);
 
-    let result = InMemoryWasmTestBuilder::default()
-        .run_genesis(&genesis_config)
-        .finish();
+    let mut builder = InMemoryWasmTestBuilder::default();
+    let result = builder.run_genesis(&genesis_config).finish();
 
-    let default_account = result
-        .builder()
+    let default_account = builder
         .get_account(DEFAULT_ACCOUNT_ADDR)
         .expect("should get account 1");
 
-    let pos = result.builder().get_pos_contract_uref();
+    let pos = builder.get_pos_contract_uref();
 
     let exec_request_1 = ExecuteRequestBuilder::standard(
         DEFAULT_ACCOUNT_ADDR,
@@ -86,31 +84,21 @@ fn should_run_successful_bond_and_unbond() {
     )
     .build();
 
-    let result = InMemoryWasmTestBuilder::from_result(result)
+    let mut builder = InMemoryWasmTestBuilder::from_result(result);
+    let result = builder
         .exec(exec_request_1)
         .expect_success()
         .commit()
         .finish();
 
-    let exec_response = result
-        .builder()
+    let exec_response = builder
         .get_exec_response(0)
         .expect("should have exec response");
     let mut genesis_gas_cost = utils::get_exec_costs(exec_response)[0];
 
-    let transforms = &result.builder().get_transforms()[0];
-
-    let pos_transform = &transforms[&Key::from(pos).normalize()];
-
-    // Verify that genesis account is in validator queue
-    let contract = if let Transform::Write(StoredValue::Contract(contract)) = pos_transform {
-        contract
-    } else {
-        panic!(
-            "pos transform is expected to be of AddKeys variant but received {:?}",
-            pos_transform
-        );
-    };
+    let contract = builder
+        .get_contract(pos.remove_access_rights())
+        .expect("should have contract");
 
     let lookup_key = format!(
         "v_{}_{}",
@@ -122,7 +110,7 @@ fn should_run_successful_bond_and_unbond() {
     // Gensis validator [42; 32] bonded 50k, and genesis account bonded 100k inside
     // the test contract
     assert_eq!(
-        get_pos_bonding_purse_balance(result.builder()),
+        get_pos_bonding_purse_balance(&builder),
         U512::from(GENESIS_VALIDATOR_STAKE + GENESIS_ACCOUNT_STAKE)
     );
 
@@ -148,7 +136,8 @@ fn should_run_successful_bond_and_unbond() {
     .build();
 
     // Create new account (from genesis funds) and bond with it
-    let result = InMemoryWasmTestBuilder::from_result(result)
+    let mut builder = InMemoryWasmTestBuilder::from_result(result);
+    let result = builder
         .exec(exec_request_2)
         .expect_success()
         .commit()
@@ -157,32 +146,21 @@ fn should_run_successful_bond_and_unbond() {
         .commit()
         .finish();
 
-    let exec_response = result
-        .builder()
+    let exec_response = builder
         .get_exec_response(0)
         .expect("should have exec response");
     genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(exec_response)[0];
 
-    let account_1 = result
-        .builder()
+    let account_1 = builder
         .get_account(ACCOUNT_1_ADDR)
         .expect("should get account 1");
 
-    let pos = result.builder().get_pos_contract_uref();
-
-    let transforms = &result.builder().get_transforms()[1];
-
-    let pos_transform = &transforms[&Key::from(pos).normalize()];
+    let pos = builder.get_pos_contract_uref();
 
     // Verify that genesis account is in validator queue
-    let contract = if let Transform::Write(StoredValue::Contract(contract)) = pos_transform {
-        contract
-    } else {
-        panic!(
-            "pos transform is expected to be of AddKeys variant but received {:?}",
-            pos_transform
-        );
-    };
+    let contract = builder
+        .get_contract(pos.remove_access_rights())
+        .expect("should have contract");
 
     let lookup_key = format!(
         "v_{}_{}",
@@ -193,7 +171,7 @@ fn should_run_successful_bond_and_unbond() {
 
     // Gensis validator [42; 32] bonded 50k, and genesis account bonded 100k inside
     // the test contract
-    let pos_bonding_purse_balance = get_pos_bonding_purse_balance(result.builder());
+    let pos_bonding_purse_balance = get_pos_bonding_purse_balance(&builder);
     assert_eq!(
         pos_bonding_purse_balance,
         U512::from(GENESIS_VALIDATOR_STAKE + GENESIS_ACCOUNT_STAKE + ACCOUNT_1_STAKE)
@@ -212,16 +190,16 @@ fn should_run_successful_bond_and_unbond() {
         ),
     )
     .build();
-    let account_1_bal_before = result.builder().get_purse_balance(account_1.purse_id());
-    let result = InMemoryWasmTestBuilder::from_result(result)
+    let account_1_bal_before = builder.get_purse_balance(account_1.purse_id());
+    let mut builder = InMemoryWasmTestBuilder::from_result(result);
+    let result = builder
         .exec(exec_request_4)
         .expect_success()
         .commit()
         .finish();
 
-    let account_1_bal_after = result.builder().get_purse_balance(account_1.purse_id());
-    let exec_response = result
-        .builder()
+    let account_1_bal_after = builder.get_purse_balance(account_1.purse_id());
+    let exec_response = builder
         .get_exec_response(0)
         .expect("should have exec response");
     let gas_cost_b = Motes::from_gas(utils::get_exec_costs(exec_response)[0], CONV_RATE)
@@ -234,11 +212,11 @@ fn should_run_successful_bond_and_unbond() {
 
     // POS bonding purse is decreased
     assert_eq!(
-        get_pos_bonding_purse_balance(result.builder()),
+        get_pos_bonding_purse_balance(&builder),
         U512::from(GENESIS_VALIDATOR_STAKE + GENESIS_ACCOUNT_STAKE + ACCOUNT_1_UNBOND_2)
     );
 
-    let pos_contract = result.builder().get_pos_contract();
+    let pos_contract = builder.get_pos_contract();
 
     let lookup_key = format!(
         "v_{}_{}",
@@ -270,22 +248,20 @@ fn should_run_successful_bond_and_unbond() {
         ),
     )
     .build();
-    let result = InMemoryWasmTestBuilder::from_result(result)
+    let mut builder = InMemoryWasmTestBuilder::from_result(result);
+    let result = builder
         .exec(exec_request_5)
         .expect_success()
         .commit()
         .finish();
 
-    let exec_response = result
-        .builder()
+    let exec_response = builder
         .get_exec_response(0)
         .expect("should have exec response");
     genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(exec_response)[0];
 
     assert_eq!(
-        result
-            .builder()
-            .get_purse_balance(default_account.purse_id()),
+        builder.get_purse_balance(default_account.purse_id()),
         U512::from(
             DEFAULT_ACCOUNT_INITIAL_BALANCE
                 - Motes::from_gas(genesis_gas_cost, CONV_RATE)
@@ -299,14 +275,14 @@ fn should_run_successful_bond_and_unbond() {
 
     // POS bonding purse is further decreased
     assert_eq!(
-        get_pos_bonding_purse_balance(result.builder()),
+        get_pos_bonding_purse_balance(&builder),
         U512::from(GENESIS_VALIDATOR_STAKE + GENESIS_ACCOUNT_UNBOND_2 + ACCOUNT_1_UNBOND_2)
     );
 
     //
     // Stage 3a - Fully unbond account1 with Some(TOTAL_AMOUNT)
     //
-    let account_1_bal_before = result.builder().get_purse_balance(account_1.purse_id());
+    let account_1_bal_before = builder.get_purse_balance(account_1.purse_id());
 
     let exec_request_6 = ExecuteRequestBuilder::standard(
         ACCOUNT_1_ADDR,
@@ -318,15 +294,15 @@ fn should_run_successful_bond_and_unbond() {
     )
     .build();
 
-    let result = InMemoryWasmTestBuilder::from_result(result)
+    let mut builder = InMemoryWasmTestBuilder::from_result(result);
+    let result = builder
         .exec(exec_request_6)
         .expect_success()
         .commit()
         .finish();
 
-    let account_1_bal_after = result.builder().get_purse_balance(account_1.purse_id());
-    let exec_response = result
-        .builder()
+    let account_1_bal_after = builder.get_purse_balance(account_1.purse_id());
+    let exec_response = builder
         .get_exec_response(0)
         .expect("should have exec response");
     let gas_cost_b = Motes::from_gas(utils::get_exec_costs(exec_response)[0], CONV_RATE)
@@ -340,11 +316,11 @@ fn should_run_successful_bond_and_unbond() {
     // POS bonding purse contains now genesis validator (50k) + genesis account
     // (55k)
     assert_eq!(
-        get_pos_bonding_purse_balance(result.builder()),
+        get_pos_bonding_purse_balance(&builder),
         U512::from(GENESIS_VALIDATOR_STAKE + GENESIS_ACCOUNT_UNBOND_2)
     );
 
-    let pos_contract = result.builder().get_pos_contract();
+    let pos_contract = builder.get_pos_contract();
 
     let lookup_key = format!(
         "v_{}_{}",
@@ -366,14 +342,14 @@ fn should_run_successful_bond_and_unbond() {
     )
     .build();
 
-    let result = InMemoryWasmTestBuilder::from_result(result)
+    let mut builder = InMemoryWasmTestBuilder::from_result(result);
+    let result = builder
         .exec(exec_request_7)
         .expect_success()
         .commit()
         .finish();
 
-    let exec_response = result
-        .builder()
+    let exec_response = builder
         .get_exec_response(0)
         .expect("should have exec response");
     genesis_gas_cost = genesis_gas_cost + utils::get_exec_costs(exec_response)[0];
@@ -395,11 +371,11 @@ fn should_run_successful_bond_and_unbond() {
 
     // Final balance after two full unbonds is the initial bond valuee
     assert_eq!(
-        get_pos_bonding_purse_balance(result.builder()),
+        get_pos_bonding_purse_balance(&builder),
         U512::from(GENESIS_VALIDATOR_STAKE)
     );
 
-    let pos_contract = result.builder().get_pos_contract();
+    let pos_contract = builder.get_pos_contract();
     let lookup_key = format!(
         "v_{}_{}",
         base16::encode_lower(&DEFAULT_ACCOUNT_ADDR),


### PR DESCRIPTION
### Overview
This PR replaces "transform sniffing" in various places with calls to functions based on `WasmTestBuilder::query` for querying the global state after running some deploys.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-551

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
