### PR TITLE
NODE-1198: Pause era when the fork choice retreats

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -177,6 +177,11 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       leaderSequencer
     )(syncId, makeSemaphoreId, C, DS, ES, FS, FC)
 
+  /** Create a runtime given an era that's supposedly the child era of another one;
+    * otherwise we should be using `genesisEraRuntime` instead. For the same reason
+    * this one's not using any default values for the implicits: they should be
+    * shared with the parent. Only practical to be used inside `Fixture`.
+    */
   def childEraRuntime(
       era: Era,
       validator: Option[String] = none,
@@ -203,6 +208,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
     )(syncId, makeSemaphoreId, C, DS, ES, FS, FC)
 
   // Make it easier to share common dependencies.
+  // TODO (NODE-1199): Use HighwayFixture instead for all tests.
   trait Fixture {
     implicit val C  = TestClock.adjustable[Id](date(2019, 12, 9))
     implicit val DS = defaultBlockDagStorage


### PR DESCRIPTION
### Overview
Adds an `ifCanBuildOn(forkChoice)` method to the `EraRuntime` which is used to skip creating messages if the fork choice reverted to a previous era.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1198

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
