### PR TITLE
NODE-977: Add is_main to block_parents.

### DIFF
--- a/storage/src/main/resources/db/migration/V20200211_977__Add_is_main_parent.sql
+++ b/storage/src/main/resources/db/migration/V20200211_977__Add_is_main_parent.sql
@@ -1,0 +1,4 @@
+-- The table is defined without rowid so there's no easy way
+-- derive `is_main` for existing records.
+ALTER TABLE block_parents
+    ADD COLUMN is_main BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
### Overview
Adds an `is_main` flag to the `block_parents` table so we can follow only main children if we need to via recursive SQL. Easier to add now than later. There used to be some Scala algorithms that utilised this info as far as I remember.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-977

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
