### PR TITLE
EE-903: add cargo audit to CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -166,6 +166,25 @@ steps:
   depends_on:
   - rust-compile-test-pr
 
+- name: run-rust-audit-pr
+  commands:
+  - "cd execution-engine"
+  - "make setup-rs"
+  - "make audit"
+  image: "casperlabs/buildenv:latest"
+  when:
+    event:
+    - pull_request
+    changeset:
+      includes:
+      - "**/.drone.yml"
+      - "**/**.rs"
+      - "**/**.proto"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+  depends_on:
+  - rust-compile-test-pr
+
 - name: black-and-flake8
   commands:
   - "python3 -m pip install pipenv"
@@ -306,6 +325,27 @@ steps:
       - "**/Cargo.toml"
       - "**/casperlabs-engine-grpc-server.spec"
       - "**/rustfmt.toml"
+  depends_on:
+  - rust-compile-test-bors
+  - sbt-test-docker-bors
+
+- name: run-rust-audit-bors
+  commands:
+  - "cd execution-engine"
+  - "make setup-rs"
+  - "make audit"
+  image: "casperlabs/buildenv:latest"
+  when:
+    branch:
+    - staging
+    - trying
+    changeset:
+      includes:
+      - "**/.drone.yml"
+      - "**/**.rs"
+      - "**/**.proto"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
   depends_on:
   - rust-compile-test-bors
   - sbt-test-docker-bors

--- a/.drone.yml
+++ b/.drone.yml
@@ -169,7 +169,7 @@ steps:
 - name: run-rust-audit-pr
   commands:
   - "cd execution-engine"
-  - "make setup-rs"
+  - "make setup-audit"
   - "make audit"
   image: "casperlabs/buildenv:latest"
   when:
@@ -332,7 +332,7 @@ steps:
 - name: run-rust-audit-bors
   commands:
   - "cd execution-engine"
-  - "make setup-rs"
+  - "make setup-audit"
   - "make audit"
   image: "casperlabs/buildenv:latest"
   when:

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -150,11 +150,17 @@ format:
 lint:
 	$(CARGO) clippy --all-targets --all -- -D warnings -A renamed_and_removed_lints
 
+.PHONY: audit
+audit:
+	$(CARGO) generate-lockfile
+	$(CARGO) audit
+
 .PHONY: check-rs
 check-rs: \
 	build \
 	check-format \
 	lint \
+	audit \
 	test-rs \
 	test-contracts-rs \
 
@@ -163,6 +169,7 @@ check: \
 	build \
 	check-format \
 	lint \
+	audit \
 	test \
 	test-contracts
 
@@ -213,6 +220,7 @@ setup-rs: rust-toolchain
 	$(RUSTUP) update
 	$(RUSTUP) toolchain install $(RUST_TOOLCHAIN)
 	$(RUSTUP) target add --toolchain $(RUST_TOOLCHAIN) wasm32-unknown-unknown
+	$(CARGO) install cargo-audit
 
 .PHONY: setup-as
 setup-as: contract-as/package.json

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -215,12 +215,15 @@ setup-cargo-packagers:
 	$(CARGO) install cargo-rpm || exit 0
 	$(CARGO) install cargo-deb || exit 0
 
+.PHONY: setup-audit
+setup-audit:
+	$(CARGO) install cargo-audit
+
 .PHONY: setup-rs
 setup-rs: rust-toolchain
 	$(RUSTUP) update
 	$(RUSTUP) toolchain install $(RUST_TOOLCHAIN)
 	$(RUSTUP) target add --toolchain $(RUST_TOOLCHAIN) wasm32-unknown-unknown
-	$(CARGO) install cargo-audit
 
 .PHONY: setup-as
 setup-as: contract-as/package.json

--- a/execution-engine/cargo-casperlabs/Cargo.toml
+++ b/execution-engine/cargo-casperlabs/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 
 [dependencies]
 clap = "2"
-colour = "0.3.0"
+colour = "0.4"
 lazy_static = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
### Overview
This adds a new `audit` target to the EE Makefile which invokes [`cargo-audit`](https://crates.io/crates/cargo-audit), and also adds this to the CI pipeline.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-903

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Note that only errors from `cargo-audit` will cause CI to fail.  If we wish to also treat warnings as failures, I can add `--deny-warnings` to the invocations.