### PR TITLE
NODE-1169: Deprecate propose in Scala and Python CLI

### DIFF
--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
@@ -16,6 +16,7 @@ import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.shared.{FilesAPI, Log}
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
+import java.util.concurrent.TimeUnit
 
 object Benchmarks {
 
@@ -66,7 +67,9 @@ object Benchmarks {
       recipientPublicKey = recipientPublicKey,
       amount = amount,
       exit = false,
-      ignoreOutput = true
+      ignoreOutput = true,
+      false,
+      FiniteDuration(3, TimeUnit.MINUTES)
     )
 
     def createAccountKeyPair(): (Keys.PrivateKey, Keys.PublicKey) =

--- a/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/io/casperlabs/benchmarks/Benchmarks.scala
@@ -15,8 +15,7 @@ import io.casperlabs.crypto.codec.Base64
 import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.shared.{FilesAPI, Log}
 
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
-import java.util.concurrent.TimeUnit
+import scala.concurrent.duration._
 
 object Benchmarks {
 
@@ -69,7 +68,7 @@ object Benchmarks {
       exit = false,
       ignoreOutput = true,
       false,
-      FiniteDuration(3, TimeUnit.MINUTES)
+      3.minutes
     )
 
     def createAccountKeyPair(): (Keys.PrivateKey, Keys.PublicKey) =

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -40,9 +40,10 @@ object DeployRuntime {
       ignoreOutput: Boolean = false
   ): F[Unit] =
     gracefulExit(
-      DeployService[F]
-        .propose()
-        .map(_.map(hash => s"Response: Success! Block $hash created and added.")),
+      (for {
+        _      <- Sync[F].delay(System.err.println("Warning: command propose is deprecated."))
+        result <- DeployService[F].propose()
+      } yield result).map(_.map(hash => s"Response: Success! Block $hash created and added.")),
       exit,
       ignoreOutput
     )

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -337,8 +337,8 @@ object DeployRuntime {
       amount: Long,
       exit: Boolean = true,
       ignoreOutput: Boolean = false,
-      waitForProcessed: Boolean = false,
-      timeoutSeconds: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
+      waitForProcessed: Boolean,
+      timeoutSeconds: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -40,10 +40,10 @@ object DeployRuntime {
       ignoreOutput: Boolean = false
   ): F[Unit] =
     gracefulExit(
-      (for {
+      for {
         _      <- Sync[F].delay(System.err.println("Warning: command propose is deprecated."))
         result <- DeployService[F].propose()
-      } yield result).map(_.map(hash => s"Response: Success! Block $hash created and added.")),
+      } yield result.map(hash => s"Response: Success! Block $hash created and added."),
       exit,
       ignoreOutput
     )
@@ -71,10 +71,10 @@ object DeployRuntime {
       bytesStandard: Boolean,
       json: Boolean,
       waitForProcessed: Boolean,
-      timeoutSeconds: FiniteDuration
+      timeout: FiniteDuration
   ): F[Unit] =
     gracefulExit(
-      DeployService[F].showDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds)
+      DeployService[F].showDeploy(hash, bytesStandard, json, waitForProcessed, timeout)
     )
 
   def showBlocks[F[_]: Sync: DeployService](
@@ -121,7 +121,7 @@ object DeployRuntime {
       deployConfig: DeployConfig,
       privateKeyFile: File,
       waitForProcessed: Boolean,
-      timeoutSeconds: FiniteDuration,
+      timeout: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -135,7 +135,7 @@ object DeployRuntime {
             sessionArgs =
               List(optionalArg("amount", maybeAmount)(Deploy.Arg.Value.Value.LongValue(_))),
             waitForProcessed = waitForProcessed,
-            timeoutSeconds = timeoutSeconds,
+            timeout = timeout,
             bytesStandard = bytesStandard,
             json = json
           )
@@ -146,7 +146,7 @@ object DeployRuntime {
       deployConfig: DeployConfig,
       privateKeyFile: File,
       waitForProcessed: Boolean,
-      timeoutSeconds: FiniteDuration,
+      timeout: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -159,7 +159,7 @@ object DeployRuntime {
             maybeEitherPrivateKey = rawPrivateKey.asLeft[PrivateKey].some,
             sessionArgs = List(longArg("amount", amount)),
             waitForProcessed = waitForProcessed,
-            timeoutSeconds = timeoutSeconds,
+            timeout = timeout,
             bytesStandard = bytesStandard,
             json = json
           )
@@ -299,7 +299,7 @@ object DeployRuntime {
       recipientPublicKey: PublicKey,
       amount: Long,
       waitForProcessed: Boolean,
-      timeoutSeconds: FiniteDuration,
+      timeout: FiniteDuration,
       bytesStandard: Boolean,
       json: Boolean
   ): F[Unit] =
@@ -324,7 +324,7 @@ object DeployRuntime {
             recipientPublicKey,
             amount,
             waitForProcessed = waitForProcessed,
-            timeoutSeconds = timeoutSeconds,
+            timeout = timeout,
             bytesStandard = bytesStandard,
             json = json
           )
@@ -339,7 +339,7 @@ object DeployRuntime {
       exit: Boolean = true,
       ignoreOutput: Boolean = false,
       waitForProcessed: Boolean,
-      timeoutSeconds: FiniteDuration,
+      timeout: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -355,7 +355,7 @@ object DeployRuntime {
       exit,
       ignoreOutput,
       waitForProcessed = waitForProcessed,
-      timeoutSeconds = timeoutSeconds,
+      timeout = timeout,
       bytesStandard = bytesStandard,
       json = json
     )
@@ -440,7 +440,7 @@ object DeployRuntime {
   def sendDeploy[F[_]: Sync: DeployService](
       deployBA: Array[Byte],
       waitForProcessed: Boolean,
-      timeoutSeconds: FiniteDuration,
+      timeout: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -448,7 +448,7 @@ object DeployRuntime {
       for {
         deploy <- Sync[F].fromTry(Try(Deploy.parseFrom(deployBA)))
         result <- if (waitForProcessed) {
-                   deployAndWaitForProcessed[F](deploy, timeoutSeconds, bytesStandard, json)
+                   deployAndWaitForProcessed[F](deploy, timeout, bytesStandard, json)
                  } else {
                    DeployService[F].deploy(deploy)
                  }
@@ -473,7 +473,7 @@ object DeployRuntime {
 
   def deployAndWaitForProcessed[F[_]: Sync: DeployService](
       deploy: Deploy,
-      timeoutSeconds: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
+      timeout: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Either[Throwable, String]] =
@@ -486,7 +486,7 @@ object DeployRuntime {
                    bytesStandard,
                    json,
                    waitForProcessed = true,
-                   timeoutSeconds
+                   timeout
                  )
     } yield result
 
@@ -499,7 +499,7 @@ object DeployRuntime {
       exit: Boolean = true,
       ignoreOutput: Boolean = false,
       waitForProcessed: Boolean = false,
-      timeoutSeconds: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
+      timeout: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] = {
@@ -528,7 +528,7 @@ object DeployRuntime {
       deploy
         .flatMap({ deploy =>
           if (waitForProcessed) {
-            deployAndWaitForProcessed[F](deploy, timeoutSeconds, bytesStandard, json)
+            deployAndWaitForProcessed[F](deploy, timeout, bytesStandard, json)
           } else {
             DeployService[F].deploy(deploy)
           }

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -70,7 +70,7 @@ object DeployRuntime {
       bytesStandard: Boolean,
       json: Boolean,
       waitForProcessed: Boolean,
-      timeoutSeconds: Long
+      timeoutSeconds: FiniteDuration
   ): F[Unit] =
     gracefulExit(
       DeployService[F].showDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds)
@@ -120,7 +120,7 @@ object DeployRuntime {
       deployConfig: DeployConfig,
       privateKeyFile: File,
       waitForProcessed: Boolean,
-      timeoutSeconds: Long,
+      timeoutSeconds: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -145,7 +145,7 @@ object DeployRuntime {
       deployConfig: DeployConfig,
       privateKeyFile: File,
       waitForProcessed: Boolean,
-      timeoutSeconds: Long,
+      timeoutSeconds: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -298,7 +298,7 @@ object DeployRuntime {
       recipientPublicKey: PublicKey,
       amount: Long,
       waitForProcessed: Boolean,
-      timeoutSeconds: Long,
+      timeoutSeconds: FiniteDuration,
       bytesStandard: Boolean,
       json: Boolean
   ): F[Unit] =
@@ -338,7 +338,7 @@ object DeployRuntime {
       exit: Boolean = true,
       ignoreOutput: Boolean = false,
       waitForProcessed: Boolean = false,
-      timeoutSeconds: Long = Options.TIMEOUT_SECONDS_DEFAULT,
+      timeoutSeconds: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -439,7 +439,7 @@ object DeployRuntime {
   def sendDeploy[F[_]: Sync: DeployService](
       deployBA: Array[Byte],
       waitForProcessed: Boolean,
-      timeoutSeconds: Long,
+      timeoutSeconds: FiniteDuration,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] =
@@ -472,7 +472,7 @@ object DeployRuntime {
 
   def deployAndWaitForProcessed[F[_]: Sync: DeployService](
       deploy: Deploy,
-      timeoutSeconds: Long = Options.TIMEOUT_SECONDS_DEFAULT,
+      timeoutSeconds: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Either[Throwable, String]] =
@@ -498,7 +498,7 @@ object DeployRuntime {
       exit: Boolean = true,
       ignoreOutput: Boolean = false,
       waitForProcessed: Boolean = false,
-      timeoutSeconds: Long = Options.TIMEOUT_SECONDS_DEFAULT,
+      timeoutSeconds: FiniteDuration = Options.TIMEOUT_SECONDS_DEFAULT,
       bytesStandard: Boolean = false,
       json: Boolean = false
   ): F[Unit] = {

--- a/client/src/main/scala/io/casperlabs/client/DeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployService.scala
@@ -5,6 +5,7 @@ import io.casperlabs.casper.consensus.state.Value
 import simulacrum.typeclass
 
 import scala.util.Either
+import scala.concurrent.duration._
 
 @typeclass trait DeployService[F[_]] {
   def deploy(
@@ -24,7 +25,7 @@ import scala.util.Either
       bytesStandard: Boolean,
       json: Boolean,
       waitForProcessed: Boolean,
-      timeoutSeconds: Long
+      timeoutSeconds: FiniteDuration
   ): F[Either[Throwable, String]]
   def showBlocks(depth: Int, bytesStandard: Boolean, json: Boolean): F[Either[Throwable, String]]
   def visualizeDag(depth: Int, showJustificationLines: Boolean): F[Either[Throwable, String]]

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -149,9 +149,9 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       casperServiceStub.getDeployInfo(GetDeployInfoRequest(hash, view = DeployInfo.View.BASIC))
 
     if (waitForProcessed) {
-      val startTime   = System.currentTimeMillis()
-      val timeoutTime = startTime + timeoutSeconds.toSeconds * 1000
-      val delay : FiniteDuration = 1.second
+      val startTime             = System.currentTimeMillis()
+      val timeoutTime           = startTime + timeoutSeconds.toSeconds * 1000
+      val delay: FiniteDuration = 1.second
 
       def deployInfo(sleepDuration: FiniteDuration): Task[DeployInfo] =
         Task.sleep(sleepDuration) >> deployInfoF

--- a/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
+++ b/client/src/main/scala/io/casperlabs/client/GrpcDeployService.scala
@@ -143,11 +143,11 @@ class GrpcDeployService(conn: ConnectOptions, scheduler: Scheduler)
       bytesStandard: Boolean,
       json: Boolean,
       waitForProcessed: Boolean,
-      timeoutSeconds: Long
+      timeoutSeconds: FiniteDuration
   ): Task[Either[Throwable, String]] =
     if (waitForProcessed) {
       val startTime   = System.currentTimeMillis()
-      val timeoutTime = startTime + timeoutSeconds * 1000
+      val timeoutTime = startTime + timeoutSeconds.toSeconds
 
       def deployInfo(sleepDuration: FiniteDuration): Task[DeployInfo] =
         Task.sleep(sleepDuration) >> casperServiceStub.getDeployInfo(

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -53,13 +53,13 @@ object Main {
     configuration match {
       case ShowBlock(hash, bytesStandard, json) =>
         DeployRuntime.showBlock[F](hash, bytesStandard, json)
-      case ShowDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds) => {
+      case ShowDeploy(hash, bytesStandard, json, waitForProcessed, timeout) => {
         DeployRuntime.showDeploy[F](
           hash,
           bytesStandard,
           json,
           waitForProcessed,
-          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS)
+          timeout.seconds
         )
       }
       case ShowDeploys(hash, bytesStandard, json) =>
@@ -71,7 +71,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds,
+          timeout,
           bytesStandard,
           json
           ) =>
@@ -80,7 +80,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
+          timeout.seconds,
           bytesStandard,
           json
         )
@@ -89,7 +89,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds,
+          timeout,
           bytesStandard,
           json
           ) =>
@@ -98,7 +98,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
+          timeout.seconds,
           bytesStandard,
           json
         )
@@ -108,7 +108,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds,
+          timeout,
           bytesStandard,
           json
           ) =>
@@ -118,7 +118,7 @@ object Main {
           recipientPublicKey,
           amount,
           waitForProcessed,
-          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
+          timeout.seconds,
           bytesStandard,
           json
         )
@@ -128,7 +128,7 @@ object Main {
           maybePublicKey,
           maybePrivateKey,
           waitForProcessed,
-          timeoutSeconds,
+          timeout,
           bytesStandard,
           json
           ) =>
@@ -144,7 +144,7 @@ object Main {
               new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PrivateKey]
           ),
           waitForProcessed = waitForProcessed,
-          timeoutSeconds = FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
+          timeout = timeout.seconds,
           bytesStandard = bytesStandard,
           json = json
         )
@@ -178,11 +178,11 @@ object Main {
           _ <- DeployRuntime.writeDeploy[F](deploy, deployPath)
         } yield ()
 
-      case SendDeploy(deploy, waitForProcessed, timeoutSeconds, bytesStandard, json) =>
+      case SendDeploy(deploy, waitForProcessed, timeout, bytesStandard, json) =>
         DeployRuntime.sendDeploy[F](
           deploy,
           waitForProcessed,
-          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
+          timeout.seconds,
           bytesStandard,
           json
         )

--- a/client/src/main/scala/io/casperlabs/client/Main.scala
+++ b/client/src/main/scala/io/casperlabs/client/Main.scala
@@ -17,6 +17,7 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import logstage.IzLogger
 import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
 
 object Main {
 
@@ -52,8 +53,15 @@ object Main {
     configuration match {
       case ShowBlock(hash, bytesStandard, json) =>
         DeployRuntime.showBlock[F](hash, bytesStandard, json)
-      case ShowDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds) =>
-        DeployRuntime.showDeploy[F](hash, bytesStandard, json, waitForProcessed, timeoutSeconds)
+      case ShowDeploy(hash, bytesStandard, json, waitForProcessed, timeoutSeconds) => {
+        DeployRuntime.showDeploy[F](
+          hash,
+          bytesStandard,
+          json,
+          waitForProcessed,
+          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS)
+        )
+      }
       case ShowDeploys(hash, bytesStandard, json) =>
         DeployRuntime.showDeploys[F](hash, bytesStandard, json)
       case ShowBlocks(depth, bytesStandard, json) =>
@@ -72,7 +80,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds,
+          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
           bytesStandard,
           json
         )
@@ -90,7 +98,7 @@ object Main {
           contracts,
           privateKey,
           waitForProcessed,
-          timeoutSeconds,
+          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
           bytesStandard,
           json
         )
@@ -110,7 +118,7 @@ object Main {
           recipientPublicKey,
           amount,
           waitForProcessed,
-          timeoutSeconds,
+          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
           bytesStandard,
           json
         )
@@ -136,7 +144,7 @@ object Main {
               new String(Files.readAllBytes(file.toPath), StandardCharsets.UTF_8).asLeft[PrivateKey]
           ),
           waitForProcessed = waitForProcessed,
-          timeoutSeconds = timeoutSeconds,
+          timeoutSeconds = FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
           bytesStandard = bytesStandard,
           json = json
         )
@@ -171,7 +179,13 @@ object Main {
         } yield ()
 
       case SendDeploy(deploy, waitForProcessed, timeoutSeconds, bytesStandard, json) =>
-        DeployRuntime.sendDeploy[F](deploy, waitForProcessed, timeoutSeconds, bytesStandard, json)
+        DeployRuntime.sendDeploy[F](
+          deploy,
+          waitForProcessed,
+          FiniteDuration(timeoutSeconds, TimeUnit.SECONDS),
+          bytesStandard,
+          json
+        )
 
       case PrintDeploy(deploy, bytesStandard, json) =>
         DeployRuntime.printDeploy[F](deploy, bytesStandard, json)

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -277,7 +277,7 @@ object Configuration {
           options.deploy.publicKey.toOption,
           options.deploy.privateKey.toOption,
           options.deploy.waitForProcessed.getOrElse(false),
-          options.deploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT),
+          options.deploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT.toSeconds),
           options.deploy.bytesStandard(),
           options.deploy.json()
         )
@@ -292,7 +292,7 @@ object Configuration {
         SendDeploy(
           options.sendDeploy.deployPath(),
           options.sendDeploy.waitForProcessed.getOrElse(false),
-          options.sendDeploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT),
+          options.sendDeploy.timeoutSeconds.getOrElse(Options.TIMEOUT_SECONDS_DEFAULT.toSeconds),
           options.sendDeploy.bytesStandard(),
           options.sendDeploy.json()
         )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -15,7 +15,7 @@ import org.rogach.scallop._
 import scala.concurrent.duration.FiniteDuration
 
 object Options {
-  val TIMEOUT_SECONDS_DEFAULT: Long = 3 * 60
+  val TIMEOUT_SECONDS_DEFAULT = FiniteDuration(3, TimeUnit.MINUTES)
 
   val hexCheck: String => Boolean  = _.matches("[0-9a-fA-F]+")
   val hashCheck: String => Boolean = x => hexCheck(x) && x.length == 64
@@ -144,7 +144,7 @@ object Options {
       )
 
     val timeoutSeconds =
-      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT))
+      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT.toSeconds))
 
     addValidation {
       val sessionsProvided =
@@ -318,7 +318,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       )
 
     val timeoutSeconds =
-      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT))
+      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT.toSeconds))
 
   }
   addSubcommand(sendDeploy)
@@ -449,7 +449,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       )
 
     val timeoutSeconds =
-      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT))
+      opt[Long](descr = "Timeout in seconds.", default = Option(TIMEOUT_SECONDS_DEFAULT.toSeconds))
   }
   addSubcommand(showDeploy)
 

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -393,7 +393,7 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val propose = new Subcommand("propose") {
     descr(
-      "Force a node to propose a block based on its accumulated deploys."
+      "[DEPRECATED] Force a node to propose a block based on its accumulated deploys."
     )
   }
   addSubcommand(propose)

--- a/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Options.scala
@@ -12,10 +12,10 @@ import io.casperlabs.crypto.codec.{Base16, Base64}
 import org.apache.commons.io.IOUtils
 import org.rogach.scallop._
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 object Options {
-  val TIMEOUT_SECONDS_DEFAULT = FiniteDuration(3, TimeUnit.MINUTES)
+  val TIMEOUT_SECONDS_DEFAULT = 3.minutes
 
   val hexCheck: String => Boolean  = _.matches("[0-9a-fA-F]+")
   val hashCheck: String => Boolean = x => hexCheck(x) && x.length == 64

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -243,6 +243,7 @@ def deploy_command(casperlabs_client, args):
 
 @guarded_command
 def propose_command(casperlabs_client, args):
+    print("Warning: command propose is deprecated.", file=sys.stderr)
     response = casperlabs_client.propose()
     print(f"Success! Block hash: {response.block_hash.hex()}")
 
@@ -522,7 +523,7 @@ def cli(*arguments) -> int:
                        [('-t', '--target-account'), dict(required=True, type=str, help="base64 or base16 representation of target account's public key")],
                        ] + deploy_options(private_key_accepted=True))
 
-    parser.addCommand('propose', propose_command, 'Force a node to propose a block based on its accumulated deploys.', [])
+    parser.addCommand('propose', propose_command, '[DEPRECATED] Force a node to propose a block based on its accumulated deploys.', [])
 
     parser.addCommand('show-block', show_block_command, 'View properties of a block known by Casper on an existing running node. Output includes: parent hashes, storage contents of the tuplespace.',
                       [[('hash',), dict(type=str, help='the hash value of the block')]])

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -215,7 +215,7 @@ class CDevelop(DevelopCommand):
 
 setup(
     name=NAME,
-    version="0.8.3",
+    version="0.8.4",
     packages=find_packages(exclude=["tests"]),
     setup_requires=[
         "protobuf==3.9.1",


### PR DESCRIPTION
### Overview

This PR deprecates `propose` command in Scala and Python CLI.

The PR also addresses some comments in the post-merge review of NODE-1197.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1169

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
NA
