### PR TITLE
OP-807: use deb for node/client docker images.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -548,7 +548,8 @@ steps:
   commands:
   - "make build-client-contracts build-node-contracts"
   - "rm -rf project/target project/project/target"
-  - "sbt update test client/debian:packageBin client/universal:packageZipTarball client/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball node/rpm:packageBin node/docker:publishLocal client/docker:publishLocal"
+  - "sbt update test client/debian:packageBin client/universal:packageZipTarball client/rpm:packageBin node/debian:packageBin node/universal:packageZipTarball node/rpm:packageBin"
+  - "make docker-build/node docker-build/client"
   - "mkdir -p artifacts/${DRONE_BRANCH}"
   - "cp client/target/casperlabs-client_*_all.deb client/target/universal/*.tgz artifacts/${DRONE_BRANCH}"
   - "cp client/target/rpm/RPMS/noarch/casperlabs-client-*.noarch.rpm artifacts/${DRONE_BRANCH}"

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ docker-push-all: \
 	docker-push/key-generator \
 	docker-push/explorer
 
-docker-build/node: .make/docker-build/universal/node
-docker-build/client: .make/docker-build/universal/client
+docker-build/node: .make/docker-build/debian/node
+docker-build/client: .make/docker-build/debian/client
 docker-build/execution-engine: .make/docker-build/execution-engine
 docker-build/integration-testing: .make/docker-build/integration-testing
 docker-build/key-generator: .make/docker-build/key-generator
@@ -95,26 +95,11 @@ cargo-native-packager/%:
 	fi
 
 # Build the `latest` docker image for local testing. Works with Scala.
-.make/docker-build/universal/%: \
+.make/docker-build/debian/%: \
 		%/Dockerfile \
-		.make/sbt-stage/%
+		.make/sbt-deb/%
 	$(eval PROJECT = $*)
-	$(eval STAGE = $(PROJECT)/target/universal/stage)
-	rm -rf $(STAGE)/.docker
-	# Copy the 3rd party dependencies to a separate directory so if they don't change we can push faster.
-	mkdir -p $(STAGE)/.docker/layers/3rd
-	find $(STAGE)/lib \
-	    -type f -not -wholename "*/io.casperlabs.*.jar" \
-	    -exec cp {} $(STAGE)/.docker/layers/3rd \;
-	# Copy our own code.
-	mkdir -p $(STAGE)/.docker/layers/1st
-	find $(STAGE)/lib \
-	    -type f -wholename "*/io.casperlabs.*.jar" \
-	    -exec cp {} $(STAGE)/.docker/layers/1st \;
-	# Use the Dockerfile to build the project. Has to be within the context.
-	cp $(PROJECT)/Dockerfile $(STAGE)/Dockerfile
-	docker build -f $(STAGE)/Dockerfile -t $(DOCKER_USERNAME)/$(PROJECT):$(DOCKER_LATEST_TAG) $(STAGE)
-	rm -rf $(STAGE)/.docker $(STAGE)/Dockerfile
+	docker build -f $(PROJECT)/Dockerfile -t $(DOCKER_USERNAME)/$(PROJECT):$(DOCKER_LATEST_TAG) $(PROJECT)
 	mkdir -p $(dir $@) && touch $@
 
 # Dockerize the Integration Tests
@@ -233,6 +218,10 @@ cargo-native-packager/%:
 	sbt -mem 5000 $(PROJECT)/universal:stage
 	mkdir -p $(dir $@) && touch $@
 
+.make/sbt-deb/%: $(SCALA_SRC) build-%-contracts
+	$(eval PROJECT = $*)
+	sbt -mem 5000 $(PROJECT)/debian:packageBin
+	mkdir -p $(dir $@) && touch $@
 
 # Create .rpm and .deb packages natively. `cargo rpm build` doesn't work on MacOS.
 #

--- a/build.sbt
+++ b/build.sbt
@@ -283,31 +283,6 @@ lazy val node = (project in file("node"))
         fi
       }
     """,
-    /* Dockerization */
-    dockerUsername := Some("casperlabs"),
-    version in Docker := version.value +
-      git.gitHeadCommit.value.fold("")("-git" + _.take(8)),
-    dockerAliases ++=
-      sys.env
-        .get("DRONE_BUILD_NUMBER")
-        .toSeq
-        .map(num => dockerAlias.value.withTag(Some(s"DRONE-$num"))),
-    dockerUpdateLatest := sys.env.get("DRONE").isEmpty,
-    dockerBaseImage := "openjdk:11-jre-slim",
-    dockerCommands := {
-      Seq(
-        Cmd("FROM", dockerBaseImage.value),
-        ExecCmd("RUN", "apt", "clean"),
-        ExecCmd("RUN", "apt", "update"),
-        ExecCmd("RUN", "apt", "install", "-yq", "openssl", "curl"),
-        Cmd("LABEL", s"""MAINTAINER="${maintainer.value}""""),
-        Cmd("WORKDIR", (defaultLinuxInstallLocation in Docker).value),
-        Cmd("ADD", "opt /opt"),
-        Cmd("USER", "root"),
-        ExecCmd("ENTRYPOINT", "bin/casperlabs-node"),
-        ExecCmd("CMD", "run")
-      )
-    },
     /* Packaging */
     linuxPackageMappings ++= {
       val service_file = baseDirectory.value / "casperlabs-node.service"
@@ -426,28 +401,6 @@ lazy val client = (project in file("client"))
     ),
     buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion, git.gitHeadCommit),
     buildInfoPackage := "io.casperlabs.client",
-    /* Dockerization */
-    dockerUsername := Some("casperlabs"),
-    version in Docker := version.value +
-      git.gitHeadCommit.value.fold("")("-git" + _.take(8)),
-    dockerAliases ++=
-      sys.env
-        .get("DRONE_BUILD_NUMBER")
-        .toSeq
-        .map(num => dockerAlias.value.withTag(Some(s"DRONE-$num"))),
-    dockerUpdateLatest := sys.env.get("DRONE").isEmpty,
-    dockerBaseImage := "openjdk:11-jre-slim",
-    dockerCommands := {
-      Seq(
-        Cmd("FROM", dockerBaseImage.value),
-        Cmd("LABEL", s"""MAINTAINER="${maintainer.value}""""),
-        Cmd("WORKDIR", (defaultLinuxInstallLocation in Docker).value),
-        Cmd("ADD", "opt /opt"),
-        Cmd("USER", "root"),
-        ExecCmd("ENTRYPOINT", "bin/casperlabs-client"),
-        ExecCmd("CMD", "run")
-      )
-    },
     /*
      * This monstrosity exists because
      * a) we want to get rid of annoying JVM >= 9 warnings,

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -5,12 +5,11 @@ LABEL MAINTAINER="CasperLabs, LLC. <info@casperlabs.io>"
 
 USER root 
 WORKDIR /opt/docker 
-ENTRYPOINT ["bin/casperlabs-client"]
+ENTRYPOINT ["casperlabs-client"]
 CMD ["run"]
 
-# Copy dependencies that rarely change.
-COPY .docker/layers/3rd/ /opt/docker/lib
-# Copy our own libraries which change with every build.
-COPY .docker/layers/1st/ /opt/docker/lib
-# Copy the starter scripts which can also change with versions.
-COPY bin /opt/docker/bin
+ADD ./target/casperlabs-client_*.deb /opt/docker/
+
+RUN dpkg -i \
+	--ignore-depends openjdk-11-jre-headless \
+	/opt/docker/casperlabs-client_*.deb

--- a/hack/docker/template/start-node.sh
+++ b/hack/docker/template/start-node.sh
@@ -4,12 +4,12 @@ set -e
 
 if [ "$HOSTNAME" = "$BOOTSTRAP_HOSTNAME" ]; then
     # Start the bootstrap node with a fixed key to get a deterministic ID.
-    exec ./bin/casperlabs-node run -s \
+    exec /usr/bin/casperlabs-node run -s \
         --server-host $HOSTNAME
 else
     # Connect to the bootstrap node.
     BOOTSTRAP_ID=$(cat $HOME/.casperlabs/bootstrap/node-id)
-    exec ./bin/casperlabs-node run \
+    exec /usr/bin/casperlabs-node run \
         --server-host $HOSTNAME \
         --server-bootstrap "casperlabs://${BOOTSTRAP_ID}@${BOOTSTRAP_HOSTNAME}?protocol=40400&discovery=40404"
 fi

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -8,13 +8,11 @@ WORKDIR /opt/docker
 # HOME points to /root
 RUN mkdir -p /root/.casperlabs/genesis
 RUN mkdir -p /root/.casperlabs/deploy
-ENTRYPOINT ["bin/casperlabs-node"]
+ENTRYPOINT ["casperlabs-node"]
 CMD ["run"]
 
+ADD ./target/casperlabs-node_*.deb /opt/docker/
 
-# Copy dependencies that rarely change.
-COPY .docker/layers/3rd/ /opt/docker/lib
-# Copy our own libraries which change with every build.
-COPY .docker/layers/1st/ /opt/docker/lib
-# Copy the starter scripts which can also change with versions.
-COPY bin /opt/docker/bin
+RUN dpkg -i \
+	--ignore-depends openjdk-11-jre-headless \
+	/opt/docker/casperlabs-node_*.deb


### PR DESCRIPTION
### Overview
Converts the node and client docker images to use the debian package.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-807

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Not sure if we still want to do this or not?
