### PR TITLE
ECO-309: ERC20-bash-fixes

### DIFF
--- a/hack/docker/scripts/erc20.sh
+++ b/hack/docker/scripts/erc20.sh
@@ -1,17 +1,14 @@
 set -e
 set -u
 
-BASE_PATH=${BASE_PATH:-"../../.."}
-CLIENT=${CLIENT:-"${BASE_PATH}/client/target/universal/stage/bin/casperlabs-client"}
-HOST=${HOST:-"localhost"}
-TOTAL_SUPPLY=${TOTAL_SUPPLY:-20000}
-AUTO_PROPOSE=${AUTO_PROPOSE:-true}
-ERC20_WASM=${ERC20_WASM:-"${BASE_PATH}/execution-engine/target/wasm32-unknown-unknown/release/erc20_smart_contract.wasm"}
+CL_CLIENT=${CL_CLIENT:-"casperlabs-client"}
+CL_HOST=${CL_HOST:-"deploy.casperlabs.io"}
+ERC20_USE_COLORS=${ERC20_USE_COLORS:-true}
+ERC20_WASM=${ERC20_WASM:-"../../../execution-engine/target/wasm32-unknown-unknown/release/erc20_smart_contract.wasm"}
 TOKEN_NAME=${TOKEN_NAME:-"test-token"}
-
-ACCOUNT_PRIVATE_FILE="account-private.pem"
-ACCOUNT_ID_HEX_FILE="account-id-hex"
-PROXY_NAME="erc20_proxy"
+AUTO_PROPOSE=${AUTO_PROPOSE:-false}
+QUERY_DEPLOY_STATUS=${QUERY_DEPLOY_STATUS:-false}
+PROXY_NAME="erc20-proxy"
 
 # At the beginning of a serialized version of Rust's Vec<u8>, first 4 bytes represent the size of the vector.
 #
@@ -29,183 +26,218 @@ BALANCE_KEY_SIZE_HEX="21000000"
 ALLOWANCE_KEY_SIZE_HEX="40000000"
 BALANCE_BYTE="01"
 
-RED="\e[91m"
-YELLOW="\e[93m"
-GREEN="\e[32m"
-RESET="\e[0m"
+if [ "${ERC20_USE_COLORS}" = true ] ; then
+    RED="\e[91m"
+    YELLOW="\e[93m"
+    GREEN="\e[32m"
+    RESET="\e[0m"
+else
+    RED=""
+    YELLOW=""
+    GREEN=""
+    RESET=""
+fi  
 
 command_help () {
-    echo "CasperLabs ERC20 bash client."
+    echo "CasperLabs ERC20 Bash client."
     echo ""
     echo "Usage: $(basename "$0") <command> [options]"
     echo ""
     echo "Commands:"
-    echo "  deploy <deployer>"
-    echo "                           Deploy ERC20 smart contract."
-    echo "  balance <deployer> <owner>" 
-    echo "                           Check the balance of <owner> account."
-    echo "  transfer <deployer> <owner> <recipient> <amount>"
-    echo "                           Transfer tokens from <owner> to <recipient>."
-    echo "  approve <deployer> <owner> <spender> <amount>"
-    echo "                           Approve <spender> account to transfer <amount>"
-    echo "                           tokens from <owner> account."
-    echo "  allowance <deployer> <owner> <spender>"
-    echo "                           Check the allowance of <spender> account for"
-    echo "                           <owner> account."
-    echo "  transferFrom <deployer> <spender> <owner> <recipient> <amount>"
-    echo "                           Transfer <amount> tokens from <owner> account"
-    echo "                           to <recipient> account using <spender> account."
-    echo "  buy <deployer> <owner> <amount>"
-    echo "                           Exchange CLX for tokens."
-    echo "  sell <deployer> <owner> <amount>"
-    echo "                           Exchange tokens for CLX."
-    echo "  help"
-    echo "                           Print this message."
+    echo "  deploy <private-key-path> <initial-amount>"
+    echo "                           Deploy ERC20 smart contract with the <initial-amount> of tokens."
+    echo "                           The account that deployed the token is refered later as <contract-host-account>"
+    echo "                           as the smart contract lives under this account."
     echo ""
-    echo "<deployer>, <recipient>, <owner>, <spender> are directories,"
-    echo "and should contain '${ACCOUNT_PRIVATE_FILE}' and '${ACCOUNT_ID_HEX_FILE}' files."
+    echo "  balance <contract-host-address> <owner-address>" 
+    echo "                           Check the balance of <owner-address> account."
+    echo ""
+    echo "  transfer <private-key-path> <contract-host-address> <recipient-address> <amount>"
+    echo "                           Transfer <amount> of tokens to <recipient-address> from your account."
+    echo ""
+    echo "  approve <private-key-path> <contract-host-address> <spender-address> <amount>"
+    echo "                           Approve <spender-address> account to transfer <amount>"
+    echo "                           tokens from your account."
+    echo ""
+    echo "  allowance <contract-host-address> <owner-address> <spender-address>"
+    echo "                           Check the amount of tokens <spender-address> can transfer from"
+    echo "                           <owner-address> account."
+    echo ""
+    echo "  transferFrom <private-key-path> <contract-host-address> <owner-address> <recipient-address> <amount>"
+    echo "                           Transfer <amount> tokens from <owner-address> account"
+    echo "                           to <recipient-address> account."
+    echo ""
+    echo "  buy <private-key-path> <contract-host-address> <amount>"
+    echo "                           Exchange CLX for tokens."
+    echo ""
+    echo "  sell <private-key-path> <contract-host-address> <amount>"
+    echo "                           Exchange tokens for CLX."
+    echo ""
+    echo "  help                     Print this message."
+    echo ""
+    echo "Exported Bash variables."
+    echo "  CL_CLIENT=${CL_CLIENT}"
+    echo "  CL_HOST=${CL_HOST}"
+    echo "  ERC20_USE_COLORS=${ERC20_USE_COLORS}"
+    echo "  ERC20_WASM=${ERC20_WASM}"
+    echo "  TOKEN_NAME=${TOKEN_NAME}"
+    echo "  AUTO_PROPOSE=${AUTO_PROPOSE}"
+    echo "  QUERY_DEPLOY_STATUS=${QUERY_DEPLOY_STATUS}"
+    echo ""
 }
 
 log() {
     echo -e "  ${GREEN}[x]${RESET} $1"
 }
 
-propose_block_if_enabled () {
+err_log() {
+    echo -e "  ${RED}[x] $1${RESET}"
+}
+
+handle_deploy_response () {
+    RESPONSE=${1}
+    DEPLOY_HASH=$(echo ${RESPONSE} | awk '{print $3}')
+    log "Deployed with hash ${DEPLOY_HASH}"
     if [ "${AUTO_PROPOSE}" = true ] ; then
         log "Proposing block."
-        $CLIENT --host $HOST propose
+        ${CL_CLIENT} --host ${CL_HOST} propose
+    fi    
+    if [ "${QUERY_DEPLOY_STATUS}" = true ] ; then
+        log "Checking deploy status."
+        ${CL_CLIENT} --host ${CL_HOST} show-deploy ${DEPLOY_HASH}
     fi    
 }
 
 last_block () {
-    RESPONSE=$($CLIENT --host $HOST show-blocks)
-    BLOCK_HASH=$(echo $RESPONSE | awk -F "block_hash: \"" '{print $2}' | awk -F "\" header" '{print $1}')
-    echo $BLOCK_HASH
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} show-blocks --depth 1)
+    BLOCK_HASH=$(echo ${RESPONSE} | awk -F "block_hash: \"" '{print $2}' | awk -F "\" header" '{print $1}')
+    echo ${BLOCK_HASH}
 }
 
 contract_hash_by_name() {
-    DEPLOYER=$1
-    CONTRACT_NAME=$2
-    BLOCK_HASH=$3
-    RESPONSE=$($CLIENT --host $HOST query-state \
+    DEPLOYER=${1}
+    CONTRACT_NAME=${2}
+    BLOCK_HASH=${3}
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} query-state \
         --block-hash ${BLOCK_HASH} \
         --type address \
         --key ${DEPLOYER} \
         --path ${CONTRACT_NAME})
-    HASH=$(echo $RESPONSE | awk -F "\"" '{print $2}')
+    HASH=$(echo ${RESPONSE} | awk -F "\"" '{print $2}')
     echo $HASH
 }
 
 command_deploy () {
-    SENDER_PRIVATE_KEY="$1/$ACCOUNT_PRIVATE_FILE"
+    SENDER_PRIVATE_KEY=${1}
+    TOTAL_SUPPLY=${2}
     ARGS="[\
         {\"name\": \"method\", \"value\": {\"string_value\": \"deploy\"}}, \
-        {\"name\": \"token_name\", \"value\": {\"string_value\": \"$TOKEN_NAME\"}}, \
-        {\"name\": \"initial_balance\", \"value\": {\"big_int\": {\"value\": \"$TOTAL_SUPPLY\", \"bit_width\": 512}}} \
+        {\"name\": \"token_name\", \"value\": {\"string_value\": \"${TOKEN_NAME}\"}}, \
+        {\"name\": \"initial_balance\", \"value\": {\"big_int\": {\"value\": \"${TOTAL_SUPPLY}\", \"bit_width\": 512}}} \
     ]"
-    RESPONSE=$($CLIENT --host $HOST deploy \
-        --private-key $SENDER_PRIVATE_KEY \
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} deploy \
+        --private-key ${SENDER_PRIVATE_KEY} \
         --payment-amount 10000000 \
-        --session $ERC20_WASM \
-        --session-args "$ARGS"
+        --session ${ERC20_WASM} \
+        --session-args "${ARGS}"
     )
-    DEPLOY_HASH=$(echo $RESPONSE | awk '{print $3}')
-    log "ERC20 deployed with hash $DEPLOY_HASH"
-    propose_block_if_enabled
-    log "Checking deploy status."
-    $CLIENT --host $HOST show-deploy $DEPLOY_HASH
+    handle_deploy_response "${RESPONSE}"
 }
 
 command_balance () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    ACCOUNT_PUBLIC_HEX=$(cat ${2}/${ACCOUNT_ID_HEX_FILE})
+    HOST_PUBLIC_HEX=${1}
+    ACCOUNT_PUBLIC_HEX=${2}
     BLOCK_HASH=$(last_block)
     log "Checking balance at block ${BLOCK_HASH}."
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    RESPONSE=$($CLIENT query-state --block-hash $BLOCK_HASH \
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    set +e
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} query-state \
+        --block-hash ${BLOCK_HASH} \
         --type local \
-        --key "${TOKEN_HASH}:${BALANCE_KEY_SIZE_HEX}${BALANCE_BYTE}${ACCOUNT_PUBLIC_HEX}")
-    BALANCE=$(echo $RESPONSE | awk -F "\"" '{print $2}')
+        --key "${TOKEN_HASH}:${BALANCE_KEY_SIZE_HEX}${BALANCE_BYTE}${ACCOUNT_PUBLIC_HEX}" 2>&1)
+    set -e
+    BALANCE=$(echo ${RESPONSE} | awk -F "\"" '{print $2}')
+    if [ "${BALANCE}" = "Value not found: " ] ; then
+        BALANCE=0
+    fi
     log "Account ${YELLOW}${ACCOUNT_PUBLIC_HEX}${RESET} has ${YELLOW}${BALANCE}${RESET} tokens."
 }
 
 command_transfer () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    SENDER_PRIVATE_KEY="${2}/${ACCOUNT_PRIVATE_FILE}"
-    RECIPIENT_PUBLIC_KEY=$(cat ${3}/${ACCOUNT_ID_HEX_FILE})
-    AMOUNT=$4
+    SENDER_PRIVATE_KEY=${1}
+    HOST_PUBLIC_HEX=${2}
+    RECIPIENT_PUBLIC_KEY=${3}
+    AMOUNT=${4}
     BLOCK_HASH=$(last_block)
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    PROXY_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    PROXY_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
     ARGS="[\
         {\"name\": \"erc20\", \"value\": {\"bytes_value\": \"${TOKEN_HASH}\"}}, \
         {\"name\": \"method\", \"value\": {\"string_value\": \"transfer\"}}, \
         {\"name\": \"recipient\", \"value\": {\"bytes_value\": \"${RECIPIENT_PUBLIC_KEY}\"}}, \
         {\"name\": \"amount\", \"value\": {\"big_int\": {\"value\": \"${AMOUNT}\", \"bit_width\": 512}}} \
     ]"
-    RESPONSE=$($CLIENT --host ${HOST} deploy \
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} deploy \
         --private-key ${SENDER_PRIVATE_KEY} \
         --payment-amount 10000000 \
         --session-hash ${PROXY_HASH} \
         --session-args "${ARGS}"
     )
-    DEPLOY_HASH=$(echo $RESPONSE | awk '{print $3}')
-    log "ERC20 transfer deployed with hash ${DEPLOY_HASH}"
-    propose_block_if_enabled
-    log "Checking transfer status."
-    $CLIENT --host $HOST show-deploy $DEPLOY_HASH   
+    handle_deploy_response "${RESPONSE}"
 }
 
 command_approve () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    OWNER_PRIVATE_KEY="${2}/${ACCOUNT_PRIVATE_FILE}"
-    SPENDER_PUBLIC_KEY=$(cat ${3}/${ACCOUNT_ID_HEX_FILE})
-    AMOUNT=$4
+    SENDER_PRIVATE_KEY=${1}
+    HOST_PUBLIC_HEX=${2}
+    SPENDER_PUBLIC_KEY=${3}
+    AMOUNT=${4}
     BLOCK_HASH=$(last_block)
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    PROXY_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    PROXY_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
     ARGS="[\
         {\"name\": \"erc20\", \"value\": {\"bytes_value\": \"${TOKEN_HASH}\"}}, \
         {\"name\": \"method\", \"value\": {\"string_value\": \"approve\"}}, \
-        {\"name\": \"recipient\", \"value\": {\"bytes_value\": \"${SPENDER_PUBLIC_KEY}\"}}, \
+        {\"name\": \"spender\", \"value\": {\"bytes_value\": \"${SPENDER_PUBLIC_KEY}\"}}, \
         {\"name\": \"amount\", \"value\": {\"big_int\": {\"value\": \"${AMOUNT}\", \"bit_width\": 512}}} \
     ]"
-    RESPONSE=$($CLIENT --host ${HOST} deploy \
-        --private-key ${OWNER_PRIVATE_KEY} \
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} deploy \
+        --private-key ${SENDER_PRIVATE_KEY} \
         --payment-amount 10000000 \
         --session-hash ${PROXY_HASH} \
         --session-args "${ARGS}"
     )
-    DEPLOY_HASH=$(echo $RESPONSE | awk '{print $3}')
-    log "ERC20 approval deployed with hash ${DEPLOY_HASH}"
-    propose_block_if_enabled
-    log "Checking approval status."
-    $CLIENT --host $HOST show-deploy $DEPLOY_HASH   
+    handle_deploy_response "${RESPONSE}"
 }
 
 command_allowance () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    OWNER_PUBLIC_KEY=$(cat ${2}/${ACCOUNT_ID_HEX_FILE})
-    SPENDER_PUBLIC_KEY=$(cat ${3}/${ACCOUNT_ID_HEX_FILE})
+    HOST_PUBLIC_HEX=${1}
+    OWNER_PUBLIC_KEY=${2}
+    SPENDER_PUBLIC_KEY=${3}
     BLOCK_HASH=$(last_block)
     log "Checking allowance at block ${BLOCK_HASH}."
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    RESPONSE=$($CLIENT query-state --block-hash $BLOCK_HASH \
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    set +e
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} query-state \
+        --block-hash ${BLOCK_HASH} \
         --type local \
-        --key "${TOKEN_HASH}:${ALLOWANCE_KEY_SIZE_HEX}${OWNER_PUBLIC_KEY}${SPENDER_PUBLIC_KEY}")
+        --key "${TOKEN_HASH}:${ALLOWANCE_KEY_SIZE_HEX}${OWNER_PUBLIC_KEY}${SPENDER_PUBLIC_KEY}" 2>&1)
+    set -e
     ALLOWANCE=$(echo $RESPONSE | awk -F "\"" '{print $2}')
+    if [ "${ALLOWANCE}" = "Value not found: " ] ; then
+        ALLOWANCE=0
+    fi
     log "Account ${YELLOW}${OWNER_PUBLIC_KEY}${RESET} allows ${YELLOW}${SPENDER_PUBLIC_KEY}${RESET} to spend ${YELLOW}${ALLOWANCE}${RESET} tokens."
 }
 
 command_transfer_from () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    SENDER_PRIVATE_KEY="${2}/${ACCOUNT_PRIVATE_FILE}"
-    OWNER_PUBLIC_KEY=$(cat ${3}/${ACCOUNT_ID_HEX_FILE})
-    RECIPIENT_PUBLIC_KEY=$(cat ${4}/${ACCOUNT_ID_HEX_FILE})
+    SENDER_PRIVATE_KEY=${1}
+    HOST_PUBLIC_HEX=${2}
+    OWNER_PUBLIC_KEY=${3}
+    RECIPIENT_PUBLIC_KEY=${4}
     AMOUNT=$5
     BLOCK_HASH=$(last_block)
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    PROXY_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    PROXY_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
     ARGS="[\
         {\"name\": \"erc20\", \"value\": {\"bytes_value\": \"${TOKEN_HASH}\"}}, \
         {\"name\": \"method\", \"value\": {\"string_value\": \"transfer_from\"}}, \
@@ -213,73 +245,61 @@ command_transfer_from () {
         {\"name\": \"recipient\", \"value\": {\"bytes_value\": \"${RECIPIENT_PUBLIC_KEY}\"}}, \
         {\"name\": \"amount\", \"value\": {\"big_int\": {\"value\": \"${AMOUNT}\", \"bit_width\": 512}}} \
     ]"
-    RESPONSE=$($CLIENT --host ${HOST} deploy \
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} deploy \
         --private-key ${SENDER_PRIVATE_KEY} \
         --payment-amount 10000000 \
         --session-hash ${PROXY_HASH} \
         --session-args "${ARGS}"
     )
-    DEPLOY_HASH=$(echo $RESPONSE | awk '{print $3}')
-    log "ERC20 transferFrom deployed with hash ${DEPLOY_HASH}."
-    propose_block_if_enabled
-    log "Checking transferFrom status."
-    $CLIENT --host $HOST show-deploy $DEPLOY_HASH   
+    handle_deploy_response "${RESPONSE}"
 }
 
 command_buy () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    BUYER_PRIVATE_KEY="${2}/${ACCOUNT_PRIVATE_FILE}"
+    SENDER_PRIVATE_KEY=${1}
+    HOST_PUBLIC_HEX=${2}
     AMOUNT=$3
     BLOCK_HASH=$(last_block)
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    PROXY_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    PROXY_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
     ARGS="[\
         {\"name\": \"erc20\", \"value\": {\"bytes_value\": \"${TOKEN_HASH}\"}}, \
         {\"name\": \"method\", \"value\": {\"string_value\": \"buy_proxy\"}}, \
         {\"name\": \"amount\", \"value\": {\"big_int\": {\"value\": \"${AMOUNT}\", \"bit_width\": 512}}} \
     ]"
-    RESPONSE=$($CLIENT --host ${HOST} deploy \
-        --private-key ${BUYER_PRIVATE_KEY} \
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} deploy \
+        --private-key ${SENDER_PRIVATE_KEY} \
         --payment-amount 10000000 \
         --session-hash ${PROXY_HASH} \
         --session-args "${ARGS}"
     )
-    DEPLOY_HASH=$(echo $RESPONSE | awk '{print $3}')
-    log "ERC20 buy deployed with hash ${DEPLOY_HASH}"
-    propose_block_if_enabled
-    log "Checking buy status."
-    $CLIENT --host $HOST show-deploy $DEPLOY_HASH   
+    handle_deploy_response "${RESPONSE}"
 }
 
 command_sell () {
-    DEPLOYER_PUBLIC_HEX=$(cat ${1}/${ACCOUNT_ID_HEX_FILE})
-    SELLER_PRIVATE_KEY="${2}/${ACCOUNT_PRIVATE_FILE}"
+    SENDER_PRIVATE_KEY=${1}
+    HOST_PUBLIC_HEX=${2}
     AMOUNT=$3
     BLOCK_HASH=$(last_block)
-    TOKEN_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
-    PROXY_HASH=$(contract_hash_by_name ${DEPLOYER_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
+    TOKEN_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${TOKEN_NAME} ${BLOCK_HASH})
+    PROXY_HASH=$(contract_hash_by_name ${HOST_PUBLIC_HEX} ${PROXY_NAME} ${BLOCK_HASH})
     ARGS="[\
         {\"name\": \"erc20\", \"value\": {\"bytes_value\": \"${TOKEN_HASH}\"}}, \
         {\"name\": \"method\", \"value\": {\"string_value\": \"sell_proxy\"}}, \
         {\"name\": \"amount\", \"value\": {\"big_int\": {\"value\": \"${AMOUNT}\", \"bit_width\": 512}}} \
     ]"
-    RESPONSE=$($CLIENT --host ${HOST} deploy \
-        --private-key ${SELLER_PRIVATE_KEY} \
+    RESPONSE=$(${CL_CLIENT} --host ${CL_HOST} deploy \
+        --private-key ${SENDER_PRIVATE_KEY} \
         --payment-amount 10000000 \
         --session-hash ${PROXY_HASH} \
         --session-args "${ARGS}"
     )
-    DEPLOY_HASH=$(echo $RESPONSE | awk '{print $3}')
-    log "ERC20 sell deployed with hash ${DEPLOY_HASH}"
-    propose_block_if_enabled
-    log "Checking sell status."
-    $CLIENT --host $HOST show-deploy $DEPLOY_HASH   
+    handle_deploy_response "${RESPONSE}"
 }
 
 COMMAND=${1:-"help"}
 case $COMMAND in
     deploy)
-        command_deploy $2
+        command_deploy $2 $3
         ;;
     balance)
         command_balance $2 $3
@@ -302,11 +322,11 @@ case $COMMAND in
     sell)
         command_sell $2 $3 $4
         ;;
-    help)
+    help|--help|-h)
         command_help
         ;;
     *)
-        log "Unknown command: ${RED}${COMMAND}${RESET}."
+        err_log "Unknown command: ${COMMAND}."
         log "Call '${YELLOW}$(basename "$0") help${RESET}' for available commands."
         exit 2
 esac


### PR DESCRIPTION
### Overview
Improvements to the erc20.sh:
- Use private keys and public keys directly, instead of directories.
- Allow to disable colors (for OSx).
- Now it works fine with the python client.
- Add --help and -h as help commands.
- Better help message. Now has exported variables.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-309

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.