### PR TITLE
NODE-1202: Use cappedEffects where needed

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -157,9 +157,11 @@ class DeploySelectionTest
     val deploySelection = DeploySelection.create[Task](sizeLimitBytes)
 
     // The very first WRITE doesn't conflict
-    val expectedCommuting = mixed.head +: mixed.zipWithIndex.filter(_._2 % 2 == 1).map(_._1)
+    val expectedCommuting = cappedEffects.head +: cappedEffects.zipWithIndex
+      .filter(_._2 % 2 == 1)
+      .map(_._1)
     // Because first WRITE doesn't conflict we will get 1 less of them in conflicting section
-    val expectedConflicting = mixed.zipWithIndex.filter(_._2 % 2 == 0).map(_._1).tail
+    val expectedConflicting = cappedEffects.zipWithIndex.filter(_._2 % 2 == 0).map(_._1).tail
 
     val test = deploySelection
       .select((prestate, blocktime, protocolVersion, stream))


### PR DESCRIPTION
### Overview
Fixed the non-det failing test

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1202

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
