### PR TITLE
OP-1139: Cleanup stale images cronjob

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1044,7 +1044,7 @@ clone:
 steps:
 - name: drone-docker-image-cleanup
   image: casperlabs/buildenv:latest
-  command:
+  commands:
   - "docker images --filter \"dangling=true\" -q --no-trunc | xargs --no-run-if-empty docker rmi -f || true"
   - "docker images | grep DRONE | grep -E '([1-9][0-9]|[4-9]).hours' | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true"
   volumes:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1034,6 +1034,26 @@ steps:
 trigger:
   cron: [ mac-hourly-cron ]
 
+---
+kind: pipeline
+name: drone-docker-image-cleanup-cron
+
+clone:
+  disable: true
+
+steps:
+- name: drone-docker-image-cleanup
+  image: casperlabs/buildenv:latest
+  command:
+  - "docker images --filter \"dangling=true\" -q --no-trunc | xargs --no-run-if-empty docker rmi -f || true"
+  - "docker images | grep DRONE | grep -E '([1-9][0-9]|[3-9]).hours' | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
+
+trigger:
+  cron: [ drone-docker-image-cleanup-cron ]
+
 # Signature for Drone
 ---
 kind: signature

--- a/.drone.yml
+++ b/.drone.yml
@@ -1051,6 +1051,11 @@ steps:
   - name: docker_sock
     path: "/var/run/docker.sock"
 
+volumes:
+- name: docker_sock
+  host:
+    path: "/var/run/docker.sock"
+
 trigger:
   cron: [ drone-docker-image-cleanup-cron ]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -1046,7 +1046,7 @@ steps:
   image: casperlabs/buildenv:latest
   command:
   - "docker images --filter \"dangling=true\" -q --no-trunc | xargs --no-run-if-empty docker rmi -f || true"
-  - "docker images | grep DRONE | grep -E '([1-9][0-9]|[3-9]).hours' | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true"
+  - "docker images | grep DRONE | grep -E '([1-9][0-9]|[4-9]).hours' | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true"
   volumes:
   - name: docker_sock
     path: "/var/run/docker.sock"

--- a/.drone.yml
+++ b/.drone.yml
@@ -708,6 +708,7 @@ steps:
   commands:
   - "docker images --filter \"dangling=true\" -q --no-trunc | xargs --no-run-if-empty docker rmi -f || true"
   - "docker images | grep \"DRONE-${DRONE_BUILD_NUMBER}\" | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true"
+  - "docker images | grep DRONE | grep -E '([1-9][0-9]|[4-9]).hours' | awk '{print $3}' | sort -n | uniq | xargs --no-run-if-empty docker rmi -f || true"
   environment:
     _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
   image: "casperlabs/buildenv:latest"
@@ -1046,7 +1047,7 @@ steps:
   image: casperlabs/buildenv:latest
   commands:
   - "docker images --filter \"dangling=true\" -q --no-trunc | xargs --no-run-if-empty docker rmi -f || true"
-  - "docker images | grep DRONE | grep -E '([1-9][0-9]|[4-9]).hours' | awk '{print $3}' | xargs --no-run-if-empty docker rmi -f || true"
+  - "docker images | grep DRONE | grep -E '([1-9][0-9]|[4-9]).hours' | awk '{print $3}' | sort -n | uniq | xargs --no-run-if-empty docker rmi -f || true"
   volumes:
   - name: docker_sock
     path: "/var/run/docker.sock"


### PR DESCRIPTION
### Overview
We recently hit an issue where old drone images were hanging around from canceled builds causing disk space issues.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1139

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
