### PR TITLE
CON-647: Add Round ID to Clarity

### DIFF
--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -186,6 +186,7 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
       </Link>],
     ['j-Rank', header.getJRank()],
     ['m-Rank', header.getMainRank()],
+    ['Round ID', header.getRoundId()],
     ['Timestamp', new Date(header.getTimestamp()).toISOString()],
     ['Type', <BlockType header={header} />],
     [

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -149,6 +149,7 @@ class BlockDetails extends React.Component<
           </Link>],
         ['j-Rank', header.getJRank()],
         ['m-Rank', header.getMainRank()],
+        ['Round ID', header.getRoundId()],
         ['Type', <BlockType header={header} />],
         [
           'Parents',

--- a/shared/src/main/scala/io/casperlabs/shared/Log.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/Log.scala
@@ -127,6 +127,7 @@ object Log {
   private def defaultSink = ConsoleSink.text(colored = false)
 
   private def defaultLevels: Map[String, IzLog.Level] = Map(
+    "com.zaxxer.hikari.pool"                              -> IzLog.Level.Warn,
     "org.http4s"                                          -> IzLog.Level.Warn,
     "io.netty"                                            -> IzLog.Level.Warn,
     "io.grpc"                                             -> IzLog.Level.Error,


### PR DESCRIPTION
### Overview
Round ID was only available in via CLI and needed for some debugging. Also silences the Hikari pool logs so the DEBUG level isn't repeating stats every 10 seconds or so.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-647

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
