### PR TITLE
NODE-1166: Deal with missing dependencies in the initial synchronizer

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -144,9 +144,6 @@ class DeploySelectionTest
   }
 
   it should "return conflicting deploys along the commuting ones if they fit the block size limit" in {
-    if (sys.env.contains("DRONE_BRANCH")) {
-      cancel("NODE-1202")
-    }
     val conflicting = List.fill(deploysInSmallBlock)(sample(arbDeploy.arbitrary))
     val commuting   = List.fill(deploysInSmallBlock)(sample(arbDeploy.arbitrary))
     val stream = fs2.Stream
@@ -156,7 +153,7 @@ class DeploySelectionTest
     val counter                                   = AtomicInt(1)
     implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherCommutesExec(counter) _)
 
-    val deploySelection = DeploySelection.create[Task](smallBlockSizeBytes * 4)
+    val deploySelection = DeploySelection.create[Task](sizeLimitBytes = Int.MaxValue)
 
     // The very first WRITE doesn't conflict
     val expectedCommuting = conflicting.head +: commuting

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -144,6 +144,9 @@ class DeploySelectionTest
   }
 
   it should "return conflicting deploys along the commuting ones if they fit the block size limit" in {
+    if (sys.env.contains("DRONE_BRANCH")) {
+      cancel("NODE-1202")
+    }
     val conflicting = List.fill(deploysInSmallBlock)(sample(arbDeploy.arbitrary))
     val commuting   = List.fill(deploysInSmallBlock)(sample(arbDeploy.arbitrary))
     val stream = fs2.Stream

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -144,21 +144,21 @@ class DeploySelectionTest
   }
 
   it should "return conflicting deploys along the commuting ones if they fit the block size limit" in {
-    val conflicting = List.fill(deploysInSmallBlock)(sample(arbDeploy.arbitrary))
-    val commuting   = List.fill(deploysInSmallBlock)(sample(arbDeploy.arbitrary))
-    val stream = fs2.Stream
-      .fromIterator(conflicting.toIterator)
-      .interleave(fs2.Stream.fromIterator(commuting.toIterator))
+    val mixed          = List.fill(deploysInSmallBlock * 2)(sample(arbDeploy.arbitrary))
+    val sizeLimitBytes = smallBlockSizeBytes * 4
+    val cappedEffects  = takeUnlessTooBig(sizeLimitBytes)(mixed)
+
+    val stream = fs2.Stream.fromIterator(mixed.toIterator)
 
     val counter                                   = AtomicInt(1)
     implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherCommutesExec(counter) _)
 
-    val deploySelection = DeploySelection.create[Task](sizeLimitBytes = Int.MaxValue)
+    val deploySelection = DeploySelection.create[Task](sizeLimitBytes)
 
     // The very first WRITE doesn't conflict
-    val expectedCommuting = conflicting.head +: commuting
+    val expectedCommuting = mixed.head +: mixed.zipWithIndex.filter(_._2 % 2 == 1).map(_._1)
     // Because first WRITE doesn't conflict we will get 1 less of them in conflicting section
-    val expectedConflicting = conflicting.drop(1)
+    val expectedConflicting = mixed.zipWithIndex.filter(_._2 % 2 == 0).map(_._1).tail
 
     val test = deploySelection
       .select((prestate, blocktime, protocolVersion, stream))

--- a/comm/src/main/scala/io/casperlabs/comm/errors.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/errors.scala
@@ -68,13 +68,17 @@ object GossipError {
   final case class InvalidChunks(msg: String, source: Node) extends Exception(msg) with GossipError
 
   /** Tried to schedule a download for which we don't have the dependencies. */
-  final case class MissingDependencies(msg: String) extends Exception(msg) with GossipError
+  final case class MissingDependencies(msg: String, missing: Seq[ByteString])
+      extends Exception(msg)
+      with GossipError
+
   object MissingDependencies {
     def apply(blockHash: ByteString, missing: Seq[ByteString]): MissingDependencies =
       MissingDependencies(
         s"Block ${Base16.encode(blockHash.toByteArray)} has missing dependencies: [${missing
           .map(x => Base16.encode(x.toByteArray))
-          .mkString(", ")}]"
+          .mkString(", ")}]",
+        missing
       )
   }
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
@@ -245,8 +245,9 @@ class InitialSynchronizationForwardImplSpec
               Some(GossipError.MissingDependencies(summary.blockHash, List(genesis.blockHash)))
             } else None,
           sync = targets =>
+            // Remember what we synced, then return what they asked for.
             syncedRef.update(_ ++ targets).map { _ =>
-              Vector(genesis).filter(x => targets(x.blockHash))
+              (genesis +: rest).filter(x => targets(x.blockHash))
             }
         ) { (initialSynchronizer, downloadManager) =>
           for {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
@@ -251,12 +251,15 @@ class InitialSynchronizationForwardImplSpec
         ) { (initialSynchronizer, downloadManager) =>
           for {
             w <- initialSynchronizer.sync()
-            _ <- w.attempt
+            r <- w.attempt
             s <- syncedRef.get
           } yield {
             s shouldBe Set(genesis.blockHash)
             // It should try download once, then sync and download genesis, then the original again.
             downloadManager.requestsCounter.get()(nodes.head) shouldBe 3
+            // For the record: because we aren't distinguishing in `maybeFail` based on which attempt
+            // it it is, the overall download will still fail in this test.
+            r.isLeft shouldBe true
           }
         }
       }

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -191,6 +191,7 @@ package object gossiping {
                                  makeInitialSynchronizer(
                                    conf,
                                    downloadManager,
+                                   synchronizer,
                                    connectToGossip,
                                    awaitApproval.join
                                  ),
@@ -664,6 +665,7 @@ package object gossiping {
   private def makeInitialSynchronizer[F[_]: Concurrent: Parallel: Log: Timer: NodeDiscovery: DagStorage](
       conf: Configuration,
       downloadManager: DownloadManager[F],
+      synchronizer: Synchronizer[F],
       connectToGossip: GossipService.Connector[F],
       awaitApproved: F[Unit]
   ): Resource[F, Fiber[F, Unit]] =
@@ -680,6 +682,7 @@ package object gossiping {
                             skipFailedNodesInNextRounds = conf.server.initSyncSkipFailedNodes,
                             connector = connectToGossip,
                             downloadManager = downloadManager,
+                            synchronizer = synchronizer,
                             step = conf.server.initSyncStep,
                             rankStartFrom = minRank,
                             roundPeriod = conf.server.initSyncRoundPeriod


### PR DESCRIPTION
### Overview
Add a fallback mechanism to the initial synchronizer so that if it encounters a `MissingDepencencies` error in a step in the forward download process it uses the regular synchronizer to go and fetch the missing block before moving on. The situation should only come up if a stray block turns up in the previous range, which means we should have most of the dependencies and the normal synchronizer should not hit any limits.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1166

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
