### PR TITLE
NO-TICK: bors down - temporary workaround

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -185,6 +185,9 @@ steps:
   - "./integration-testing/build_contracts.sh"
   - "make docker-build/execution-engine docker-build/node docker-build/client docker-build/integration-testing"
   image: "casperlabs/buildenv:latest"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
   when:
     event:
     - pull_request

--- a/.drone.yml
+++ b/.drone.yml
@@ -182,8 +182,10 @@ steps:
 - name: temp_build_docker_images
   commands:
   - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
+  - "~/.cargo/bin/rustup toolchain install $(cat execution-engine/rust-toolchain)"
+  - "rustup target add --toolchain $(cat execution-engine/rust-toolchain) wasm32-unknown-unknown"
   - "./integration-testing/build_contracts.sh"
-  - "make docker-build/execution-engine docker-build/node docker-build/client docker-build/integration-testing"
+  - "make docker-build/execution-engine docker-build/node docker-build/client docker-build/integration-testing docker-build/explorer docker-build/grpcwebproxy"
   image: "casperlabs/buildenv:latest"
   volumes:
   - name: docker_sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -179,6 +179,92 @@ steps:
       - "**/.drone.yml"
       - "integration-testing/**"
 
+- name: temp_build_docker_images
+  commands:
+  - "export DOCKER_LATEST_TAG=DRONE-${DRONE_BUILD_NUMBER}"
+  - "./integration-testing/build_contracts.sh"
+  - "make docker-build/execution-engine docker-build/node docker-build/client docker-build/integration-testing"
+  image: "casperlabs/buildenv:latest"
+  when:
+    event:
+    - pull_request
+  depends_on:
+  - sbt-compile-test-pr
+
+- name: temp-run-integration-tests-parallel-0
+  commands:
+  - "cd integration-testing"
+  - "./docker_run_tests.sh --unique_run_num 0"
+  environment:
+    _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+  image: "casperlabs/buildenv:latest"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
+  - name: temp
+    path: "/tmp"
+  when:
+    event:
+    - pull_request
+  depends_on:
+  - temp_build_docker_images
+
+- name: temp-run-integration-tests-parallel-1
+  commands:
+  - "cd integration-testing"
+  - "./docker_run_tests.sh --unique_run_num 1"
+  environment:
+    _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+  image: "casperlabs/buildenv:latest"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
+  - name: temp
+    path: "/tmp"
+  when:
+    event:
+    - pull_request
+  depends_on:
+  - temp_build_docker_images
+
+- name: temp-run-integration-tests-parallel-2
+  commands:
+  - "cd integration-testing"
+  - "./docker_run_tests.sh --unique_run_num 2"
+  environment:
+    _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+  image: "casperlabs/buildenv:latest"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
+  - name: temp
+    path: "/tmp"
+  when:
+    event:
+    - pull_request
+  depends_on:
+  - temp_build_docker_images
+
+- name: temp-run-integration-tests-serial-3
+  commands:
+  - "cd integration-testing"
+  - "./docker_run_tests.sh --unique_run_num 3"
+  environment:
+    _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+  image: "casperlabs/buildenv:latest"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
+  - name: temp
+    path: "/tmp"
+  when:
+    event:
+    - pull_request
+  depends_on:
+  - temp-run-integration-tests-parallel-0
+  - temp-run-integration-tests-parallel-1
+  - temp-run-integration-tests-parallel-2
+
 # This section is for bors' branches only
 
 #NOTE: allowing failures here since we've seen site temporarily go down and cause


### PR DESCRIPTION
### Overview
runs int tests on every commit

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
