### PR TITLE
NODE-1222: Add support for deploy state transition events to Python client

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -648,10 +648,49 @@ class CasperLabsClient:
         )
 
     @api
-    def stream_events(self, block_added: bool = True, block_finalized: bool = True):
+    def stream_events(
+        self,
+        all: bool = True,
+        block_added: bool = True,
+        block_finalized: bool = True,
+        deploy_added: bool = True,
+        deploy_discarded: bool = True,
+        deploy_requeued: bool = True,
+        deploy_processed: bool = True,
+        deploy_finalized: bool = True,
+        deploy_orphaned: bool = True,
+        account_public_keys=None,
+        deploy_hashes=None,
+    ):
+        """
+        See StreamEventsRequest in ~/CasperLabs/protobuf/io/casperlabs/node/api/casper.proto
+        """
+        if all:
+            block_added = True
+            block_finalized = True
+            deploy_added = True
+            deploy_discarded = True
+            deploy_requeued = True
+            deploy_processed = True
+            deploy_finalized = True
+            deploy_orphaned = True
+
         yield from self.casperService.StreamEvents_stream(
             casper.StreamEventsRequest(
-                block_added=block_added, block_finalized=block_finalized
+                block_added=block_added,
+                block_finalized=block_finalized,
+                deploy_added=deploy_added,
+                deploy_discarded=deploy_discarded,
+                deploy_requeued=deploy_requeued,
+                deploy_processed=deploy_processed,
+                deploy_finalized=deploy_finalized,
+                deploy_orphaned=deploy_orphaned,
+                deploy_filter=casper.StreamEventsRequest.DeployFilter(
+                    account_public_keys=[
+                        bytes.fromhex(pk) for pk in account_public_keys or []
+                    ],
+                    deploy_hashes=[bytes.fromhex(h) for h in deploy_hashes or []],
+                ),
             )
         )
 


### PR DESCRIPTION
### Overview
This PR adds support for deploy state transition events to `stream_events` Python API.
It also adds `stream-events` command to Python CLI.

```
$ casperlabs_client stream-events --help
usage: casperlabs_client stream-events [-h] [--all] [--block-added]
                                       [--block-finalized] [--deploy-added]
                                       [--deploy-discarded]
                                       [--deploy-requeued]
                                       [--deploy-processed]
                                       [--deploy-finalized]
                                       [--deploy-orphaned]
                                       [-k ACCOUNT_PUBLIC_KEY]
                                       [-d DEPLOY_HASH]

optional arguments:
  -h, --help            show this help message and exit
  --all                 Subscribe to all events
  --block-added         Block added
  --block-finalized     Block finalized
  --deploy-added        Deploy added
  --deploy-discarded    Deploy discarded
  --deploy-requeued     Deploy requeued
  --deploy-processed    Deploy processed
  --deploy-finalized    Deploy finalized
  --deploy-orphaned     Deploy orphaned
  -k ACCOUNT_PUBLIC_KEY, --account-public-key ACCOUNT_PUBLIC_KEY
                        Filter by (possibly multiple) account public key(s)
  -d DEPLOY_HASH, --deploy-hash DEPLOY_HASH
                        Filter by (possibly multiple) deploy hash(es)

```

Example output:

```
$ casperlabs_client stream-events --all
------------- 2020-02-27 12:37:05 -------------
deploy_added {
  deploy {
    deploy_hash: "6dd31623becfa80f83a94cb64f1fd49e7a25fcb255923e624887595b449a2e06"
    header {
      account_public_key: "0f9dfca1c434d5d49724bb4efc0662525c41a7add0b145cb913408ad912ce041"
      timestamp: 1582803425615
      gas_price: 10
      body_hash: "6d51dee11962d3e760d83fd7a2656bd28b8f4da470395ea41b07bdda9a40b080"
    }
    approvals {
      approver_public_key: "0f9dfca1c434d5d49724bb4efc0662525c41a7add0b145cb913408ad912ce041"
      signature {
        sig_algorithm: "ed25519"
        sig: "a5074a8962aef6912dab6142c2cd67ecde2d701ebe1b80ddcfffbf784480990e78111ee2a3e6a22177257a52ea9a34be62f2084dde9cd3cc8173cd10afb42704"
      }
    }
  }
}

```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1222

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
