### PR TITLE
NODE-1171: Add `--wait-for-processed` and `--timeout-seconds` to `show-deploy` and `deploy`

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -231,6 +231,14 @@ def deploy_command(casperlabs_client, args):
     kwargs = _deploy_kwargs(args)
     deploy_hash = casperlabs_client.deploy(**kwargs)
     print(f"Success! Deploy {deploy_hash} deployed")
+    if args.wait_for_processed:
+        deploy_info = casperlabs_client.showDeploy(
+            deploy_hash,
+            full_view=False,
+            wait_for_processed=args.wait_for_processed,
+            timeout_seconds=args.timeout_seconds,
+        )
+        print(hexify(deploy_info))
 
 
 @guarded_command
@@ -392,6 +400,8 @@ def deploy_options(private_key_accepted=True):
         [('--session-args',), dict(required=False, type=str, help="""JSON encoded list of session args, e.g.: '[{"name": "amount", "value": {"long_value": 123456}}]'""")],
         [('--payment-args',), dict(required=False, type=str, help="""JSON encoded list of payment args, e.g.: '[{"name": "amount", "value": {"big_int": {"value": "123456", "bit_width": 512}}}]'""")],
         [('--ttl-millis',), dict(required=False, type=int, help="""Time to live. Time (in milliseconds) that the deploy will remain valid for.'""")],
+        [('-w', '--wait-for-processed'), dict(action='store_true', help='Wait for deploy status PROCESSED or DISCARDED')],
+        [('--timeout-seconds',), dict(type=int, default=CasperLabsClient.DEPLOY_STATUS_TIMEOUT, help='Timeout in seconds')],
         [('--public-key',), dict(required=False, default=None, type=str, help='Path to the file with account public key (Ed25519)')]]
         + (private_key_accepted
            and [[('--private-key',), dict(required=True, default=None, type=str, help='Path to the file with account private key (Ed25519)')]]

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -139,6 +139,8 @@ def _deploy_kwargs(args, private_key_accepted=True):
     from_addr = (
         getattr(args, "from")
         and bytes.fromhex(getattr(args, "from"))
+        or getattr(args, "public_key")
+        and read_pem_key(args.public_key)
         or private_to_public_key(args.private_key)
     )
     if from_addr and len(from_addr) != 32:
@@ -189,7 +191,7 @@ def make_deploy_command(casperlabs_client, args):
     deploy = casperlabs_client.make_deploy(**kwargs)
     data = deploy.SerializeToString()
     if not args.deploy_path:
-        sys.stdout.write(data)
+        sys.stdout.buffer.write(data)
     else:
         with open(args.deploy_path, "wb") as f:
             f.write(data)
@@ -276,7 +278,12 @@ def balance_command(casperlabs_client, args):
 
 @guarded_command
 def show_deploy_command(casperlabs_client, args):
-    response = casperlabs_client.showDeploy(args.hash, full_view=False)
+    response = casperlabs_client.showDeploy(
+        args.hash,
+        full_view=False,
+        wait_for_processed=args.wait_for_processed,
+        timeout_seconds=args.timeout_seconds,
+    )
     print(hexify(response))
 
 
@@ -514,7 +521,9 @@ def cli(*arguments) -> int:
                       [[('-d', '--depth'), dict(required=True, type=int, help='depth in terms of block height')]])
 
     parser.addCommand('show-deploy', show_deploy_command, 'View properties of a deploy known by Casper on an existing running node.',
-                      [[('hash',), dict(type=str, help='Value of the deploy hash, base16 encoded.')]])
+                      [[('hash',), dict(type=str, help='Value of the deploy hash, base16 encoded.')],
+                       [('-w', '--wait-for-processed'), dict(action='store_true', help='Wait for deploy status PROCESSED or DISCARDED')],
+                       [('--timeout-seconds',), dict(type=int, default=CasperLabsClient.DEPLOY_STATUS_TIMEOUT, help='Timeout in seconds')]])
 
     parser.addCommand('show-deploys', show_deploys_command, 'View deploys included in a block.',
                       [[('hash',), dict(type=str, help='Value of the block hash, base16 encoded.')]])


### PR DESCRIPTION
### Overview
This PR adds options `--wait-for-processed` and `--timeout-seconds` to Python client CLI `show-deploy` and `deploy` commands.

See design document: [CLI extensions compensating removed propose command](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/262078618/CLI+extensions+compensating+removed+propose+command)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1171

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
