### PR TITLE
NODE-1217: Fix own latest

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -234,7 +234,7 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
                                      keyBlockHash = era.keyBlockHash,
                                      roundId = Ticks(lambdaMessage.roundId),
                                      target = choice.block.messageHash,
-                                     justifications = justifications
+                                     justifications = choice.justificationsMap
                                    )
                                }
               } yield maybeMessage

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -203,7 +203,7 @@ object MessageProducer {
         for {
           // NOTE: The validator sequence number restarts in each era, and `justifications`
           // can contain entries for the parent era as well as the child.
-          justificationMessages <- (parents.map(_.messageHash) ++ justifications.values.flatten).toSet.toList
+          justificationMessages <- justifications.values.flatten.toSet.toList
                                     .traverse { h =>
                                       BlockStorage[F]
                                         .getBlockSummaryUnsafe(h)

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -68,7 +68,8 @@ object MessageProducer {
   def apply[F[_]: Concurrent: Clock: Log: Metrics: DagStorage: BlockStorage: DeployBuffer: DeployStorage: EraStorage: CasperLabsProtocol: ExecutionEngineService: DeploySelection](
       validatorIdentity: ValidatorIdentity,
       chainName: String,
-      upgrades: Seq[ipc.ChainSpec.UpgradePoint]
+      upgrades: Seq[ipc.ChainSpec.UpgradePoint],
+      onlyTakeOwnLatestFromJustifications: Boolean = false
   ): MessageProducer[F] =
     new MessageProducer[F] {
       override val validatorId =
@@ -211,14 +212,29 @@ object MessageProducer {
                                           MonadThrowable[F].fromTry(Message.fromBlockSummary(s))
                                         }
                                     }
-          // Find the latest justification we picked. We must make sure they don't change
-          // due to concurrency between the time the justifications are collected and
-          // the sequence number is calculated, otherwise we could be equivocating.
-          // This, currently, is catered for by a Semaphore in the EraRuntime, which
-          // spans the fork choice as well as the block production.
-          ownLatests = justificationMessages.filter { j =>
+
+          // Find the latest justification of the validator. They might be eliminated with transitives.
+          validatorLatests = justificationMessages.filter { j =>
             j.validatorId == validatorId && j.eraId == keyBlockHash
           }
+
+          // If they were eliminated we can look them up, as long as we make sure they don't change
+          // due to concurrency since the time the justifications were collected, otherwise we could
+          // be equivocating. This, currently, is catered for by a Semaphore in the EraRuntime around
+          // the use of MessageProducer, which spans the fork choice as well as the block production.
+          ownLatests <- if (validatorLatests.nonEmpty || onlyTakeOwnLatestFromJustifications)
+                         validatorLatests.pure[F]
+                       else {
+                         for {
+                           dag  <- DagStorage[F].getRepresentation
+                           tips <- dag.latestInEra(keyBlockHash)
+                           // Looking up hashes should be faster than full messages, and the following lookup is cached.
+                           // Alternatively we could traverse the DAG from the justifications (currently transitions are eliminated).
+                           ownLatestsHashes <- tips.latestMessageHash(validatorId)
+                           ownLatests       <- ownLatestsHashes.toList.traverse(dag.lookupUnsafe)
+                         } yield ownLatests
+                       }
+
           maybeOwnLatest = Option(ownLatests)
             .filterNot(_.isEmpty)
             .map(_.maxBy(_.validatorMsgSeqNum))


### PR DESCRIPTION
### Overview
Due to transitive elimination, the `ownLatests` in the `MessageProducer` sometimes wasn't found, causing the `validatorPrevMessageHash` to be sometimes empty. The PR adds a fallback lookup in the database, which should be fine because the the validator is only allowed to create one message per era at a time, protected by a sempahore.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1217

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.


### Note
https://casperlabs.atlassian.net/browse/NODE-1219 will remove transitive elimination, at which point this will no longer be necessary. There's a flag to turn it off but that's also because of the `ForkChoiceTest`.
