### PR TITLE
NODE-1197: Add --wait-for-processed and --timeout-seconds to Scala CLI

### DIFF
--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -69,9 +69,12 @@ object DeployRuntime {
       hash: String,
       bytesStandard: Boolean,
       json: Boolean,
-      waitForProcessed: Boolean
+      waitForProcessed: Boolean,
+      timeoutSeconds: Long
   ): F[Unit] =
-    gracefulExit(DeployService[F].showDeploy(hash, bytesStandard, json, waitForProcessed))
+    gracefulExit(
+      DeployService[F].showDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds)
+    )
 
   def showBlocks[F[_]: Sync: DeployService](
       depth: Int,

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -68,9 +68,10 @@ object DeployRuntime {
   def showDeploy[F[_]: Sync: DeployService](
       hash: String,
       bytesStandard: Boolean,
-      json: Boolean
+      json: Boolean,
+      waitForProcessed: Boolean
   ): F[Unit] =
-    gracefulExit(DeployService[F].showDeploy(hash, bytesStandard, json))
+    gracefulExit(DeployService[F].showDeploy(hash, bytesStandard, json, waitForProcessed))
 
   def showBlocks[F[_]: Sync: DeployService](
       depth: Int,

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -477,19 +477,17 @@ object DeployRuntime {
       json: Boolean = false
   ): F[Either[Throwable, String]] =
     for {
-      a <- DeployService[F].deploy(deploy)
-      _ = print(a match {
-        case Right(message) => message + "\n"
-        case Left(_)        => ""
-      })
-      b <- DeployService[F].showDeploy(
-            Base16.encode(deploy.deployHash.toByteArray),
-            bytesStandard,
-            json,
-            true,
-            timeoutSeconds
-          )
-    } yield b
+      message <- DeployService[F].deploy(deploy).rethrow
+      _       <- Sync[F].delay(println(message))
+      result <- DeployService[F]
+                 .showDeploy(
+                   Base16.encode(deploy.deployHash.toByteArray),
+                   bytesStandard,
+                   json,
+                   waitForProcessed = true,
+                   timeoutSeconds
+                 )
+    } yield result
 
   def deployFileProgram[F[_]: Sync: DeployService](
       from: Option[PublicKey],

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -478,7 +478,10 @@ object DeployRuntime {
   ): F[Either[Throwable, String]] =
     for {
       a <- DeployService[F].deploy(deploy)
-      _ = println(a)
+      _ = print(a match {
+        case Right(message) => message + "\n"
+        case Left(_)        => ""
+      })
       b <- DeployService[F].showDeploy(
             Base16.encode(deploy.deployHash.toByteArray),
             bytesStandard,

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -7,7 +7,9 @@ import simulacrum.typeclass
 import scala.util.Either
 
 @typeclass trait DeployService[F[_]] {
-  def deploy(d: consensus.Deploy): F[Either[Throwable, String]]
+  def deploy(
+      d: consensus.Deploy
+  ): F[Either[Throwable, String]]
   def propose(): F[Either[Throwable, String]]
   def showBlock(
       blockHash: String

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -20,7 +20,8 @@ import scala.util.Either
   def showDeploy(
       blockHash: String,
       bytesStandard: Boolean,
-      json: Boolean
+      json: Boolean,
+      waitForProcessed: Boolean
   ): F[Either[Throwable, String]]
   def showBlocks(depth: Int, bytesStandard: Boolean, json: Boolean): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -21,7 +21,8 @@ import scala.util.Either
       blockHash: String,
       bytesStandard: Boolean,
       json: Boolean,
-      waitForProcessed: Boolean
+      waitForProcessed: Boolean,
+      timeoutSeconds: Long
   ): F[Either[Throwable, String]]
   def showBlocks(depth: Int, bytesStandard: Boolean, json: Boolean): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -20,7 +20,7 @@ import scala.util.Either
       json: Boolean
   ): F[Either[Throwable, String]]
   def showDeploy(
-      blockHash: String,
+      deployHash: String,
       bytesStandard: Boolean,
       json: Boolean,
       waitForProcessed: Boolean,

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -149,15 +149,13 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       val startTime   = System.currentTimeMillis()
       val timeoutTime = startTime + timeoutSeconds * 1000
 
-      def deployInfo(sleep: java.lang.Long): DeployInfo = {
+      def deployInfo(delayMillis: java.lang.Long): DeployInfo = {
+        Thread.sleep(delayMillis)
         val future: CancelableFuture[DeployInfo] =
           casperServiceStub
             .getDeployInfo(GetDeployInfoRequest(hash, view = DeployInfo.View.BASIC))
             .runToFuture
-
-        val result = Await.result(future, 5.seconds)
-        Thread.sleep(sleep)
-        result
+        Await.result(future, 5.seconds)
       }
 
       def deployInfos: Stream[DeployInfo] = deployInfo(0) #:: {

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -61,40 +61,54 @@ object Main {
       case Unbond(
           amount,
           contracts,
-          privateKey
+          privateKey,
+          waitForProcessed,
+          timeoutSeconds
           ) =>
         DeployRuntime.unbond[F](
           amount,
           contracts,
-          privateKey
+          privateKey,
+          waitForProcessed,
+          timeoutSeconds
         )
       case Bond(
           amount,
           contracts,
-          privateKey
+          privateKey,
+          waitForProcessed,
+          timeoutSeconds
           ) =>
         DeployRuntime.bond[F](
           amount,
           contracts,
-          privateKey
+          privateKey,
+          waitForProcessed,
+          timeoutSeconds
         )
       case Transfer(
           amount,
           recipientPublicKey,
           contracts,
-          privateKey
+          privateKey,
+          waitForProcessed,
+          timeoutSeconds
           ) =>
         DeployRuntime.transferCLI[F](
           contracts,
           privateKey,
           recipientPublicKey,
-          amount
+          amount,
+          waitForProcessed,
+          timeoutSeconds
         )
       case Deploy(
           from,
           contracts,
           maybePublicKey,
-          maybePrivateKey
+          maybePrivateKey,
+          waitForProcessed,
+          timeoutSeconds
           ) =>
         DeployRuntime.deployFileProgram[F](
           from,
@@ -106,7 +120,9 @@ object Main {
           maybePrivateKey.map(
             file =>
               new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PrivateKey]
-          )
+          ),
+          waitForProcessed = waitForProcessed,
+          timeoutSeconds = timeoutSeconds
         )
       case MakeDeploy(
           from,
@@ -138,8 +154,8 @@ object Main {
           _ <- DeployRuntime.writeDeploy[F](deploy, deployPath)
         } yield ()
 
-      case SendDeploy(deploy) =>
-        DeployRuntime.sendDeploy[F](deploy)
+      case SendDeploy(deploy, waitForProcessed, timeoutSeconds) =>
+        DeployRuntime.sendDeploy[F](deploy, waitForProcessed, timeoutSeconds)
 
       case PrintDeploy(deploy, bytesStandard, json) =>
         DeployRuntime.printDeploy[F](deploy, bytesStandard, json)

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -63,28 +63,36 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
           ) =>
         DeployRuntime.unbond[F](
           amount,
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
         )
       case Bond(
           amount,
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
           ) =>
         DeployRuntime.bond[F](
           amount,
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
         )
       case Transfer(
           amount,
@@ -92,7 +100,9 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
           ) =>
         DeployRuntime.transferCLI[F](
           contracts,
@@ -100,7 +110,9 @@ object Main {
           recipientPublicKey,
           amount,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
         )
       case Deploy(
           from,
@@ -108,7 +120,9 @@ object Main {
           maybePublicKey,
           maybePrivateKey,
           waitForProcessed,
-          timeoutSeconds
+          timeoutSeconds,
+          bytesStandard,
+          json
           ) =>
         DeployRuntime.deployFileProgram[F](
           from,
@@ -122,7 +136,9 @@ object Main {
               new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PrivateKey]
           ),
           waitForProcessed = waitForProcessed,
-          timeoutSeconds = timeoutSeconds
+          timeoutSeconds = timeoutSeconds,
+          bytesStandard = bytesStandard,
+          json = json
         )
       case MakeDeploy(
           from,
@@ -154,8 +170,8 @@ object Main {
           _ <- DeployRuntime.writeDeploy[F](deploy, deployPath)
         } yield ()
 
-      case SendDeploy(deploy, waitForProcessed, timeoutSeconds) =>
-        DeployRuntime.sendDeploy[F](deploy, waitForProcessed, timeoutSeconds)
+      case SendDeploy(deploy, waitForProcessed, timeoutSeconds, bytesStandard, json) =>
+        DeployRuntime.sendDeploy[F](deploy, waitForProcessed, timeoutSeconds, bytesStandard, json)
 
       case PrintDeploy(deploy, bytesStandard, json) =>
         DeployRuntime.printDeploy[F](deploy, bytesStandard, json)

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -52,8 +52,8 @@ object Main {
     configuration match {
       case ShowBlock(hash, bytesStandard, json) =>
         DeployRuntime.showBlock[F](hash, bytesStandard, json)
-      case ShowDeploy(hash, bytesStandard, json) =>
-        DeployRuntime.showDeploy[F](hash, bytesStandard, json)
+      case ShowDeploy(hash, bytesStandard, json, waitForProcessed) =>
+        DeployRuntime.showDeploy[F](hash, bytesStandard, json, waitForProcessed)
       case ShowDeploys(hash, bytesStandard, json) =>
         DeployRuntime.showDeploys[F](hash, bytesStandard, json)
       case ShowBlocks(depth, bytesStandard, json) =>

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -52,8 +52,8 @@ object Main {
     configuration match {
       case ShowBlock(hash, bytesStandard, json) =>
         DeployRuntime.showBlock[F](hash, bytesStandard, json)
-      case ShowDeploy(hash, bytesStandard, json, waitForProcessed) =>
-        DeployRuntime.showDeploy[F](hash, bytesStandard, json, waitForProcessed)
+      case ShowDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds) =>
+        DeployRuntime.showDeploy[F](hash, bytesStandard, json, waitForProcessed, timeoutSeconds)
       case ShowDeploys(hash, bytesStandard, json) =>
         DeployRuntime.showDeploys[F](hash, bytesStandard, json)
       case ShowBlocks(depth, bytesStandard, json) =>

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -145,8 +145,11 @@ final case class MakeDeploy(
 final case class SendDeploy(
     deploy: Array[Byte],
     waitForProcessed: Boolean,
-    timeoutSeconds: Long
+    timeoutSeconds: Long,
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 
 final case class PrintDeploy(
     deploy: Array[Byte],
@@ -161,8 +164,11 @@ final case class Deploy(
     publicKey: Option[File],
     privateKey: Option[File],
     waitForProcessed: Boolean,
-    timeoutSeconds: Long
+    timeoutSeconds: Long,
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 
 /** Client command to sign a deploy.
   */
@@ -197,23 +203,32 @@ final case class Bond(
     deployConfig: DeployConfig,
     privateKey: File,
     waitForProcessed: Boolean,
-    timeoutSeconds: Long
+    timeoutSeconds: Long,
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 final case class Transfer(
     amount: Long,
     recipientPublicKey: PublicKey,
     deployConfig: DeployConfig,
     privateKey: File,
     waitForProcessed: Boolean,
-    timeoutSeconds: Long
+    timeoutSeconds: Long,
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 final case class Unbond(
     amount: Option[Long],
     deployConfig: DeployConfig,
     privateKey: File,
     waitForProcessed: Boolean,
-    timeoutSeconds: Long
+    timeoutSeconds: Long,
+    bytesStandard: Boolean,
+    json: Boolean
 ) extends Configuration
+    with Formatting
 final case class VisualizeDag(
     depth: Int,
     showJustificationLines: Boolean,
@@ -262,7 +277,9 @@ object Configuration {
           options.deploy.publicKey.toOption,
           options.deploy.privateKey.toOption,
           options.deploy.waitForProcessed.getOrElse(false),
-          options.deploy.timeoutSeconds.getOrElse(3 * 60)
+          options.deploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT),
+          options.deploy.bytesStandard(),
+          options.deploy.json()
         )
       case options.makeDeploy =>
         MakeDeploy(
@@ -275,7 +292,9 @@ object Configuration {
         SendDeploy(
           options.sendDeploy.deployPath(),
           options.deploy.waitForProcessed.getOrElse(false),
-          options.deploy.timeoutSeconds.getOrElse(3 * 60)
+          options.deploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT),
+          options.deploy.bytesStandard(),
+          options.deploy.json()
         )
       case options.printDeploy =>
         PrintDeploy(
@@ -324,7 +343,9 @@ object Configuration {
           DeployConfig(options.unbond),
           options.unbond.privateKey(),
           options.unbond.waitForProcessed(),
-          options.unbond.timeoutSeconds()
+          options.unbond.timeoutSeconds(),
+          options.unbond.bytesStandard(),
+          options.unbond.json()
         )
       case options.bond =>
         Bond(
@@ -332,7 +353,9 @@ object Configuration {
           DeployConfig(options.bond),
           options.bond.privateKey(),
           options.bond.waitForProcessed(),
-          options.bond.timeoutSeconds()
+          options.bond.timeoutSeconds(),
+          options.bond.bytesStandard(),
+          options.bond.json()
         )
       case options.transfer =>
         Transfer(
@@ -341,7 +364,9 @@ object Configuration {
           DeployConfig(options.transfer),
           options.transfer.privateKey(),
           options.transfer.waitForProcessed(),
-          options.transfer.timeoutSeconds()
+          options.transfer.timeoutSeconds(),
+          options.transfer.bytesStandard(),
+          options.transfer.json()
         )
       case options.visualizeBlocks =>
         VisualizeDag(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -181,7 +181,8 @@ final case class ShowDeploy(
     deployHash: String,
     bytesStandard: Boolean,
     json: Boolean,
-    waitForProcessed: Boolean
+    waitForProcessed: Boolean,
+    timeoutSeconds: Long
 ) extends Configuration
     with Formatting
 final case class ShowBlocks(depth: Int, bytesStandard: Boolean, json: Boolean)
@@ -292,7 +293,8 @@ object Configuration {
           options.showDeploy.hash(),
           options.showDeploy.bytesStandard(),
           options.showDeploy.json(),
-          options.showDeploy.waitForProcessed()
+          options.showDeploy.waitForProcessed(),
+          options.showDeploy.timeoutSeconds()
         )
       case options.showBlocks =>
         ShowBlocks(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -177,8 +177,12 @@ final case class ShowBlock(blockHash: String, bytesStandard: Boolean, json: Bool
 final case class ShowDeploys(blockHash: String, bytesStandard: Boolean, json: Boolean)
     extends Configuration
     with Formatting
-final case class ShowDeploy(deployHash: String, bytesStandard: Boolean, json: Boolean)
-    extends Configuration
+final case class ShowDeploy(
+    deployHash: String,
+    bytesStandard: Boolean,
+    json: Boolean,
+    waitForProcessed: Boolean
+) extends Configuration
     with Formatting
 final case class ShowBlocks(depth: Int, bytesStandard: Boolean, json: Boolean)
     extends Configuration
@@ -287,7 +291,8 @@ object Configuration {
         ShowDeploy(
           options.showDeploy.hash(),
           options.showDeploy.bytesStandard(),
-          options.showDeploy.json()
+          options.showDeploy.json(),
+          options.showDeploy.waitForProcessed()
         )
       case options.showBlocks =>
         ShowBlocks(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -291,10 +291,10 @@ object Configuration {
       case options.sendDeploy =>
         SendDeploy(
           options.sendDeploy.deployPath(),
-          options.deploy.waitForProcessed.getOrElse(false),
-          options.deploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT),
-          options.deploy.bytesStandard(),
-          options.deploy.json()
+          options.sendDeploy.waitForProcessed.getOrElse(false),
+          options.sendDeploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT),
+          options.sendDeploy.bytesStandard(),
+          options.sendDeploy.json()
         )
       case options.printDeploy =>
         PrintDeploy(

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -310,6 +310,16 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     ).map(file => Files.readAllBytes(file.toPath))
       .orElse(Some(IOUtils.toByteArray(System.in)))
 
+    val waitForProcessed =
+      opt[Boolean](
+        descr = "Wait for deploy status PROCESSED or DISCARDED",
+        default = false.some,
+        short = 'w'
+      )
+
+    val timeoutSeconds =
+      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT))
+
   }
   addSubcommand(sendDeploy)
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -135,6 +135,15 @@ object Options {
       default = "".some
     )
 
+    val waitForProcessed =
+      opt[Boolean](
+        descr = "Wait for deploy status PROCESSED or DISCARDED",
+        default = false.some
+      )
+
+    val timeoutSeconds =
+      opt[Long](descr = "Timeout in seconds.", default = Option(3 * 60))
+
     addValidation {
       val sessionsProvided =
         List(session.isDefined, sessionHash.isDefined, sessionName.isDefined, sessionUref.isDefined)
@@ -423,7 +432,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     val waitForProcessed =
       opt[Boolean](
         descr = "Wait for deploy status PROCESSED or DISCARDED",
-        default = false.some
+        default = false.some,
+        short = 'w'
       )
 
     val timeoutSeconds =

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -422,9 +422,12 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
     val waitForProcessed =
       opt[Boolean](
-        descr = "",
+        descr = "Wait for deploy status PROCESSED or DISCARDED",
         default = false.some
       )
+
+    val timeoutSeconds =
+      opt[Long](descr = "Timeout in seconds.", default = Option(3 * 60))
   }
   addSubcommand(showDeploy)
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -419,6 +419,12 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
         descr = "Value of the deploy hash, base16 encoded.",
         validate = hashCheck
       )
+
+    val waitForProcessed =
+      opt[Boolean](
+        descr = "",
+        default = false.some
+      )
   }
   addSubcommand(showDeploy)
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -15,6 +15,8 @@ import org.rogach.scallop._
 import scala.concurrent.duration.FiniteDuration
 
 object Options {
+  val TIMEOUT_SECONDS_DEFAULT: Long = 3 * 60
+
   val hexCheck: String => Boolean  = _.matches("[0-9a-fA-F]+")
   val hashCheck: String => Boolean = x => hexCheck(x) && x.length == 64
 
@@ -142,7 +144,7 @@ object Options {
       )
 
     val timeoutSeconds =
-      opt[Long](descr = "Timeout in seconds.", default = Option(3 * 60))
+      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT))
 
     addValidation {
       val sessionsProvided =
@@ -293,7 +295,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(makeDeploy)
 
-  val sendDeploy = new Subcommand("send-deploy") {
+  val sendDeploy = new Subcommand("send-deploy") with FormattingOptions {
     descr(
       "Deploy a smart contract source file to Casper on an existing running node. " +
         "The deploy will be packaged and sent as a block to the network depending " +
@@ -311,7 +313,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(sendDeploy)
 
-  val deploy = new Subcommand("deploy") with DeployOptions {
+  val deploy = new Subcommand("deploy") with DeployOptions with FormattingOptions {
     descr(
       "Constructs a Deploy and sends it to Casper on an existing running node. " +
         "The deploy will be packaged and sent as a block to the network depending " +
@@ -437,7 +439,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       )
 
     val timeoutSeconds =
-      opt[Long](descr = "Timeout in seconds.", default = Option(3 * 60))
+      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT))
   }
   addSubcommand(showDeploy)
 
@@ -470,7 +472,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(showBlocks)
 
-  val unbond = new Subcommand("unbond") with DeployOptions {
+  val unbond = new Subcommand("unbond") with DeployOptions with FormattingOptions {
     descr("Issues unbonding request")
 
     override def sessionRequired = false
@@ -492,7 +494,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(unbond)
 
-  val bond = new Subcommand("bond") with DeployOptions {
+  val bond = new Subcommand("bond") with DeployOptions with FormattingOptions {
     descr("Issues bonding request")
 
     override def sessionRequired = false
@@ -514,7 +516,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(bond)
 
-  val transfer = new Subcommand("transfer") with DeployOptions {
+  val transfer = new Subcommand("transfer") with DeployOptions with FormattingOptions {
     descr("Transfers funds between accounts")
 
     override def sessionRequired = false


### PR DESCRIPTION
### Overview
This PR adds flag `--wait-for-processed`, short version: `-w`,  as well as accompanying `--timeout-seconds`, short version `-t`, to Scala client's `show-deploy` and `deploy` commands (`deploy`, `send-deploy`, `transfer`, `bond`, `unbond`).

See design document: [CLI extensions compensating removed propose command](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/262078618/CLI+extensions+compensating+removed+propose+command), Python implementation: NODE-1171.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1197

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
