### PR TITLE
NO-TICKET: Minor assemblyscript cleanups

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -32,6 +32,20 @@ SYSTEM_CONTRACTS    := $(patsubst %, build-contract-rs/%, $(SYSTEM_CONTRACTS))
 TEST_CONTRACTS      := $(patsubst %, build-contract-rs/%, $(TEST_CONTRACTS))
 
 # AssemblyScript Contracts
+ASC_VERSION := 0.9.1
+
+# Checks if AssemblyScript compiler is found in $PATH
+ifeq (, $(shell which asc))
+	$(error "No asc in $(PATH). Please run npm install -g assemblyscript@$(ASC_VERSION) first")
+endif
+
+# Checks if AssemblyScript compiler is at correct version
+ASC_VERSION_OUTPUT:=$(shell asc --version | cut -d' ' -f2)
+ifeq (,$(findstring $(ASC_VERSION),$(ASC_VERSION_OUTPUT)))
+    $(error "Found asc version $(ASC_VERSION_OUTPUT) but version $(ASC_VERSION) is required.\
+	  Please run npm install -g assemblyscript@$(ASC_VERSION) first")
+endif
+
 CLIENT_CONTRACTS_AS  = $(shell find ./contracts-as/client   -mindepth 1 -maxdepth 1 -type d)
 TEST_CONTRACTS_AS    = $(shell find ./contracts-as/test     -mindepth 1 -maxdepth 1 -type d)
 EXAMPLE_CONTRACTS_AS = $(shell find ./contracts-as/examples -mindepth 1 -maxdepth 1 -type d)

--- a/execution-engine/contract-as/assembly/account.ts
+++ b/execution-engine/contract-as/assembly/account.ts
@@ -81,9 +81,10 @@ export function getMainPurse(): PurseId | null {
     let data = new Uint8Array(PURSE_ID_SERIALIZED_LENGTH);
     data.fill(0);
     externals.get_main_purse(data.dataStart);
-    let uref = URef.fromBytes(data);
-    if (uref === null)
+    let urefResult = URef.fromBytes(data);
+    if (urefResult.hasError()) {
         return null;
-    let purseId = new PurseId(uref);
+    }
+    let purseId = new PurseId(urefResult.value);
     return purseId;
 }

--- a/execution-engine/contract-as/assembly/bignum.ts
+++ b/execution-engine/contract-as/assembly/bignum.ts
@@ -1,5 +1,4 @@
-import {SetLastError, GetLastError, Error,
-        toBytesU64} from "./bytesrepr";
+import {Error, Result, Ref} from "./bytesrepr";
 import {Pair} from "./pair";
 
 const HEX_LOWERCASE: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
@@ -393,10 +392,9 @@ export class U512 {
         return this.toHex();
     }
 
-    static fromBytes(bytes: Uint8Array): U512 | null {
+    static fromBytes(bytes: Uint8Array): Result<U512> {
         if (bytes.length < 1) {
-            SetLastError(Error.EarlyEndOfStream);
-            return null;
+            return new Result<U512>(null, Error.EarlyEndOfStream, 0);
         }
 
         const lengthPrefix = <i32>bytes[0];
@@ -409,8 +407,8 @@ export class U512 {
         }
 
         res.setBytesLE(buffer);
-        SetLastError(Error.Ok);
-        return res;
+        let ref = new Ref<U512>(res);
+        return new Result<U512>(ref, Error.Ok, 1 + lengthPrefix);
     }
 
     toBytes(): Array<u8> {

--- a/execution-engine/contract-as/assembly/bignum.ts
+++ b/execution-engine/contract-as/assembly/bignum.ts
@@ -1,4 +1,5 @@
-import {toBytesU64} from "./bytesrepr";
+import {SetLastError, GetLastError, Error,
+        toBytesU64} from "./bytesrepr";
 import {Pair} from "./pair";
 
 const HEX_LOWERCASE: string[] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'];
@@ -394,6 +395,7 @@ export class U512 {
 
     static fromBytes(bytes: Uint8Array): U512 | null {
         if (bytes.length < 1) {
+            SetLastError(Error.EarlyEndOfStream);
             return null;
         }
 
@@ -407,6 +409,7 @@ export class U512 {
         }
 
         res.setBytesLE(buffer);
+        SetLastError(Error.Ok);
         return res;
     }
 

--- a/execution-engine/contract-as/assembly/bytesrepr.ts
+++ b/execution-engine/contract-as/assembly/bytesrepr.ts
@@ -25,18 +25,14 @@ export function SetLastError(error: i32): void {
 // Any fromBytes operation sets this, so caller can know how much bytes to
 // skip in the input stream for complex types
 @lazy
-let LastDecodedBytesCount: u32 = 0;
+let lastDecodedBytesCount: u32 = 0;
 
 export function SetDecodedBytesCount(value: u32): void {
-    LastDecodedBytesCount = value;
-}
-
-export function AddDecodedBytesCount(value: u32): void {
-    LastDecodedBytesCount += value;
+    lastDecodedBytesCount = value;
 }
 
 export function GetDecodedBytesCount(): u32 {
-    return LastDecodedBytesCount;
+    return lastDecodedBytesCount;
 }
 
 export function toBytesU8(num: u8): u8[] {
@@ -49,6 +45,7 @@ export function fromBytesU8(bytes: Uint8Array): u8 {
         return 0;
     }
     SetLastError(Error.Ok);
+    SetDecodedBytesCount(1);
     return load<u8>(bytes.dataStart);
 }
 
@@ -70,9 +67,8 @@ export function fromBytesU32(bytes: Uint8Array): u32 {
     }
     const number = <u32>load<u32>(bytes.dataStart);
 
-    SetDecodedBytesCount(4);
-
     SetLastError(Error.Ok);
+    SetDecodedBytesCount(4);
     return number;
 }
 
@@ -112,9 +108,8 @@ export function fromBytesU64(bytes: Uint8Array): u64 {
         return 0;
     }
 
-    SetDecodedBytesCount(8);
-
     SetLastError(Error.Ok);
+    SetDecodedBytesCount(8);
     return load<u64>(bytes.dataStart);
 }
 

--- a/execution-engine/contract-as/assembly/externals.ts
+++ b/execution-engine/contract-as/assembly/externals.ts
@@ -87,7 +87,6 @@ export declare function transfer_from_purse_to_purse(
 export declare function get_balance(purse_id_ptr: usize, purse_id_size: usize, result_size: u32): i32;
 @external("env", "get_phase")
 export declare function get_phase(dest_ptr: usize): void;
-// TODO: upgrade_contract_at_uref
 @external("env", "upgrade_contract_at_uref")
 export declare function upgrade_contract_at_uref(
     name_ptr: usize,

--- a/execution-engine/contract-as/assembly/index.ts
+++ b/execution-engine/contract-as/assembly/index.ts
@@ -68,7 +68,11 @@ export function getSystemContract(system_contract: SystemContract): URef | null 
     // TODO: revert
     return null;
   }
-  return URef.fromBytes(data);
+  let decodeResult = URef.fromBytes(data);
+  if (decodeResult.hasError()) {
+    return null;
+  }
+  return decodeResult.value;
 }
 
 export function storeFunction(name: String, namedKeysBytes: u8[]): Key {
@@ -152,7 +156,7 @@ export function getKey(name: String): Key | null {
     return null;
   }
   let key = Key.fromBytes(keyBytes.slice(0, <i32>resultSize[0])); // total guess
-  return key;
+  return key.ok();
 }
 
 export function ret(value: CLValue): void {
@@ -226,11 +230,11 @@ export function listNamedKeys(): Array<Pair<String, Key>> {
     fromBytesString,
     Key.fromBytes);
 
-  if (maybeMap === null) {
+  if (maybeMap.hasError()) {
     Error.fromErrorCode(ErrorCode.Deserialize).revert();
     return <Array<Pair<String, Key>>>unreachable();
   }
-  return <Array<Pair<String, Key>>>maybeMap;
+  return maybeMap.value;
 }
 
 export function upgradeContractAtURef(name: String, uref: URef): void {

--- a/execution-engine/contract-as/assembly/index.ts
+++ b/execution-engine/contract-as/assembly/index.ts
@@ -137,7 +137,7 @@ export function putKey(name: String, key: Key): void {
 
 export function getKey(name: String): Key | null {
   var nameBytes = toBytesString(name);
-  let keyBytes = new Uint8Array(KEY_UREF_SERIALIZED_LENGTH); // TODO: some equivalent of Key::serialized_size_hint() ?
+  let keyBytes = new Uint8Array(KEY_UREF_SERIALIZED_LENGTH);
   let resultSize = new Uint32Array(1);
   let ret =  externals.get_key(
       nameBytes.dataStart,

--- a/execution-engine/contract-as/assembly/key.ts
+++ b/execution-engine/contract-as/assembly/key.ts
@@ -5,7 +5,7 @@ import {URef} from "./uref";
 import {CLValue} from "./clvalue";
 import {Error} from "./error";
 import {checkTypedArrayEqual, typedToArray} from "./utils";
-import {GetDecodedBytesCount, AddDecodedBytesCount, SetDecodedBytesCount,
+import {GetDecodedBytesCount, SetDecodedBytesCount,
         SetLastError, GetLastError, Error as BytesreprError} from "./bytesrepr";
 
 export enum KeyVariant {
@@ -71,7 +71,7 @@ export class Key {
         SetDecodedBytesCount(1);
         if (tag == KeyVariant.HASH_ID) {
             var hashBytes = bytes.subarray(1, 32 + 1);
-            AddDecodedBytesCount(32);
+            SetDecodedBytesCount(1 + 32);
             SetLastError(BytesreprError.Ok);
             return Key.fromHash(hashBytes);
         }
@@ -87,14 +87,13 @@ export class Key {
             }
 
             let decodedBytes = GetDecodedBytesCount();
-            SetDecodedBytesCount(savedOffset);
-            AddDecodedBytesCount(decodedBytes);
+            SetDecodedBytesCount(savedOffset + decodedBytes);
             SetLastError(BytesreprError.Ok);
             return Key.fromURef(<URef>uref);
         }
         else if (tag == KeyVariant.ACCOUNT_ID) {
             var accountBytes = bytes.subarray(1, 32 + 1);
-            AddDecodedBytesCount(32);
+            SetDecodedBytesCount(1 + 32);
             SetLastError(BytesreprError.Ok);
             return Key.fromAccount(accountBytes);
         }

--- a/execution-engine/contract-as/assembly/purseid.ts
+++ b/execution-engine/contract-as/assembly/purseid.ts
@@ -4,6 +4,7 @@ import {readHostBuffer} from "./index";
 import {U512} from "./bignum";
 import {Error, ErrorCode} from "./error";
 import {PURSE_ID_SERIALIZED_LENGTH} from "./constants";
+import { SetLastError, Error as BytesreprError} from "./bytesrepr";
 
 export enum TransferredTo {
     TransferError = -1,
@@ -24,8 +25,11 @@ export class PurseId {
 
     static fromBytes(bytes: Uint8Array): PurseId | null {
         let uref = URef.fromBytes(bytes);
-        if(uref === null)
+        if(uref === null) {
+            SetLastError(BytesreprError.FormattingError);
             return null;
+        }
+        SetLastError(BytesreprError.Ok);
         return new PurseId(uref);
     }
 

--- a/execution-engine/contract-as/assembly/purseid.ts
+++ b/execution-engine/contract-as/assembly/purseid.ts
@@ -4,7 +4,7 @@ import {readHostBuffer} from "./index";
 import {U512} from "./bignum";
 import {Error, ErrorCode} from "./error";
 import {PURSE_ID_SERIALIZED_LENGTH} from "./constants";
-import { SetLastError, Error as BytesreprError} from "./bytesrepr";
+import {Result, Ref} from "./bytesrepr";
 
 export enum TransferredTo {
     TransferError = -1,
@@ -23,14 +23,14 @@ export class PurseId {
         return this.uref.toBytes();
     }
 
-    static fromBytes(bytes: Uint8Array): PurseId | null {
-        let uref = URef.fromBytes(bytes);
-        if(uref === null) {
-            SetLastError(BytesreprError.FormattingError);
-            return null;
+    static fromBytes(bytes: Uint8Array): Result<PurseId> {
+        let result = URef.fromBytes(bytes);
+        if (result.hasError()) {
+            return new Result<PurseId>(null, result.error, result.position);
         }
-        SetLastError(BytesreprError.Ok);
-        return new PurseId(uref);
+        let purseId = new PurseId(result.value);
+        let ref = new Ref<PurseId>(purseId);
+        return new Result<PurseId>(ref, result.error, result.position);
     }
 
     static create(): PurseId | null {
@@ -45,13 +45,13 @@ export class PurseId {
             return null;
         }
 
-        let uref = URef.fromBytes(bytes);
-        if(uref === null){
+        let urefResult = URef.fromBytes(bytes);
+        if (urefResult.hasError()) {
             Error.fromErrorCode(ErrorCode.PurseNotCreated).revert();
             return null;
         }
 
-        return new PurseId(uref);
+        return new PurseId(urefResult.value);
     }
 
     asURef(): URef{
@@ -77,12 +77,8 @@ export class PurseId {
             return null;
         }
 
-        let balance = U512.fromBytes(bytes);
-        if (balance === null) {
-            return null;
-        }
-
-        return balance;
+        let balanceResult = U512.fromBytes(bytes);
+        return balanceResult.ok();
     }
 
     transferToAccount(target: Uint8Array, amount: U512): TransferredTo {
@@ -99,7 +95,6 @@ export class PurseId {
             sourceBytes.length,
             targetBytes.dataStart,
             targetBytes.length,
-            // NOTE: amount has U512 type but is not deserialized throughout the execution, as there's no direct replacement for big ints
             amountBytes.dataStart,
             amountBytes.length,
         );

--- a/execution-engine/contract-as/assembly/uref.ts
+++ b/execution-engine/contract-as/assembly/uref.ts
@@ -1,4 +1,5 @@
-import {AddDecodedBytesCount, SetDecodedBytesCount} from "./bytesrepr";
+import {AddDecodedBytesCount, SetDecodedBytesCount,
+        GetLastError, SetLastError, Error} from "./bytesrepr";
 import {UREF_ADDR_LENGTH} from "./constants";
 import {checkTypedArrayEqual} from "./utils";
 import {is_valid_uref, revert} from "./externals";
@@ -42,21 +43,25 @@ export class URef {
 
     static fromBytes(bytes: Uint8Array): URef | null {
         if (bytes.length < 33) {
+            SetLastError(Error.EarlyEndOfStream);
             return null;
         }
-        
+
         let urefBytes = bytes.subarray(0, UREF_ADDR_LENGTH);
         SetDecodedBytesCount(33);
         if (bytes[UREF_ADDR_LENGTH] == 1) {
             if (bytes.length < 34) {
+                SetLastError(Error.EarlyEndOfStream);
                 return null;
             }
             let accessRights = bytes[UREF_ADDR_LENGTH + 1];
             AddDecodedBytesCount(1);
+            SetLastError(Error.Ok);
             return new URef(urefBytes, accessRights);
         }
         else {
             let urefBytes = bytes.subarray(0, UREF_ADDR_LENGTH);
+            SetLastError(Error.Ok);
             return new URef(urefBytes, AccessRights.NONE);
         }
     }

--- a/execution-engine/contract-as/assembly/uref.ts
+++ b/execution-engine/contract-as/assembly/uref.ts
@@ -1,4 +1,4 @@
-import {AddDecodedBytesCount, SetDecodedBytesCount,
+import {SetDecodedBytesCount,
         GetLastError, SetLastError, Error} from "./bytesrepr";
 import {UREF_ADDR_LENGTH} from "./constants";
 import {checkTypedArrayEqual} from "./utils";
@@ -55,7 +55,7 @@ export class URef {
                 return null;
             }
             let accessRights = bytes[UREF_ADDR_LENGTH + 1];
-            AddDecodedBytesCount(1);
+            SetDecodedBytesCount(33 + 1);
             SetLastError(Error.Ok);
             return new URef(urefBytes, accessRights);
         }

--- a/execution-engine/contract-as/tests/assembly/bignum.spec.as.ts
+++ b/execution-engine/contract-as/tests/assembly/bignum.spec.as.ts
@@ -1,5 +1,6 @@
 import { hex2bin } from "../utils/helpers";
 import { U512 } from "../../assembly/bignum";
+import { GetLastError, Error } from "../../assembly/bytesrepr";
 import { Pair } from "../../assembly/pair";
 import { checkArraysEqual } from "../../assembly/utils";
 import { arrayToTyped, typedToArray } from "../../assembly/utils";
@@ -199,6 +200,7 @@ export function testDivision(): bool {
 export function testSerializeU512Zero(): bool {
     let truth = hex2bin("00");
     let zero = U512.fromBytes(truth);
+    assert(GetLastError() == Error.Ok);
     assert(zero !== null);
     assert(zero.isZero());
     const bytes = zero.toBytes();
@@ -208,6 +210,7 @@ export function testSerializeU512Zero(): bool {
 export function testSerializeU512_3BytesWide(): bool {
     let truth = hex2bin("03807801");
     let num = U512.fromBytes(truth);
+    assert(GetLastError() == Error.Ok);
     assert(num !== null);
     assert(num.toString() == "17880"); // dec: 96384
     const bytes = num.toBytes();
@@ -217,6 +220,7 @@ export function testSerializeU512_3BytesWide(): bool {
 export function testSerializeU512_2BytesWide(): bool {
     let truth = hex2bin("020004");
     let num = U512.fromBytes(truth);
+    assert(GetLastError() == Error.Ok);
     assert(num !== null);
     assert(num.toString() == "400"); // dec: 1024
     const bytes = num.toBytes();
@@ -226,6 +230,8 @@ export function testSerializeU512_2BytesWide(): bool {
 export function testSerializeU512_1BytesWide(): bool {
     let truth = hex2bin("0101");
     let num = U512.fromBytes(truth);
+    assert(GetLastError() == Error.Ok);
+    assert(num !== null);
     assert(num.toString() == "1");
     const bytes = num.toBytes();
     return checkArraysEqual(bytes, typedToArray(truth));
@@ -244,7 +250,7 @@ export function testSerialize100mTimes10(): bool {
     assert(checkArraysEqual(bytes, typedToArray(truth)));
 
     let roundTrip = U512.fromBytes(arrayToTyped(bytes));
-    assert(roundTrip !== null);
+    assert(GetLastError() == Error.Ok);
     assert(roundTrip.toString() == hex);
 
     return true;
@@ -258,6 +264,7 @@ export function testDeserLargeRandomU512(): bool {
     let truth = hex2bin("40752c392d2ecd6123de0f1d3d4cdb7992aa85e049a94795975e81e20b78731cde6d4aa13da210479acce5f24a296ae787bada0aba1889c8fe2f2fb030d62feed2");
 
     let deser = U512.fromBytes(truth);
+    assert(GetLastError() == Error.Ok);
     assert(deser !== null);
     assert(deser.toString() == hex);
 

--- a/execution-engine/contract-as/tests/assembly/bignum.spec.as.ts
+++ b/execution-engine/contract-as/tests/assembly/bignum.spec.as.ts
@@ -1,6 +1,6 @@
 import { hex2bin } from "../utils/helpers";
 import { U512 } from "../../assembly/bignum";
-import { GetLastError, Error } from "../../assembly/bytesrepr";
+import { Error } from "../../assembly/bytesrepr";
 import { Pair } from "../../assembly/pair";
 import { checkArraysEqual } from "../../assembly/utils";
 import { arrayToTyped, typedToArray } from "../../assembly/utils";
@@ -199,9 +199,10 @@ export function testDivision(): bool {
 
 export function testSerializeU512Zero(): bool {
     let truth = hex2bin("00");
-    let zero = U512.fromBytes(truth);
-    assert(GetLastError() == Error.Ok);
-    assert(zero !== null);
+    let result = U512.fromBytes(truth);
+    assert(result.error == Error.Ok);
+    assert(result.hasValue());
+    let zero = result.value;
     assert(zero.isZero());
     const bytes = zero.toBytes();
     return checkArraysEqual(bytes, typedToArray(truth));
@@ -209,9 +210,10 @@ export function testSerializeU512Zero(): bool {
 
 export function testSerializeU512_3BytesWide(): bool {
     let truth = hex2bin("03807801");
-    let num = U512.fromBytes(truth);
-    assert(GetLastError() == Error.Ok);
-    assert(num !== null);
+    let result = U512.fromBytes(truth);
+    assert(result.error == Error.Ok);
+    assert(result.hasValue());
+    let num = result.value;
     assert(num.toString() == "17880"); // dec: 96384
     const bytes = num.toBytes();
     return checkArraysEqual(bytes, typedToArray(truth));
@@ -219,9 +221,10 @@ export function testSerializeU512_3BytesWide(): bool {
 
 export function testSerializeU512_2BytesWide(): bool {
     let truth = hex2bin("020004");
-    let num = U512.fromBytes(truth);
-    assert(GetLastError() == Error.Ok);
-    assert(num !== null);
+    let result = U512.fromBytes(truth);
+    assert(result.error == Error.Ok);
+    assert(result.hasValue());
+    let num = result.value;
     assert(num.toString() == "400"); // dec: 1024
     const bytes = num.toBytes();
     return checkArraysEqual(bytes, typedToArray(truth));
@@ -229,9 +232,10 @@ export function testSerializeU512_2BytesWide(): bool {
 
 export function testSerializeU512_1BytesWide(): bool {
     let truth = hex2bin("0101");
-    let num = U512.fromBytes(truth);
-    assert(GetLastError() == Error.Ok);
-    assert(num !== null);
+    let result = U512.fromBytes(truth);
+    assert(result.error == Error.Ok);
+    assert(result.hasValue());
+    let num = result.value;
     assert(num.toString() == "1");
     const bytes = num.toBytes();
     return checkArraysEqual(bytes, typedToArray(truth));
@@ -250,8 +254,8 @@ export function testSerialize100mTimes10(): bool {
     assert(checkArraysEqual(bytes, typedToArray(truth)));
 
     let roundTrip = U512.fromBytes(arrayToTyped(bytes));
-    assert(GetLastError() == Error.Ok);
-    assert(roundTrip.toString() == hex);
+    assert(roundTrip.error == Error.Ok);
+    assert(roundTrip.value.toString() == hex);
 
     return true;
 }
@@ -264,11 +268,11 @@ export function testDeserLargeRandomU512(): bool {
     let truth = hex2bin("40752c392d2ecd6123de0f1d3d4cdb7992aa85e049a94795975e81e20b78731cde6d4aa13da210479acce5f24a296ae787bada0aba1889c8fe2f2fb030d62feed2");
 
     let deser = U512.fromBytes(truth);
-    assert(GetLastError() == Error.Ok);
+    assert(deser.error == Error.Ok);
     assert(deser !== null);
-    assert(deser.toString() == hex);
+    assert(deser.value.toString() == hex);
 
-    let ser = deser.toBytes();
+    let ser = deser.value.toBytes();
     assert(checkArraysEqual(ser, typedToArray(truth)));
 
     return true;

--- a/execution-engine/contract-as/tests/assembly/bytesrepr.spec.as.ts
+++ b/execution-engine/contract-as/tests/assembly/bytesrepr.spec.as.ts
@@ -6,8 +6,7 @@ import { fromBytesU64, toBytesU64,
          toBytesPair,
          toBytesString, fromBytesString,
          toBytesVecT,
-         GetDecodedBytesCount,
-         GetLastError, Error } from "../../assembly/bytesrepr";
+         Error } from "../../assembly/bytesrepr";
 import { CLValue } from "../../assembly/clvalue";
 import { Key, KeyVariant } from "../../assembly/key";
 import { URef, AccessRights } from "../../assembly/uref";
@@ -23,9 +22,9 @@ import { Pair } from "../../assembly/pair";
 export function testDeserializeInvalidU8(): bool {
     const bytes: u8[] = [];
     let deser = fromBytesU8(arrayToTyped(bytes));
-    assert(GetLastError() == Error.EarlyEndOfStream);
-    assert(deser == 0);
-    return !deser;
+    assert(deser.error == Error.EarlyEndOfStream);
+    assert(deser.position == 0);
+    return !deser.hasValue();
 }
 
 export function testDeSerU8(): bool {
@@ -33,9 +32,8 @@ export function testDeSerU8(): bool {
     let ser = toBytesU8(222);
     assert(checkArraysEqual(ser, truth));
     let deser = fromBytesU8(arrayToTyped(ser));
-    assert(GetLastError() == Error.Ok);
-    assert(deser !== null);
-    return deser == 222;
+    assert(deser.error == Error.Ok);
+    return deser.value == 222;
 }
 
 export function xtestDeSerU8_Zero(): bool {
@@ -45,17 +43,18 @@ export function xtestDeSerU8_Zero(): bool {
     let ser = toBytesU8(0);
     assert(checkArraysEqual(ser, truth));
     let deser = fromBytesU8(arrayToTyped(ser));
-    assert(GetLastError() == Error.Ok);
-    return deser == 0;
+    assert(deser.error == Error.Ok);
+    return deser.value == 0;
 }
 
 export function testDeSerU32(): bool {
     const truth: u8[] = [239, 190, 173, 222];
-    let deser = toBytesU32(3735928559);
-    assert(checkArraysEqual(deser, truth));
-    let ser = fromBytesU32(arrayToTyped(deser));
-    assert(GetLastError() == Error.Ok);
-    return ser == 0xdeadbeef;
+    let ser = toBytesU32(3735928559);
+    assert(checkArraysEqual(ser, truth));
+    let deser = fromBytesU32(arrayToTyped(ser));
+    assert(deser.error == Error.Ok);
+    assert(deser.position == 4);
+    return deser.value == 0xdeadbeef;
 }
 
 export function testDeSerZeroU32(): bool {
@@ -63,86 +62,98 @@ export function testDeSerZeroU32(): bool {
     let ser = toBytesU32(0);
     assert(checkArraysEqual(ser, truth));
     let deser = fromBytesU32(arrayToTyped(ser));
-    assert(GetLastError() == Error.Ok);
-    return deser === 0;
+    assert(deser.error == Error.Ok);
+    assert(deser.hasValue());
+    return deser.value == 0;
 }
 
 export function testDeserializeU64_1024(): bool {
     const truth = hex2bin("0004000000000000");
-    var value = fromBytesU64(truth);
-    assert(GetLastError() == Error.Ok);
-    return value == <u64>1024;
+    var deser = fromBytesU64(truth);
+    assert(deser.error == Error.Ok);
+    assert(deser.position == 8);
+    return deser.value == <u64>1024;
 }
 
 export function testDeserializeU64_zero(): bool {
     const truth = hex2bin("0000000000000000");
-    var value = fromBytesU64(truth);
-    assert(GetLastError() == Error.Ok);
-    return value == <u64>0;
+    var deser = fromBytesU64(truth);
+    assert(deser.error == Error.Ok);
+    assert(deser.position == 8);
+    assert(deser.hasValue());
+    return deser.value == 0;
 }
 
 export function testDeserializeU64_u32max(): bool {
     const truth = hex2bin("ffffffff00000000");
-    const value = fromBytesU64(truth);
-    assert(GetLastError() == Error.Ok);
-    return value == 0xffffffff;
+    const deser = fromBytesU64(truth);
+    assert(deser.error == Error.Ok);
+    assert(deser.position == 8);
+    return deser.value == 0xffffffff;
 }
 
 export function testDeserializeU64_u32max_plus1(): bool {
     const truth = hex2bin("0000000001000000");
-    const value = fromBytesU64(truth);
-    assert(GetLastError() == Error.Ok);
-    return value == 4294967296;
+    const deser = fromBytesU64(truth);
+    assert(deser.hasValue());
+    assert(deser.error == Error.Ok);
+    assert(deser.position == 8);
+    return deser.value == 4294967296;
 }
 
 export function testDeserializeU64_EOF(): bool {
     const truth = hex2bin("0000");
-    const value = fromBytesU64(truth);
-    assert(GetLastError() == Error.EarlyEndOfStream);
-    return !value;
+    const deser = fromBytesU64(truth);
+    assert(deser.error == Error.EarlyEndOfStream);
+    assert(deser.position == 0);
+    return !deser.hasValue();
 }
 
 export function testDeserializeU64_u64max(): bool {
     const truth = hex2bin("feffffffffffffff");
-    const value = fromBytesU64(truth);
-    assert(GetLastError() == Error.Ok);
-    return value == <u64>18446744073709551614;
+    const deser = fromBytesU64(truth);
+    assert(deser.error == Error.Ok);
+    assert(deser.position == 8);
+    return deser.value == <u64>18446744073709551614;
 }
 
 export function testDeSerListOfStrings(): bool {
     const truth = hex2bin("03000000030000006162630a0000003132333435363738393006000000717765727479");
-    const maybeResult = fromBytesStringList(truth);
-    assert(GetLastError() == Error.Ok);
-    assert(maybeResult != null);
-    const result = <String[]>maybeResult;
+    const result = fromBytesStringList(truth);
+    assert(result.error == Error.Ok);
+    assert(result.hasValue());
+    const strList = result.value;
+    assert(result.position == truth.length);
 
-    assert(checkArraysEqual(result, <String[]>[
+    assert(checkArraysEqual(strList, <String[]>[
         "abc",
         "1234567890",
         "qwerty",
     ]));
 
-    let lhs = toBytesStringList(result);
+    let lhs = toBytesStringList(strList);
     let rhs = typedToArray(truth);
     return checkArraysEqual(lhs, rhs);
 };
 
 export function testDeSerEmptyListOfStrings(): bool {
     const truth = hex2bin("00000000");
-    const maybeResult = fromBytesStringList(truth);
-    assert(GetLastError() == Error.Ok);
-    return checkArraysEqual(<String[]>maybeResult, <String[]>[]);
+    const result = fromBytesStringList(truth);
+    assert(result.error == Error.Ok);
+    assert(result.position == 4);
+    return checkArraysEqual(<String[]>result.value, <String[]>[]);
 };
 
 export function testDeSerEmptyMap(): bool {
     const truth = hex2bin("00000000");
-    const maybeResult = fromBytesMap<String, Key>(
+    const result = fromBytesMap<String, Key>(
         truth,
         fromBytesString,
         Key.fromBytes);
-    assert(GetLastError() == Error.Ok);
-    assert(maybeResult !== null);
-    return checkArraysEqual(<Array<Pair<String, Key>>>maybeResult, <Array<Pair<String, Key>>>[]);
+    assert(result.error == Error.Ok);
+    assert(result.hasValue());
+    assert(result.position == 4);
+    return checkArraysEqual(result.value, <Array<Pair<String, Key>>>[]);
 };
 
 export function testSerializeMap(): bool {
@@ -161,28 +172,28 @@ export function testSerializeMap(): bool {
     const serialized = toBytesMap(map);
     assert(checkArraysEqual(serialized, typedToArray(truth)));
 
-    const maybeDeser = fromBytesMap<String, String>(
+    const deser = fromBytesMap<String, String>(
         arrayToTyped(serialized),
         fromBytesString,
         fromBytesString);
 
-    assert(GetLastError() == Error.Ok);
-    assert(maybeDeser !== null);
-    let deser = <Array<Pair<String, String>>>maybeDeser;
+    assert(deser.error == Error.Ok);
+    assert(deser.position == truth.length);
+    let listOfPairs = deser.value;
 
     let res1 = false;
     let res2 = false;
-    for (let i = 0; i < deser.length; i++) {
-        if (deser[i].first == "Key1" && deser[i].second == "Value1") {
+    for (let i = 0; i < listOfPairs.length; i++) {
+        if (listOfPairs[i].first == "Key1" && listOfPairs[i].second == "Value1") {
             res1 = true;
         }
-        if (deser[i].first == "Key2" && deser[i].second == "Value2") {
+        if (listOfPairs[i].first == "Key2" && listOfPairs[i].second == "Value2") {
             res2 = true;
         }
     }
     assert(res1);
     assert(res2);
-    return deser.length == 2;
+    return listOfPairs.length == 2;
 }
 
 export function testToBytesVecT(): bool {
@@ -213,8 +224,8 @@ export function testDeSerString(): bool {
     assert(checkArraysEqual(ser, typedToArray(truth)));
 
     const deser = fromBytesString(arrayToTyped(ser));
-    assert(GetLastError() == Error.Ok);
-    return deser == "hello_world";
+    assert(deser.error == Error.Ok);
+    return deser.value == "hello_world";
 }
 
 export function testDeSerIncompleteString(): bool {
@@ -222,18 +233,20 @@ export function testDeSerIncompleteString(): bool {
     const truth = hex2bin("0b00000068656c6c6f5f776f726c");
     // last byte removed from the truth to signalize incomplete data
     const deser = fromBytesString(truth);
-    assert(GetLastError() == Error.EarlyEndOfStream);
-    return deser === null;
+    assert(deser.error == Error.EarlyEndOfStream);
+    return !deser.hasValue();
 }
 
 export function testDecodeURefFromBytesWithoutAccessRights(): bool {
     const truth = hex2bin("2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a00");
-    let uref = URef.fromBytes(truth);
-    assert(GetLastError() == Error.Ok);
-    assert(uref !== null);
+    let urefResult = URef.fromBytes(truth);
+    assert(urefResult.error == Error.Ok);
+    assert(urefResult.hasValue());
+    let uref = urefResult.value;
 
     let urefBytes = new Array<u8>(32);
     urefBytes.fill(42);
+
 
     assert(checkArraysEqual(typedToArray(uref.getBytes()), urefBytes));
     assert(uref.getAccessRights() === AccessRights.NONE);
@@ -243,9 +256,10 @@ export function testDecodeURefFromBytesWithoutAccessRights(): bool {
 
 export function testDecodeURefFromBytesWithAccessRights(): bool {
     const truth = hex2bin("2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a2a0107");
-    const maybeURef = URef.fromBytes(truth);
-    assert(maybeURef !== null);
-    const uref = <URef>maybeURef;
+    const urefResult = URef.fromBytes(truth);
+    assert(urefResult.error == Error.Ok);
+    assert(urefResult.position == truth.length);
+    const uref = urefResult.value;
     assert(checkArraysEqual(typedToArray(uref.getBytes()), <u8[]>[
         42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
         42, 42, 42, 42, 42, 42, 42, 42, 42, 42,
@@ -283,16 +297,15 @@ export function testDeserMapOfNamedKeys(): bool {
 
     let truth = hex2bin(truthBytes + extraBytes);
 
-    const maybeDeser = fromBytesMap<String, Key>(
+    const mapResult = fromBytesMap<String, Key>(
         truth,
         fromBytesString,
         Key.fromBytes);
-    assert(GetLastError() == Error.Ok);
-    let deserializedBytes = GetDecodedBytesCount();
+    assert(mapResult.error == Error.Ok);
+    let deserializedBytes = mapResult.position;
     assert(<u32>deserializedBytes == <i32>truth.length - hex2bin(extraBytes).length);
 
-    assert(maybeDeser !== null);
-    let deser = <Array<Pair<String, Key>>>maybeDeser;
+    let deser = mapResult.value;
     assert(deser.length === 3);
 
     assert(deser[0].first == "A");

--- a/execution-engine/contracts-as/client/bonding/assembly/index.ts
+++ b/execution-engine/contracts-as/client/bonding/assembly/index.ts
@@ -33,11 +33,13 @@ export function call(): void {
         return;
     }
 
-    let amount = U512.fromBytes(amountBytes);
-    if (amount === null) {
+    let amountResult = U512.fromBytes(amountBytes);
+    if (amountResult.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+
+    let amount = amountResult.value;
 
     let ret = mainPurse.transferToPurse(
         <PurseId>(bondingPurse),
@@ -52,7 +54,7 @@ export function call(): void {
     let key = Key.fromURef(proofOfStake);
     let args: CLValue[] = [
         CLValue.fromString(POS_ACTION),
-        CLValue.fromU512(<U512>amount),
+        CLValue.fromU512(amount),
         bondingPurseValue
     ];
     let output = CL.callContract(key, args);

--- a/execution-engine/contracts-as/client/named-purse-payment/assembly/index.ts
+++ b/execution-engine/contracts-as/client/named-purse-payment/assembly/index.ts
@@ -25,12 +25,12 @@ export function call(): void {
   }
 
   let purseName = fromBytesString(purseNameBytes);
-  if (purseName === null) {
+  if (purseName.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument);
     return;
   }
 
-  let purseKey = getKey(<String>purseName);
+  let purseKey = getKey(purseName.value);
   if (purseKey === null) {
     Error.fromErrorCode(ErrorCode.InvalidArgument);
     return;
@@ -49,11 +49,12 @@ export function call(): void {
     return;
   }
 
-  let amount = U512.fromBytes(amountBytes);
-  if (amount === null) {
+  let amountResult = U512.fromBytes(amountBytes);
+  if (amountResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let amount = amountResult.value;
 
   let proofOfStakeKey = Key.fromURef(proofOfStake);
 
@@ -65,11 +66,12 @@ export function call(): void {
     Error.fromErrorCode(ErrorCode.PurseNotCreated).revert();
     return;
   }
-  let paymentPurse = PurseId.fromBytes(paymentPurseOutput);
-  if (paymentPurse === null) {
+  let paymentPurseResult = PurseId.fromBytes(paymentPurseOutput);
+  if (paymentPurseResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidPurse).revert();
     return;
   }
+  let paymentPurse = paymentPurseResult.value;
 
   // Set Refund Purse
   let args: CLValue[] = [CLValue.fromString(SET_REFUND_PURSE), CLValue.fromURef(purseId.asURef())];
@@ -80,8 +82,8 @@ export function call(): void {
   }
 
   let ret = purseId.transferToPurse(
-    <PurseId>(paymentPurse),
-    <U512>amount,
+    paymentPurse,
+    amount,
   );
   if (ret > 0) {
     Error.fromErrorCode(ErrorCode.Transfer).revert();

--- a/execution-engine/contracts-as/client/standard-payment-stored/assembly/index.ts
+++ b/execution-engine/contracts-as/client/standard-payment-stored/assembly/index.ts
@@ -34,11 +34,12 @@ export function call(): void {
     return;
   }
 
-  let destination = fromBytesString(destinationBytes);
-  if (destination === null) {
+  let destinationResult = fromBytesString(destinationBytes);
+  if (destinationResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument);
     return;
   }
+  let destination = destinationResult.value;
 
   if (destination == DESTINATION_HASH) {
     const key = storeAtHash();

--- a/execution-engine/contracts-as/client/standard-payment/assembly/index.ts
+++ b/execution-engine/contracts-as/client/standard-payment/assembly/index.ts
@@ -30,14 +30,15 @@ export function entryPoint(amount: U512): void {
     return;
   }
 
-  let paymentPurse = PurseId.fromBytes(output);
-  if (paymentPurse === null) {
+  let paymentPurseResult = PurseId.fromBytes(output);
+  if (paymentPurseResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidPurse).revert();
     return;
   }
+  let paymentPurse = paymentPurseResult.value;
 
   let ret = mainPurse.transferToPurse(
-    <PurseId>(paymentPurse),
+    paymentPurse,
     amount,
   );
   if (ret > 0) {
@@ -53,11 +54,11 @@ export function call(): void {
     return;
   }
 
-  let amount = U512.fromBytes(amountBytes);
-  if (amount === null) {
+  let amountResult = U512.fromBytes(amountBytes);
+  if (amountResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
 
-  entryPoint(amount);
+  entryPoint(amountResult.value);
 }

--- a/execution-engine/contracts-as/client/transfer-to-account-u512/assembly/index.ts
+++ b/execution-engine/contracts-as/client/transfer-to-account-u512/assembly/index.ts
@@ -5,34 +5,35 @@ import {getMainPurse} from "../../../../contract-as/assembly/account";
 import {TransferredTo} from "../../../../contract-as/assembly/purseid";
 
 enum Args{
-  Account = 0,
-  Amount = 1
+    Account = 0,
+    Amount = 1
 }
 
 export function call(): void {
-  const accountBytes = CL.getArg(Args.Account);
-  if (accountBytes === null) {
-    Error.fromErrorCode(ErrorCode.MissingArgument).revert();
-    return;
-  }
-  const amountBytes = CL.getArg(Args.Amount);
-  if (amountBytes === null) {
-    Error.fromErrorCode(ErrorCode.MissingArgument).revert();
-    return;
-  }
-  const amount = U512.fromBytes(amountBytes);
-  if(amount === null){
-      Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
-      return;
+    const accountBytes = CL.getArg(Args.Account);
+    if (accountBytes === null) {
+        Error.fromErrorCode(ErrorCode.MissingArgument).revert();
+        return;
     }
-  const mainPurse = getMainPurse();
-  if (mainPurse === null){
-      Error.fromErrorCode(ErrorCode.InvalidPurse).revert();
-      return;
-  }
-    const result = mainPurse.transferToAccount(accountBytes, <U512>amount);
-  if (result == TransferredTo.TransferError){
-      Error.fromErrorCode(ErrorCode.Transfer).revert();
-      return;
-  }
+    const amountBytes = CL.getArg(Args.Amount);
+    if (amountBytes === null) {
+        Error.fromErrorCode(ErrorCode.MissingArgument).revert();
+        return;
+    }
+    const amountResult = U512.fromBytes(amountBytes);
+    if (amountResult.hasError()){
+        Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
+        return;
+    }
+    let amount = amountResult.value;
+    const mainPurse = getMainPurse();
+    if (mainPurse === null){
+        Error.fromErrorCode(ErrorCode.InvalidPurse).revert();
+        return;
+    }
+    const result = mainPurse.transferToAccount(accountBytes, amount);
+    if (result == TransferredTo.TransferError){
+        Error.fromErrorCode(ErrorCode.Transfer).revert();
+        return;
+    }
 }

--- a/execution-engine/contracts-as/client/unbonding/assembly/index.ts
+++ b/execution-engine/contracts-as/client/unbonding/assembly/index.ts
@@ -19,16 +19,17 @@ export function call(): void {
         return;
     }
 
-    let amount = U512.fromBytes(amountBytes);
-    if (amount === null) {
+    let amountResult = U512.fromBytes(amountBytes);
+    if (amountResult.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    let amount = amountResult.value;
 
     let key = Key.fromURef(proofOfStake);
     let args: CLValue[] = [
         CLValue.fromString(POS_ACTION),
-        CLValue.fromU512(<U512>amount)
+        CLValue.fromU512(amount)
     ];
     let output = CL.callContract(key, args);
     if (output === null) {

--- a/execution-engine/contracts-as/examples/bonding-call/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/bonding-call/assembly/index.ts
@@ -27,17 +27,18 @@ export function call(): void {
         return;
     }
 
-    let bond_amount = CL.getArg(0);
-    if (bond_amount === null) {
+    let amountBytes = CL.getArg(0);
+    if (amountBytes === null) {
         Error.fromErrorCode(ErrorCode.MissingArgument).revert();
         return;
     }
 
-    let amount = U512.fromBytes(bond_amount);
-    if (amount === null) {
+    let amountResult = U512.fromBytes(amountBytes);
+    if (amountResult.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    let amount = amountResult.value;
 
     let ret = mainPurse.transferToPurse(
         <PurseId>(bondingPurse),
@@ -52,7 +53,7 @@ export function call(): void {
     let key = Key.fromURef(proofOfStake);
     let args: CLValue[] = [
         CLValue.fromString(POS_ACTION),
-        CLValue.fromU512(<U512>amount),
+        CLValue.fromU512(amount),
         bondingPurseValue
     ];
 

--- a/execution-engine/contracts-as/examples/counter-define/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/counter-define/assembly/index.ts
@@ -29,11 +29,12 @@ export function counter_ext(): void {
         return;
     }
 
-    const methodName = fromBytesString(methodNameBytes);
-    if (methodName === null) {
+    const methodNameResult = fromBytesString(methodNameBytes);
+    if (methodNameResult.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    const methodName = methodNameResult.value;
 
     if (methodName == INC_METHOD) {
         const oneValue = U512.fromU64(1);
@@ -47,13 +48,13 @@ export function counter_ext(): void {
             return;
         }
 
-        let valueI32 = fromBytesI32(valueBytes);
-        if (valueI32 === null) {
+        let i32Result = fromBytesI32(valueBytes);
+        if (i32Result.hasError()) {
             Error.fromUserError(4).revert();
             return;
         }
         
-        let returnValue = CLValue.fromI32(changetype<i32>(valueI32));
+        let returnValue = CLValue.fromI32(i32Result.value);
         ret(returnValue);
     }
     else {

--- a/execution-engine/contracts-as/examples/hello-name-call/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/hello-name-call/assembly/index.ts
@@ -24,11 +24,12 @@ export function call(): void {
         Error.fromUserError(1).revert();
         return;
     }
-    let outputMessage = fromBytesString(output);
-    if (outputMessage === null) {
+    let outputMessageResult = fromBytesString(output);
+    if (outputMessageResult.hasError()) {
         Error.fromUserError(2).revert();
         return;
     }
+    let outputMessage = outputMessageResult.value;
 
     if (outputMessage != EXPECTED){
         Error.fromUserError(3).revert();

--- a/execution-engine/contracts-as/examples/hello-name-define/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/hello-name-define/assembly/index.ts
@@ -26,11 +26,12 @@ export function hello_name_ext(): void {
         return;
     }
 
-    const name = fromBytesString(nameBytes);
-    if (name === null) {
+    const nameResult = fromBytesString(nameBytes);
+    if (nameResult.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    const name = nameResult.value;
 
     let hello = "Hello, " + name;
 

--- a/execution-engine/contracts-as/examples/mailing-list-call/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/mailing-list-call/assembly/index.ts
@@ -43,11 +43,12 @@ export function call(): void {
     }
 
     let subKeyBytes = <Uint8Array>maybeSubKey.unwrap();
-    let subKey = Key.fromBytes(subKeyBytes);
-    if (subKey === null) {
+    let subKeyResult = Key.fromBytes(subKeyBytes);
+    if (subKeyResult === null) {
         Error.fromUserError(<u16>UserError.NoSubKey).revert();
         return;
     }
+    let subKey = subKeyResult.value;
 
     putKey(MAIL_FEED_KEY, subKey);
 
@@ -77,12 +78,14 @@ export function call(): void {
     }
 
     const messageBytes = <Uint8Array>maybeMessagesBytes;
-    const messages = fromBytesStringList(messageBytes);
-    if (messages === null) {
+    const messagesResult = fromBytesStringList(messageBytes);
+    if (messagesResult.hasError()) {
         Error.fromUserError(<u16>UserError.FindMessagesURef).revert();
+        return;
     }
+    let messages = messagesResult.value;
 
-    if ((<String[]>messages).length == 0) {
+    if (messages.length == 0) {
         Error.fromUserError(<u16>UserError.NoMessages).revert();
     }
 }

--- a/execution-engine/contracts-as/examples/mailing-list-call/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/mailing-list-call/assembly/index.ts
@@ -25,7 +25,7 @@ export function call(): void {
         Error.fromErrorCode(ErrorCode.GetKey).revert();
         return;
     }
-    
+
     let name = "CasperLabs";
     let maybeSubKeyBytes = callContract(<Key>contractKey, [
         CLValue.fromString(SUB_METHOD),
@@ -75,8 +75,6 @@ export function call(): void {
         Error.fromUserError(<u16>UserError.GetMessagesURef)
         return;
     }
-
-    // TODO: Decode list of strings and do the check (currently fails)
 
     const messageBytes = <Uint8Array>maybeMessagesBytes;
     const messages = fromBytesStringList(messageBytes);

--- a/execution-engine/contracts-as/examples/mailing-list-define/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/mailing-list-define/assembly/index.ts
@@ -43,12 +43,13 @@ function updateList(name: String): void {
         return;
     }
 
-    let lst = fromBytesStringList(<Uint8Array>listBytes);
-    if (lst === null) {
+    let lstResult = fromBytesStringList(<Uint8Array>listBytes);
+    if (lstResult.hasError()) {
         Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
         return;
     }
 
+    let lst = lstResult.value;
     lst.push(name);
 
     listKey.write(CLValue.fromStringList(lst));
@@ -80,11 +81,12 @@ function publish(msg: String): void {
         return;
     }
 
-    let lst = fromBytesStringList(<Uint8Array>listBytes);
-    if (lst === null) {
+    let lstResult = fromBytesStringList(<Uint8Array>listBytes);
+    if (lstResult.hasError()) {
         Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
         return;
     }
+    let lst = lstResult.value;
 
     for (let i = 0; i < lst.length; i++) {
         const name = lst[i];
@@ -94,11 +96,12 @@ function publish(msg: String): void {
             Error.fromErrorCode(ErrorCode.Read).revert();
             return;
         }
-        let messages = fromBytesStringList(messagesBytes);
-        if (messages === null) {
+        let messagesResult = fromBytesStringList(messagesBytes);
+        if (messagesResult.hasError()) {
             Error.fromErrorCode(ErrorCode.ValueNotFound).revert();
             return;
         }
+        let messages = messagesResult.value;
         messages.push(msg);
         key.write(CLValue.fromStringList(messages));
     }
@@ -111,11 +114,12 @@ export function mailing_list_ext(): void {
         return;
     }
 
-    let methodName = fromBytesString(methodNameBytes);
-    if (methodName === null) {
+    let methodNameResult = fromBytesString(methodNameBytes);
+    if (methodNameResult === null) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    let methodName = methodNameResult.value;
 
     let arg1Bytes = getArg(Arg.Arg1);
     if (arg1Bytes === null) {
@@ -123,11 +127,12 @@ export function mailing_list_ext(): void {
         return;
     }
 
-    let arg1 = fromBytesString(arg1Bytes);
-    if (arg1 === null) {
+    let arg1Result = fromBytesString(arg1Bytes);
+    if (arg1Result.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    let arg1 = arg1Result.value;
 
     if (methodName == "sub") {
         let maybeKey = sub(arg1);

--- a/execution-engine/contracts-as/examples/unbonding-call/assembly/index.ts
+++ b/execution-engine/contracts-as/examples/unbonding-call/assembly/index.ts
@@ -19,16 +19,17 @@ export function call(): void {
         return;
     }
 
-    let amount = U512.fromBytes(amountBytes);
-    if (amount === null) {
+    let amountResult = U512.fromBytes(amountBytes);
+    if (amountResult.hasError()) {
         Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
         return;
     }
+    let amount = amountResult.value;
 
     let key = Key.fromURef(proofOfStake);
     let args: CLValue[] = [
         CLValue.fromString(POS_ACTION),
-        CLValue.fromU512(<U512>amount)
+        CLValue.fromU512(amount)
     ];
     let output = CL.callContract(key, args);
     if (output === null) {

--- a/execution-engine/contracts-as/test/create-purse-01/assembly/index.ts
+++ b/execution-engine/contracts-as/test/create-purse-01/assembly/index.ts
@@ -23,11 +23,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingPurseNameArg).revert();
     return;
   }
-  const purseName = fromBytesString(purseNameArg);
-  if (purseName === null){
+  const purseNameResult = fromBytesString(purseNameArg);
+  if (purseNameResult.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
     return;
   }
+  let purseName = purseNameResult.value;
 
   const maybePurse = PurseId.create();
   if (maybePurse === null){

--- a/execution-engine/contracts-as/test/do-nothing-stored-caller/assembly/index.ts
+++ b/execution-engine/contracts-as/test/do-nothing-stored-caller/assembly/index.ts
@@ -24,11 +24,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingDoNothingURefArg).revert();
     return;
   }
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
   if (uref.isValid() == false){
     Error.fromUserError(<u16>CustomError.InvalidDoNothingURefArg).revert();
     return;
@@ -39,16 +40,17 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingPurseNameArg).revert();
     return;
   }
-  const purseName = fromBytesString(purseNameArg);
-  if (purseName === null){
+  const purseNameResult = fromBytesString(purseNameArg);
+  if (purseNameResult.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
     return;
   }
+  const purseName = purseNameResult.value;
 
   let key = Key.fromURef(uref);
 
   const args: CLValue[] = [
-    CLValue.fromString(purseName)
+    CLValue.fromString(purseName),
   ];
 
   CL.callContract(key, args);

--- a/execution-engine/contracts-as/test/do-nothing-stored-upgrader/assembly/index.ts
+++ b/execution-engine/contracts-as/test/do-nothing-stored-upgrader/assembly/index.ts
@@ -32,11 +32,12 @@ export function delegate(): void {
     Error.fromUserError(<u16>CustomError.MissingPurseNameArg).revert();
     return;
   }
-  const purseName = fromBytesString(purseNameArg);
-  if (purseName === null){
+  const purseNameResult = fromBytesString(purseNameArg);
+  if (purseNameResult.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
     return;
   }
+  let purseName = purseNameResult.value;
 
   const maybePurse = PurseId.create();
   if (maybePurse === null){
@@ -55,11 +56,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingDoNothingURefArg).revert();
     return;
   }
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
   if (uref.isValid() == false){
     Error.fromUserError(<u16>CustomError.InvalidDoNothingURefArg).revert();
     return;

--- a/execution-engine/contracts-as/test/do-nothing-stored/assembly/index.ts
+++ b/execution-engine/contracts-as/test/do-nothing-stored/assembly/index.ts
@@ -43,12 +43,12 @@ export function call(): void {
     return;
   }
 
-  let destination = fromBytesString(destinationBytes);
-  if (destination === null) {
+  let destinationResult = fromBytesString(destinationBytes);
+  if (destinationResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument);
     return;
   }
-
+  let destination = destinationResult.value;
   if (destination == DESTINATION_HASH) {
     const key = storeAtHash();
     CL.putKey(CONTRACT_NAME, key);

--- a/execution-engine/contracts-as/test/get-arg/assembly/index.ts
+++ b/execution-engine/contracts-as/test/get-arg/assembly/index.ts
@@ -25,7 +25,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingArgument0).revert();
     return;
   }
-  const stringVal = fromBytesString(stringArg)
+  const stringValResult = fromBytesString(stringArg)
+  if (stringValResult.hasError()) {
+    Error.fromUserError(<u16>CustomError.InvalidArgument0).revert();
+    return;
+  }
+  let stringVal = stringValResult.value;
   if (stringVal != EXPECTED_STRING){
     Error.fromUserError(<u16>CustomError.InvalidArgument0).revert();
     return;
@@ -35,7 +40,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingArgument1).revert();
     return;
   }
-  const u512Val = U512.fromBytes(u512Arg);
+  const u512ValResult = U512.fromBytes(u512Arg);
+  if (u512ValResult.hasError()) {
+    Error.fromUserError(<u16>CustomError.InvalidArgument1).revert();
+    return;    
+  }
+  let u512Val = u512ValResult.value;
   if (u512Val != U512.fromU64(EXPECTED_NUM)){
     Error.fromUserError(<u16>CustomError.InvalidArgument1).revert();
     return;

--- a/execution-engine/contracts-as/test/get-blocktime/assembly/index.ts
+++ b/execution-engine/contracts-as/test/get-blocktime/assembly/index.ts
@@ -1,6 +1,6 @@
 import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
-import {fromBytesU64, GetLastError, Error as BytesreprError} from "../../../../contract-as/assembly/bytesrepr";
+import {fromBytesU64} from "../../../../contract-as/assembly/bytesrepr";
 
 export function call(): void {
   const knownBlockTimeBytes = CL.getArg(0);
@@ -9,11 +9,11 @@ export function call(): void {
     return;
   }
   const knownBlockTime = fromBytesU64(knownBlockTimeBytes);
-  if (GetLastError() != BytesreprError.Ok) {
+  if (knownBlockTime.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
 
   const blockTime = CL.getBlockTime();
-  assert(blockTime == <u64>knownBlockTime);
+  assert(blockTime == knownBlockTime.value);
 }

--- a/execution-engine/contracts-as/test/get-blocktime/assembly/index.ts
+++ b/execution-engine/contracts-as/test/get-blocktime/assembly/index.ts
@@ -1,6 +1,6 @@
 import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
-import {fromBytesU64} from "../../../../contract-as/assembly/bytesrepr";
+import {fromBytesU64, GetLastError, Error as BytesreprError} from "../../../../contract-as/assembly/bytesrepr";
 
 export function call(): void {
   const knownBlockTimeBytes = CL.getArg(0);
@@ -9,7 +9,7 @@ export function call(): void {
     return;
   }
   const knownBlockTime = fromBytesU64(knownBlockTimeBytes);
-  if (knownBlockTime === null) {
+  if (GetLastError() != BytesreprError.Ok) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }

--- a/execution-engine/contracts-as/test/key-management-thresholds/assembly/index.ts
+++ b/execution-engine/contracts-as/test/key-management-thresholds/assembly/index.ts
@@ -13,11 +13,13 @@ export function call(): void {
     return;
   }
 
-  let stage = fromBytesString(stageBytes);
-  if (stage === null) {
+  let stageResult = fromBytesString(stageBytes);
+  if (stageResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let stage = stageResult.value;
+
   let key42s = new Array<u8>(32);
   key42s.fill(42);
 

--- a/execution-engine/contracts-as/test/list-named-keys/assembly/index.ts
+++ b/execution-engine/contracts-as/test/list-named-keys/assembly/index.ts
@@ -26,15 +26,16 @@ export function call(): void {
     return;
   }
 
-  const expectedInitialNamedKeys = fromBytesMap<String, Key>(
+  const mapResult = fromBytesMap<String, Key>(
     expectedInitialNamedKeysBytes,
     fromBytesString,
     Key.fromBytes
   );
-  if (expectedInitialNamedKeys === null) {
+  if (mapResult.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidInitialNamedKeys).revert();
     return;
   }
+  let expectedInitialNamedKeys = mapResult.value;
 
   let actualNamedKeys = CL.listNamedKeys();
   if (actualNamedKeys === null) {
@@ -53,16 +54,16 @@ export function call(): void {
     return;
   }
 
-  const newNamedKeys = fromBytesMap<String, Key>(
+  const mapResult2 = fromBytesMap<String, Key>(
     newNamedKeysBytes,
     fromBytesString,
     Key.fromBytes
   );
-
-  if (newNamedKeys === null) {
+  if (mapResult2.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidNewNamedKeys).revert();
     return;
   }
+  let newNamedKeys = mapResult2.value;
 
   let expectedNamedKeys = expectedInitialNamedKeys;
 

--- a/execution-engine/contracts-as/test/local-state-add/assembly/index.ts
+++ b/execution-engine/contracts-as/test/local-state-add/assembly/index.ts
@@ -31,11 +31,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingCommandArg).revert();
     return;
   }
-  const command = fromBytesString(commandArg);
-  if (command === null){
+  const commandResult = fromBytesString(commandArg);
+  if (commandResult.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidCommandArg).revert();
     return;
   }
+  const command = commandResult.value;
   if (command == CMD_WRITE){
     writeLocal(local, CLValue.fromU64(INITIAL_VALUE));
   } else if (command == CMD_ADD){

--- a/execution-engine/contracts-as/test/local-state-stored-caller/assembly/index.ts
+++ b/execution-engine/contracts-as/test/local-state-stored-caller/assembly/index.ts
@@ -20,11 +20,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingURefArg).revert();
     return;
   }
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
   if (uref.isValid() == false){
     Error.fromUserError(<u16>CustomError.InvalidURefArg).revert();
     return;

--- a/execution-engine/contracts-as/test/local-state-stored-upgrader/assembly/index.ts
+++ b/execution-engine/contracts-as/test/local-state-stored-upgrader/assembly/index.ts
@@ -41,10 +41,8 @@ export function delegate(): void {
     maybeValue = new Uint8Array(0);
   }
 
-  let storedValue = fromBytesString(maybeValue);
-  if (storedValue === null){
-    storedValue = "";
-  }
+  let storedValueResult = fromBytesString(maybeValue);
+  let storedValue = storedValueResult.hasError() ? "" : storedValueResult.value;
 
   writeLocal(local, CLValue.fromString(storedValue + HELLO_PREFIX));
 
@@ -54,10 +52,8 @@ export function delegate(): void {
     return;
   }
 
-  let newValue = fromBytesString(readback);
-  if (newValue === null){
-    newValue = "";
-  }
+  let newValueResult = fromBytesString(readback);
+  let newValue = newValueResult.hasError() ? "" : newValueResult.value;
 
   newValue = newValue + WORLD_SUFFIX;
   writeLocal(local, CLValue.fromString(newValue.trim()));
@@ -68,8 +64,8 @@ export function delegate(): void {
     return;
   }
 
-  newValue = fromBytesString(readback);
-  if (newValue === null){
+  newValueResult = fromBytesString(readback);
+  if (newValueResult.hasError()) {
     newValue = "";
   }
 
@@ -84,7 +80,7 @@ export function delegate(): void {
 
   let finalValue = fromBytesString(readback);
 
-  if (finalValue === null){
+  if (finalValue.hasError()){
     Error.fromUserError(<u16>DelegatedError.FailedFinalReadback).revert()
     return;
   }
@@ -96,11 +92,12 @@ export function call(): void{
     Error.fromUserError(<u16>CustomError.MissingURefArg).revert();
     return;
   }
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
   if (uref.isValid() == false){
     Error.fromUserError(<u16>CustomError.InvalidURefArg).revert();
     return;

--- a/execution-engine/contracts-as/test/local-state-stored/assembly/index.ts
+++ b/execution-engine/contracts-as/test/local-state-stored/assembly/index.ts
@@ -28,10 +28,8 @@ export function delegate(): void {
     maybeValue = new Uint8Array(0);
   }
 
-  let storedValue = fromBytesString(maybeValue);
-  if (storedValue === null){
-    storedValue = "";
-  }
+  let storedValueResult = fromBytesString(maybeValue);
+  let storedValue = storedValueResult.hasError() ? "" : storedValueResult.value;
 
   writeLocal(local, CLValue.fromString(storedValue + HELLO_PREFIX));
 
@@ -41,10 +39,8 @@ export function delegate(): void {
     return;
   }
 
-  let newValue = fromBytesString(maybeReadBack);
-  if (newValue === null){
-    newValue = "";
-  }
+  let newValueResult = fromBytesString(maybeReadBack);
+  let newValue = newValueResult.hasError() ? "" : newValueResult.value;
 
   newValue = newValue + WORLD_SUFFIX;
 

--- a/execution-engine/contracts-as/test/local-state/assembly/index.ts
+++ b/execution-engine/contracts-as/test/local-state/assembly/index.ts
@@ -22,10 +22,8 @@ export function call(): void {
     maybeValue = new Uint8Array(0);
   }
 
-  let storedValue = fromBytesString(maybeValue);
-  if (storedValue === null){
-    storedValue = "";
-  }
+  let storedValueResult = fromBytesString(maybeValue);
+  let storedValue = storedValueResult.hasError() ? "" : storedValueResult.value;
 
   writeLocal(local, CLValue.fromString(storedValue + HELLO_PREFIX));
 
@@ -35,10 +33,8 @@ export function call(): void {
     return;
   }
 
-  let newValue = fromBytesString(maybeReadBack);
-  if (newValue === null){
-    newValue = "";
-  }
+  let newValueResult = fromBytesString(maybeReadBack);
+  let newValue = newValueResult.hasError() ? "" : newValueResult.value;
 
   newValue = newValue + WORLD_SUFFIX;
 

--- a/execution-engine/contracts-as/test/main-purse/assembly/index.ts
+++ b/execution-engine/contracts-as/test/main-purse/assembly/index.ts
@@ -21,11 +21,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingExpectedMainPurseArg).revert();
     return;
   }
-  let expectedMainPurse = PurseId.fromBytes(expectedMainPurseArg);
-  if (expectedMainPurse === null){
+  let purseResult = PurseId.fromBytes(expectedMainPurseArg);
+  if (purseResult === null){
     Error.fromUserError(<u16>CustomError.InvalidExpectedMainPurseArg).revert();
     return;
   }
+  const expectedMainPurse = purseResult.value;
   const actualMainPurse = getMainPurse();
   if (actualMainPurse === null){
     Error.fromUserError(<u16>CustomError.UnableToGetMainPurse).revert();

--- a/execution-engine/contracts-as/test/named-keys/assembly/index.ts
+++ b/execution-engine/contracts-as/test/named-keys/assembly/index.ts
@@ -21,13 +21,14 @@ export function call(): void {
     return;
   }
 
-  let command = fromBytesString(commandBytes);
-  if (command === null) {
+  let commandResult = fromBytesString(commandBytes);
+  if (commandResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument);
     return;
   }
+  let command = commandResult.value;
 
-  else if (command == COMMAND_CREATE_UREF1) {
+  if (command == COMMAND_CREATE_UREF1) {
     let helloWorldKey = Key.create(CLValue.fromString("Hello, world!"));
     if (helloWorldKey === null) {
       Error.fromUserError(4464 + 1).revert();
@@ -68,11 +69,11 @@ export function call(): void {
         }
 
         let bytesString = fromBytesString(bytes);
-        if (bytesString === null) {
+        if (bytesString.hasError()) {
           Error.fromUserError(4464 + 2000 + <u16>i).revert();
           return;
         }
-        helloWorld = bytesString;
+        helloWorld = bytesString.value;
       }
     }
 
@@ -89,11 +90,11 @@ export function call(): void {
       return;
     }
     let uref1Str = fromBytesString(uref1Bytes);
-    if (uref1Str === null) {
+    if (uref1Str.hasError()) {
       Error.fromUserError(4464 + 8).revert();
       return;
     }
-    if (uref1Str != "Hello, world!") {
+    if (uref1Str.value != "Hello, world!") {
       Error.fromUserError(4464 + 9).revert();
       return;
     }
@@ -108,12 +109,12 @@ export function call(): void {
       return;
     }
     let bigValue = U512.fromBytes(bigValueBytes);
-    if (bigValue === null) {
+    if (bigValue.hasError()) {
       Error.fromUserError(4464 + 13).revert();
       return;
     }
 
-    if (bigValue != U512.MAX_VALUE) {
+    if (bigValue.value != U512.MAX_VALUE) {
       Error.fromUserError(4464 + 14).revert();
       return;
     }
@@ -130,11 +131,11 @@ export function call(): void {
       return;
     }
     let newBigValue = U512.fromBytes(newBigValueBytes);
-    if (newBigValue === null) {
+    if (newBigValue.hasError()) {
       Error.fromUserError(4464 + 16).revert();
       return;
     }
-    if (newBigValue != U512.MIN_VALUE) {
+    if (newBigValue.value != U512.MIN_VALUE) {
       Error.fromUserError(4464 + 17).revert();
       return;
     }
@@ -152,11 +153,11 @@ export function call(): void {
       return;
     }
     let newBigValue = U512.fromBytes(newBigValueBytes);
-    if (newBigValue === null) {
+    if (newBigValue.hasError()) {
       Error.fromUserError(4464 + 19).revert();
       return;
     }
-    if (newBigValue != U512.fromU64(123456789)) {
+    if (newBigValue.value != U512.fromU64(123456789)) {
       Error.fromUserError(4464 + 20).revert();
       return;
     }

--- a/execution-engine/contracts-as/test/overwrite-uref-content/assembly/index.ts
+++ b/execution-engine/contracts-as/test/overwrite-uref-content/assembly/index.ts
@@ -13,11 +13,12 @@ export function call(): void {
     return;
   }
 
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
 
   if (uref.isValid() == false){
     Error.fromUserError(1).revert();

--- a/execution-engine/contracts-as/test/purse-holder-stored-caller/assembly/index.ts
+++ b/execution-engine/contracts-as/test/purse-holder-stored-caller/assembly/index.ts
@@ -33,11 +33,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingPurseHolderURefArg).revert();
     return;
   }
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
   if (uref.isValid() == false){
     Error.fromUserError(<u16>CustomError.InvalidPurseHolderURefArg).revert();
     return;
@@ -47,11 +48,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingMethodNameArg).revert();
     return;
   }
-  const methodName = fromBytesString(methodNameArg);
-  if (methodName === null){
+  const methodNameResult = fromBytesString(methodNameArg);
+  if (methodNameResult.hasError()) {
     Error.fromUserError(<u16>CustomError.InvalidMethodNameArg).revert();
     return;
   }
+  let methodName = methodNameResult.value;
 
   let key = Key.fromURef(uref);
 
@@ -65,11 +67,12 @@ export function call(): void {
       Error.fromUserError(<u16>CustomError.UnableToGetVersion).revert();
       return;
     }
-    const version = fromBytesString(versionBytes);
-    if (version === null) {
+    const versionResult = fromBytesString(versionBytes);
+    if (versionResult.hasError()) {
       Error.fromUserError(<u16>CustomError.InvalidVersion).revert();
       return;
     }
+    let version = versionResult.value;
     const maybeVersionKey = Key.create(CLValue.fromString(version));
     if (maybeVersionKey === null) {
       Error.fromUserError(<u16>CustomError.UnableToStoreVersion).revert();
@@ -85,11 +88,13 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingPurseNameArg).revert();
     return;
   }
-  const purseName = fromBytesString(purseNameArg);
-  if (purseName === null){
+  const purseNameResult = fromBytesString(purseNameArg);
+  if (purseNameResult.hasError()){
     Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
     return;
   }
+  const purseName = purseNameResult.value;
+
   const args: CLValue[] = [
     CLValue.fromString(methodName),
     CLValue.fromString(purseName)

--- a/execution-engine/contracts-as/test/purse-holder-stored-upgrader/assembly/index.ts
+++ b/execution-engine/contracts-as/test/purse-holder-stored-upgrader/assembly/index.ts
@@ -43,11 +43,12 @@ export function delegate(): void {
     Error.fromUserError(<u16>CustomError.MissingMethodNameArg).revert();
     return;
   }
-  const methodName = fromBytesString(methodNameArg);
-  if (methodName === null){
+  const methodNameResult = fromBytesString(methodNameArg);
+  if (methodNameResult === null){
     Error.fromUserError(<u16>CustomError.InvalidMethodNameArg).revert();
     return;
   }
+  let methodName = methodNameResult.value;
   if (methodName == METHOD_ADD){
     // purseName
     const purseNameArg = CL.getArg(ApplyArgs.PurseName);
@@ -55,11 +56,13 @@ export function delegate(): void {
       Error.fromUserError(<u16>CustomError.MissingPurseNameArg).revert();
       return;
     }
-    const purseName = fromBytesString(purseNameArg);
-    if (purseName === null){
+    const purseNameResult = fromBytesString(purseNameArg);
+    if (purseNameResult === null){
       Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
       return;
     }
+    let purseName = purseNameResult.value;
+
     let purseId = PurseId.create();
     if (purseId === null) {
       Error.fromUserError(<u16>CustomError.NamedPurseNotCreated).revert();
@@ -77,11 +80,12 @@ export function delegate(): void {
       Error.fromUserError(<u16>CustomError.MissingPurseNameArg).revert();
       return;
     }
-    const purseName = fromBytesString(purseNameArg);
-    if (purseName === null){
+    const purseNameResult = fromBytesString(purseNameArg);
+    if (purseNameResult === null){
       Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
       return;
     }
+    let purseName = purseNameResult.value;
     removeKey(purseName);
     return;
   }
@@ -98,11 +102,12 @@ export function call(): void {
     Error.fromUserError(<u16>CustomError.MissingPurseHolderURefArg).revert();
     return;
   }
-  let uref = URef.fromBytes(urefBytes);
-  if (uref === null) {
+  let urefResult = URef.fromBytes(urefBytes);
+  if (urefResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
+  let uref = urefResult.value;
   if (uref.isValid() == false){
     Error.fromUserError(<u16>CustomError.InvalidPurseHolderURefArg).revert();
     return;

--- a/execution-engine/contracts-as/test/purse-holder-stored/assembly/index.ts
+++ b/execution-engine/contracts-as/test/purse-holder-stored/assembly/index.ts
@@ -33,11 +33,13 @@ export function delegate(): void {
     Error.fromUserError(<u16>CustomError.MissingMethodNameArg).revert();
     return;
   }
-  const methodName = fromBytesString(methodNameArg);
-  if (methodName === null){
+  const methodNameResult = fromBytesString(methodNameArg);
+  if (methodNameResult === null){
     Error.fromUserError(<u16>CustomError.InvalidMethodNameArg).revert();
     return;
   }
+  let methodName = methodNameResult.value;
+
   if (methodName == METHOD_ADD){
     const purseNameArg = CL.getArg(Args.PurseName);
     if (purseNameArg === null){
@@ -51,11 +53,12 @@ export function delegate(): void {
     }
     const uref = (<PurseId>purseId).asURef();
     const key = Key.fromURef(uref);
-    const purseName = fromBytesString(purseNameArg);
-    if (purseName === null){
+    const purseNameResult = fromBytesString(purseNameArg);
+    if (purseNameResult.hasError()) {
       Error.fromUserError(<u16>CustomError.InvalidPurseNameArg).revert();
       return;
     }
+    let purseName = purseNameResult.value;
     putKey(purseName, <Key>key);
     return;
   }

--- a/execution-engine/contracts-as/test/transfer-main-purse-to-new-purse/assembly/index.ts
+++ b/execution-engine/contracts-as/test/transfer-main-purse-to-new-purse/assembly/index.ts
@@ -28,21 +28,23 @@ export function call(): void {
         Error.fromUserError(<u16>CustomError.MissingAmountArg).revert();
         return;
     }
-    const amount = U512.fromBytes(amountArg);
-    if (amount === null) {
+    const amountResult = U512.fromBytes(amountArg);
+    if (amountResult.hasError()) {
         Error.fromUserError(<u16>CustomError.InvalidAmountArg).revert();
         return;
     }
+    let amount = amountResult.value;
     const destinationPurseNameArg = CL.getArg(Args.DestinationPurseName);
     if (destinationPurseNameArg === null) {
         Error.fromUserError(<u16>CustomError.MissingDestinationArg).revert();
         return;
     }
-    const destinationPurseName = fromBytesString(destinationPurseNameArg);
-    if (destinationPurseName === null){
+    const destinationPurseNameResult = fromBytesString(destinationPurseNameArg);
+    if (destinationPurseNameResult.hasError()) {
         Error.fromUserError(<u16>CustomError.InvalidDestinationArg).revert();
         return;
     }
+    let destinationPurseName = destinationPurseNameResult.value;
     const maybeMainPurse = getMainPurse();
     if (maybeMainPurse === null) {
         Error.fromUserError(<u16>CustomError.UnableToGetMainPurse).revert();

--- a/execution-engine/contracts-as/test/transfer-purse-to-account-stored/assembly/index.ts
+++ b/execution-engine/contracts-as/test/transfer-purse-to-account-stored/assembly/index.ts
@@ -44,13 +44,14 @@ export function delegate(): void {
         Error.fromUserError(<u16>CustomError.MissingAmountArg).revert();
         return;
     }
-    const amount = U512.fromBytes(amountArg);
-    if (amount === null) {
+    const amountResult = U512.fromBytes(amountArg);
+    if (amountResult.hasError()) {
         Error.fromUserError(<u16>CustomError.InvalidAmountArg).revert();
         return;
     }
+    let amount = amountResult.value;
     let message = "";
-    const result = mainPurse.transferToAccount(<Uint8Array>destinationAccountAddrArg, <U512>amount);
+    const result = mainPurse.transferToAccount(<Uint8Array>destinationAccountAddrArg, amount);
     switch (result) {
         case TransferredTo.NewAccount:
             message = "Ok(NewAccount)";

--- a/execution-engine/contracts-as/test/transfer-purse-to-account/assembly/index.ts
+++ b/execution-engine/contracts-as/test/transfer-purse-to-account/assembly/index.ts
@@ -42,13 +42,14 @@ export function call(): void {
         Error.fromUserError(<u16>CustomError.MissingAmountArg).revert();
         return;
     }
-    const amount = U512.fromBytes(amountArg);
-    if (amount === null) {
+    const amountResult = U512.fromBytes(amountArg);
+    if (amountResult.hasError()) {
         Error.fromUserError(<u16>CustomError.InvalidAmountArg).revert();
         return;
     }
+    let amount = amountResult.value;
     let message = "";
-    const result = mainPurse.transferToAccount(<Uint8Array>destinationAccountAddrArg, <U512>amount);
+    const result = mainPurse.transferToAccount(<Uint8Array>destinationAccountAddrArg, amount);
     switch (result) {
         case TransferredTo.NewAccount:
             message = "Ok(NewAccount)";

--- a/execution-engine/contracts-as/test/transfer-purse-to-purse/assembly/index.ts
+++ b/execution-engine/contracts-as/test/transfer-purse-to-purse/assembly/index.ts
@@ -60,13 +60,14 @@ export function call(): void {
         Error.fromUserError(<u16>CustomError.MissingSourcePurseArg).revert();
         return;
     }
-    const sourcePurse = fromBytesString(sourcePurseArg);
-    if(sourcePurse === null){
+    const sourcePurseResult = fromBytesString(sourcePurseArg);
+    if(sourcePurseResult.hasError()) {
         Error.fromUserError(<u16>CustomError.InvalidSourcePurseArg).revert();
         return;
     }
+    const sourcePurse = sourcePurseResult.value;
     const sourcePurseKey = getKey(sourcePurse);
-    if(sourcePurseKey === null){
+    if (sourcePurseKey === null){
         Error.fromUserError(<u16>CustomError.InvalidSourcePurseKey).revert();
         return;
     }
@@ -81,11 +82,12 @@ export function call(): void {
         Error.fromUserError(<u16>CustomError.MissingDestinationPurseArg).revert();
         return;
     }
-    const destinationPurse = fromBytesString(destinationPurseArg);
-    if(destinationPurse === null){
+    const destinationPurseResult = fromBytesString(destinationPurseArg);
+    if(destinationPurseResult.hasError()){
         Error.fromUserError(<u16>CustomError.InvalidDestinationPurseArg).revert();
         return;
     }
+    let destinationPurse = destinationPurseResult.value;
     let destinationPurseId: PurseId | null;
     let destinationKey: Key | null;
     if(!hasKey(destinationPurse)){
@@ -122,13 +124,14 @@ export function call(): void {
         Error.fromUserError(<u16>CustomError.MissingAmountArg).revert();
         return;
     }
-    const amount = U512.fromBytes(amountArg);
-    if (amount === null) {
+    const amountResult = U512.fromBytes(amountArg);
+    if (amountResult.hasError()) {
         Error.fromUserError(<u16>CustomError.InvalidAmountArg).revert();
         return;
     }
+    const amount = amountResult.value;
 
-    const result = sourcePurseId.transferToPurse(<PurseId>destinationPurseId, <U512>amount);
+    const result = sourcePurseId.transferToPurse(<PurseId>destinationPurseId, amount);
     let message = SUCCESS_MESSAGE;
     if (result !== null && result > 0){
         message = TRANSFER_ERROR_MESSAGE;


### PR DESCRIPTION
### Overview

Cleanups

- Removed some stalled todos
- Removed union types in bytesrepr (i.e. `foo(): U32 | null` is now `foo(): u32` and `GetLastError() != Error.Ok`)
- Improved usage of "Last decoded bytes counter"

### Which JIRA ticket does this PR relate to?

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
