### PR TITLE
OP-1133: pin ssh plugin to released version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -822,7 +822,7 @@ steps:
   - package-sbt-artifacts-tag
 
 - name: mac-ee-tarball-tag
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host
@@ -893,7 +893,7 @@ steps:
   - rsync-mac-tarball-tag
 
 - name: cleanup-mac-tag
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host
@@ -934,7 +934,7 @@ clone:
 
 steps:
 - name: mac-clone
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host
@@ -952,7 +952,7 @@ steps:
     - git clone -b dev https://github.com/CasperLabs/CasperLabs.git
 
 - name: build-node
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host
@@ -969,7 +969,7 @@ steps:
     - /usr/local/bin/sbt node/universal:stage
 
 - name: build-client
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host
@@ -986,7 +986,7 @@ steps:
     - /usr/local/bin/sbt client/universal:stage
 
 - name: build-ee
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host
@@ -1006,7 +1006,7 @@ steps:
     - make build
 
 - name: cleanup-mac
-  image: appleboy/drone-ssh:latest
+  image: appleboy/drone-ssh:1.5.5
   environment:
     SSH_HOST:
       from_secret: mac-host


### PR DESCRIPTION
### Overview
The plugin updated today and broke our mac cron. This pins the version to the latest release from the dev.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1133

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
