### PR TITLE
EE-892: avoid following circular references in query logic

### DIFF
--- a/execution-engine/contract/src/contract_api/account.rs
+++ b/execution-engine/contract/src/contract_api/account.rs
@@ -55,7 +55,7 @@ pub fn add_associated_key(public_key: PublicKey, weight: Weight) -> Result<(), A
     }
 }
 
-/// Removes the given [`PublicKey'] from the account's associated keys.
+/// Removes the given [`PublicKey`] from the account's associated keys.
 pub fn remove_associated_key(public_key: PublicKey) -> Result<(), RemoveKeyFailure> {
     let (public_key_ptr, _public_key_size, _bytes) = to_ptr(public_key);
     let result = unsafe { ext_ffi::remove_associated_key(public_key_ptr) };

--- a/execution-engine/contract/src/contract_api/storage.rs
+++ b/execution-engine/contract/src/contract_api/storage.rs
@@ -131,7 +131,7 @@ pub fn store_function_at_hash(name: &str, named_keys: BTreeMap<String, Key>) -> 
     ContractRef::Hash(addr)
 }
 
-/// Returns a new unforgeable pointer, where the value is initialized to `init`
+/// Returns a new unforgeable pointer, where the value is initialized to `init`.
 pub fn new_turef<T: CLTyped + ToBytes>(init: T) -> TURef<T> {
     let key_ptr = contract_api::alloc_bytes(Key::serialized_size_hint());
     let cl_value = CLValue::from_t(init).unwrap_or_revert();

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -603,9 +603,9 @@ where
             None => return Ok(QueryResult::RootNotFound),
         };
 
-        let mut mut_tracking_copy = tracking_copy.borrow_mut();
+        let tracking_copy = tracking_copy.borrow();
 
-        Ok(mut_tracking_copy
+        Ok(tracking_copy
             .query(correlation_id, query_request.key(), query_request.path())
             .map_err(|err| Error::Exec(err.into()))?
             .into())

--- a/execution-engine/engine-core/src/engine_state/query.rs
+++ b/execution-engine/engine-core/src/engine_state/query.rs
@@ -6,6 +6,7 @@ use crate::tracking_copy::TrackingCopyQueryResult;
 pub enum QueryResult {
     RootNotFound,
     ValueNotFound(String),
+    CircularReference(String),
     Success(StoredValue),
 }
 
@@ -41,8 +42,9 @@ impl QueryRequest {
 impl From<TrackingCopyQueryResult> for QueryResult {
     fn from(tracking_copy_query_result: TrackingCopyQueryResult) -> Self {
         match tracking_copy_query_result {
-            TrackingCopyQueryResult::ValueNotFound(full_path) => {
-                QueryResult::ValueNotFound(full_path)
+            TrackingCopyQueryResult::ValueNotFound(message) => QueryResult::ValueNotFound(message),
+            TrackingCopyQueryResult::CircularReference(message) => {
+                QueryResult::CircularReference(message)
             }
             TrackingCopyQueryResult::Success(value) => QueryResult::Success(value),
         }

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -25,7 +25,6 @@ pub enum Error {
     ForgedReference(URef),
     URefNotFound(String),
     FunctionNotFound(String),
-    CircularReferenceInQuery(String),
     ParityWasm(elements::Error),
     GasLimit,
     Ret(Vec<URef>),

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -25,6 +25,7 @@ pub enum Error {
     ForgedReference(URef),
     URefNotFound(String),
     FunctionNotFound(String),
+    CircularReferenceInQuery(String),
     ParityWasm(elements::Error),
     GasLimit,
     Ret(Vec<URef>),

--- a/execution-engine/engine-core/src/tracking_copy/ext.rs
+++ b/execution-engine/engine-core/src/tracking_copy/ext.rs
@@ -7,10 +7,7 @@ use engine_shared::{
 use engine_storage::global_state::StateReader;
 use types::{bytesrepr::ToBytes, CLValue, Key, URef, U512};
 
-use crate::{
-    execution,
-    tracking_copy::{TrackingCopy, TrackingCopyQueryResult},
-};
+use crate::{execution, tracking_copy::TrackingCopy};
 
 pub trait TrackingCopyExt<R> {
     type Error;
@@ -80,16 +77,18 @@ where
         let local_key_bytes = uref.addr().into_bytes()?;
         let balance_mapping_key = Key::local(mint_contract_uref.addr(), &local_key_bytes);
         match self
-            .query(correlation_id, balance_mapping_key, &[])
+            .read(correlation_id, &balance_mapping_key)
             .map_err(Into::into)?
         {
-            TrackingCopyQueryResult::Success(stored_value) => {
+            Some(stored_value) => {
                 let cl_value: CLValue = stored_value
                     .try_into()
                     .map_err(execution::Error::TypeMismatch)?;
                 Ok(cl_value.into_t()?)
             }
-            TrackingCopyQueryResult::ValueNotFound(msg) => Err(execution::Error::URefNotFound(msg)),
+            None => Err(execution::Error::URefNotFound(
+                "public purse balance".to_string(),
+            )),
         }
     }
 
@@ -98,19 +97,19 @@ where
         correlation_id: CorrelationId,
         key: Key,
     ) -> Result<Motes, Self::Error> {
-        let query_result = match self.query(correlation_id, key, &[]) {
-            Ok(query_result) => query_result,
+        let read_result = match self.read(correlation_id, &key) {
+            Ok(read_result) => read_result,
             Err(_) => return Err(execution::Error::KeyNotFound(key)),
         };
-        match query_result {
-            TrackingCopyQueryResult::Success(stored_value) => {
+        match read_result {
+            Some(stored_value) => {
                 let cl_value: CLValue = stored_value
                     .try_into()
                     .map_err(execution::Error::TypeMismatch)?;
                 let balance: U512 = cl_value.into_t()?;
                 Ok(Motes::new(balance))
             }
-            TrackingCopyQueryResult::ValueNotFound(_) => Err(execution::Error::KeyNotFound(key)),
+            None => Err(execution::Error::KeyNotFound(key)),
         }
     }
 

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -291,7 +291,7 @@ proptest! {
         let correlation_id = CorrelationId::new();
         let (gs, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &[(k, v.to_owned())]).unwrap();
         let view = gs.checkout(root_hash).unwrap().unwrap();
-        let mut tc = TrackingCopy::new(view);
+        let tc = TrackingCopy::new(view);
         let empty_path = Vec::new();
         if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, k, &empty_path) {
             assert_eq!(v, result);
@@ -326,7 +326,7 @@ proptest! {
             &[(k, v.to_owned()), (contract_key, contract)]
         ).unwrap();
         let view = gs.checkout(root_hash).unwrap().unwrap();
-        let mut tc = TrackingCopy::new(view);
+        let tc = TrackingCopy::new(view);
         let path = vec!(name.clone());
         if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, contract_key, &path) {
             assert_eq!(v, result);
@@ -368,7 +368,7 @@ proptest! {
             &[(k, v.to_owned()), (account_key, StoredValue::Account(account))],
         ).unwrap();
         let view = gs.checkout(root_hash).unwrap().unwrap();
-        let mut tc = TrackingCopy::new(view);
+        let tc = TrackingCopy::new(view);
         let path = vec!(name.clone());
         if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
             assert_eq!(v, result);
@@ -422,7 +422,7 @@ proptest! {
             (account_key, StoredValue::Account(account)),
         ]).unwrap();
         let view = gs.checkout(root_hash).unwrap().unwrap();
-        let mut tc = TrackingCopy::new(view);
+        let tc = TrackingCopy::new(view);
         let path = vec!(contract_name, state_name);
         if let Ok(TrackingCopyQueryResult::Success(result)) = tc.query(correlation_id, account_key, &path) {
             assert_eq!(v, result);
@@ -477,4 +477,54 @@ fn cache_writes_not_invalidated() {
     assert_eq!(tc_cache.get(&k1), Some(&v1));
     assert_eq!(tc_cache.get(&k2), Some(&v2)); // k2 and k3 should be there
     assert_eq!(tc_cache.get(&k3), Some(&v3));
+}
+
+#[test]
+fn query_for_circular_references_should_fail() {
+    // create self-referential key
+    let cl_value_key = Key::URef(URef::new([255; 32], AccessRights::READ));
+    let cl_value = StoredValue::CLValue(CLValue::from_t(cl_value_key).unwrap());
+    let key_name = "key".to_string();
+
+    // create contract with this self-referential key in its named keys, and also a key referring to
+    // itself in its named keys.
+    let contract_key = Key::URef(URef::new([1; 32], AccessRights::READ));
+    let contract_name = "contract".to_string();
+    let mut named_keys = BTreeMap::new();
+    named_keys.insert(key_name.clone(), cl_value_key);
+    named_keys.insert(contract_name.clone(), contract_key);
+    let contract =
+        StoredValue::Contract(Contract::new(vec![], named_keys, ProtocolVersion::V1_0_0));
+
+    let correlation_id = CorrelationId::new();
+    let (global_state, root_hash) = InMemoryGlobalState::from_pairs(
+        correlation_id,
+        &[(cl_value_key, cl_value), (contract_key, contract)],
+    )
+    .unwrap();
+    let view = global_state.checkout(root_hash).unwrap().unwrap();
+    let tracking_copy = TrackingCopy::new(view);
+
+    // query for the self-referential key (second path element of arbitrary value required to cause
+    // iteration _into_ the self-referential key)
+    let path = vec![key_name, String::new()];
+    if let Ok(TrackingCopyQueryResult::CircularReference(msg)) =
+        tracking_copy.query(correlation_id, contract_key, &path)
+    {
+        let expected_path_msg = format!("at path: {:?}/{}", contract_key, path[0]);
+        assert!(msg.contains(&expected_path_msg));
+    } else {
+        panic!("Query didn't fail with a circular reference error");
+    }
+
+    // query for itself in its own named keys
+    let path = vec![contract_name];
+    if let Ok(TrackingCopyQueryResult::CircularReference(msg)) =
+        tracking_copy.query(correlation_id, contract_key, &path)
+    {
+        let expected_path_msg = format!("at path: {:?}/{}", contract_key, path[0]);
+        assert!(msg.contains(&expected_path_msg));
+    } else {
+        panic!("Query didn't fail with a circular reference error");
+    }
 }

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -109,11 +109,10 @@ where
                 }
                 result
             }
-            Ok(QueryResult::ValueNotFound(full_path)) => {
-                let log_message = format!("Value not found: {:?}", full_path);
-                logging::log_warning(&log_message);
+            Ok(QueryResult::ValueNotFound(msg)) => {
+                logging::log_warning(&msg);
                 let mut result = ipc::QueryResponse::new();
-                result.set_failure(log_message);
+                result.set_failure(msg);
                 result
             }
             Ok(QueryResult::RootNotFound) => {
@@ -121,6 +120,12 @@ where
                 logging::log_error(log_message);
                 let mut result = ipc::QueryResponse::new();
                 result.set_failure(log_message.to_string());
+                result
+            }
+            Ok(QueryResult::CircularReference(msg)) => {
+                logging::log_warning(&msg);
+                let mut result = ipc::QueryResponse::new();
+                result.set_failure(msg);
                 result
             }
             Err(err) => {

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -284,7 +284,7 @@ block_hash_queries = [
         {"key": "a91208047c", "path": "file.xxx", "key_type": "hash"},
         "INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes",
     ),
-    ({"path": "file.xxx", "key_type": "hash"}, "INVALID_ARGUMENT: Value not found"),
+    ({"path": "file.xxx", "key_type": "hash"}, "INVALID_ARGUMENT: Failed to find base key"),
 ]
 
 

--- a/integration-testing/test/test_single_network_one.py
+++ b/integration-testing/test/test_single_network_one.py
@@ -284,7 +284,10 @@ block_hash_queries = [
         {"key": "a91208047c", "path": "file.xxx", "key_type": "hash"},
         "INVALID_ARGUMENT: Key of type hash must have exactly 32 bytes",
     ),
-    ({"path": "file.xxx", "key_type": "hash"}, "INVALID_ARGUMENT: Failed to find base key"),
+    (
+        {"path": "file.xxx", "key_type": "hash"},
+        "INVALID_ARGUMENT: Failed to find base key",
+    ),
 ]
 
 


### PR DESCRIPTION
### Overview
This changes `TrackingCopy::query()` to return an error upon detecting a circular reference, hence avoiding a potential stack overflow.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-892

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I changed `TrackingCopy::query()` to not touch the inner cache, since this allows it to be cheaper to execute, and doesn't require `&mut self`.

I believe this is in line with how it's intended to be used (i.e. to satisfy `QueryRequest`s).  In such cases, it should be fine to avoid querying into the inner cache, since it will always be empty (no mutations of the `TrackingCopy` should happen as a result of responding to a `QueryRequest`).

If this rationale is wrong, or there's a desire to retain the old behaviour in terms of accessing and writing to the cache during a query, I can easily change it back.