### PR TITLE
NODE-1212: Fix grep looking for nodes.

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -156,8 +156,8 @@ reset-highway-env: .casperlabs
 
 # Reset highway env if there are no nodes running at the moment or there's only one node directory created (we are restarting the 1 node we have)
 maybe-reset-highway-env:
-	DEFINED=$$(find . -maxdepth 1 -type d | grep -e node-[0-9] | wc -l); \
-	RUNNING=$$(docker ps --format '{{.Names}}' | grep -e node-[0-9] | wc -l); \
+	DEFINED=$$(find . -maxdepth 1 -type d | grep -e 'node-[0-9]' | wc -l); \
+	RUNNING=$$(docker ps --format '{{.Names}}' | grep -e 'node-[0-9]' | wc -l); \
 	if [ "$${RUNNING}" = "0" ] || [ "$${DEFINED}" = "1" ]; then \
 		$(RESET_HIGHWAY_ENV); \
 	fi


### PR DESCRIPTION
### Overview
Got an error once the nodes were actually running about `grep: node-1: Is a directory` and it always returned 0, so it made a mistake and the third node ended up having different settings.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1212

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
