### PR TITLE
ECO-333: Clarity live update of `isFinalized` info is missing

### DIFF
--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -5,6 +5,8 @@ import { ListInline, Loading, RefreshButton, shortHash } from './Utils';
 import * as d3 from 'd3';
 import { encodeBase16 } from 'casperlabs-sdk';
 import { ToggleButton, ToggleStore } from './ToggleButton';
+import { reaction } from 'mobx';
+import { observer } from 'mobx-react';
 
 // https://bl.ocks.org/mapio/53fed7d84cd1812d6a6639ed7aa83868
 
@@ -27,12 +29,23 @@ export interface Props {
   onSelected?: (block: BlockInfo) => void;
 }
 
+@observer
 export class BlockDAG extends React.Component<Props, {}> {
   svg: SVGSVGElement | null = null;
   hint: HTMLDivElement | null = null;
   xTrans: d3.ScaleLinear<number, number> | null = null;
   yTrans: d3.ScaleLinear<number, number> | null = null;
   initialized = false;
+
+  constructor(props: Props) {
+    super(props);
+    reaction(() => this.props.blocks, (_, reaction) => {
+      this.renderGraph();
+    }, {
+      fireImmediately: false,
+      delay: 100
+    });
+  }
 
   render() {
     return (
@@ -97,11 +110,6 @@ export class BlockDAG extends React.Component<Props, {}> {
         )}
       </div>
     );
-  }
-
-  /** Called when the data is refreshed, when we get the blocks if they were null to begin with. */
-  componentDidUpdate() {
-    this.renderGraph();
   }
 
   componentDidMount() {


### PR DESCRIPTION
### Overview
Subscribes to event stream of finalizedBlock to update the finality status of DAG blocks.

Demo:
![demo](http://g.recordit.co/d5m6gjPGPx.gif)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-333

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
