### PR TITLE
OP-1147: Remove int test dependencies from drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -418,7 +418,6 @@ steps:
 
 - name: run-integration-tests-parallel-0
   commands:
-  - "apt-get update && apt-get -y install gcc"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 0"
   environment:
@@ -439,7 +438,6 @@ steps:
 
 - name: run-integration-tests-parallel-1
   commands:
-  - "apt-get update && apt-get -y install gcc"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 1"
   environment:
@@ -460,7 +458,6 @@ steps:
 
 - name: run-integration-tests-parallel-2
   commands:
-  - "apt-get update && apt-get -y install gcc"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 2"
   environment:
@@ -481,7 +478,6 @@ steps:
 
 - name: run-integration-tests-serial-3
   commands:
-  - "apt-get update && apt-get -y install gcc"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 3"
   environment:

--- a/.drone.yml
+++ b/.drone.yml
@@ -168,7 +168,6 @@ steps:
 
 - name: black-and-flake8
   commands:
-  - "python3 -m pip install pipenv"
   - "cd integration-testing"
   - "./run_flake8_black.sh"
   image: "casperlabs/buildenv:latest"
@@ -200,7 +199,6 @@ steps:
 
 - name: black-and-flake8-bors
   commands:
-  - "python3 -m pip install pipenv"
   - "cd integration-testing"
   - "./run_flake8_black.sh"
   image: "casperlabs/buildenv:latest"
@@ -421,7 +419,6 @@ steps:
 - name: run-integration-tests-parallel-0
   commands:
   - "apt-get update && apt-get -y install gcc"
-  - "python3 -m pip install pipenv pytest dataclasses typing_extensions dataclasses grpcio grpcio_tools protobuf in-place ed25519 pyblake2 lz4"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 0"
   environment:
@@ -443,7 +440,6 @@ steps:
 - name: run-integration-tests-parallel-1
   commands:
   - "apt-get update && apt-get -y install gcc"
-  - "python3 -m pip install pipenv pytest dataclasses typing_extensions dataclasses grpcio grpcio_tools protobuf in-place ed25519 pyblake2 lz4"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 1"
   environment:
@@ -465,7 +461,6 @@ steps:
 - name: run-integration-tests-parallel-2
   commands:
   - "apt-get update && apt-get -y install gcc"
-  - "python3 -m pip install pipenv pytest dataclasses typing_extensions dataclasses grpcio grpcio_tools protobuf in-place ed25519 pyblake2 lz4"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 2"
   environment:
@@ -487,7 +482,6 @@ steps:
 - name: run-integration-tests-serial-3
   commands:
   - "apt-get update && apt-get -y install gcc"
-  - "python3 -m pip install pipenv pytest dataclasses typing_extensions dataclasses grpcio grpcio_tools protobuf in-place ed25519 pyblake2 lz4"
   - "cd integration-testing"
   - "./docker_run_tests.sh --unique_run_num 3"
   environment:


### PR DESCRIPTION
### Overview
The dependencies are now in the buildenv (https://github.com/CasperLabs/buildenv/pull/24).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1147

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
