### PR TITLE
CON-647: Init sync round period adjustment

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -98,7 +98,7 @@ init-sync-skip-failed-nodes = false
 init-sync-step = 100
 
 # Time to wait between initial synchronization attempts.
-init-sync-round-period = "30second"
+init-sync-round-period = "1second"
 
 # Maximum number of blocks to allow to be synced initially.
 init-sync-max-block-count = 1000000


### PR DESCRIPTION
### Overview
Changes the initial synchronization round period from 30 seconds to 1 second. This was inherited from the backwards synchronizer, but in the forward going one (goes by ranks of 100) it doesn't make any sense since we are not trying to sync the whole thing and then sleep in between, it sleeps between every 100 ranks. I left in 1 second in case it reaches the end but there are just less than the required number of peers, so it doesn't hammer them in a tight loop.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-647

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
When I first saw this in a workshop I thought it was just how fetching 100 ranks works that it took a long time, and hence created the pre-fetch ticket https://casperlabs.atlassian.net/browse/NODE-1059
The actual reason for pauses may be just that it was sleeping.
