### PR TITLE
NO-TICKET: configure rustfmt to use the 2018 edition

### DIFF
--- a/execution-engine/rustfmt.toml
+++ b/execution-engine/rustfmt.toml
@@ -1,3 +1,4 @@
 wrap_comments = true
 comment_width = 100
 merge_imports = true
+edition = "2018"


### PR DESCRIPTION
### Overview
`rustfmt` uses the 2015 edition standards by default, which breaks some automated formatters. This makes sure that it will always use the 2018 edition for our repo.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
