### PR TITLE
NODE-1147: Clear deploy body from event

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -143,7 +143,7 @@ object EventStream {
 
       override def deployAdded(deploy: Deploy): F[Unit] =
         emit {
-          Event().withDeployAdded(DeployAdded().withDeploy(deploy))
+          Event().withDeployAdded(DeployAdded().withDeploy(deploy.clearBody))
         }
 
       override def deploysDiscarded(deployHashesWithReasons: Seq[(DeployHash, String)]): F[Unit] = {


### PR DESCRIPTION
### Overview
Clear out the deploy body from the `DeployAdded` event so as not to send full Wasm.
Thanks to @piokuc for raising the issue.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1147


### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
