### PR TITLE
NO-TICKET: correcting crates.io badge on README, added npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://drone-auto.casperlabs.io/api/badges/CasperLabs/CasperLabs/status.svg?branch=dev)](http://drone-auto.casperlabs.io/CasperLabs/CasperLabs)
 [![Current Release](https://img.shields.io/github/release-pre/CasperLabs/CasperLabs.svg?color=red)](https://github.com/CasperLabs/CasperLabs/releases)
-[![Crates.io](https://img.shields.io/crates/v/casperlabs-engine-grpc-server)](https://crates.io/crates/casperlabs-engine-grpc-server)
-[![npm](https://img.shields.io/npm/v/@casperlabs/contract)](https://www.npmjs.com/package/@casperlabs/contract)
+[![Crates.io](https://img.shields.io/crates/v/casperlabs-contract)](https://crates.io/crates/casperlabs-contract)
+[![npm](https://img.shields.io/npm/v/@casperlabs/contract?color=teal)](https://www.npmjs.com/package/@casperlabs/contract)
 [![PyPI](https://img.shields.io/pypi/v/casperlabs-client?color=purple)](https://pypi.org/project/casperlabs-client)
 [![License](https://img.shields.io/badge/license-COSL-blue.svg)](https://github.com/CasperLabs/CasperLabs/blob/master/LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Build Status](https://drone-auto.casperlabs.io/api/badges/CasperLabs/CasperLabs/status.svg?branch=dev)](http://drone-auto.casperlabs.io/CasperLabs/CasperLabs)
 [![Current Release](https://img.shields.io/github/release-pre/CasperLabs/CasperLabs.svg?color=red)](https://github.com/CasperLabs/CasperLabs/releases)
-[![Crates.io](https://img.shields.io/crates/v/casperlabs-contract-ffi)](https://crates.io/crates/casperlabs-contract-ffi)
+[![Crates.io](https://img.shields.io/crates/v/casperlabs-engine-grpc-server)](https://crates.io/crates/casperlabs-engine-grpc-server)
+[![npm](https://img.shields.io/npm/v/@casperlabs/contract)](https://www.npmjs.com/package/@casperlabs/contract)
 [![PyPI](https://img.shields.io/pypi/v/casperlabs-client?color=purple)](https://pypi.org/project/casperlabs-client)
 [![License](https://img.shields.io/badge/license-COSL-blue.svg)](https://github.com/CasperLabs/CasperLabs/blob/master/LICENSE)
 


### PR DESCRIPTION
This PR changes the target crate for version badge on the repo README and adds a badge for the `AssemblyScript` package we now publish to npm.

- [X] This PR contains no more than 2 lines of not code.
- [X] This PR is assigned.
