### PR TITLE
CON-617: Highway config

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/HighwayConf.scala
@@ -56,13 +56,10 @@ final case class HighwayConf(
       case EraDuration.Calendar(length, unit) =>
         val s = LocalDateTime.ofInstant(start, UTC)
         val e = unit match {
-          case SECONDS => s.plusSeconds(length)
-          case MINUTES => s.plusMinutes(length)
-          case HOURS   => s.plusHours(length)
-          case DAYS    => s.plusDays(length)
-          case WEEKS   => s.plusWeeks(length)
-          case MONTHS  => s.plusMonths(length)
-          case YEARS   => s.plusYears(length)
+          case DAYS   => s.plusDays(length)
+          case WEEKS  => s.plusWeeks(length)
+          case MONTHS => s.plusMonths(length)
+          case YEARS  => s.plusYears(length)
         }
         e.atZone(UTC).toInstant
     }
@@ -143,18 +140,17 @@ object HighwayConf {
     /** Fixed endings can be calculated with the calendar, to make eras take exactly one week (or a month),
       * but it means eras might have different lengths. Using this might mean that a different platform
       * which handles leap seconds differently could assign different tick IDs.
+      *
+      * In practice at least the JVM doesn't make leap seconds visible, they get distributed over the last day of the year.
       */
     case class Calendar(length: Long, unit: CalendarUnit) extends EraDuration
 
     sealed trait CalendarUnit
     object CalendarUnit {
-      case object SECONDS extends CalendarUnit
-      case object MINUTES extends CalendarUnit
-      case object HOURS   extends CalendarUnit
-      case object DAYS    extends CalendarUnit
-      case object WEEKS   extends CalendarUnit
-      case object MONTHS  extends CalendarUnit
-      case object YEARS   extends CalendarUnit
+      case object DAYS   extends CalendarUnit
+      case object WEEKS  extends CalendarUnit
+      case object MONTHS extends CalendarUnit
+      case object YEARS  extends CalendarUnit
     }
   }
 

--- a/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
@@ -43,7 +43,7 @@ booking-duration = "10days"
 entropy-duration = "3hours"
 
 # Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
-voting-period-duration = "0days"
+voting-period-duration = "2days"
 
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1

--- a/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
@@ -22,6 +22,32 @@ pos-code-path = "pos_install.wasm"
 # To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
+[highway]
+
+# Tick unit is milliseconds.
+
+# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
+# is active in order to make key blocks for the upcoming eras. If the era is over by the time
+# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
+# era build either. That means when a completely new network is started, the genesis era
+# start time has to be adjusted to be active at the time.
+genesis-era-start = 1583712000000
+
+# Era duration defined as a fixed amount of time.
+era-duration = "7days"
+
+# Amount of time to go back before the start of the era for picking the booking block.
+booking-duration = "10days"
+
+# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
+entropy-duration = "3hours"
+
+# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
+voting-period-duration = "0days"
+
+# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
+voting-period-summit-level = 1
+
 [deploys]
 # 1 day
 max-ttl-millis = 86400000

--- a/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
@@ -1,75 +1,44 @@
 [genesis]
 
-# Human readable name for convenience; the genesis_hash is the true identifier.
-# The name influences the genesis hash by contributing to the seeding of the pseudo-
-# random number generator used in execution engine for computing genesis post-state.
 name = "casperlabs-devnet"
 
-# Timestamp for the genesis block, also used in seeding the pseudo-random number
-# generator used in execution engine for computing genesis post-state.
 timestamp = 0
 
-# Later will be replaced by semver.
 protocol-version = "1.0.0"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
-# To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
 [highway]
 
-# Tick unit is milliseconds.
 
-# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
-# is active in order to make key blocks for the upcoming eras. If the era is over by the time
-# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
-# era build either. That means when a completely new network is started, the genesis era
-# start time has to be adjusted to be active at the time.
 genesis-era-start = 1583712000000
 
-# Era duration defined as a fixed amount of time.
 era-duration = "7days"
 
-# Amount of time to go back before the start of the era for picking the booking block.
 booking-duration = "10days"
 
-# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
 entropy-duration = "3hours"
 
-# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
 voting-period-duration = "2days"
 
-# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1
 
 [deploys]
-# 1 day
 max-ttl-millis = 86400000
 max-dependencies = 10
 
 [wasm-costs]
-# Default opcode cost
 regular = 1
-# Div operations multiplier.
 div-multiplier = 16
-# Mul operations multiplier.
 mul-multiplier = 4
-# Memory (load/store) operations multiplier.
 mem-multiplier = 2
-# Amount of free memory (in 64kb pages) each contract can use for stack.
 mem-initial-pages = 4096
-# Grow memory cost, per page (64kb)
 mem-grow-per-page = 8192
-# Memory copy cost, per byte
 mem-copy-per-byte = 1
-# Max stack height (native WebAssembly stack limiter)
 max-stack-height = 65536
-# Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` / `opcodes_div`
 opcodes-multiplier = 3
 opcodes-divisor = 8

--- a/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
@@ -43,7 +43,7 @@ booking-duration = "10days"
 entropy-duration = "3hours"
 
 # Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
-voting-period-duration = "0days"
+voting-period-duration = "2days"
 
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1

--- a/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
@@ -22,6 +22,32 @@ pos-code-path = "pos_install.wasm"
 # To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
+[highway]
+
+# Tick unit is milliseconds.
+
+# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
+# is active in order to make key blocks for the upcoming eras. If the era is over by the time
+# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
+# era build either. That means when a completely new network is started, the genesis era
+# start time has to be adjusted to be active at the time.
+genesis-era-start = 1583712000000
+
+# Era duration defined as a fixed amount of time.
+era-duration = "7days"
+
+# Amount of time to go back before the start of the era for picking the booking block.
+booking-duration = "10days"
+
+# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
+entropy-duration = "3hours"
+
+# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
+voting-period-duration = "0days"
+
+# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
+voting-period-summit-level = 1
+
 [deploys]
 # 1 day
 max-ttl-millis = 86400000

--- a/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
@@ -1,75 +1,44 @@
 [genesis]
 
-# Human readable name for convenience; the genesis_hash is the true identifier.
-# The name influences the genesis hash by contributing to the seeding of the pseudo-
-# random number generator used in execution engine for computing genesis post-state.
 name = "casperlabs-devnet"
 
-# Timestamp for the genesis block, also used in seeding the pseudo-random number
-# generator used in execution engine for computing genesis post-state.
 timestamp = 0
 
-# Later will be replaced by semver.
 protocol-version = "1.0.0"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
-# To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
 [highway]
 
-# Tick unit is milliseconds.
 
-# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
-# is active in order to make key blocks for the upcoming eras. If the era is over by the time
-# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
-# era build either. That means when a completely new network is started, the genesis era
-# start time has to be adjusted to be active at the time.
 genesis-era-start = 1583712000000
 
-# Era duration defined as a fixed amount of time.
 era-duration = "7days"
 
-# Amount of time to go back before the start of the era for picking the booking block.
 booking-duration = "10days"
 
-# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
 entropy-duration = "3hours"
 
-# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
 voting-period-duration = "2days"
 
-# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1
 
 [deploys]
-# 1 day
 max-ttl-millis = 86400000
 max-dependencies = 10
 
 [wasm-costs]
-# Default opcode cost
 regular = 1
-# Div operations multiplier.
 div-multiplier = 16
-# Mul operations multiplier.
 mul-multiplier = 4
-# Memory (load/store) operations multiplier.
 mem-multiplier = 2
-# Amount of free memory (in 64kb pages) each contract can use for stack.
 mem-initial-pages = 4096
-# Grow memory cost, per page (64kb)
 mem-grow-per-page = 8192
-# Memory copy cost, per byte
 mem-copy-per-byte = 1
-# Max stack height (native WebAssembly stack limiter)
 max-stack-height = 65536
-# Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` / `opcodes_div`
 opcodes-multiplier = 3
 opcodes-divisor = 8

--- a/integration-testing/resources/test-chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec/genesis/manifest.toml
@@ -43,7 +43,7 @@ booking-duration = "10days"
 entropy-duration = "3hours"
 
 # Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
-voting-period-duration = "0days"
+voting-period-duration = "2days"
 
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1

--- a/integration-testing/resources/test-chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec/genesis/manifest.toml
@@ -22,6 +22,32 @@ pos-code-path = "pos_install.wasm"
 # To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
+[highway]
+
+# Tick unit is milliseconds.
+
+# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
+# is active in order to make key blocks for the upcoming eras. If the era is over by the time
+# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
+# era build either. That means when a completely new network is started, the genesis era
+# start time has to be adjusted to be active at the time.
+genesis-era-start = 1583712000000
+
+# Era duration defined as a fixed amount of time.
+era-duration = "7days"
+
+# Amount of time to go back before the start of the era for picking the booking block.
+booking-duration = "10days"
+
+# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
+entropy-duration = "3hours"
+
+# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
+voting-period-duration = "0days"
+
+# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
+voting-period-summit-level = 1
+
 [deploys]
 # 1 day
 max-ttl-millis = 86400000

--- a/integration-testing/resources/test-chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec/genesis/manifest.toml
@@ -1,75 +1,44 @@
 [genesis]
 
-# Human readable name for convenience; the genesis_hash is the true identifier.
-# The name influences the genesis hash by contributing to the seeding of the pseudo-
-# random number generator used in execution engine for computing genesis post-state.
 name = "casperlabs-devnet"
 
-# Timestamp for the genesis block, also used in seeding the pseudo-random number
-# generator used in execution engine for computing genesis post-state.
 timestamp = 0
 
-# Later will be replaced by semver.
 protocol-version = "1.0.0"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos_install.wasm"
 
-# Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
-# To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
 [highway]
 
-# Tick unit is milliseconds.
 
-# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
-# is active in order to make key blocks for the upcoming eras. If the era is over by the time
-# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
-# era build either. That means when a completely new network is started, the genesis era
-# start time has to be adjusted to be active at the time.
 genesis-era-start = 1583712000000
 
-# Era duration defined as a fixed amount of time.
 era-duration = "7days"
 
-# Amount of time to go back before the start of the era for picking the booking block.
 booking-duration = "10days"
 
-# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
 entropy-duration = "3hours"
 
-# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
 voting-period-duration = "2days"
 
-# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1
 
 [deploys]
-# 1 day
 max-ttl-millis = 86400000
 max-dependencies = 10
 
 [wasm-costs]
-# Default opcode cost
 regular = 1
-# Div operations multiplier.
 div-multiplier = 16
-# Mul operations multiplier.
 mul-multiplier = 4
-# Memory (load/store) operations multiplier.
 mem-multiplier = 2
-# Amount of free memory (in 64kb pages) each contract can use for stack.
 mem-initial-pages = 4096
-# Grow memory cost, per page (64kb)
 mem-grow-per-page = 8192
-# Memory copy cost, per byte
 mem-copy-per-byte = 1
-# Max stack height (native WebAssembly stack limiter)
 max-stack-height = 65536
-# Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` / `opcodes_div`
 opcodes-multiplier = 3
 opcodes-divisor = 8

--- a/node/src/main/resources/chainspec/genesis/manifest.toml
+++ b/node/src/main/resources/chainspec/genesis/manifest.toml
@@ -43,7 +43,7 @@ booking-duration = "10days"
 entropy-duration = "3hours"
 
 # Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
-voting-period-duration = "0days"
+voting-period-duration = "2days"
 
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1

--- a/node/src/main/resources/chainspec/genesis/manifest.toml
+++ b/node/src/main/resources/chainspec/genesis/manifest.toml
@@ -22,6 +22,32 @@ pos-code-path = "pos_install.wasm"
 # To override the default values, create a file at ~/.casperlabs/chainspec/genesis/accounts.csv
 initial-accounts-path = "accounts.csv"
 
+[highway]
+
+# Tick unit is milliseconds.
+
+# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
+# is active in order to make key blocks for the upcoming eras. If the era is over by the time
+# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
+# era build either. That means when a completely new network is started, the genesis era
+# start time has to be adjusted to be active at the time.
+genesis-era-start = 1583712000000
+
+# Era duration defined as a fixed amount of time.
+era-duration = "7days"
+
+# Amount of time to go back before the start of the era for picking the booking block.
+booking-duration = "10days"
+
+# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
+entropy-duration = "3hours"
+
+# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
+voting-period-duration = "0days"
+
+# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
+voting-period-summit-level = 1
+
 [deploys]
 # 1 day
 max-ttl-millis = 86400000

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -249,6 +249,18 @@ max-block-size-bytes = 10485760
 # Minimum TTL value of a deploy
 min-ttl = "1hour"
 
+# Highway parameters that we can freely choose or tweak; the rest is in the Genesis chain spec.
+[highway]
+
+# Fraction of time through the round after which we can create an omega message.
+omega-message-time-start = 0.5
+
+# Fraction of time through the round before which we must have created the omega message.
+omega-message-time-end = 0.75
+
+# Initial round exponent to start the node with, before auto-adjustment takes over; corresponds to the tick unit of the chain.
+init-round-exponent = 14
+
 # io.casperlabs.node.configuration.Configuration.Kamon
 [metrics]
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -28,6 +28,7 @@ final case class Configuration(
     grpc: Configuration.Grpc,
     tls: Tls,
     casper: CasperConf,
+    highway: Configuration.Highway,
     blockstorage: Configuration.BlockStorage,
     metrics: Configuration.Kamon,
     influx: Option[Configuration.Influx]
@@ -111,6 +112,12 @@ object Configuration extends ParserImplicits {
       portExternal: Int,
       portInternal: Int,
       useTls: Boolean
+  ) extends SubConfig
+
+  case class Highway(
+      omegaMessageTimeStart: Double Refined Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T],
+      omegaMessageTimeEnd: Double Refined Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T],
+      initRoundExponent: Int Refined NonNegative
   ) extends SubConfig
 
   sealed trait Command extends Product with Serializable

--- a/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
@@ -89,6 +89,14 @@ private[configuration] trait ParserImplicits {
         w <- refineV[GreaterEqual[W.`0.0`.T]](d)
       } yield w
 
+  implicit val gt0lte1DoubleParser
+      : Parser[Refined[Double, Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]]] =
+    s =>
+      for {
+        d <- Try(s.toDouble).toEither.leftMap(_.getMessage)
+        w <- refineV[Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]](d)
+      } yield w
+
   implicit def listParser[T: Parser] = new Parser[List[T]] {
     override def parse(s: String) =
       s.split(' ').filterNot(_.isEmpty).map(Parser[T].parse).toList.sequence

--- a/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
@@ -97,6 +97,13 @@ private[configuration] trait ParserImplicits {
         w <- refineV[Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]](d)
       } yield w
 
+  implicit val gte0lte1IntParser: Parser[Refined[Int, Interval.Closed[W.`0`.T, W.`1`.T]]] =
+    s =>
+      for {
+        d <- Try(s.toInt).toEither.leftMap(_.getMessage)
+        w <- refineV[Interval.Closed[W.`0`.T, W.`1`.T]](d)
+      } yield w
+
   implicit def listParser[T: Parser] = new Parser[List[T]] {
     override def parse(s: String) =
       s.split(' ').filterNot(_.isEmpty).map(Parser[T].parse).toList.sequence

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -82,6 +82,11 @@ auto-propose-acc-count = 1
 max-block-size-bytes = 1
 min-ttl = "1hour"
 
+[highway]
+omega-message-time-start = 1.0
+omega-message-time-end = 1.0
+init-round-exponent = 0
+
 [blockstorage]
 cache-max-size-bytes = 1
 cache-neighborhood-before = 1

--- a/node/src/test/resources/test-chainspec/genesis/manifest.toml
+++ b/node/src/test/resources/test-chainspec/genesis/manifest.toml
@@ -1,73 +1,44 @@
 [genesis]
 
-# Human readable name for convenience; the genesis_hash is the true identifier.
-# The name influences the genesis hash by contributing to the seeding of the pseudo-
-# random number generator used in execution engine for computing genesis post-state.
 name = "test-chain"
 
-# Timestamp for the genesis block, also used in seeding the pseudo-random number
-# generator used in execution engine for computing genesis post-state.
 timestamp = 1568805354071
 
 protocol-version = "0.1"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the mint system contract.
 mint-code-path = "mint.wasm"
 
-# Path (absolute, or relative to the manifest) to the file containing wasm bytecode for installing the PoS system contract.
 pos-code-path = "pos.wasm"
 
-# Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
 initial-accounts-path = "accounts.csv"
 
 [highway]
 
-# Tick unit is milliseconds.
 
-# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
-# is active in order to make key blocks for the upcoming eras. If the era is over by the time
-# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
-# era build either. That means when a completely new network is started, the genesis era
-# start time has to be adjusted to be active at the time.
 genesis-era-start = 1583712000000
 
-# Era duration defined as a fixed amount of time.
 era-duration = "7days"
 
-# Amount of time to go back before the start of the era for picking the booking block.
 booking-duration = "10days"
 
-# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
 entropy-duration = "3hours"
 
-# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
 voting-period-duration = "2days"
 
-# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1
 
 [deploys]
-# 1 day
 max-ttl-millis = 86400000
 max-dependencies = 10
 
 [wasm-costs]
-# Default opcode cost
 regular = 1
-# Div operations multiplier.
 div-multiplier = 2
-# Mul operations multiplier.
 mul-multiplier = 3
-# Memory (load/store) operations multiplier.
 mem-multiplier = 4
-# Amount of free memory (in 64kb pages) each contract can use for stack.
 mem-initial-pages = 5
-# Grow memory cost, per page (64kb)
 mem-grow-per-page = 6
-# Memory copy cost, per byte
 mem-copy-per-byte = 7
-# Max stack height (native WebAssembly stack limiter)
 max-stack-height = 8
-# Cost of wasm opcode is calculated as TABLE_ENTRY_COST * `opcodes_mul` / `opcodes_div`
 opcodes-multiplier = 9
 opcodes-divisor = 10

--- a/node/src/test/resources/test-chainspec/genesis/manifest.toml
+++ b/node/src/test/resources/test-chainspec/genesis/manifest.toml
@@ -20,6 +20,32 @@ pos-code-path = "pos.wasm"
 # Path (absolute, or relative to the manifest) to the CSV file containing initial account balances and bonds.
 initial-accounts-path = "accounts.csv"
 
+[highway]
+
+# Tick unit is milliseconds.
+
+# Unix timestamp for the genesis era. At least one node has to be started when the genesis era
+# is active in order to make key blocks for the upcoming eras. If the era is over by the time
+# we start the nodes, they'll not be able to produce blocks in it, and there won't be a new
+# era build either. That means when a completely new network is started, the genesis era
+# start time has to be adjusted to be active at the time.
+genesis-era-start = 1583712000000
+
+# Era duration defined as a fixed amount of time.
+era-duration = "7days"
+
+# Amount of time to go back before the start of the era for picking the booking block.
+booking-duration = "10days"
+
+# Amount of time to wait after the booking before we pick the key block, collecting the magic bits along the way.
+entropy-duration = "3hours"
+
+# Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
+voting-period-duration = "0days"
+
+# Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
+voting-period-summit-level = 1
+
 [deploys]
 # 1 day
 max-ttl-millis = 86400000

--- a/node/src/test/resources/test-chainspec/genesis/manifest.toml
+++ b/node/src/test/resources/test-chainspec/genesis/manifest.toml
@@ -41,7 +41,7 @@ booking-duration = "10days"
 entropy-duration = "3hours"
 
 # Keep voting on the switch block for a fixed amount of time; effective if the summit level is zero.
-voting-period-duration = "0days"
+voting-period-duration = "2days"
 
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ArbitraryImplicits.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ArbitraryImplicits.scala
@@ -81,6 +81,13 @@ trait ArbitraryImplicits {
     } yield refineV[GreaterEqual[W.`0.0`.T]](d).right.get
   }
 
+  implicit val gt0lte1DoubleGen
+      : Arbitrary[Refined[Double, Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]]] = Arbitrary {
+    for {
+      d <- Gen.choose(0.0, 1.0).filter(_ > 0)
+    } yield refineV[Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]](d).right.get
+  }
+
   implicit val levelGen: Arbitrary[IzLog.Level] = Arbitrary {
     Gen.oneOf(List(IzLog.Level.Debug, IzLog.Level.Info, IzLog.Level.Error, IzLog.Level.Warn))
   }

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -128,6 +128,11 @@ class ConfigurationSpec
       maxBlockSizeBytes = 1,
       minTtl = FiniteDuration(1, TimeUnit.HOURS)
     )
+    val highway = Configuration.Highway(
+      omegaMessageTimeStart = 1.0,
+      omegaMessageTimeEnd = 1.0,
+      initRoundExponent = 0
+    )
     val tls = Tls(
       certificate = Paths.get("/tmp/test.crt"),
       key = Paths.get("/tmp/test.key"),
@@ -165,6 +170,7 @@ class ConfigurationSpec
       grpcServer,
       tls,
       casper,
+      highway,
       blockStorage,
       kamonSettings,
       influx.some

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -245,6 +245,7 @@ message ChainSpec {
         // costs at genesis
         CostTable costs = 7;
         DeployConfig deploy_config = 8;
+        HighwayConfig highway_config = 9;
     }
 
     message GenesisAccount {
@@ -256,6 +257,21 @@ message ChainSpec {
     message DeployConfig {
         uint32 max_ttl_millis = 2;
         uint32 max_dependencies = 3;
+    }
+
+    message HighwayConfig {
+        // Unix timestamp of the Genesis era start.
+        uint64 genesis_era_start_timestamp = 1;
+        // Fixed length duration of an era.
+        uint64 era_duration_millis = 2;
+        // Amount of time to look back from the start of an era to pick the booking block.
+        uint64 booking_duration_millis = 3;
+        // Amount of time after the booking block to allow for magic bits to accumulate before picking the key block.
+        uint64 entropy_duration_millis = 4;
+        // Fixed length duration of the post-era voting period. If zero, then using the summit level.
+        uint64 voting_period_duration_millis = 5;
+        // Stop the post-era voting period when the switch block reaches a certain summit level; currently 0 means off, 1 on.
+        uint32 voting_period_summit_level = 6;
     }
 
     message CostTable {

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -266,11 +266,11 @@ message ChainSpec {
         uint64 era_duration_millis = 2;
         // Amount of time to look back from the start of an era to pick the booking block.
         uint64 booking_duration_millis = 3;
-        // Amount of time after the booking block to allow for magic bits to accumulate before picking the key block.
+        // Amount of time after the booking time to allow for magic bits to accumulate before picking the key block.
         uint64 entropy_duration_millis = 4;
-        // Fixed length duration of the post-era voting period. If zero, then using the summit level.
+        // Fixed length duration of the post-era voting period; used when summit level is zero.
         uint64 voting_period_duration_millis = 5;
-        // Stop the post-era voting period when the switch block reaches a certain summit level; currently 0 means off, 1 on.
+        // Stop the post-era voting period when the switch block reaches a certain summit level; when 0 use the duration instead.
         uint32 voting_period_summit_level = 6;
     }
 


### PR DESCRIPTION
### Overview
Makes some of the Highway parameters configurable.

The following was added to the nodes normal default configuration: 
* omega start and end fractions
* initial round exponent

The rest was added to the chain spec's genesis config section: 
* era duration
* booking and entropy duration
* voting period duration

I didn't make the tick unit configurable, as far as I know it's going to be milliseconds. I doubt our Java stuff will need microseconds, and anything higher than seconds is also probably out of the question. We also never agreed whether to go with the `TimeUnit` based definition or exponents of 10. 

I also didn't bother with the calendar based era duration. Based on experiments the leap seconds don't appear in Java, so 7 days will take us a week forward and arrive at the same Unix timestamp as if we were using the calendar. The only difference would be if we used months, or years, which I don't think we'll do, so I thought I'll keep the configuration short and sweet.

A bit of a pain point is putting the era start timestamp into the genesis config without an easy way to override: it means if it's a point in the past then a node started much later (after the genesis era ended) will not do anything. Maybe allow an env var override?

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-617

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Noticed that there's no way for providing extra default config in the chainspec, everyone who made a copy has to procure and merge the changes into their version. Can add it if necessary, it would possibly lead to less errors, but instead there might be mysterious changes in the node's chain ID and the genesis block would change, so that's no good either. In the end I still think the entire chainspec should come from something you download and never edit.