### PR TITLE
NO-TICKET: privatize RootNotFound member

### DIFF
--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -83,4 +83,14 @@ impl From<!> for Error {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct RootNotFound(pub Blake2bHash);
+pub struct RootNotFound(Blake2bHash);
+
+impl RootNotFound {
+    pub fn new(hash: Blake2bHash) -> Self {
+        RootNotFound(hash)
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -915,7 +915,7 @@ where
         // validation_spec_2: prestate_hash check
         let tracking_copy = match self.tracking_copy(prestate_hash) {
             Err(error) => return Ok(ExecutionResult::precondition_failure(error)),
-            Ok(None) => return Err(RootNotFound(prestate_hash)),
+            Ok(None) => return Err(RootNotFound::new(prestate_hash)),
             Ok(Some(tracking_copy)) => Rc::new(RefCell::new(tracking_copy)),
         };
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -179,9 +179,7 @@ where
             Ok(results) => results,
             Err(error) => {
                 info!("deploy results error: RootNotFound");
-                exec_response
-                    .mut_missing_parent()
-                    .set_hash(error.0.to_vec());
+                exec_response.mut_missing_parent().set_hash(error.to_vec());
                 log_duration(
                     correlation_id,
                     METRIC_DURATION_EXEC,


### PR DESCRIPTION
This PR removes pub from `Blake2bHash` member of `RootNotFound` struct.

This work is not ticketed, but precedes proof of stake re-implementation.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR does not add a new feature, it is a refactor.
- [X] This PR is assigned.