### PR TITLE
NODE-1216: Clarity era cues

### DIFF
--- a/explorer/README.md
+++ b/explorer/README.md
@@ -28,6 +28,27 @@ make up node-0/up
 cd -
 ```
 
+Start the `server` in one console:
+
+```sh
+cd server
+npm run dev
+```
+
+and the `ui` in another one:
+
+```sh
+cd ui
+npm start
+```
+
+A new browser window will automatically open pointing at the app running at http://localhost:8000
+
+The server should serve the config that will route traffic to the `grpcwebproxy` container running in Docker,
+while we can work on the UI and see it reload after each change. Check out the `server` README for details
+about how it can be configured to tell the UI to connect to a remote server like devnet.
+
+
 ### Fund the Faucet
 
 If we were not using the `faucet-account` that's created in the `hack/docker` setup as the Faucet account,

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -231,7 +231,7 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
       'Is Finalized',
       block
         .getStatus()!
-        .getIsFinalized()
+        .getIsFinalized().toString()
     ]
   ];
 };

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -187,6 +187,7 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
     ['j-Rank', header.getJRank()],
     ['m-Rank', header.getMainRank()],
     ['Timestamp', new Date(header.getTimestamp()).toISOString()],
+    ['Type', <BlockType header={header} />],
     [
       'Parents',
       <ul>
@@ -254,5 +255,11 @@ export const Balance = observer(
     return <span>{value.toLocaleString()}</span>;
   }
 );
+
+export const BlockType = (props: { header: Block.Header }) => {
+  let typ = props.header.getMessageType();
+  let lbl = typ == Block.MessageType.BLOCK ? "Block" : typ == Block.MessageType.BALLOT ? "Ballot" : "n/a"
+  return <span>{lbl}</span>;
+}
 
 export default BlockDetails;

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -258,7 +258,7 @@ export const Balance = observer(
 
 export const BlockType = (props: { header: Block.Header }) => {
   let typ = props.header.getMessageType();
-  let lbl = typ == Block.MessageType.BLOCK ? "Block" : typ == Block.MessageType.BALLOT ? "Ballot" : "n/a"
+  let lbl = typ === Block.MessageType.BLOCK ? "Block" : typ === Block.MessageType.BALLOT ? "Ballot" : "n/a"
   return <span>{lbl}</span>;
 }
 

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -180,7 +180,12 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
   const stats = block.getStatus()!.getStats()!;
   return [
     ['Block Hash', id],
+    ['Key Block Hash',
+      <Link to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}>
+        {shortHash(header.getKeyBlockHash_asU8())}
+      </Link>],
     ['j-Rank', header.getJRank()],
+    ['m-Rank', header.getMainRank()],
     ['Timestamp', new Date(header.getTimestamp()).toISOString()],
     [
       'Parents',

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -13,6 +13,7 @@ import { Link, RouteComponentProps, withRouter } from 'react-router-dom';
 import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
 import Timestamp from './TimeStamp';
+import { BlockType } from './BlockDetails';
 import * as H from 'history';
 
 export interface Props extends RouteComponentProps<{}> {
@@ -52,7 +53,7 @@ class _BlockList extends RefreshableComponent<Props, {}> {
         }
         refresh={() => this.refresh()}
         subscribeToggleStore={dag.subscribeToggleStore}
-        headers={['Block Hash', 'j-Rank', 'm-Rank', 'Timestamp', 'Validator', 'Key Block Hash']}
+        headers={['Block Hash', 'j-Rank', 'm-Rank', 'Timestamp', 'Validator', 'Type', 'Key Block Hash']}
         rows={dag.blocks}
         renderRow={(block: BlockInfo) => {
           const header = block.getSummary()!.getHeader()!;
@@ -68,6 +69,7 @@ class _BlockList extends RefreshableComponent<Props, {}> {
                 <Timestamp timestamp={header.getTimestamp()} />
               </td>
               <td>{shortHash(header.getValidatorPublicKey_asU8())}</td>
+              <td><BlockType header={header} /></td>
               <td>
                 <Link to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}>
                   {shortHash(header.getKeyBlockHash_asU8())}

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -52,7 +52,7 @@ class _BlockList extends RefreshableComponent<Props, {}> {
         }
         refresh={() => this.refresh()}
         subscribeToggleStore={dag.subscribeToggleStore}
-        headers={['Block hash', 'j-Rank', 'Timestamp', 'Validator']}
+        headers={['Block Hash', 'j-Rank', 'm-Rank', 'Timestamp', 'Validator', 'Key Block Hash']}
         rows={dag.blocks}
         renderRow={(block: BlockInfo) => {
           const header = block.getSummary()!.getHeader()!;
@@ -63,10 +63,16 @@ class _BlockList extends RefreshableComponent<Props, {}> {
                 <Link to={Pages.block(id)}>{id}</Link>
               </td>
               <td>{header.getJRank()}</td>
+              <td>{header.getMainRank()}</td>
               <td>
                 <Timestamp timestamp={header.getTimestamp()} />
               </td>
               <td>{shortHash(header.getValidatorPublicKey_asU8())}</td>
+              <td>
+                <Link to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}>
+                  {shortHash(header.getKeyBlockHash_asU8())}
+                </Link>
+              </td>
             </tr>
           );
         }}

--- a/explorer/ui/src/components/DeployDetails.tsx
+++ b/explorer/ui/src/components/DeployDetails.tsx
@@ -122,7 +122,8 @@ const ResultsTable = observer(
                 {proc
                   .getBlockInfo()!
                   .getStatus()!
-                  .getIsFinalized()}
+                  .getIsFinalized()
+                  .toString()}
               </td>
               <td className="text-right">{proc.getCost().toLocaleString()}</td>
               <td className="text-right">

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -16,6 +16,7 @@ import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
 import { BondedValidatorsTable } from './BondedValidatorsTable';
 import { ToggleButton } from './ToggleButton';
+import { BlockType } from './BlockDetails';
 
 /** Show the tips of the DAG. */
 @observer
@@ -139,20 +140,16 @@ class BlockDetails extends React.Component<
     let id = encodeBase16(summary.getBlockHash_asU8());
     let idB64 = summary.getBlockHash_asB64();
     let validatorId = encodeBase16(header.getValidatorPublicKey_asU8());
-    // Grouped attributes so we could display 2 sets of fields next to each other.
-    let attrs: Array<Array<[string, any]>> = [
+    let attrs: Array<[string, any]> =
       [
         ['Block Hash', <Link to={Pages.block(id)}>{shortHash(id)}</Link>],
         ['Key Block Hash',
           <Link to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}>
             {shortHash(header.getKeyBlockHash_asU8())}
           </Link>],
-      ],
-      [
         ['j-Rank', header.getJRank()],
         ['m-Rank', header.getMainRank()],
-      ],
-      [
+        ['Type', <BlockType header={header} />],
         [
           'Parents',
           <ul>
@@ -184,17 +181,11 @@ class BlockDetails extends React.Component<
                 </li>
               ))}
           </ul>
-        ]
-      ],
-      [
+        ],
         ['Timestamp', new Date(header.getTimestamp()).toISOString()],
-        ['Deploy Count', header.getDeployCount()]
-      ],
-      [
+        ['Deploy Count', header.getDeployCount()],
         ['Validator', shortHash(validatorId)],
-        ['Validator Block Number', header.getValidatorBlockSeqNum()]
-      ],
-      [
+        ['Validator Block Number', header.getValidatorBlockSeqNum()],
         [
           'Validator Stake',
           (() => {
@@ -221,9 +212,8 @@ class BlockDetails extends React.Component<
           block
             .getStatus()!
             .getIsFinalized().toString()
-        ]
-      ]
-    ];
+        ],
+      ];
     return (
       <div
         ref={x => {
@@ -234,21 +224,11 @@ class BlockDetails extends React.Component<
           title={`Block ${shortHash(id)}`}
           headers={[]}
           rows={attrs}
-          renderRow={(group, i) =>
-            // <tr key={i}>
-            //   {
-            //     group.flatMap((attr, j) => [
-            //       <th key={'${i}/${j}/0'}>{attr[0]}</th>,
-            //       <td key={'${i}/${j}/1'}>{attr[1]}</td>
-            //     ])
-            //   }
-            // </tr>
-            group.flatMap((attr, j) => [
-              <tr key={`${i}/${j}`}>
-                <th>{attr[0]}</th>
-                <td>{attr[1]}</td>
-              </tr>
-            ])
+          renderRow={(attr, i) =>
+            <tr key={i}>
+              <th>{attr[0]}</th>
+              <td>{attr[1]}</td>
+            </tr>
           }
           footerMessage="Click the links to select the parents and children."
         />

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -213,7 +213,7 @@ class BlockDetails extends React.Component<
           'Is Finalized',
           block
             .getStatus()!
-            .getIsFinalized()
+            .getIsFinalized().toString()
         ]
       ]
     ];

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -143,7 +143,14 @@ class BlockDetails extends React.Component<
     let attrs: Array<Array<[string, any]>> = [
       [
         ['Block Hash', <Link to={Pages.block(id)}>{shortHash(id)}</Link>],
-        ['j-Rank', header.getJRank()]
+        ['Key Block Hash',
+          <Link to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}>
+            {shortHash(header.getKeyBlockHash_asU8())}
+          </Link>],
+      ],
+      [
+        ['j-Rank', header.getJRank()],
+        ['m-Rank', header.getMainRank()],
       ],
       [
         [

--- a/explorer/ui/src/contracts/Vesting/component/Vesting.tsx
+++ b/explorer/ui/src/contracts/Vesting/component/Vesting.tsx
@@ -15,9 +15,6 @@ interface Props {
 
 @observer
 class Vesting extends RefreshableComponent<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
 
   refresh() {
     this.props.auth.refreshAccounts();
@@ -27,24 +24,24 @@ class Vesting extends RefreshableComponent<Props, {}> {
     const { vesting } = this.props;
     return (
       <div>
-        <VestingHashesManageForm vestingContainer={this.props.vesting}/>
+        <VestingHashesManageForm vestingContainer={this.props.vesting} />
         {vesting.selectedVestingHash && !vesting.vestingDetails && (
           <div className="col-12">
-            <Loading/>
+            <Loading />
           </div>
         )}
         {vesting.selectedVestingHash && vesting.vestingDetails && (
           <div>
             <Card title="Vesting Schedule">
               <div className="col-8 container">
-                <VestingChart vestingDetail={vesting.vestingDetails}/>
+                <VestingChart vestingDetail={vesting.vestingDetails} />
               </div>
             </Card>
             <VestingDetails hash={vesting.selectedVestingHash!.hashBase16}
-                            vestingDetail={vesting.vestingDetails}
-                            refresh={
-                              () => vesting.init(vesting.selectedVestingHash!.hashBase16)
-                            }/>
+              vestingDetail={vesting.vestingDetails}
+              refresh={
+                () => vesting.init(vesting.selectedVestingHash!.hashBase16)
+              } />
           </div>
         )}
       </div>
@@ -131,10 +128,10 @@ const VestingHashesManageForm = observer(
             onClick={() => vestingContainer.configureImportVestingHash()}
           />
           <Button title="Remove" type="danger" onClick={() => {
-            if(vestingContainer.selectedVestingHash?.hashBase16){
+            if (vestingContainer.selectedVestingHash?.hashBase16) {
               vestingContainer.deleteVestingHash(vestingContainer.selectedVestingHash!.hashBase16);
             }
-          }} disabled={vestingContainer.selectedVestingHash === null}/>
+          }} disabled={vestingContainer.selectedVestingHash === null} />
         </ListInline>
       </Card>
     );
@@ -184,60 +181,60 @@ const VestingDetails = observer(
       >
         <table className="table table-bordered">
           <tbody>
-          <TableRow title="Hash of the Vesting Contract">
-            {props.hash}
-          </TableRow>
-          <TableRow title="Current Time">
-            {moment().format()}
-          </TableRow>
-          <TableRow title="Cliff Timestamp">
-            {moment(vestingDetail.cliffTimestamp).fromNow()}
-          </TableRow>
-          <TableRow title="Cliff Amount">
-            <CLX amount={vestingDetail.cliffAmount}/>
-          </TableRow>
-          <TableRow title="Drip Duration">
-            {duration(vestingDetail.dripDuration)}
-          </TableRow>
-          <TableRow title="Drip Amount">
-            <CLX amount={vestingDetail.dripAmount}/>
-          </TableRow>
-          <TableRow title="Total Amount">
-            <CLX amount={vestingDetail.totalAmount}/>
-          </TableRow>
-          <TableRow title="Released Amount">
-            <CLX amount={vestingDetail.releasedAmount}/>
-          </TableRow>
-          <TableRow title="Admin Release Duration">
-         <span className="mr-3">
-          {duration(vestingDetail.adminReleaseDuration)}
-         </span>
-            {vestingDetail.isReleasable && (
-              <Icon name="check-circle" color="green" title="Available to release"/>
-            )}
-          </TableRow>
-          <TableRow title="Paused State">
-            {vestingDetail.isPaused ? 'Paused' : 'Not Paused'}
-          </TableRow>
-          {
-            vestingDetail.isPaused && (
-              <TableRow title="Last Time Paused">
-                {moment(vestingDetail.lastPauseTimestamp).fromNow()}
-              </TableRow>
-            )
-          }
-          <TableRow title="On Pause Duration">
-            {duration(vestingDetail.onPauseDuration)}
-          </TableRow>
-          <TableRow title="Admin Account">
-            {vestingDetail.adminAccount}
-          </TableRow>
-          <TableRow title="Recipient Account">
-            {vestingDetail.recipientAccount}
-          </TableRow>
-          <TableRow title="Available Amount">
-            <CLX amount={vestingDetail.available_amount}/>
-          </TableRow>
+            <TableRow title="Hash of the Vesting Contract">
+              {props.hash}
+            </TableRow>
+            <TableRow title="Current Time">
+              {moment().format()}
+            </TableRow>
+            <TableRow title="Cliff Timestamp">
+              {moment(vestingDetail.cliffTimestamp).fromNow()}
+            </TableRow>
+            <TableRow title="Cliff Amount">
+              <CLX amount={vestingDetail.cliffAmount} />
+            </TableRow>
+            <TableRow title="Drip Duration">
+              {duration(vestingDetail.dripDuration)}
+            </TableRow>
+            <TableRow title="Drip Amount">
+              <CLX amount={vestingDetail.dripAmount} />
+            </TableRow>
+            <TableRow title="Total Amount">
+              <CLX amount={vestingDetail.totalAmount} />
+            </TableRow>
+            <TableRow title="Released Amount">
+              <CLX amount={vestingDetail.releasedAmount} />
+            </TableRow>
+            <TableRow title="Admin Release Duration">
+              <span className="mr-3">
+                {duration(vestingDetail.adminReleaseDuration)}
+              </span>
+              {vestingDetail.isReleasable && (
+                <Icon name="check-circle" color="green" title="Available to release" />
+              )}
+            </TableRow>
+            <TableRow title="Paused State">
+              {vestingDetail.isPaused ? 'Paused' : 'Not Paused'}
+            </TableRow>
+            {
+              vestingDetail.isPaused && (
+                <TableRow title="Last Time Paused">
+                  {moment(vestingDetail.lastPauseTimestamp).fromNow()}
+                </TableRow>
+              )
+            }
+            <TableRow title="On Pause Duration">
+              {duration(vestingDetail.onPauseDuration)}
+            </TableRow>
+            <TableRow title="Admin Account">
+              {vestingDetail.adminAccount}
+            </TableRow>
+            <TableRow title="Recipient Account">
+              {vestingDetail.recipientAccount}
+            </TableRow>
+            <TableRow title="Available Amount">
+              <CLX amount={vestingDetail.available_amount} />
+            </TableRow>
           </tbody>
         </table>
       </Card>

--- a/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
@@ -25,7 +25,7 @@ entropy-duration = "3hours"
 
 voting-period-duration = "2days"
 
-voting-period-summit-level = 1
+voting-period-summit-level = 0
 
 [deploys]
 max-ttl-millis = 86400000

--- a/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
@@ -25,7 +25,7 @@ entropy-duration = "3hours"
 
 voting-period-duration = "2days"
 
-voting-period-summit-level = 1
+voting-period-summit-level = 0
 
 [deploys]
 max-ttl-millis = 86400000

--- a/integration-testing/resources/test-chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec/genesis/manifest.toml
@@ -25,7 +25,7 @@ entropy-duration = "3hours"
 
 voting-period-duration = "2days"
 
-voting-period-summit-level = 1
+voting-period-summit-level = 0
 
 [deploys]
 max-ttl-millis = 86400000

--- a/node/src/main/resources/chainspec/genesis/manifest.toml
+++ b/node/src/main/resources/chainspec/genesis/manifest.toml
@@ -46,7 +46,7 @@ entropy-duration = "3hours"
 voting-period-duration = "2days"
 
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
-voting-period-summit-level = 1
+voting-period-summit-level = 0
 
 [deploys]
 # 1 day

--- a/node/src/test/resources/test-chainspec/genesis/manifest.toml
+++ b/node/src/test/resources/test-chainspec/genesis/manifest.toml
@@ -25,7 +25,7 @@ entropy-duration = "3hours"
 
 voting-period-duration = "2days"
 
-voting-period-summit-level = 1
+voting-period-summit-level = 0
 
 [deploys]
 max-ttl-millis = 86400000


### PR DESCRIPTION
### Overview
Some simple changes to make eras more tractable in Clarity:
* Added _Key Block Hash_ link in block details and listings
* Added _Block Type_ in block details and listings
* Made ballots smaller in the Explorer
* Added a colourful edge to the blocks/ballots in explorer depending on the era
* Fix _Is Finalized_ display
* Added _m-Rank_ next to _j-Rank_
* Made lines between finalized blocks green

![image](https://user-images.githubusercontent.com/2684603/74937643-60ce4080-53e4-11ea-839b-150cab0b46b2.png)


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1216

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Fixed the chainspec not to start with summit level based voting period.
Switch blocks have all their voting ballots show up as their children. That's a huge list.