### PR TITLE
EE-909: Do not include length in array serialization

### DIFF
--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -347,8 +347,8 @@ mod tests {
     fn initial_state_has_the_expected_hash() {
         let correlation_id = CorrelationId::new();
         let expected_bytes = vec![
-            51, 7, 165, 76, 166, 213, 191, 186, 252, 14, 241, 176, 3, 243, 236, 73, 65, 192, 17,
-            238, 127, 121, 136, 158, 68, 65, 103, 84, 222, 47, 9, 29,
+            243, 47, 248, 24, 18, 220, 95, 83, 103, 81, 100, 141, 145, 156, 26, 225, 23, 211, 126,
+            219, 65, 215, 200, 175, 255, 183, 116, 198, 144, 222, 99, 246,
         ];
         let (_, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &[]).unwrap();
         assert_eq!(expected_bytes, root_hash.to_vec())

--- a/execution-engine/types/src/bytesrepr.rs
+++ b/execution-engine/types/src/bytesrepr.rs
@@ -385,7 +385,6 @@ macro_rules! impl_to_from_bytes_for_array {
                     }
 
                     let mut result = Vec::with_capacity(approx_size);
-                    result.append(&mut ($N as u32).to_bytes()?);
 
                     for item in self.iter() {
                         result.append(&mut item.to_bytes()?);
@@ -397,12 +396,6 @@ macro_rules! impl_to_from_bytes_for_array {
 
             impl<T: FromBytes> FromBytes for [T; $N] {
                default fn from_bytes(mut bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-                    let (size, remainder) = u32::from_bytes(bytes)?;
-                    bytes = remainder;
-                    if size != $N as u32 {
-                        return Err(Error::Formatting);
-                    }
-
                     let mut result: MaybeUninit<[T; $N]> = MaybeUninit::uninit();
                     let result_ptr = result.as_mut_ptr() as *mut T;
                     unsafe {

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -74,8 +74,8 @@ class GrpcExecutionEngineService[F[_]: Defer: Concurrent: Log: TaskLift: Metrics
 
   override def emptyStateHash: ByteString = {
     val arr: Array[Byte] = Array(
-      51, 7, 165, 76, 166, 213, 191, 186, 252, 14, 241, 176, 3, 243, 236, 73, 65, 192, 17, 238, 127,
-      121, 136, 158, 68, 65, 103, 84, 222, 47, 9, 29
+      243, 47, 248, 24, 18, 220, 95, 83, 103, 81, 100, 141, 145, 156, 26, 225, 23, 211, 126, 219,
+      65, 215, 200, 175, 255, 183, 116, 198, 144, 222, 99, 246
     ).map(_.toByte)
     ByteString.copyFrom(arr)
   }


### PR DESCRIPTION
### Overview
Previously, we included the length in the generic array serialization implementation, but not in the specific `u8` version. This is an inconsistency and was noticed because the scala implementation is consistent with the treatment of arrays in this respect. In this PR we make the treatment of arrays consistent in the rust implementation as well.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-909

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
