### PR TITLE
CON-648: Fix bug in the `FinalityDetector` when network runs in `Highway` mode.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetectorUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetectorUtil.scala
@@ -10,6 +10,7 @@ import io.casperlabs.models.Message
 import io.casperlabs.storage.dag.DagRepresentation
 
 import scala.collection.mutable.{IndexedSeq => MutableSeq}
+import io.casperlabs.casper.validation.Validation
 
 object FinalityDetectorUtil {
 
@@ -144,7 +145,8 @@ object FinalityDetectorUtil {
       blockSummary: Message
   ): F[MutableSeq[Level]] =
     for {
-      equivocators <- dag.getEquivocators
+      equivocators <- if (Validation.isHighway) dag.getEquivocatorsInEra(blockSummary.eraId)
+                     else dag.getEquivocators
       latestBlockDagLevelAsMap <- FinalityDetectorUtil
                                    .panoramaDagLevelsOfBlock(
                                      dag,


### PR DESCRIPTION
### Overview
We were looking up equivocators in the global storage which would (eventually) recognize all validators as equivocators b/c of the voting-only period. 

This PR looks up equivocators in the era-aware DAG if the node is running in Highway mode.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-648

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
