### PR TITLE
NO-TICKET: execution-engine: remove asc checks in Makefile

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -1,24 +1,7 @@
-SHELL := bash
-
 # This supports environments where $HOME/.cargo/env has not been sourced (CI, CLion Makefile runner)
 CARGO  = $(or $(shell which cargo),  $(HOME)/.cargo/bin/cargo)
 RUSTUP = $(or $(shell which rustup), $(HOME)/.cargo/bin/rustup)
 NPM    = $(or $(shell which npm),    /usr/bin/npm)
-
-# AssemblyScript Compiler
-ASC_VERSION := 0.9.1
-
-# Checks if AssemblyScript compiler is found in $PATH
-ifeq (,$(shell which asc))
-    $(error "No asc in $(PATH). Please run npm install -g assemblyscript@$(ASC_VERSION) first")
-endif
-
-# Checks if AssemblyScript compiler is at correct version
-ASC_VERSION_OUTPUT:=$(shell asc --version | cut -d' ' -f2)
-ifeq (,$(findstring $(ASC_VERSION),$(ASC_VERSION_OUTPUT)))
-    $(error "Found asc version $(ASC_VERSION_OUTPUT) but version $(ASC_VERSION) is required.\
-             Please run npm install -g assemblyscript@$(ASC_VERSION) first")
-endif
 
 RUST_TOOLCHAIN := $(shell cat rust-toolchain)
 


### PR DESCRIPTION
### Overview
This PR removes the ASC checks from our Makefile.  While I'm not opposed to adding such a check, it needs to be more robust than this one, so that it will not cause failures in hermetic environments like the CLion Makefile runner where a user's local shell configuration may not have been sourced.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
