### PR TITLE
EE-887: Rewrite trie_store::operations::keys as an iterator

### DIFF
--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -768,12 +768,7 @@ where
                     let mut index: usize = maybe_index.unwrap_or_default();
                     while index < RADIX {
                         if let Some(ref pointer) = pointer_block[index] {
-                            maybe_next_trie = match self.store.get(self.txn, pointer.hash()) {
-                                Ok(next_trie) => next_trie,
-                                Err(_) => {
-                                    return None;
-                                }
-                            };
+                            maybe_next_trie = self.store.get(self.txn, pointer.hash()).ok()?;
                             debug_assert!(maybe_next_trie.is_some());
                             self.visited.push((trie, Some(index + 1), path.clone()));
                             path.push(index as u8);
@@ -783,12 +778,7 @@ where
                     }
                 }
                 Trie::Extension { affix, pointer } => {
-                    maybe_next_trie = match self.store.get(self.txn, pointer.hash()) {
-                        Ok(next_trie) => next_trie,
-                        Err(_) => {
-                            return None;
-                        }
-                    };
+                    maybe_next_trie = self.store.get(self.txn, pointer.hash()).ok()?;
                     debug_assert!({
                         match &maybe_next_trie {
                             Some(Trie::Node { .. }) => true,

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
@@ -39,6 +39,7 @@ mod partial_tries {
                     &context.store,
                     &root_hash,
                 )
+                .filter_map(Result::ok)
                 .collect::<Vec<TestKey>>();
                 txn.commit().unwrap();
                 tmp.sort();
@@ -74,6 +75,7 @@ mod partial_tries {
                     &context.store,
                     &root_hash,
                 )
+                .filter_map(Result::ok)
                 .collect::<Vec<TestKey>>();
                 txn.commit().unwrap();
                 tmp.sort();
@@ -131,6 +133,7 @@ mod full_tries {
                         &context.store,
                         &state,
                     )
+                    .filter_map(Result::ok)
                     .collect::<Vec<TestKey>>();
                     txn.commit().unwrap();
                     tmp.sort();

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
@@ -2,7 +2,6 @@ mod partial_tries {
     use engine_shared::newtypes::CorrelationId;
 
     use crate::{
-        error::{self, in_memory},
         transaction_source::{Transaction, TransactionSource},
         trie::Trie,
         trie_store::operations::{
@@ -34,13 +33,13 @@ mod partial_tries {
             };
             let actual = {
                 let txn = context.environment.create_read_txn().unwrap();
-                let mut tmp = operations::keys::<TestKey, TestValue, _, _, error::Error>(
+                let mut tmp = operations::keys::<TestKey, TestValue, _, _>(
                     correlation_id,
                     &txn,
                     &context.store,
                     &root_hash,
                 )
-                .unwrap();
+                .collect::<Vec<TestKey>>();
                 txn.commit().unwrap();
                 tmp.sort();
                 tmp
@@ -69,13 +68,13 @@ mod partial_tries {
             };
             let actual = {
                 let txn = context.environment.create_read_txn().unwrap();
-                let mut tmp = operations::keys::<TestKey, TestValue, _, _, in_memory::Error>(
+                let mut tmp = operations::keys::<TestKey, TestValue, _, _>(
                     correlation_id,
                     &txn,
                     &context.store,
                     &root_hash,
                 )
-                .unwrap();
+                .collect::<Vec<TestKey>>();
                 txn.commit().unwrap();
                 tmp.sort();
                 tmp
@@ -89,7 +88,6 @@ mod full_tries {
     use engine_shared::newtypes::{Blake2bHash, CorrelationId};
 
     use crate::{
-        error::in_memory,
         transaction_source::{Transaction, TransactionSource},
         trie::Trie,
         trie_store::operations::{
@@ -127,13 +125,13 @@ mod full_tries {
                 };
                 let actual = {
                     let txn = context.environment.create_read_txn().unwrap();
-                    let mut tmp = operations::keys::<TestKey, TestValue, _, _, in_memory::Error>(
+                    let mut tmp = operations::keys::<TestKey, TestValue, _, _>(
                         correlation_id,
                         &txn,
                         &context.store,
                         &state,
                     )
-                    .unwrap();
+                    .collect::<Vec<TestKey>>();
                     txn.commit().unwrap();
                     tmp.sort();
                     tmp

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
@@ -144,3 +144,104 @@ mod full_tries {
         }
     }
 }
+
+#[cfg(debug_assertions)]
+mod keys_iterator {
+    use engine_shared::newtypes::{Blake2bHash, CorrelationId};
+    use types::bytesrepr;
+
+    use crate::{
+        transaction_source::TransactionSource,
+        trie::{Pointer, Trie},
+        trie_store::operations::{
+            self,
+            tests::{
+                hash_test_tries, HashedTestTrie, HashedTrie, InMemoryTestContext, TestKey,
+                TestValue, TEST_LEAVES,
+            },
+        },
+    };
+
+    fn create_invalid_extension_trie(
+    ) -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error> {
+        let leaves = hash_test_tries(&TEST_LEAVES[2..3])?;
+        let ext_1 = HashedTrie::new(Trie::extension(
+            vec![0u8, 0],
+            Pointer::NodePointer(leaves[0].hash),
+        ))?;
+
+        let root = HashedTrie::new(Trie::node(&[(0, Pointer::NodePointer(ext_1.hash))]))?;
+        let root_hash = root.hash;
+
+        let tries = vec![root, ext_1, leaves[0].clone()];
+
+        Ok((root_hash, tries))
+    }
+
+    fn create_invalid_path_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error> {
+        let leaves = hash_test_tries(&TEST_LEAVES[..1])?;
+
+        let root = HashedTrie::new(Trie::node(&[(1, Pointer::NodePointer(leaves[0].hash))]))?;
+        let root_hash = root.hash;
+
+        let tries = vec![root, leaves[0].clone()];
+
+        Ok((root_hash, tries))
+    }
+
+    fn create_invalid_hash_trie() -> Result<(Blake2bHash, Vec<HashedTestTrie>), bytesrepr::Error> {
+        let leaves = hash_test_tries(&TEST_LEAVES[..2])?;
+
+        let root = HashedTrie::new(Trie::node(&[(0, Pointer::NodePointer(leaves[1].hash))]))?;
+        let root_hash = root.hash;
+
+        let tries = vec![root, leaves[0].clone()];
+
+        Ok((root_hash, tries))
+    }
+
+    macro_rules! return_on_err {
+        ($x:expr) => {
+            match $x {
+                Ok(result) => result,
+                Err(_) => {
+                    return; // we expect the test to panic, so this will cause a test failure
+                }
+            }
+        };
+    }
+
+    fn test_trie(root_hash: Blake2bHash, tries: Vec<HashedTestTrie>) {
+        let correlation_id = CorrelationId::new();
+        let context = return_on_err!(InMemoryTestContext::new(&tries));
+        let txn = return_on_err!(context.environment.create_read_txn());
+        let _tmp = operations::keys::<TestKey, TestValue, _, _>(
+            correlation_id,
+            &txn,
+            &context.store,
+            &root_hash,
+        )
+        .collect::<Vec<_>>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn should_panic_on_leaf_after_extension() {
+        let (root_hash, tries) = return_on_err!(create_invalid_extension_trie());
+        test_trie(root_hash, tries);
+    }
+
+    #[test]
+    #[should_panic]
+    fn should_panic_when_key_not_matching_path() {
+        let (root_hash, tries) = return_on_err!(create_invalid_path_trie());
+        test_trie(root_hash, tries);
+    }
+
+    #[test]
+    #[should_panic]
+    fn should_panic_on_pointer_to_nonexisting_hash() {
+        let (root_hash, tries) = return_on_err!(create_invalid_hash_trie());
+        test_trie(root_hash, tries);
+    }
+}

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -612,8 +612,9 @@ where
         tmp
     };
     let actual = {
-        let mut tmp =
-            operations::keys::<_, _, _, _>(correlation_id, txn, store, root).collect::<Vec<K>>();
+        let mut tmp = operations::keys::<_, _, _, _>(correlation_id, txn, store, root)
+            .filter_map(Result::ok)
+            .collect::<Vec<K>>();
         tmp.sort();
         tmp
     };
@@ -738,6 +739,7 @@ where
         };
         let actual = {
             let mut tmp = operations::keys::<_, _, _, _>(correlation_id, &txn, store, root_hash)
+                .filter_map(Result::ok)
                 .collect::<Vec<K>>();
             tmp.sort();
             tmp

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -612,7 +612,8 @@ where
         tmp
     };
     let actual = {
-        let mut tmp = operations::keys::<_, _, _, _, E>(correlation_id, txn, store, root)?;
+        let mut tmp =
+            operations::keys::<_, _, _, _>(correlation_id, txn, store, root).collect::<Vec<K>>();
         tmp.sort();
         tmp
     };
@@ -736,8 +737,8 @@ where
             tmp
         };
         let actual = {
-            let mut tmp =
-                operations::keys::<_, _, _, _, E>(correlation_id, &txn, store, root_hash)?;
+            let mut tmp = operations::keys::<_, _, _, _>(correlation_id, &txn, store, root_hash)
+                .collect::<Vec<K>>();
             tmp.sort();
             tmp
         };


### PR DESCRIPTION
### Overview
This reimplements the method returning keys of a Trie store as an iterator over these keys

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-887

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The iterator interface doesn't provide any error propagation facilities, so any errors that may happen during iteration only result in the iterator ceasing to yield any items.
If desired, instead of keys, the iterator could return `Result<K, Error>` as items, so that the errors could be returned somehow.
