### PR TITLE
NODE-1238: Fix mac highway timestamp

### DIFF
--- a/hack/docker/scripts/highway-env.sh
+++ b/hack/docker/scripts/highway-env.sh
@@ -5,7 +5,8 @@
 set -e
 
 # Milliseconds since epoch.
-TIMESTAMP=$(date +%s%3N)
+# TIMESTAMP=$(date +%s%3N) # Doesn't work on Mac.
+TIMESTAMP=$(python -c 'from time import time; print int(round(time() * 1000))')
 
 # This is not a real chainspec variable. Set it to "true" to make the genesis era start
 # align to rounded era durations, e.g. with 1hour eras they'd start at 0:00, 1:00, 2:00;


### PR DESCRIPTION
### Overview
The way the era epoch timestamp was generated doesn't work on Mac.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1238

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
