### PR TITLE
NODE-1187: Chainspec envvar override

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -264,9 +264,6 @@ omega-message-time-end = 0.75
 # Initial round exponent to start the node with, before auto-adjustment takes over; corresponds to the tick unit of the chain.
 init-round-exponent = 14
 
-# For testing purposes allow overriding the start of the genesis era, to avoid having to edit the chainspec.
-genesis-era-start-override = 0
-
 # io.casperlabs.node.configuration.Configuration.Kamon
 [metrics]
 

--- a/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
@@ -250,15 +250,10 @@ object Highway {
                                                       }
                                                     }
 
-      // Allow specifying the start outside the chain spec, for convenience.
-      genesisEraStart = Option(conf.highway.genesisEraStartOverride)
-        .filter(_ > 0)
-        .getOrElse(hc.genesisEraStartTimestamp)
-
       supervisor <- EraSupervisor(
                      conf = HighwayConf(
                        tickUnit = TimeUnit.MILLISECONDS,
-                       genesisEraStart = Instant.ofEpochMilli(genesisEraStart),
+                       genesisEraStart = Instant.ofEpochMilli(hc.genesisEraStartTimestamp),
                        eraDuration =
                          HighwayConf.EraDuration.FixedLength(hc.eraDurationMillis.millis),
                        bookingDuration = hc.bookingDurationMillis.millis,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -138,10 +138,7 @@ object Configuration extends ParserImplicits {
       command         <- options.parseCommand
       defaultDataDir  <- readDefaultDataDir
       maybeConfigFile <- options.readConfigFile.map(_.map(parseToml))
-      envSnakeCase = envVars.flatMap {
-        case (k, v) if k.startsWith("CL_") && isSnakeCase(k) => List(SnakeCase(k) -> v)
-        case _                                               => Nil
-      }
+      envSnakeCase    = Utils.collectEnvVars(envVars)
     } yield parse(options.fieldByName, envSnakeCase, maybeConfigFile, defaultDataDir, defaults)
       .map(conf => (command, conf))
     res.fold(_.invalidNel[(Command, Configuration)], identity)

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -118,8 +118,7 @@ object Configuration extends ParserImplicits {
       enabled: Boolean,
       omegaMessageTimeStart: Double Refined Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T],
       omegaMessageTimeEnd: Double Refined Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T],
-      initRoundExponent: Int Refined NonNegative,
-      genesisEraStartOverride: Long
+      initRoundExponent: Int Refined NonNegative
   ) extends SubConfig
 
   sealed trait Command extends Product with Serializable

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -551,12 +551,6 @@ private[configuration] final case class Options private (
       )
 
     @scallop
-    val highwayGenesisEraStartOverride =
-      gen[Long](
-        "For testing purposes allow overriding the start of the genesis era, to avoid having to edit the chainspec."
-      )
-
-    @scallop
     val metricsPrometheus =
       gen[Flag]("Enable the Prometheus metrics reporter.")
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Utils.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Utils.scala
@@ -28,6 +28,15 @@ private[configuration] object Utils {
   def isSnakeCase(s: String): Boolean = s.matches("[A-Z_]+")
   def SnakeCase(s: String): SnakeCase = s.asInstanceOf[SnakeCase]
 
+  def collectEnvVars(
+      envVars: Map[String, String] = sys.env,
+      prefix: String = "CL_"
+  ): Map[SnakeCase, String] =
+    envVars.collect {
+      case (k, v) if k.startsWith(prefix) && isSnakeCase(k) =>
+        SnakeCase(k) -> v
+    }
+
   def readFile(source: => Source): Either[String, String] = {
     val src = source
     try {

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -87,7 +87,6 @@ enabled = false
 omega-message-time-start = 1.0
 omega-message-time-end = 1.0
 init-round-exponent = 0
-genesis-era-start-override = 0
 
 [blockstorage]
 cache-max-size-bytes = 1

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -132,8 +132,7 @@ class ConfigurationSpec
       enabled = false,
       omegaMessageTimeStart = 1.0,
       omegaMessageTimeEnd = 1.0,
-      initRoundExponent = 0,
-      genesisEraStartOverride = 0
+      initRoundExponent = 0
     )
     val tls = Tls(
       certificate = Paths.get("/tmp/test.crt"),


### PR DESCRIPTION
### Overview
Removes the `--highway-genesis-era-start-override` CLI option and adds the ability to override any setting in the Genesis chainspec manifest by using environment variables starting with `CL_CHAINSPEC_rest_of_the_field_structure`, for example `CL_CHAINSPEC_GENESIS_NAME` or `CL_CHAINSPEC_HIGHWAY_GENESIS_ERA_START`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1187

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
