### PR TITLE
EE-927: expand service to include new PoS-related endpoints

### DIFF
--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -45,8 +45,10 @@ use types::{bytesrepr::ToBytes, ProtocolVersion};
 
 use self::{
     ipc::{
-        ChainSpec_GenesisConfig, CommitRequest, CommitResponse, ExecuteResponse, GenesisResponse,
-        QueryResponse, UpgradeRequest, UpgradeResponse,
+        BidStateRequest, BidStateResponse, ChainSpec_GenesisConfig, CommitRequest, CommitResponse,
+        DistributeRewardsRequest, DistributeRewardsResponse, ExecuteResponse, GenesisResponse,
+        QueryResponse, SlashRequest, SlashResponse, UnbondPayoutRequest, UnbondPayoutResponse,
+        UpgradeRequest, UpgradeResponse,
     },
     ipc_grpc::{ExecutionEngineService, ExecutionEngineServiceServer},
     mappings::{ParsingError, TransformMap},
@@ -441,6 +443,42 @@ where
         );
 
         SingleResponse::completed(upgrade_response)
+    }
+
+    fn bid_state(
+        &self,
+        _request_options: RequestOptions,
+        _bid_state_request: BidStateRequest,
+    ) -> SingleResponse<BidStateResponse> {
+        let response = BidStateResponse::new();
+        SingleResponse::completed(response)
+    }
+
+    fn distribute_rewards(
+        &self,
+        _request_options: RequestOptions,
+        _distribute_rewards_request: DistributeRewardsRequest,
+    ) -> SingleResponse<DistributeRewardsResponse> {
+        let response = DistributeRewardsResponse::new();
+        SingleResponse::completed(response)
+    }
+
+    fn slash(
+        &self,
+        _request_options: RequestOptions,
+        _slash_request: SlashRequest,
+    ) -> SingleResponse<SlashResponse> {
+        let response = SlashResponse::new();
+        SingleResponse::completed(response)
+    }
+
+    fn unbond_payout(
+        &self,
+        _request_options: RequestOptions,
+        _unbond_payout_request: UnbondPayoutRequest,
+    ) -> SingleResponse<UnbondPayoutResponse> {
+        let response = UnbondPayoutResponse::new();
+        SingleResponse::completed(response)
     }
 }
 

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -5,6 +5,8 @@ package io.casperlabs.ipc;
 import "io/casperlabs/casper/consensus/state.proto";
 import "io/casperlabs/ipc/transforms.proto";
 
+// --- BEGIN EXECUTION ENGINE SERVICE DEFINITION --- //
+
 message DeployCode {
   bytes code = 1; // wasm byte code
   bytes args = 2; // ABI-encoded arguments
@@ -344,12 +346,112 @@ message UpgradeResponse {
     }
 }
 
+// --- END EXECUTION ENGINE SERVICE DEFINITION --- //
+
+// --- BEGIN PROOF-OF-STAKE SERVICE DEFINITION --- //
+
+message BidStateRequest {
+    bytes parent_state_hash = 1;
+    io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 2;
+}
+
+message BidState {
+    repeated Bid bids = 1;
+
+    message Bid {
+        bytes id = 1;
+        io.casperlabs.casper.consensus.state.BigInt value = 2;
+    }
+}
+
+message BidStateResponse {
+    oneof result {
+        BidState success = 1;
+        RootNotFound missing_parent = 2;
+    }
+}
+
+message DistributeRewardsRequest {
+    bytes parent_state_hash = 1;
+    repeated ValidatorReward rewards = 2;
+    io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 3;
+
+    message ValidatorReward {
+        bytes validator_id = 1;
+        io.casperlabs.casper.consensus.state.BigInt value = 2;
+    }
+}
+
+message DistibuteRewardsError {
+    string message = 1; // TODO: enum of possible errors
+}
+
+message DistributeRewardsResponse {
+    oneof result {
+        // effects of rewards distribution are committed automatically, so commit result is returned in the success case
+        CommitResult success = 1;
+        RootNotFound missing_parent = 2;
+        DistibuteRewardsError error = 3;
+    }
+}
+
+message SlashRequest {
+    bytes parent_state_hash = 1;
+    repeated ValidatorSlash slashes = 2;
+    io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 3;
+
+    message ValidatorSlash{
+        bytes validator_id = 1;
+        io.casperlabs.casper.consensus.state.BigInt value = 2;
+    }
+}
+
+message SlashError {
+    string message = 1; // TODO: enum of possible errors
+}
+
+message SlashResponse {
+    oneof result {
+        // effects of slashing are committed automatically, so commit result is returned in the success case
+        CommitResult success = 1;
+        RootNotFound missing_parent = 2;
+        SlashError error = 3;
+    }
+}
+
+message UnbondPayoutRequest {
+    bytes parent_state_hash = 1;
+    uint64 era_height = 2;
+    io.casperlabs.casper.consensus.state.ProtocolVersion protocol_version = 3;
+}
+
+message UnbondPayoutError {
+    string message = 1; // TODO: enum of possible errors
+}
+
+message UnbondPayoutResponse {
+    oneof result {
+        // effects of unbond payment are committed automatically, so commit result is returned in the success case
+        CommitResult success = 1;
+        RootNotFound missing_parent = 2;
+        UnbondPayoutError error = 3;
+    }
+}
+
+// --- END PROOF-OF-STAKE SERVICE DEFINITION --- //
+
 // Definition of the service.
 // ExecutionEngine implements server part while Consensus implements client part.
 service ExecutionEngineService {
+    // execution endpoints
     rpc commit (CommitRequest) returns (CommitResponse) {}
     rpc query (QueryRequest) returns (QueryResponse) {}
     rpc execute (ExecuteRequest) returns (ExecuteResponse) {}
     rpc run_genesis (ChainSpec.GenesisConfig) returns (GenesisResponse) {}
     rpc upgrade (UpgradeRequest) returns (UpgradeResponse) {}
+    // proof-of-stake endpoints
+    rpc bid_state(BidStateRequest) returns (BidStateResponse) {}
+    rpc distribute_rewards(DistributeRewardsRequest) returns (DistributeRewardsResponse) {}
+    rpc slash(SlashRequest) returns (SlashResponse) {}
+    rpc unbond_payout(UnbondPayoutRequest) returns (UnbondPayoutResponse) {}
 }


### PR DESCRIPTION
### Overview
This PR introduces the following endpoint stubs:
- `bid_state`
- `distribute_rewards`
- `slash`
- `unbond_payment`

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-927

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The Monix code generation prevented us from defining a separate service, so we decided to take the path of least resistance and included these endpoints in the existing service.
