### PR TITLE
NODE-1182: Track success or failure of converting deploys to ipc format individually, instead of failing the whole batch

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -634,11 +634,11 @@ object ProtoUtil {
   // Later, post DEV NET, conversion rate will be part of a deploy.
   val GAS_PRICE = 10L
 
-  def deployDataToEEDeploy[F[_]: MonadThrowable](d: Deploy): Try[ipc.DeployItem] = {
+  def deployDataToEEDeploy(d: Deploy): Try[ipc.DeployItem] = {
     def toPayload(maybeCode: Option[Deploy.Code]): Try[Option[ipc.DeployPayload]] =
       maybeCode match {
         case None       => Try(none[ipc.DeployPayload])
-        case Some(code) => (deployCodeToDeployPayload[F](code).map(Some(_)))
+        case Some(code) => (deployCodeToDeployPayload(code).map(Some(_)))
       }
 
     for {
@@ -656,7 +656,7 @@ object ProtoUtil {
     }
   }
 
-  def deployCodeToDeployPayload[F[_]: MonadThrowable](code: Deploy.Code): Try[ipc.DeployPayload] = {
+  def deployCodeToDeployPayload(code: Deploy.Code): Try[ipc.DeployPayload] = {
     val argsF: Try[ByteString] = code.args.toList.traverse(cltype.ProtoMappings.fromArg) match {
       case Left(err) =>
         Try(throw new SmartContractEngineError(s"Error parsing deploy arguments: $err"))

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -32,6 +32,7 @@ import io.casperlabs.storage.deploy.{DeployStorage, DeployStorageWriter}
 import io.casperlabs.models.BlockImplicits._
 import io.casperlabs.metrics.implicits._
 import io.casperlabs.smartcontracts.ExecutionEngineService.CommitResult
+import scala.util.{Failure, Success}
 
 import scala.util.Either
 
@@ -284,20 +285,33 @@ object ExecEngineUtil {
       blocktime: Long,
       deploys: Seq[Deploy],
       protocolVersion: state.ProtocolVersion
-  )(eeExec: EEExecFun[F]): F[List[ProcessedDeployResult]] =
+  )(eeExec: EEExecFun[F]): F[List[ProcessedDeployResult]] = {
+    val (eeDeploys, goodDeploys, badArgs) =
+      deploys.foldLeft(
+        (Vector.empty[DeployItem], Vector.empty[Deploy], Vector.empty[PreconditionFailure])
+      ) {
+        case ((eeAcc, goodAcc, failAcc), deploy) =>
+          ProtoUtil.deployDataToEEDeploy(deploy) match {
+            case Failure(err) =>
+              val updated = failAcc :+ PreconditionFailure(deploy, err.getMessage)
+              (eeAcc, goodAcc, updated)
+
+            case Success(ipcDeploy) =>
+              (eeAcc :+ ipcDeploy, goodAcc :+ deploy, failAcc)
+          }
+      }
+
     for {
-      eeDeploys <- MonadThrowable[F].fromTry(
-                    deploys.toList.traverse(ProtoUtil.deployDataToEEDeploy[F](_))
-                  )
       results <- eeExec(prestate, blocktime, eeDeploys, protocolVersion).rethrow
       _ <- MonadThrowable[F]
             .raiseError[List[ProcessedDeployResult]](
               SmartContractEngineError(
-                s"Unexpected number of results (${results.size} vs ${deploys.size} expected."
+                s"Unexpected number of results (${results.size} vs ${goodDeploys.size} expected."
               )
             )
-            .whenA(results.size != deploys.size)
-    } yield zipDeploysResults(deploys, results)
+            .whenA(results.size != goodDeploys.size)
+    } yield zipDeploysResults(goodDeploys, results) ++ badArgs
+  }
 
   /** Chooses a set of commuting effects.
     *

--- a/integration-testing/test/test_invalid_bigint.py
+++ b/integration-testing/test/test_invalid_bigint.py
@@ -1,0 +1,48 @@
+from casperlabs_local_net.casperlabs_accounts import GENESIS_ACCOUNT
+from casperlabs_local_net.cli import DockerCLI
+from casperlabs_local_net.common import Contract
+from casperlabs_local_net.wait import wait_for_no_new_deploys
+
+
+def test_invalid_bigint(one_node_network_fn):
+    # Test covering fix for NODE-1182
+    # Use a malformed BigInt contract argument
+    node = one_node_network_fn.docker_nodes[0]
+    cli = DockerCLI(node)
+    session_wasm = cli.resource(Contract.ARGS_U512)
+
+    # Send in u512 with invalid string format, surrounded []
+    args = '[{"name": "arg_u512", "value": {"big_int": {"value": "[1000]", "bit_width": 512}}}]'
+    # fmt: off
+    deploy_hash = cli("deploy",
+                      "--private-key", cli.private_key_path(GENESIS_ACCOUNT),
+                      "--payment-amount", 10000000,
+                      "--session", session_wasm,
+                      "--session-args", cli.format_json_str(args))
+    # fmt: on
+
+    wait_for_no_new_deploys(node)
+
+    status = node.d_client.show_deploy(deploy_hash).status
+    assert "state: DISCARDED" in str(status)
+    assert (
+        'message: "Error parsing deploy arguments: InvalidBigIntValue([1000])"'
+        in str(status)
+    )
+
+    # Send in u512 valid as 1000.
+    args = '[{"name": "arg_u512", "value": {"big_int": {"value": "1000", "bit_width": 512}}}]'
+    # fmt: off
+    deploy_hash = cli("deploy",
+                      "--private-key", cli.private_key_path(GENESIS_ACCOUNT),
+                      "--payment-amount", 10000000,
+                      "--session", session_wasm,
+                      "--session-args", cli.format_json_str(args))
+    # fmt: on
+
+    node.wait_for_deploy_processed_and_get_block_hash(deploy_hash, on_error_raise=False)
+
+    result = node.d_client.show_deploy(deploy_hash)
+
+    # User(code) in revert adds 65536 to the 1000
+    assert f"Exit code: {1000 + 65536}" in str(result)

--- a/integration-testing/test/test_invalid_bigint.py
+++ b/integration-testing/test/test_invalid_bigint.py
@@ -24,9 +24,9 @@ def test_invalid_bigint(one_node_network_fn):
     wait_for_no_new_deploys(node)
 
     status = node.d_client.show_deploy(deploy_hash).status
-    assert "state: DISCARDED" in str(status)
+    assert "'state': 'DISCARDED'" in str(status)
     assert (
-        'message: "Error parsing deploy arguments: InvalidBigIntValue([1000])"'
+        "'message': 'Error parsing deploy arguments: InvalidBigIntValue([1000])'"
         in str(status)
     )
 


### PR DESCRIPTION
### Overview
This fixes the release-blocking bug. The reason this fix works is because we capture deploys that fail to parse into the ipc format as precondition failures, whereas previously we were failing the whole execution.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1182

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I think the regression test will need to written as an integration test. I'm pushing the fix now though so that we can unblock the release. I'll push a regression test hopefully later today, but possibly tomorrow.
