### PR TITLE
NO-TICKET: Add ByteString Prettifier

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -32,8 +32,13 @@ import scala.concurrent.duration._
 import org.scalatest.Suite
 import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.casper.finality.MultiParentFinalizer
+import io.casperlabs.casper.util.ByteStringPrettifier
 
-trait HighwayFixture extends StorageFixture with TickUtils with ArbitraryConsensus { self: Suite =>
+trait HighwayFixture
+    extends StorageFixture
+    with TickUtils
+    with ByteStringPrettifier
+    with ArbitraryConsensus { self: Suite =>
 
   /** Create multiple databases, one for each validator. */
   def testFixtures(validators: List[String])(

--- a/casper/src/test/scala/io/casperlabs/casper/util/ByteStringPrettifier.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/ByteStringPrettifier.scala
@@ -1,0 +1,76 @@
+package io.casperlabs.casper.util
+
+import org.scalactic.Prettifier
+import io.casperlabs.casper.PrettyPrinter
+import com.google.protobuf.ByteString
+import scala.util.Success
+import scala.collection.{mutable, GenMap}
+import scala.collection.GenTraversable
+import _root_.cats.instances.`package`.byte
+
+trait ByteStringPrettifier {
+  // Shameless copy-paste of Scalactic's Prettifier that injects special pretty-printer for ByteString.
+  implicit val byteStringPrettifier: Prettifier = Prettifier {
+    case bs: ByteString    => PrettyPrinter.buildString(bs)
+    case Some(e)           => "Some(" + byteStringPrettifier(e) + ")"
+    case Success(e)        => "Success(" + byteStringPrettifier(e) + ")"
+    case Left(e)           => "Left(" + byteStringPrettifier(e) + ")"
+    case Right(e)          => "Right(" + byteStringPrettifier(e) + ")"
+    case anArray: Array[_] => "Array(" + (anArray.map(byteStringPrettifier(_))).mkString(", ") + ")"
+    case aWrappedArray: mutable.WrappedArray[_] =>
+      "Array(" + (aWrappedArray.map(byteStringPrettifier(_))).mkString(", ") + ")"
+    case anArrayOps: mutable.ArrayOps[_] =>
+      "Array(" + (anArrayOps.map(byteStringPrettifier(_))).mkString(", ") + ")"
+    case aGenMap: GenMap[_, _] =>
+      aGenMap.stringPrefix + "(" +
+        (aGenMap.toIterator
+          .map {
+            case (key, value) => // toIterator is needed for consistent ordering
+              byteStringPrettifier(key) + " -> " + byteStringPrettifier(value)
+          })
+          .mkString(", ") + ")"
+    case aGenTraversable: GenTraversable[_] =>
+      val isSelf =
+        if (aGenTraversable.size == 1) {
+          aGenTraversable.head match {
+            case ref: AnyRef => ref eq aGenTraversable
+            case other       => other == aGenTraversable
+          }
+        } else
+          false
+      if (isSelf)
+        aGenTraversable.toString
+      else
+        aGenTraversable.stringPrefix + "(" + aGenTraversable.toIterator
+          .map(byteStringPrettifier(_))
+          .mkString(", ") + ")" // toIterator is needed for consistent ordering
+    // SKIP-SCALATESTJS-START
+    case javaCol: java.util.Collection[_] =>
+      // By default java collection follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractCollection.html#toString()
+      // let's do our best to prettify its element when it is not overriden
+      import scala.collection.JavaConverters._
+      val theToString = javaCol.toString
+      if (theToString.startsWith("[") && theToString.endsWith("]"))
+        "[" + javaCol.iterator().asScala.map(byteStringPrettifier(_)).mkString(", ") + "]"
+      else
+        theToString
+    case javaMap: java.util.Map[_, _] =>
+      // By default java map follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractMap.html#toString()
+      // let's do our best to prettify its element when it is not overriden
+      import scala.collection.JavaConverters._
+      val theToString = javaMap.toString
+      if (theToString.startsWith("{") && theToString.endsWith("}"))
+        "{" + javaMap.entrySet.iterator.asScala
+          .map { entry =>
+            byteStringPrettifier(entry.getKey) + "=" + byteStringPrettifier(entry.getValue)
+          }
+          .mkString(", ") + "}"
+      else
+        theToString
+    case tuple2: Tuple2[_, _] =>
+      "(" ++ byteStringPrettifier(tuple2._1) ++ ", " ++ byteStringPrettifier(tuple2._2) ++ ")"
+    case other => Prettifier.default(other)
+  }
+}
+
+object ByteStringPrettifier extends ByteStringPrettifier


### PR DESCRIPTION
### Overview
Adds custom `org.scalactic.Prettifier` instance that prints `ByteString` in scalatest messages using our `PrettyPrinter`.

### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
