### PR TITLE
EE-890: Gracefully reject WASM that contains 'start' node

### DIFF
--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -47,6 +47,7 @@ pub enum Error {
     },
     CLValue(CLValueError),
     HostBufferEmpty,
+    UnsupportedWasmStart,
 }
 
 impl fmt::Display for Error {

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -64,8 +64,11 @@ pub fn instance_and_memory(
     let resolver = create_module_resolver(protocol_version)?;
     let mut imports = ImportsBuilder::new();
     imports.push_resolver("env", &resolver);
-    let instance = ModuleInstance::new(&module, &imports)?.assert_no_start();
-
+    let not_started_module = ModuleInstance::new(&module, &imports)?;
+    if not_started_module.has_start() {
+        return Err(Error::UnsupportedWasmStart);
+    }
+    let instance = not_started_module.not_started_instance().clone();
     let memory = resolver.memory_ref()?;
     Ok((instance, memory))
 }

--- a/execution-engine/engine-test-support/src/internal/deploy_item_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/deploy_item_builder.rs
@@ -85,18 +85,16 @@ impl DeployItemBuilder {
         self
     }
 
-    pub fn with_session_code<T: AsRef<Path>>(
-        mut self,
-        file_name: T,
-        args: impl ArgsParser,
-    ) -> Self {
-        let wasm_bytes = utils::read_wasm_file_bytes(file_name);
+    pub fn with_session_bytes(mut self, module_bytes: Vec<u8>, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        self.deploy_item.session_code = Some(ExecutableDeployItem::ModuleBytes {
-            module_bytes: wasm_bytes,
-            args,
-        });
+        self.deploy_item.session_code =
+            Some(ExecutableDeployItem::ModuleBytes { module_bytes, args });
         self
+    }
+
+    pub fn with_session_code<T: AsRef<Path>>(self, file_name: T, args: impl ArgsParser) -> Self {
+        let module_bytes = utils::read_wasm_file_bytes(file_name);
+        self.with_session_bytes(module_bytes, args)
     }
 
     pub fn with_stored_session_hash(mut self, hash: Vec<u8>, args: impl ArgsParser) -> Self {

--- a/execution-engine/engine-test-support/src/internal/deploy_item_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/deploy_item_builder.rs
@@ -33,18 +33,16 @@ impl DeployItemBuilder {
         self
     }
 
-    pub fn with_payment_code<T: AsRef<Path>>(
-        mut self,
-        file_name: T,
-        args: impl ArgsParser,
-    ) -> Self {
-        let wasm_bytes = utils::read_wasm_file_bytes(file_name);
+    pub fn with_payment_bytes(mut self, module_bytes: Vec<u8>, args: impl ArgsParser) -> Self {
         let args = Self::serialize_args(args);
-        self.deploy_item.payment_code = Some(ExecutableDeployItem::ModuleBytes {
-            module_bytes: wasm_bytes,
-            args,
-        });
+        self.deploy_item.payment_code =
+            Some(ExecutableDeployItem::ModuleBytes { module_bytes, args });
         self
+    }
+
+    pub fn with_payment_code<T: AsRef<Path>>(self, file_name: T, args: impl ArgsParser) -> Self {
+        let module_bytes = utils::read_wasm_file_bytes(file_name);
+        self.with_payment_bytes(module_bytes, args)
     }
 
     pub fn with_stored_payment_hash(mut self, hash: Vec<u8>, args: impl ArgsParser) -> Self {

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -25,6 +25,7 @@ engine-wasm-prep = { path = "../engine-wasm-prep", package = "casperlabs-engine-
 lazy_static = "1"
 num-traits = "0.2.10"
 tempfile = "3"
+wabt = "0.9.2"
 
 [features]
 use-as-wasm = ["engine-test-support/use-as-wasm"]

--- a/execution-engine/engine-tests/src/test/regression/ee_890.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_890.rs
@@ -1,0 +1,48 @@
+use engine_test_support::{
+    internal::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG,
+        DEFAULT_PAYMENT, STANDARD_PAYMENT_CONTRACT,
+    },
+    DEFAULT_ACCOUNT_ADDR,
+};
+use types::account::PublicKey;
+
+// NOTE: Apparently rustc does not emit "start" when targeting wasm32
+// Ref: https://github.com/rustwasm/team/issues/108
+const CONTRACT_WAT_WITH_START: &str = r#"
+(module
+    (memory (;0;) 1)
+    (export "memory" (memory 0))
+    (type (;0;) (func))
+    (func (;0;) (type 0)
+      nop)
+    (start 0))
+"#;
+
+#[ignore]
+#[test]
+fn should_run_ee_890_gracefully_reject_start_node_in_session() {
+    let wasm_binary = wabt::wat2wasm(CONTRACT_WAT_WITH_START).expect("should parse");
+
+    let deploy_1 = DeployItemBuilder::new()
+        .with_address(DEFAULT_ACCOUNT_ADDR)
+        .with_session_bytes(wasm_binary, ())
+        .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,))
+        .with_authorization_keys(&[PublicKey::new(DEFAULT_ACCOUNT_ADDR)])
+        .with_deploy_hash([123; 32])
+        .build();
+
+    let exec_request_1 = ExecuteRequestBuilder::new().push_deploy(deploy_1).build();
+
+    let result = InMemoryWasmTestBuilder::default()
+        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .exec(exec_request_1)
+        .commit()
+        .finish();
+    let message = result.builder().exec_error_message(0).expect("should fail");
+    assert!(
+        message.contains("UnsupportedWasmStart"),
+        "Error message {:?} does not contain expected pattern",
+        message
+    );
+}

--- a/execution-engine/engine-tests/src/test/regression/ee_890.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_890.rs
@@ -7,6 +7,8 @@ use engine_test_support::{
 };
 use types::account::PublicKey;
 
+const DO_NOTHING_WASM: &str = "do_nothing.wasm";
+
 // NOTE: Apparently rustc does not emit "start" when targeting wasm32
 // Ref: https://github.com/rustwasm/team/issues/108
 const CONTRACT_WAT_WITH_START: &str = r#"
@@ -28,6 +30,34 @@ fn should_run_ee_890_gracefully_reject_start_node_in_session() {
         .with_address(DEFAULT_ACCOUNT_ADDR)
         .with_session_bytes(wasm_binary, ())
         .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,))
+        .with_authorization_keys(&[PublicKey::new(DEFAULT_ACCOUNT_ADDR)])
+        .with_deploy_hash([123; 32])
+        .build();
+
+    let exec_request_1 = ExecuteRequestBuilder::new().push_deploy(deploy_1).build();
+
+    let result = InMemoryWasmTestBuilder::default()
+        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .exec(exec_request_1)
+        .commit()
+        .finish();
+    let message = result.builder().exec_error_message(0).expect("should fail");
+    assert!(
+        message.contains("UnsupportedWasmStart"),
+        "Error message {:?} does not contain expected pattern",
+        message
+    );
+}
+
+#[ignore]
+#[test]
+fn should_run_ee_890_gracefully_reject_start_node_in_payment() {
+    let wasm_binary = wabt::wat2wasm(CONTRACT_WAT_WITH_START).expect("should parse");
+
+    let deploy_1 = DeployItemBuilder::new()
+        .with_address(DEFAULT_ACCOUNT_ADDR)
+        .with_session_code(DO_NOTHING_WASM, ())
+        .with_payment_bytes(wasm_binary, ())
         .with_authorization_keys(&[PublicKey::new(DEFAULT_ACCOUNT_ADDR)])
         .with_deploy_hash([123; 32])
         .build();

--- a/execution-engine/engine-tests/src/test/regression/mod.rs
+++ b/execution-engine/engine-tests/src/test/regression/mod.rs
@@ -16,3 +16,4 @@ mod ee_598;
 mod ee_599;
 mod ee_601;
 mod ee_803;
+mod ee_890;


### PR DESCRIPTION
### Overview
Detects if WASM module contains a "start" node and then rejects it gracefully.

This test uses WAT contract file, as supposedly, rustc doesn't generate a "start" node yet in wasm32 target (https://github.com/rustwasm/team/issues/108).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-890

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
