### PR TITLE
NODE-1212: Pull images on

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -78,6 +78,9 @@ node-%/metrics:
 # Start common components.
 up: .make/docker/network .casperlabs
 	$(REFRESH_TARGETS)
+	if [ "$(CL_VERSION)" != "latest" ]; then \
+		docker-compose pull; \
+	fi
 	docker-compose -p casperlabs up -d --remove-orphans
 
 # Stop common components.


### PR DESCRIPTION
### Overview
Forgot to add `docker-compose pull` of non-latest images to `make up` in `hack/docker` so Clarity wasn't refreshed from `dev`.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
