### PR TITLE
NODE-1231: Return a wait handle from `MessageProducer.effectsAfterAdded`

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -190,7 +190,7 @@ object MessageProducer {
         DeployBuffer[F].requeueOrphanedDeploys(parentHashes) >>= { requeued =>
           Log[F].info(s"Re-queued ${requeued.size} orphaned deploys.").whenA(requeued.nonEmpty)
         }
-      }.forkAndLog
+      }.forkAndLog.void
 
       private def messageProps(
           keyBlockHash: BlockHash,

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
@@ -341,7 +341,8 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
         for {
           block   <- insertFirstBlock()
           message = Message.fromBlock(block).get
-          _       <- messageExecutor.effectsAfterAdded(message)
+          wait    <- messageExecutor.effectsAfterAdded(message)
+          _       <- wait
           events  <- eventEmitter.events
         } yield {
           forExactly(1, events) { event =>
@@ -373,7 +374,8 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
         for {
           block   <- insertFirstBlock()
           message = Message.fromBlock(block).get
-          _       <- messageExecutor.effectsAfterAdded(message)
+          wait    <- messageExecutor.effectsAfterAdded(message)
+          _       <- wait
           _       <- messageAddedRef.get shouldBeF Some(message)
           _       <- FinalityStorage[Task].isFinalized(block.blockHash) shouldBeF true
           events  <- eventEmitter.events
@@ -394,7 +396,8 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
           _       <- DeployStorage[Task].writer.addAsPending(deploys)
           _       <- BlockStorage[Task].put(block, BlockEffects.empty.effects)
           message = Message.fromBlock(block).get
-          _       <- messageExecutor.effectsAfterAdded(message)
+          wait    <- messageExecutor.effectsAfterAdded(message)
+          _       <- wait
           statuses <- deploys.traverse { d =>
                        DeployStorage[Task].reader.getBufferedStatus(d.deployHash)
                      }

--- a/shared/src/main/scala/io/casperlabs/catscontrib/FiberSyntax.scala
+++ b/shared/src/main/scala/io/casperlabs/catscontrib/FiberSyntax.scala
@@ -8,13 +8,14 @@ import io.casperlabs.shared.Log
 class FiberSyntax[F[_]: Concurrent: Log: MonadThrowable, A](fa: F[A]) {
 
   /** Forks execution into a fiber.
-    * Logs any errors thrown in the fiber */
-  def forkAndLog: F[Unit] =
+    * Logs any errors thrown in the fiber.
+    * Return something we can wait upon until the fiber is finished. */
+  def forkAndLog: F[F[A]] =
     fa.onError {
         case error =>
           Log[F].error(s"Error was thrown in the forked fiber: $error")
       }
       .start
-      .as(())
+      .map(_.join)
 
 }


### PR DESCRIPTION
### Overview
Make sure tests await on the async effects started by the `MessageExecutor`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1231

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
