### PR TITLE
NODE-1147: gRPC Deploy Stream

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -59,7 +59,7 @@ sealed abstract class MultiParentCasperInstances {
     } yield casperState
 
   /** Create a MultiParentCasper instance from the new RPC style gossiping. */
-  def fromGossipServices[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagStorage: DeployBuffer: FinalityStorage: ExecutionEngineService: DeployStorage: Validation: DeploySelection: CasperLabsProtocol: EventEmitter](
+  def fromGossipServices[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagStorage: DeployBuffer: FinalityStorage: ExecutionEngineService: DeployStorage: Validation: DeploySelection: CasperLabsProtocol: BlockEventEmitter](
       validatorId: Option[ValidatorIdentity],
       genesis: Block,
       genesisPreState: StateHash,

--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -6,6 +6,7 @@ import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import simulacrum.typeclass
 
+/** Emit events to be observed by the outside world. */
 @typeclass trait EventEmitter[F[_]] {
   def blockAdded(blockInfo: BlockInfo): F[Unit]
   def newLastFinalizedBlock(

--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -1,7 +1,6 @@
 package io.casperlabs.casper
 
 import io.casperlabs.casper.Estimator.BlockHash
-import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import simulacrum.typeclass
@@ -17,7 +16,7 @@ import simulacrum.typeclass
 
 /** Emit events based on whole blocks. Includes raising events for the deploys embedded in the blocks. */
 @typeclass trait BlockEventEmitter[F[_]] {
-  def blockAdded(blockInfo: BlockInfo): F[Unit]
+  def blockAdded(blockHash: BlockHash): F[Unit]
   def newLastFinalizedBlock(
       lfb: BlockHash,
       indirectlyFinalized: Set[BlockHash]

--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -6,20 +6,23 @@ import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import simulacrum.typeclass
 
-/** Emit events to be observed by the outside world. */
-@typeclass trait EventEmitter[F[_]] {
+/** Emit events based on the local deploy buffer, which are only
+  * observed on the nodes where the deploy was sent.
+  */
+@typeclass trait DeployEventEmitter[F[_]] {
+  def deployAdded(deploy: Deploy): F[Unit]
+  def deployDiscarded(deployHash: DeployHash, message: String): F[Unit]
+  def deployRequeued(deployHash: DeployHash): F[Unit]
+}
+
+/** Emit events based on whole blocks. Includes raising events for the deploys embedded in the blocks. */
+@typeclass trait BlockEventEmitter[F[_]] {
   def blockAdded(blockInfo: BlockInfo): F[Unit]
   def newLastFinalizedBlock(
       lfb: BlockHash,
       indirectlyFinalized: Set[BlockHash]
   ): F[Unit]
-
-  // The following `deploy*` methods are based on the local deploy buffer,
-  // they are not observed on every node (unless there's deploy gossiping).
-  // The missing ones (deployProcessed, deployFinalized) can be handled
-  // internally by the `blockAdded` and `newLastFinalizedBlock` methods.
-
-  def deployAdded(deploy: Deploy): F[Unit]
-  def deployDiscarded(deployHash: DeployHash, message: String): F[Unit]
-  def deployRequeued(deployHash: DeployHash): F[Unit]
 }
+
+/** Emit events to be observed by the outside world. */
+@typeclass trait EventEmitter[F[_]] extends BlockEventEmitter[F] with DeployEventEmitter[F]

--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -2,6 +2,8 @@ package io.casperlabs.casper
 
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus.info.BlockInfo
+import io.casperlabs.casper.consensus.Deploy
+import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import simulacrum.typeclass
 
 @typeclass trait EventEmitter[F[_]] {
@@ -10,4 +12,13 @@ import simulacrum.typeclass
       lfb: BlockHash,
       indirectlyFinalized: Set[BlockHash]
   ): F[Unit]
+
+  // The following `deploy*` methods are based on the local deploy buffer,
+  // they are not observed on every node (unless there's deploy gossiping).
+  // The missing ones (deployProcessed, deployFinalized) can be handled
+  // internally by the `blockAdded` and `newLastFinalizedBlock` methods.
+
+  def deployAdded(deploy: Deploy): F[Unit]
+  def deployDiscarded(deployHash: DeployHash, message: String): F[Unit]
+  def deployRequeued(deployHash: DeployHash): F[Unit]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -11,8 +11,8 @@ import simulacrum.typeclass
   */
 @typeclass trait DeployEventEmitter[F[_]] {
   def deployAdded(deploy: Deploy): F[Unit]
-  def deployDiscarded(deployHash: DeployHash, message: String): F[Unit]
-  def deployRequeued(deployHash: DeployHash): F[Unit]
+  def deploysDiscarded(deployHashesWithReasons: Seq[(DeployHash, String)]): F[Unit]
+  def deploysRequeued(deployHashes: Seq[DeployHash]): F[Unit]
 }
 
 /** Emit events based on whole blocks. Includes raising events for the deploys embedded in the blocks. */

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -265,7 +265,6 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
               _ <- Log[F]
                     .info(s"Re-queued ${requeued.size} orphaned deploys.")
                     .whenA(requeued.nonEmpty)
-              _ <- requeued.toList.traverse(EventEmitter[F].deployRequeued(_))
             } yield ()
           }.forkAndLog
 

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -732,11 +732,7 @@ object MultiParentCasperImpl {
               BlockStorage[F]
                 .put(block.blockHash, block, blockEffects.effects)
             }
-        blockInfo <- BlockAPI.getBlockInfo[F](
-                      Base16.encode(block.blockHash.toByteArray),
-                      BlockInfo.View.FULL
-                    )
-        _ <- EventEmitter[F].blockAdded(blockInfo)
+        _ <- EventEmitter[F].blockAdded(block.blockHash)
       } yield ()
 
     /** Check if the block has dependencies that we don't have in store.

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -54,7 +54,7 @@ object BlockAPI {
       _ <- Metrics[F].incrementCounter("create-blocks-success", 0)
     } yield ()
 
-  def deploy[F[_]: MonadThrowable: DeployBuffer: MultiParentCasperRef: BlockStorage: Validation: Log: Metrics](
+  def deploy[F[_]: MonadThrowable: DeployBuffer: MultiParentCasperRef: BlockStorage: Validation: Log: Metrics: EventEmitter](
       d: Deploy
   ): F[Unit] =
     for {
@@ -62,7 +62,7 @@ object BlockAPI {
       r <- DeployBuffer[F].addDeploy(d)
       _ <- r match {
             case Right(_) =>
-              Metrics[F].incrementCounter("deploys-success") *> ().pure[F]
+              Metrics[F].incrementCounter("deploys-success") *> EventEmitter[F].deployAdded(d)
             case Left(ex: IllegalArgumentException) =>
               MonadThrowable[F].raiseError[Unit](InvalidArgument(ex.getMessage))
             case Left(ex: IllegalStateException) =>

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -54,7 +54,7 @@ object BlockAPI {
       _ <- Metrics[F].incrementCounter("create-blocks-success", 0)
     } yield ()
 
-  def deploy[F[_]: MonadThrowable: DeployBuffer: MultiParentCasperRef: BlockStorage: Validation: Log: Metrics: DeployEventEmitter](
+  def deploy[F[_]: MonadThrowable: DeployBuffer: Metrics](
       d: Deploy
   ): F[Unit] =
     for {

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -54,7 +54,7 @@ object BlockAPI {
       _ <- Metrics[F].incrementCounter("create-blocks-success", 0)
     } yield ()
 
-  def deploy[F[_]: MonadThrowable: DeployBuffer: MultiParentCasperRef: BlockStorage: Validation: Log: Metrics: EventEmitter](
+  def deploy[F[_]: MonadThrowable: DeployBuffer: MultiParentCasperRef: BlockStorage: Validation: Log: Metrics: DeployEventEmitter](
       d: Deploy
   ): F[Unit] =
     for {
@@ -62,7 +62,7 @@ object BlockAPI {
       r <- DeployBuffer[F].addDeploy(d)
       _ <- r match {
             case Right(_) =>
-              Metrics[F].incrementCounter("deploys-success") *> EventEmitter[F].deployAdded(d)
+              Metrics[F].incrementCounter("deploys-success")
             case Left(ex: IllegalArgumentException) =>
               MonadThrowable[F].raiseError[Unit](InvalidArgument(ex.getMessage))
             case Left(ex: IllegalStateException) =>

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -134,7 +134,7 @@ object ExecEngineUtil {
     *
     * In essence, this simulates sequential execution EE should be providing natively.
     */
-  protected[execengine] def execCommitSeqDeploys[F[_]: MonadThrowable: Log: Metrics: DeployStorage: DeployEventEmitter: ExecutionEngineService](
+  protected[execengine] def execCommitSeqDeploys[F[_]: MonadThrowable: Log: Metrics: DeployStorage: DeployBuffer: ExecutionEngineService](
       prestateHash: ByteString,
       blocktime: Long,
       protocolVersion: state.ProtocolVersion,
@@ -195,7 +195,7 @@ object ExecEngineUtil {
 
   /** Given a set of chosen parents create a "deploy checkpoint".
     */
-  def computeDeploysCheckpoint[F[_]: MonadThrowable: DeployStorage: DeployEventEmitter: Log: ExecutionEngineService: DeploySelection: Metrics](
+  def computeDeploysCheckpoint[F[_]: MonadThrowable: DeployStorage: DeployBuffer: Log: ExecutionEngineService: DeploySelection: Metrics](
       merged: MergeResult[TransformMap, Block],
       deployStream: fs2.Stream[F, Deploy],
       blocktime: Long,
@@ -260,7 +260,7 @@ object ExecEngineUtil {
   // Then if a block gets finalized and we remove the deploys it contains, and _then_ one of them
   // turns up again for some reason, we'll treat it again as a pending deploy and try to include it.
   // At that point the EE will discard it as the nonce is in the past and we'll drop it here.
-  def handleInvalidDeploys[F[_]: MonadThrowable: DeployStorage: DeployEventEmitter: Log: Metrics](
+  def handleInvalidDeploys[F[_]: MonadThrowable: DeployStorage: DeployBuffer: Log: Metrics](
       invalidDeploys: List[PreconditionFailure]
   ): F[Unit] = Metrics[F].timer("handleInvalidDeploys") {
     for {
@@ -270,7 +270,7 @@ object ExecEngineUtil {
               s"${PrettyPrinter.buildString(d.deploy.deployHash) -> "deploy"} failed precondition error: ${d.errorMessage}"
             )
           }
-      _ <- DeployBuffer.discardDeploys[F](
+      _ <- DeployBuffer[F].discardDeploys(
             invalidDeploys.map(d => (d.deploy.deployHash, d.errorMessage))
           )
     } yield ()

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -25,14 +25,45 @@ import simulacrum.typeclass
   /** If a deploy is valid (according to node rules), adds is the deploy buffer.
     * Otherwise returns an error.
     */
-  def addDeploy(d: Deploy)(implicit e: DeployEventEmitter[F]): F[Either[Throwable, Unit]]
+  def addDeploy(d: Deploy): F[Either[Throwable, Unit]]
+
+  /** Returns deploys that are not present in the p-past-cone of chosen parents. */
+  def remainingDeploys(
+      dag: DagRepresentation[F],
+      parents: Set[BlockHash],
+      timestamp: Long,
+      deployConfig: DeployConfig
+  ): F[Set[DeployHash]]
+
+  /** If another node proposed a block which orphaned something proposed by this node,
+    * and we still have these deploys in the `processedDeploys` buffer then put them
+    * back into the `pendingDeploys` so that the `AutoProposer` can pick them up again. */
+  def requeueOrphanedDeploys(
+      tips: Set[BlockHash]
+  ): F[Set[DeployHash]]
+
+  /** Remove deploys from the buffer which are included in blocks that are finalized.
+    * Those deploys won't be requeued anymore. */
+  def removeFinalizedDeploys(
+      lfbs: Set[BlockHash]
+  ): F[Unit]
+
+  /** Discard deploys and emit the necessary events. */
+  def discardDeploys(
+      deploysWithReasons: List[(DeployHash, String)]
+  ): F[Unit]
+
+  /** Discard deploys that sat in the buffer for too long. */
+  def discardExpiredDeploys(
+      expirationPeriod: FiniteDuration
+  ): F[Unit]
 }
 
 object DeployBuffer {
   implicit val DeployBufferMetricsSource: Metrics.Source =
     Metrics.Source(Metrics.BaseSource, "deploy_buffer")
 
-  def create[F[_]: MonadThrowable: Log: DeployStorage](
+  def create[F[_]: MonadThrowable: Fs2Compiler: Log: Metrics: DeployStorage: BlockStorage: DagStorage: DeployEventEmitter](
       chainName: String,
       minTtl: FiniteDuration
   ): DeployBuffer[F] =
@@ -67,136 +98,126 @@ object DeployBuffer {
 
       override def addDeploy(
           d: Deploy
-      )(implicit e: DeployEventEmitter[F]): F[Either[Throwable, Unit]] =
+      ): F[Either[Throwable, Unit]] =
         (for {
           _ <- validateDeploy(d)
           _ <- Log[F].info(s"Received ${PrettyPrinter.buildString(d) -> "deploy" -> null}")
           _ <- DeployStorageWriter[F].addAsPending(List(d))
           _ <- DeployEventEmitter[F].deployAdded(d)
         } yield ()).attempt
+
+      override def remainingDeploys(
+          dag: DagRepresentation[F],
+          parents: Set[BlockHash],
+          timestamp: Long,
+          deployConfig: DeployConfig
+      ): F[Set[DeployHash]] = Metrics[F].timer("remainingDeploys") {
+        // We have re-queued orphan deploys already, so we can just look at pending ones.
+        val earlierPendingDeploys = DeployStorageReader[F].readPendingHashesAndHeaders
+          .through(DeployFilters.Pipes.timestampBefore[F](timestamp))
+          .timer("timestampBeforeFilter")
+        val unexpired = earlierPendingDeploys
+          .through(
+            DeployFilters.Pipes.notExpired[F](timestamp, deployConfig.maxTtlMillis)
+          )
+          .through(DeployFilters.Pipes.validMaxTtl[F](deployConfig.maxTtlMillis))
+          .timer("notExpiredFilter")
+
+        for {
+          // We compile `earlierPendingDeploys` here to avoid a race condition where
+          // the stream may be updated by receiving a new deploy after `unexpired`
+          // has been compiled, causing some deploys to be erroneously marked as DISCARDED.
+          earlierPendingSet <- earlierPendingDeploys.map(_._1).compile.to[Set]
+          unexpiredList     <- unexpired.map(_._1).compile.toList
+          // Make sure pending deploys have never been processed in the past cone of the new parents.
+          validDeploys <- DeployFilters
+                           .filterDeploysNotInPast(dag, parents, unexpiredList)
+                           .map(_.toSet)
+                           .timer("remainingDeploys_filterDeploysNotInPast")
+          // anything with timestamp earlier than now and not included in the valid deploys
+          // can be discarded as a duplicate and/or expired deploy
+          deploysToDiscard = earlierPendingSet diff validDeploys
+          _                <- discardDeploys(deploysToDiscard.toList.map(_ -> "Duplicate or expired"))
+        } yield validDeploys
+      }
+
+      override def requeueOrphanedDeploys(
+          tips: Set[BlockHash]
+      ): F[Set[DeployHash]] =
+        Metrics[F].timer("requeueOrphanedDeploys") {
+          for {
+            dag <- DagStorage[F].getRepresentation
+            // Consider deploys which this node has processed but hasn't finalized yet.
+            processedDeploys <- DeployStorageReader[F].readProcessedHashes
+            orphanedDeploys <- filterDeploysNotInPast[F](
+                                dag,
+                                tips,
+                                processedDeploys
+                              ).timer("requeueOrphanedDeploys_filterDeploysNotInPast")
+            _ <- DeployStorageWriter[F]
+                  .markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
+            _ <- DeployEventEmitter[F].deploysRequeued(orphanedDeploys)
+          } yield orphanedDeploys.toSet
+        }
+
+      override def removeFinalizedDeploys(
+          lfbs: Set[BlockHash]
+      ): F[Unit] = Metrics[F].timer("removeFinalizedDeploys") {
+        for {
+          deployHashes <- DeployStorageReader[F].readProcessedHashes
+
+          blockHashes <- BlockStorage[F]
+                          .findBlockHashesWithDeployHashes(deployHashes)
+                          .map(_.values.flatten.toList.distinct)
+
+          finalizedBlockHashes = blockHashes.filter(lfbs.contains(_))
+          _ <- finalizedBlockHashes.traverse { blockHash =>
+                removeDeploysInBlock(blockHash) flatMap { removed =>
+                  Log[F]
+                    .info(
+                      s"Removed $removed deploys from deploy history as we finalized block ${PrettyPrinter
+                        .buildString(blockHash)}"
+                    )
+                    .whenA(removed > 0L)
+                }
+              }
+        } yield ()
+      }
+
+      /** Remove deploys from the history which are included in a just finalised block. */
+      private def removeDeploysInBlock(
+          blockHash: BlockHash
+      ): F[Long] =
+        for {
+          block           <- ProtoUtil.unsafeGetBlock[F](blockHash)
+          deploysToRemove = block.body.get.deploys.map(_.deploy.get).toList
+          // NOTE: Do we really need this metric? It will make unncessary calls to the DB.
+          initialHistorySize <- DeployStorageReader[F].sizePendingOrProcessed()
+          _                  <- DeployStorageWriter[F].markAsFinalized(deploysToRemove)
+          deploysRemoved <- DeployStorageReader[F]
+                             .sizePendingOrProcessed()
+                             .map(after => initialHistorySize - after)
+        } yield deploysRemoved
+
+      override def discardDeploys(
+          deploysWithReasons: List[(DeployHash, String)]
+      ): F[Unit] =
+        for {
+          _ <- DeployStorageWriter[F]
+                .markAsDiscardedByHashes(deploysWithReasons)
+                .whenA(deploysWithReasons.nonEmpty)
+          _ <- DeployEventEmitter[F].deploysDiscarded(deploysWithReasons)
+        } yield ()
+
+      override def discardExpiredDeploys(
+          expirationPeriod: FiniteDuration
+      ): F[Unit] = {
+        val msg = "TTL Expired"
+        for {
+          discarded <- DeployStorageWriter[F]
+                        .markAsDiscarded(expirationPeriod, msg)
+          _ <- DeployEventEmitter[F].deploysDiscarded(discarded.toList.map(_ -> msg))
+        } yield ()
+      }
     }
-
-  /** Returns deploys that are not present in the p-past-cone of chosen parents. */
-  def remainingDeploys[F[_]: MonadThrowable: BlockStorage: DeployStorage: DeployEventEmitter: Metrics: Fs2Compiler](
-      dag: DagRepresentation[F],
-      parents: Set[BlockHash],
-      timestamp: Long,
-      deployConfig: DeployConfig
-  ): F[Set[DeployHash]] = Metrics[F].timer("remainingDeploys") {
-    // We have re-queued orphan deploys already, so we can just look at pending ones.
-    val earlierPendingDeploys = DeployStorageReader[F].readPendingHashesAndHeaders
-      .through(DeployFilters.Pipes.timestampBefore[F](timestamp))
-      .timer("timestampBeforeFilter")
-    val unexpired = earlierPendingDeploys
-      .through(
-        DeployFilters.Pipes.notExpired[F](timestamp, deployConfig.maxTtlMillis)
-      )
-      .through(DeployFilters.Pipes.validMaxTtl[F](deployConfig.maxTtlMillis))
-      .timer("notExpiredFilter")
-
-    for {
-      // We compile `earlierPendingDeploys` here to avoid a race condition where
-      // the stream may be updated by receiving a new deploy after `unexpired`
-      // has been compiled, causing some deploys to be erroneously marked as DISCARDED.
-      earlierPendingSet <- earlierPendingDeploys.map(_._1).compile.to[Set]
-      unexpiredList     <- unexpired.map(_._1).compile.toList
-      // Make sure pending deploys have never been processed in the past cone of the new parents.
-      validDeploys <- DeployFilters
-                       .filterDeploysNotInPast(dag, parents, unexpiredList)
-                       .map(_.toSet)
-                       .timer("remainingDeploys_filterDeploysNotInPast")
-      // anything with timestamp earlier than now and not included in the valid deploys
-      // can be discarded as a duplicate and/or expired deploy
-      deploysToDiscard = earlierPendingSet diff validDeploys
-      _                <- discardDeploys[F](deploysToDiscard.toList.map(_ -> "Duplicate or expired"))
-    } yield validDeploys
-  }
-
-  /** If another node proposed a block which orphaned something proposed by this node,
-    * and we still have these deploys in the `processedDeploys` buffer then put them
-    * back into the `pendingDeploys` so that the `AutoProposer` can pick them up again. */
-  def requeueOrphanedDeploys[F[_]: MonadThrowable: DagStorage: BlockStorage: DeployStorage: Metrics: DeployEventEmitter](
-      tips: Set[BlockHash]
-  ): F[Set[DeployHash]] =
-    Metrics[F].timer("requeueOrphanedDeploys") {
-      for {
-        dag <- DagStorage[F].getRepresentation
-        // Consider deploys which this node has processed but hasn't finalized yet.
-        processedDeploys <- DeployStorageReader[F].readProcessedHashes
-        orphanedDeploys <- filterDeploysNotInPast[F](
-                            dag,
-                            tips,
-                            processedDeploys
-                          ).timer("requeueOrphanedDeploys_filterDeploysNotInPast")
-        _ <- DeployStorageWriter[F]
-              .markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
-        _ <- DeployEventEmitter[F].deploysRequeued(orphanedDeploys)
-      } yield orphanedDeploys.toSet
-    }
-
-  /** Remove deploys from the buffer which are included in blocks that are finalized.
-    *
-    * Those deploys won't be requeued anymore.
-    */
-  def removeFinalizedDeploys[F[_]: MonadThrowable: DeployStorage: BlockStorage: Log: Metrics](
-      lfbs: Set[BlockHash]
-  ): F[Unit] = Metrics[F].timer("removeFinalizedDeploys") {
-    for {
-      deployHashes <- DeployStorageReader[F].readProcessedHashes
-
-      blockHashes <- BlockStorage[F]
-                      .findBlockHashesWithDeployHashes(deployHashes)
-                      .map(_.values.flatten.toList.distinct)
-
-      finalizedBlockHashes = blockHashes.filter(lfbs.contains(_))
-      _ <- finalizedBlockHashes.traverse { blockHash =>
-            removeDeploysInBlock[F](blockHash) flatMap { removed =>
-              Log[F]
-                .info(
-                  s"Removed $removed deploys from deploy history as we finalized block ${PrettyPrinter
-                    .buildString(blockHash)}"
-                )
-                .whenA(removed > 0L)
-            }
-          }
-    } yield ()
-  }
-
-  /** Remove deploys from the history which are included in a just finalised block. */
-  private def removeDeploysInBlock[F[_]: MonadThrowable: DeployStorage: BlockStorage](
-      blockHash: BlockHash
-  ): F[Long] =
-    for {
-      block           <- ProtoUtil.unsafeGetBlock[F](blockHash)
-      deploysToRemove = block.body.get.deploys.map(_.deploy.get).toList
-      // NOTE: Do we really need this metric? It will make unncessary calls to the DB.
-      initialHistorySize <- DeployStorageReader[F].sizePendingOrProcessed()
-      _                  <- DeployStorageWriter[F].markAsFinalized(deploysToRemove)
-      deploysRemoved <- DeployStorageReader[F]
-                         .sizePendingOrProcessed()
-                         .map(after => initialHistorySize - after)
-    } yield deploysRemoved
-
-  /** Discard deploys and emit the necessary events. */
-  def discardDeploys[F[_]: Monad: DeployStorageWriter: DeployEventEmitter](
-      deploysWithReasons: List[(DeployHash, String)]
-  ): F[Unit] =
-    for {
-      _ <- DeployStorageWriter[F]
-            .markAsDiscardedByHashes(deploysWithReasons)
-            .whenA(deploysWithReasons.nonEmpty)
-      _ <- DeployEventEmitter[F].deploysDiscarded(deploysWithReasons)
-    } yield ()
-
-  /** Discard deploys that sat in the buffer for too long. */
-  def discardExpiredDeploys[F[_]: Monad: DeployStorageWriter: DeployEventEmitter](
-      expirationPeriod: FiniteDuration
-  ): F[Unit] = {
-    val msg = "TTL Expired"
-    for {
-      discarded <- DeployStorageWriter[F]
-                    .markAsDiscarded(expirationPeriod, msg)
-      _ <- DeployEventEmitter[F].deploysDiscarded(discarded.toList.map(_ -> msg))
-    } yield ()
-  }
 }

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -130,7 +130,7 @@ object DeployBuffer {
                           ).timer("requeueOrphanedDeploys_filterDeploysNotInPast")
         _ <- DeployStorageWriter[F]
               .markAsPendingByHashes(orphanedDeploys) whenA orphanedDeploys.nonEmpty
-        _ <- orphanedDeploys.toList.traverse(DeployEventEmitter[F].deployRequeued(_))
+        _ <- DeployEventEmitter[F].deploysRequeued(orphanedDeploys)
       } yield orphanedDeploys.toSet
     }
 
@@ -185,8 +185,6 @@ object DeployBuffer {
       _ <- DeployStorageWriter[F]
             .markAsDiscardedByHashes(deploysWithReasons)
             .whenA(deploysWithReasons.nonEmpty)
-      _ <- deploysWithReasons.traverse {
-            case (d, r) => DeployEventEmitter[F].deployDiscarded(d, r)
-          }
+      _ <- DeployEventEmitter[F].deploysDiscarded(deploysWithReasons)
     } yield ()
 }

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -9,7 +9,6 @@ import io.casperlabs.casper.Estimator.Validator
 import io.casperlabs.casper.MultiParentCasperImpl.Broadcaster
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.consensus._
-import io.casperlabs.casper.helper.NoOpsEventEmitter
 import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.{ArbitraryConsensus, Weight}
@@ -179,7 +178,6 @@ object AutoProposerTest {
                                                           MockDeployStorage.create[Task]()
                                                         )
         implicit0(emptyRef: MultiParentCasperRef[Task]) = MultiParentCasperRef.unsafe[Task]()
-        implicit0(eventEmitter: EventEmitter[Task])     = NoOpsEventEmitter.create[Task]()
         blockApiLock                                    <- Resource.liftF(Semaphore[Task](1))
         deployBuffer                                    = DeployBuffer.create[Task]("casperlabs", 1.minute)
         proposer <- AutoProposer[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -9,6 +9,7 @@ import io.casperlabs.casper.Estimator.Validator
 import io.casperlabs.casper.MultiParentCasperImpl.Broadcaster
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.consensus._
+import io.casperlabs.casper.helper.NoOpsEventEmitter
 import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.{ArbitraryConsensus, Weight}
@@ -178,6 +179,7 @@ object AutoProposerTest {
                                                           MockDeployStorage.create[Task]()
                                                         )
         implicit0(emptyRef: MultiParentCasperRef[Task]) = MultiParentCasperRef.unsafe[Task]()
+        implicit0(eventEmitter: EventEmitter[Task])     = NoOpsEventEmitter.create[Task]()
         blockApiLock                                    <- Resource.liftF(Semaphore[Task](1))
         deployBuffer                                    = DeployBuffer.create[Task]("casperlabs", 1.minute)
         proposer <- AutoProposer[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -9,6 +9,7 @@ import io.casperlabs.casper.Estimator.Validator
 import io.casperlabs.casper.MultiParentCasperImpl.Broadcaster
 import io.casperlabs.casper.MultiParentCasperRef.MultiParentCasperRef
 import io.casperlabs.casper.consensus._
+import io.casperlabs.casper.helper.NoOpsEventEmitter
 import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.{ArbitraryConsensus, Weight}
@@ -30,7 +31,8 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
 
   import AutoProposerTest._
 
-  implicit val cc = ConsensusConfig()
+  implicit val cc      = ConsensusConfig()
+  implicit val emitter = NoOpsEventEmitter.create[Task]()
 
   def sampleDeployData = sample(arbitrary[consensus.Deploy])
 

--- a/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/AutoProposerTest.scala
@@ -32,7 +32,7 @@ class AutoProposerTest extends FlatSpec with Matchers with ArbitraryConsensus {
   import AutoProposerTest._
 
   implicit val cc      = ConsensusConfig()
-  implicit val emitter = NoOpsEventEmitter.create[Task]()
+  implicit val emitter = NoOpsEventEmitter.create[Task]
 
   def sampleDeployData = sample(arbitrary[consensus.Deploy])
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -46,6 +46,8 @@ abstract class HashSetCasperTest
 
   import HashSetCasperTest._
 
+  implicit val emitter = NoOpsEventEmitter.create[Task]()
+
   implicit class TestNodeOps(node: TestNode[Task]) {
     def addAndBroadcast(b: Block): Task[BlockStatus] =
       node.casperEff.addBlock(b).flatTap(node.broadcaster.networkEffects(b, _))

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -46,7 +46,7 @@ abstract class HashSetCasperTest
 
   import HashSetCasperTest._
 
-  implicit val emitter = NoOpsEventEmitter.create[Task]()
+  implicit val emitter = NoOpsEventEmitter.create[Task]
 
   implicit class TestNodeOps(node: TestNode[Task]) {
     def addAndBroadcast(b: Block): Task[BlockStatus] =

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -65,7 +65,7 @@ class ValidationTest
     with BlockGenerator
     with StorageFixture
     with ArbitraryConsensus {
-  implicit val emitter                                = NoOpsEventEmitter.create[Task]()
+  implicit val emitter                                = NoOpsEventEmitter.create[Task]
   implicit val timeEff                                = new LogicalTime[Task](System.currentTimeMillis)
   override implicit val log: LogIO[Task] with LogStub = LogStub[Task]()
   implicit val raiseValidateErr                       = validation.raiseValidateErrorThroughApplicativeError[Task]

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -37,6 +37,7 @@ import io.casperlabs.crypto.Keys.PrivateKey
 import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import io.casperlabs.ipc.ChainSpec.DeployConfig
+import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.models.ArbitraryConsensus
 import io.casperlabs.models.BlockImplicits.BlockOps
 import io.casperlabs.p2p.EffectsTestInstances.LogicalTime
@@ -1292,6 +1293,9 @@ class ValidationTest
       implicit val deploySelection: DeploySelection[Task] = DeploySelection.create[Task](
         5 * 1024 * 1024
       )
+
+      implicit val deployBuffer = DeployBuffer.create[Task]("casperlabs", Duration.Zero)
+
       for {
         _ <- deployStorage.writer.addAsPending(deploys.toList)
         deploysCheckpoint <- ExecEngineUtil.computeDeploysCheckpoint[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -13,6 +13,7 @@ import io.casperlabs.casper.helper.{
   BlockGenerator,
   DeployOps,
   HashSetCasperTestNode,
+  NoOpsEventEmitter,
   StorageFixture
 }
 import io.casperlabs.casper.helper.DeployOps.ChangeDeployOps
@@ -64,6 +65,7 @@ class ValidationTest
     with BlockGenerator
     with StorageFixture
     with ArbitraryConsensus {
+  implicit val emitter                                = NoOpsEventEmitter.create[Task]()
   implicit val timeEff                                = new LogicalTime[Task](System.currentTimeMillis)
   override implicit val log: LogIO[Task] with LogStub = LogStub[Task]()
   implicit val raiseValidateErr                       = validation.raiseValidateErrorThroughApplicativeError[Task]

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -15,7 +15,11 @@ import io.casperlabs.casper.consensus._
 import io.casperlabs.casper.consensus.info.{BlockInfo, DeployInfo}
 import io.casperlabs.casper.consensus.info.BlockInfo.Status.Stats
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
-import io.casperlabs.casper.helper.{GossipServiceCasperTestNodeFactory, HashSetCasperTestNode}
+import io.casperlabs.casper.helper.{
+  GossipServiceCasperTestNodeFactory,
+  HashSetCasperTestNode,
+  NoOpsEventEmitter
+}
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.util._
 import io.casperlabs.casper.validation.Validation
@@ -52,8 +56,9 @@ class CreateBlockAPITest
   implicit val metrics              = new Metrics.MetricsNOP[Task]
   implicit val raiseValidateErr =
     casper.validation.raiseValidateErrorThroughApplicativeError[Task]
-  implicit val logEff      = LogStub[Task]()
-  implicit val broadcaster = Broadcaster.noop[Task]
+  implicit val logEff       = LogStub[Task]()
+  implicit val broadcaster  = Broadcaster.noop[Task]
+  implicit val eventEmitter = NoOpsEventEmitter.create[Task]()
 
   private val (validatorKeys, validators)             = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
   private val bonds                                   = createBonds(validators)

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -58,7 +58,7 @@ class CreateBlockAPITest
     casper.validation.raiseValidateErrorThroughApplicativeError[Task]
   implicit val logEff       = LogStub[Task]()
   implicit val broadcaster  = Broadcaster.noop[Task]
-  implicit val eventEmitter = NoOpsEventEmitter.create[Task]()
+  implicit val eventEmitter = NoOpsEventEmitter.create[Task]
 
   private val (validatorKeys, validators)             = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
   private val bonds                                   = createBonds(validators)

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -81,9 +81,8 @@ class CreateBlockAPITest
       )
     )
 
-    implicit val logEff       = LogStub[Task]()
-    implicit val blockStorage = node.blockStorage
-    implicit val db           = node.deployBuffer
+    implicit val logEff = LogStub[Task]()
+    implicit val db     = node.deployBuffer
 
     def testProgram(blockApiLock: Semaphore[Task])(
         implicit casperRef: MultiParentCasperRef[Task]
@@ -125,7 +124,6 @@ class CreateBlockAPITest
     // fact that each rank is occupied by a single block.
     val node = standaloneEff(genesis, validatorKeys.head)
 
-    implicit val bs = node.blockStorage
     implicit val db = node.deployBuffer
 
     def deployAndPropose(
@@ -185,9 +183,8 @@ class CreateBlockAPITest
     val node =
       standaloneEff(genesis, validatorKeys.head)
 
-    implicit val logEff       = LogStub[Task]()
-    implicit val blockStorage = node.blockStorage
-    implicit val db           = node.deployBuffer
+    implicit val logEff = LogStub[Task]()
+    implicit val db     = node.deployBuffer
 
     def testProgram(blockApiLock: Semaphore[Task])(
         implicit casperRef: MultiParentCasperRef[Task]
@@ -330,7 +327,6 @@ class CreateBlockAPITest
       standaloneEff(genesis, validatorKeys.head)
 
     implicit val logEff        = LogStub[Task]()
-    implicit val blockStorage  = node.blockStorage
     implicit val deployStorage = node.deployStorage
     implicit val db            = node.deployBuffer
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -17,6 +17,7 @@ import io.casperlabs.casper.util.execengine.{DeploysCheckpoint, ExecEngineUtil}
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.crypto.Keys
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.p2p.EffectsTestInstances.LogicalTime
 import io.casperlabs.shared.{Log, Time}
 import io.casperlabs.smartcontracts.ExecutionEngineService
@@ -32,7 +33,7 @@ object BlockGenerator {
   implicit val timeEff = new LogicalTime[Task]()
   implicit val emitter = NoOpsEventEmitter.create[Task]
 
-  def updateChainWithBlockStateUpdate[F[_]: Sync: BlockStorage: IndexedDagStorage: DeployStorage: DeployEventEmitter: ExecutionEngineService: Log: Metrics](
+  def updateChainWithBlockStateUpdate[F[_]: Sync: BlockStorage: IndexedDagStorage: DeployStorage: DeployBuffer: ExecutionEngineService: Log: Metrics](
       id: Int
   ): F[Block] =
     for {
@@ -67,7 +68,7 @@ object BlockGenerator {
       IndexedDagStorage[F].inject(id, updatedBlock)
   }
 
-  private[casper] def computeBlockCheckpointFromDeploys[F[_]: Sync: BlockStorage: DeployStorage: DeployEventEmitter: Log: ExecutionEngineService: Metrics](
+  private[casper] def computeBlockCheckpointFromDeploys[F[_]: Sync: BlockStorage: DeployStorage: DeployBuffer: Log: ExecutionEngineService: Metrics](
       b: Block,
       dag: DagRepresentation[F]
   ): F[DeploysCheckpoint] =

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -30,7 +30,7 @@ import scala.language.higherKinds
 
 object BlockGenerator {
   implicit val timeEff = new LogicalTime[Task]()
-  implicit val emitter = NoOpsEventEmitter.create[Task]()
+  implicit val emitter = NoOpsEventEmitter.create[Task]
 
   def updateChainWithBlockStateUpdate[F[_]: Sync: BlockStorage: IndexedDagStorage: DeployStorage: DeployEventEmitter: ExecutionEngineService: Log: Metrics](
       id: Int

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -131,6 +131,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
     implicit val timeEff   = new LogicalTime[F]
     implicit val log       = LogStub[F](printEnabled = false)
     implicit val metricEff = new Metrics.MetricsNOP[F]
+    implicit val em        = NoOpsEventEmitter.create[F]
     implicit val nodeAsk   = makeNodeAsk(identity)(concurrentF)
     implicit val functorRaiseInvalidBlock =
       casper.validation.raiseValidateErrorThroughApplicativeError[F]
@@ -146,6 +147,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
     initStorage() flatMap {
       case (blockStorage, dagStorage, deployStorage, finalityStorage) =>
         implicit val ds = deployStorage
+        implicit val bs = blockStorage
+        implicit val gs = dagStorage
         for {
           casperState  <- Cell.mvarCell[F, CasperState](CasperState())
           semaphoreMap <- SemaphoreMap[F, ByteString](1)
@@ -219,6 +222,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
         case (peer, sk) =>
           implicit val log       = LogStub[F](peer.host, printEnabled = false)
           implicit val metricEff = new Metrics.MetricsNOP[F]
+          implicit val emitter   = NoOpsEventEmitter.create[F]
           implicit val nodeAsk   = makeNodeAsk(peer)(concurrentF)
           implicit val functorRaiseInvalidBlock =
             casper.validation.raiseValidateErrorThroughApplicativeError[F]
@@ -245,6 +249,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
           initStorage() flatMap {
             case (blockStorage, dagStorage, deployStorage, finalityStorage) =>
               implicit val ds = deployStorage
+              implicit val bs = blockStorage
+              implicit val gs = dagStorage
               for {
                 casperState <- Cell.mvarCell[F, CasperState](
                                 CasperState()

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -145,8 +145,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
 
     initStorage() flatMap {
       case (blockStorage, dagStorage, deployStorage, finalityStorage) =>
-        implicit val ds           = deployStorage
-        implicit val eventEmitter = NoOpsEventEmitter.create[F]()
+        implicit val ds = deployStorage
         for {
           casperState  <- Cell.mvarCell[F, CasperState](CasperState())
           semaphoreMap <- SemaphoreMap[F, ByteString](1)
@@ -245,8 +244,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
 
           initStorage() flatMap {
             case (blockStorage, dagStorage, deployStorage, finalityStorage) =>
-              implicit val ds           = deployStorage
-              implicit val eventEmitter = NoOpsEventEmitter.create[F]()
+              implicit val ds = deployStorage
               for {
                 casperState <- Cell.mvarCell[F, CasperState](
                                 CasperState()

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -73,7 +73,7 @@ class GossipServiceCasperTestNode[F[_]](
     Broadcaster.fromGossipServices(Some(validatorId), relaying)
   implicit val deploySelection   = DeploySelection.create[F](5 * 1024 * 1024)
   implicit val derivedValidation = DeriveValidation.deriveValidationImpl[F]
-  implicit val eventEmitter      = TestEventEmitter.create[F]
+  implicit val eventEmitter      = NoOpsEventEmitter.create[F]
 
   // `addBlock` called in many ways:
   // - test proposes a block on the node that created it

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -145,7 +145,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
 
     initStorage() flatMap {
       case (blockStorage, dagStorage, deployStorage, finalityStorage) =>
-        implicit val ds = deployStorage
+        implicit val ds           = deployStorage
+        implicit val eventEmitter = NoOpsEventEmitter.create[F]()
         for {
           casperState  <- Cell.mvarCell[F, CasperState](CasperState())
           semaphoreMap <- SemaphoreMap[F, ByteString](1)
@@ -244,7 +245,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
 
           initStorage() flatMap {
             case (blockStorage, dagStorage, deployStorage, finalityStorage) =>
-              implicit val ds = deployStorage
+              implicit val ds           = deployStorage
+              implicit val eventEmitter = NoOpsEventEmitter.create[F]()
               for {
                 casperState <- Cell.mvarCell[F, CasperState](
                                 CasperState()

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -7,7 +7,6 @@ import io.casperlabs.casper.DeployHash
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.EventEmitter
 import io.casperlabs.casper.consensus.Deploy
-import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.storage.block.BlockStorage
@@ -18,7 +17,7 @@ import io.casperlabs.storage.dag.FinalityStorage
 object NoOpsEventEmitter {
   def create[F[_]: Applicative]: EventEmitter[F] =
     new EventEmitter[F] {
-      override def blockAdded(block: BlockInfo): F[Unit] = ().pure[F]
+      override def blockAdded(blockHash: BlockHash): F[Unit] = ().pure[F]
 
       override def newLastFinalizedBlock(
           lfb: BlockHash,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -16,7 +16,7 @@ import io.casperlabs.shared.Log
 import io.casperlabs.storage.dag.FinalityStorage
 
 object NoOpsEventEmitter {
-  def create[F[_]: Applicative](): EventEmitter[F] =
+  def create[F[_]: Applicative]: EventEmitter[F] =
     new EventEmitter[F] {
       override def blockAdded(block: BlockInfo): F[Unit] = ().pure[F]
 
@@ -24,33 +24,6 @@ object NoOpsEventEmitter {
           lfb: BlockHash,
           indirectlyFinalized: Set[BlockHash]
       ): F[Unit] = ().pure[F]
-
-      override def deployAdded(deploy: Deploy): F[Unit] =
-        ().pure[F]
-      override def deploysDiscarded(deployHashesWithReasons: Seq[(DeployHash, String)]): F[Unit] =
-        ().pure[F]
-      override def deploysRequeued(deployHashes: Seq[DeployHash]): F[Unit] =
-        ().pure[F]
-    }
-}
-
-object TestEventEmitter {
-  // Can't reuse production version because it couples `EventEmitter` with `EventStream`.
-  def create[F[_]: Sync: DeployStorage: BlockStorage: FinalityStorage: Log: Metrics]
-      : EventEmitter[F] =
-    new EventEmitter[F] {
-      // Production `EventEmitter` publishes `BlockAdded` event to the observable.
-      // We don't need it in tests at the moment.
-      override def blockAdded(blockInfo: BlockInfo): F[Unit] = ().pure[F]
-
-      // Mimicks production `EventEmitter` impl.
-      // Some tests depend on what is being done there.
-      override def newLastFinalizedBlock(
-          lfb: BlockHash,
-          indirectlyFinalized: Set[BlockHash]
-      ): F[Unit] =
-        FinalityStorage[F].markAsFinalized(lfb, indirectlyFinalized) >>
-          DeployBuffer.removeFinalizedDeploys[F](indirectlyFinalized + lfb)
 
       override def deployAdded(deploy: Deploy): F[Unit] =
         ().pure[F]

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -3,8 +3,10 @@ package io.casperlabs.casper.helper
 import cats.Applicative
 import cats.effect.Sync
 import cats.implicits._
+import io.casperlabs.casper.DeployHash
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.EventEmitter
+import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.metrics.Metrics
@@ -22,6 +24,10 @@ object NoOpsEventEmitter {
           lfb: BlockHash,
           indirectlyFinalized: Set[BlockHash]
       ): F[Unit] = ().pure[F]
+
+      override def deployAdded(deploy: Deploy): F[Unit]                              = ().pure[F]
+      override def deployDiscarded(deployHash: DeployHash, message: String): F[Unit] = ().pure[F]
+      override def deployRequeued(deployHash: DeployHash): F[Unit]                   = ().pure[F]
     }
 }
 
@@ -42,5 +48,9 @@ object TestEventEmitter {
       ): F[Unit] =
         FinalityStorage[F].markAsFinalized(lfb, indirectlyFinalized) >>
           DeployBuffer.removeFinalizedDeploys[F](indirectlyFinalized + lfb)
+
+      override def deployAdded(deploy: Deploy): F[Unit]                              = ().pure[F]
+      override def deployDiscarded(deployHash: DeployHash, message: String): F[Unit] = ().pure[F]
+      override def deployRequeued(deployHash: DeployHash): F[Unit]                   = ().pure[F]
     }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -25,9 +25,12 @@ object NoOpsEventEmitter {
           indirectlyFinalized: Set[BlockHash]
       ): F[Unit] = ().pure[F]
 
-      override def deployAdded(deploy: Deploy): F[Unit]                              = ().pure[F]
-      override def deployDiscarded(deployHash: DeployHash, message: String): F[Unit] = ().pure[F]
-      override def deployRequeued(deployHash: DeployHash): F[Unit]                   = ().pure[F]
+      override def deployAdded(deploy: Deploy): F[Unit] =
+        ().pure[F]
+      override def deploysDiscarded(deployHashesWithReasons: Seq[(DeployHash, String)]): F[Unit] =
+        ().pure[F]
+      override def deploysRequeued(deployHashes: Seq[DeployHash]): F[Unit] =
+        ().pure[F]
     }
 }
 
@@ -49,8 +52,11 @@ object TestEventEmitter {
         FinalityStorage[F].markAsFinalized(lfb, indirectlyFinalized) >>
           DeployBuffer.removeFinalizedDeploys[F](indirectlyFinalized + lfb)
 
-      override def deployAdded(deploy: Deploy): F[Unit]                              = ().pure[F]
-      override def deployDiscarded(deployHash: DeployHash, message: String): F[Unit] = ().pure[F]
-      override def deployRequeued(deployHash: DeployHash): F[Unit]                   = ().pure[F]
+      override def deployAdded(deploy: Deploy): F[Unit] =
+        ().pure[F]
+      override def deploysDiscarded(deployHashesWithReasons: Seq[(DeployHash, String)]): F[Unit] =
+        ().pure[F]
+      override def deploysRequeued(deployHashes: Seq[DeployHash]): F[Unit] =
+        ().pure[F]
     }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -45,6 +45,8 @@ class ExecEngineUtilTest
   implicit val executionEngineService: ExecutionEngineService[Task] =
     HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
 
+  implicit val emitter = NoOpsEventEmitter.create[Task]()
+
   "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
       val genesisDeploys = Vector(ProtoUtil.deploy(System.currentTimeMillis))
@@ -408,7 +410,7 @@ class ExecEngineUtilTest
           ProtocolVersion(1),
           rank = 0,
           upgrades = Nil
-        )(Sync[Task], deployStorage, logEff, ee, deploySelection, Metrics[Task])
+        )(Sync[Task], deployStorage, emitter, logEff, ee, deploySelection, Metrics[Task])
         .map { result =>
           assert(result.postStateHash == lastPostStateHash)
           assert(result.bondedValidators == lastBondedValidators)

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -45,7 +45,7 @@ class ExecEngineUtilTest
   implicit val executionEngineService: ExecutionEngineService[Task] =
     HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
 
-  implicit val emitter = NoOpsEventEmitter.create[Task]()
+  implicit val emitter = NoOpsEventEmitter.create[Task]
 
   "computeBlockCheckpoint" should "compute the final post-state of a chain properly" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -47,7 +47,7 @@ max-num-of-connections = 500
 max-message-size = 4194304
 
 # Size of the buffer to store emitted block events
-event-stream-buffer-size = 10
+event-stream-buffer-size = 1000
 
 # Target parallelism for execution engine requests.
 engine-parallelism = 1

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -167,6 +167,14 @@ class NodeRuntime private[node] (
 
       validatorId <- Resource.liftF(ValidatorIdentity.fromConfig[Task](conf.casper))
 
+      implicit0(eventsStream: EventStream[Task]) <- Resource.pure[Task, EventStream[Task]](
+                                                     EventStream
+                                                       .create[Task](
+                                                         ingressScheduler,
+                                                         conf.server.eventStreamBufferSize.value
+                                                       )
+                                                   )
+
       implicit0(deployBuffer: DeployBuffer[Task]) <- Resource.pure[Task, DeployBuffer[Task]](
                                                       DeployBuffer.create[Task](
                                                         chainSpec.getGenesis.name,
@@ -192,14 +200,6 @@ class NodeRuntime private[node] (
       lfb <- Resource.liftF[Task, BlockHash](
               storage.getLastFinalizedBlock
             )
-
-      implicit0(eventsStream: EventStream[Task]) <- Resource.pure[Task, EventStream[Task]](
-                                                     EventStream
-                                                       .create[Task](
-                                                         ingressScheduler,
-                                                         conf.server.eventStreamBufferSize.value
-                                                       )
-                                                   )
 
       implicit0(finalizedBlocksStream: FinalizedBlocksStream[Task]) <- Resource.suspend(
                                                                         FinalizedBlocksStream

--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -48,11 +48,11 @@ object EventStream {
             case Empty                      => false
             case Value.BlockAdded(_)        => request.blockAdded
             case Value.NewFinalizedBlock(_) => request.blockFinalized
-            case Value.DeployAdded(_)       => false
-            case Value.DeployDiscarded(_)   => false
-            case Value.DeployFinalized(_)   => false
-            case Value.DeployProcessed(_)   => false
-            case Value.DeployRequeued(_)    => false
+            case Value.DeployAdded(_)       => request.deployAdded
+            case Value.DeployDiscarded(_)   => request.deployDiscarded
+            case Value.DeployRequeued(_)    => request.deployRequeued
+            case Value.DeployProcessed(_)   => request.deployProcessed
+            case Value.DeployFinalized(_)   => request.deployFinalized
           }
         }
       }

--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -4,8 +4,10 @@ import cats.effect._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.apply._
+import io.casperlabs.casper.DeployHash
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.consensus.info.{BlockInfo, Event}
+import io.casperlabs.casper.consensus.Deploy
 import io.casperlabs.casper.EventEmitter
 import io.casperlabs.casper.consensus.info.Event.{BlockAdded, NewFinalizedBlock, Value}
 import io.casperlabs.mempool.DeployBuffer
@@ -41,6 +43,11 @@ object EventStream {
             case Empty                      => false
             case Value.BlockAdded(_)        => request.blockAdded
             case Value.NewFinalizedBlock(_) => request.blockFinalized
+            case Value.DeployAdded(_)       => false
+            case Value.DeployDiscarded(_)   => false
+            case Value.DeployFinalized(_)   => false
+            case Value.DeployProcessed(_)   => false
+            case Value.DeployRequeued(_)    => false
           }
         }
       }
@@ -63,6 +70,10 @@ object EventStream {
             )
             source.onNext(event)
           }
+
+      override def deployAdded(deploy: Deploy): F[Unit]                              = ???
+      override def deployDiscarded(deployHash: DeployHash, message: String): F[Unit] = ???
+      override def deployRequeued(deployHash: DeployHash): F[Unit]                   = ???
     }
   }
 }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -85,6 +85,7 @@ message Event {
         DeployDiscarded deploy_discarded = 5;
         DeployProcessed deploy_processed = 6;
         DeployFinalized deploy_finalized = 7;
+        DeployOrphaned deploy_orphaned = 8;
     }
 
     message BlockAdded {
@@ -96,6 +97,7 @@ message Event {
         bytes block_hash = 1;
         // Set of blocks that were finalized indirectly (secondary parents of the new main-chain LFB).
         repeated bytes indirectly_finalized_block_hashes = 2;
+        // TODO (CON-631): Add `orphaned_block_hashes`.
     }
 
     // A deploy was added to the to the local buffer.
@@ -118,7 +120,7 @@ message Event {
     // A deploy was included in a block.
     message DeployProcessed {
         bytes block_hash = 1;
-        io.casperlabs.casper.consensus.Block.ProcessedDeploy deploy = 2;
+        io.casperlabs.casper.consensus.Block.ProcessedDeploy processed_deploy = 2;
     }
 
     // A block the deploy was included in has been finalized. Every DeployProcessed event should eventually end up being
@@ -128,10 +130,10 @@ message Event {
         bytes block_hash = 1;
         // This deploy cannot appear in the descendants of the finalized block as that would be a duplicate,
         // so these results are considered final.
-        io.casperlabs.casper.consensus.Block.ProcessedDeploy deploy = 2;
+        io.casperlabs.casper.consensus.Block.ProcessedDeploy processed_deploy = 2;
     }
 
-    // TODO (CON-631): Emit the anti-finalization event.
+    // TODO (CON-631): Emit the anti-finalization event (currently just a placeholder).
     // A block the deploy was included in has been anti-finalized, i.e. orphaned by the LFB.
     // The deploy can still be finalized in a different block, if it was requeued or re-sent.
     message DeployOrphaned {
@@ -140,6 +142,6 @@ message Event {
        // Including the full DeployInfo with all the alternative processing results so we can see if there's another,
        // finalized block, or something else to wait for. Otherwise the client could pair up Processed and
        // Finalized/Anti-finalized events but if they miss something they'd most likely query the status of the deploy anyway.
-       DeployInfo deploy = 2;
+       DeployInfo deploy_info = 2;
     }
 }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -76,10 +76,15 @@ message DeployInfo {
     }
 }
 
-message Event{
+message Event {
     oneof value {
         BlockAdded block_added = 1;
         NewFinalizedBlock new_finalized_block = 2;
+        DeployAdded deploy_added = 3;
+        DeployRequeued deploy_requeued = 4;
+        DeployDiscarded deploy_discarded = 5;
+        DeployProcessed deploy_processed = 6;
+        DeployFinalized deploy_finalized = 7;
     }
 
     message BlockAdded {
@@ -91,5 +96,50 @@ message Event{
         bytes block_hash = 1;
         // Set of blocks that were finalized indirectly (secondary parents of the new main-chain LFB).
         repeated bytes indirectly_finalized_block_hashes = 2;
+    }
+
+    // A deploy was added to the to the local buffer.
+    message DeployAdded {
+        io.casperlabs.casper.consensus.Deploy deploy = 1;
+    }
+
+    // A deploy was discarded from the local buffer either due to a pre-condition error or TTL expiration.
+    message DeployDiscarded {
+        io.casperlabs.casper.consensus.Deploy deploy = 1;
+        string message = 2;
+    }
+
+    // A deploy has been requeued in the local buffer because the blocks it was included in no longer lead to the fork choice.
+    // Some of the old blocks may become un-orphaned again if the fork choice switches back to their branch.
+    message DeployRequeued {
+        io.casperlabs.casper.consensus.Deploy deploy = 1;
+    }
+
+    // A deploy was included in a block.
+    message DeployProcessed {
+        bytes block_hash = 1;
+        io.casperlabs.casper.consensus.Block.ProcessedDeploy deploy = 2;
+    }
+
+    // A block the deploy was included in has been finalized. Every DeployProcessed event should eventually end up being
+    // finalized or orphaned (anti-finalized).
+    message DeployFinalized {
+        // This block has been finalized directly or indirectly.
+        bytes block_hash = 1;
+        // This deploy cannot appear in the descendants of the finalized block as that would be a duplicate,
+        // so these results are considered final.
+        io.casperlabs.casper.consensus.Block.ProcessedDeploy deploy = 2;
+    }
+
+    // TODO (CON-631): Emit the anti-finalization event.
+    // A block the deploy was included in has been anti-finalized, i.e. orphaned by the LFB.
+    // The deploy can still be finalized in a different block, if it was requeued or re-sent.
+    message DeployOrphaned {
+       // This block has been passed by the Last Finalized Block and will never be included in the main chain.
+       bytes block_hash = 1;
+       // Including the full DeployInfo with all the alternative processing results so we can see if there's another,
+       // finalized block, or something else to wait for. Otherwise the client could pair up Processed and
+       // Finalized/Anti-finalized events but if they miss something they'd most likely query the status of the deploy anyway.
+       DeployInfo deploy = 2;
     }
 }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -100,7 +100,7 @@ message Event {
         // TODO (CON-631): Add `orphaned_block_hashes`.
     }
 
-    // A deploy was added to the to the local buffer.
+    // A deploy was added to the local buffer.
     message DeployAdded {
         io.casperlabs.casper.consensus.Deploy deploy = 1;
     }
@@ -111,20 +111,21 @@ message Event {
         string message = 2;
     }
 
-    // A deploy has been requeued in the local buffer because the blocks it was included in no longer lead to the fork choice.
-    // Some of the old blocks may become un-orphaned again if the fork choice switches back to their branch.
+    // A deploy has been requeued in the local buffer because none of the blocks it was included in are
+    // in the p-past cone of the fork choice. Some of the existing blocks may become un-orphaned again if
+    // the fork choice switches back to their branch.
     message DeployRequeued {
         io.casperlabs.casper.consensus.Deploy deploy = 1;
     }
 
-    // A deploy was included in a block.
+    // A deploy was executed and included in a block.
     message DeployProcessed {
         bytes block_hash = 1;
         io.casperlabs.casper.consensus.Block.ProcessedDeploy processed_deploy = 2;
     }
 
-    // A block the deploy was included in has been finalized. Every DeployProcessed event should eventually end up being
-    // finalized or orphaned (anti-finalized).
+    // A block the deploy was included in has been finalized. Every `DeployProcessed` event should
+    // eventually end up being finalized or orphaned (anti-finalized).
     message DeployFinalized {
         // This block has been finalized directly or indirectly.
         bytes block_hash = 1;
@@ -139,7 +140,7 @@ message Event {
     message DeployOrphaned {
        // This block has been passed by the Last Finalized Block and will never be included in the main chain.
        bytes block_hash = 1;
-       // Including the full DeployInfo with all the alternative processing results so we can see if there's another,
+       // Including the full `DeployInfo `with all the alternative processing results so we can see if there's another,
        // finalized block, or something else to wait for. Otherwise the client could pair up Processed and
        // Finalized/Anti-finalized events but if they miss something they'd most likely query the status of the deploy anyway.
        DeployInfo deploy_info = 2;

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -186,4 +186,16 @@ message StreamEventsRequest {
   bool deploy_requeued = 5;
   bool deploy_processed = 6;
   bool deploy_finalized = 7;
+  bool deploy_orphaned = 8;
+
+  // Optional filters for deploy events; applies to anything opted into via the flags.
+  DeployFilter deploy_filter = 9;
+
+  // Filters to apply on deploy events; different fields combined with AND operator.
+  message DeployFilter {
+      // Filter to any of the accounts on the list.
+      repeated bytes account_public_keys = 1;
+      // Filter for specific deploy hashes.
+      repeated bytes deploy_hashes = 2;
+  }
 }

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -181,4 +181,9 @@ message GetLastFinalizedBlockInfoRequest {
 message StreamEventsRequest {
   bool block_added = 1;
   bool block_finalized = 2;
+  bool deploy_added = 3;
+  bool deploy_discarded = 4;
+  bool deploy_requeued = 5;
+  bool deploy_processed = 6;
+  bool deploy_finalized = 7;
 }

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
@@ -57,7 +57,7 @@ import cats.mtl.ApplicativeAsk
 
   /** Will have an effect only on pending deploys.
     * Marks deploys as discarded that were added as pending more than 'now - expirationPeriod' time ago. */
-  def markAsDiscarded(expirationPeriod: FiniteDuration): F[Unit]
+  def markAsDiscarded(expirationPeriod: FiniteDuration, message: String): F[Set[ByteString]]
 
   /** Deletes discarded deploys from buffer that are older than 'now - expirationPeriod'.
     * Won't delete bodies of deploys which were [[addAsExecuted]] before.
@@ -153,8 +153,8 @@ object DeployStorageWriter {
     abstract override def markAsDiscardedByHashes(hashesAndReasons: List[(ByteString, String)]) =
       incAndMeasure("markAsDiscardedByHashes", super.markAsDiscardedByHashes(hashesAndReasons))
 
-    abstract override def markAsDiscarded(expirationPeriod: FiniteDuration) =
-      incAndMeasure("markAsDiscarded", super.markAsDiscarded(expirationPeriod))
+    abstract override def markAsDiscarded(expirationPeriod: FiniteDuration, message: String) =
+      incAndMeasure("markAsDiscarded", super.markAsDiscarded(expirationPeriod, message))
 
     abstract override def cleanupDiscarded(expirationPeriod: FiniteDuration) =
       incAndMeasure("cleanupDiscarded", super.cleanupDiscarded(expirationPeriod))

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
@@ -347,10 +347,10 @@ trait DeployStorageSpec
             _ <- writer.addAsProcessed(List(second))
             _ <- writer.markAsPending(List(second))
             _ <- reader.pendingNum.foreachL(_ shouldBe 2)
-            _ <- writer.markAsDiscarded(expirationPeriod = 1.second)
+            _ <- writer.markAsDiscarded(expirationPeriod = 1.second, "TTL Expired")
             _ <- reader.pendingNum.foreachL(_ shouldBe 1)
             _ <- Task.sleep(2.seconds)
-            _ <- writer.markAsDiscarded(expirationPeriod = 1.second)
+            _ <- writer.markAsDiscarded(expirationPeriod = 1.second, "TTL Expired")
             _ <- reader.pendingNum.foreachL(_ shouldBe 0)
           } yield ()
         },


### PR DESCRIPTION
### Overview
Adding deploy level events to the gRPC event stream to make it easier for clients to follow what's going on without having to do that much polling.
- [x] emit `DeployAdded`
- [x] emit `DeployRequeued`
- [x] emit `DeployDiscarded`
- [x] emit `DeployProcessed`
- [x] emit `DeployFinalized`
- [x] enrich event data
- [x] subscription filters
- [x] create ticket to update Highway with changes to the EventStream effects

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1147

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Ran into the problem that the `EventStream` was doing more than just publish events: it was removing finalized deploys from the `DeployBuffer` and updating the `FinalityStorage`. This was inconvenient, since I wanted to raise events from the `DeployBuffer`; if sometimes goes one way sometimes the other that's a design smell. Decided that `EventEmitter` and `EventStream` should be kept to inform the public and in not for internal processing, it gets too tangled. Moved what extra responsibilities it had back to `MultiParentCasperImpl`.

Created https://casperlabs.atlassian.net/browse/NODE-1210 to update Highway so the `MessageExecutor` raises the same events as `MultiParentCasperImpl`.

Added a `DeployEventEmitter` trait for the methods which arise from the local buffer. These are all raised by the `DeployBuffer` but the dependency is handed to it via method parameters. Be very careful never to call the `DeployStorageWriter.markAsDiscarded` methods without going through the `DeployBuffer`. The storage can't raise events because the event stream itself needs the storage. This should be in the service layer; unfortunately we don't seem to have the right abstractions in place, but hopefully they will emerge in the future when we stabilise on one protocol.
