### PR TITLE
NODE-1243: Limit the latest messages asked in pull based gossiping

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -65,6 +65,8 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: EraStorage: Relaying: ForkChoi
       // See what reactions the protocol dictates.
       (events, ()) <- entry.runtime.handleMessage(message).run
       _            <- handleEvents(events)
+
+      _ <- Log[F].info(s"Finished handling ${block.blockHash.show -> "message"}")
     } yield ()
 
   private def ensureNotShutdown: F[Unit] =

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -482,7 +482,7 @@ package object gossiping {
     } yield cont
 
   /** Create gossip service. */
-  def makeGossipServiceServer[F[_]: ConcurrentEffect: Parallel: Log: Metrics: BlockStorage: DagStorage](
+  def makeGossipServiceServer[F[_]: ConcurrentEffect: Parallel: Log: Metrics: BlockStorage: DagStorage: Consensus](
       conf: Configuration,
       synchronizer: Synchronizer[F],
       downloadManager: DownloadManager[F],
@@ -506,12 +506,7 @@ package object gossiping {
                     /** Returns latest messages as seen currently by the node.
                       * NOTE: In the future we will remove redundant messages. */
                     override def latestMessages: F[Set[Block.Justification]] =
-                      for {
-                        dag <- DagStorage[F].getRepresentation
-                        lm  <- dag.latestMessages
-                      } yield lm.values.flatten
-                        .map(m => Block.Justification(m.validatorId, m.messageHash))
-                        .toSet
+                      Consensus[F].latestMessages
 
                     override def dagTopoSort(
                         startRank: Long,


### PR DESCRIPTION
### Overview
The pull based gossiping asked for the latest messages of the other node. Limit these now to the childless eras and their parents, because otherwise it will just grow bigger and bigger.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1243

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
There could be other, more complicated definitions, like eras which (recently) had agendas, but this is the easiest to implement.
