### PR TITLE
ECO-340: Labels of block node in Explorer don't look well in Safari.

### DIFF
--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -231,8 +231,7 @@ export class BlockDAG extends React.Component<Props, {}> {
       .style('font-family', 'Arial')
       .style('font-size', 12)
       .style('pointer-events', 'none') // to prevent mouseover/drag capture
-      .style('text-anchor', 'start')
-      .attr('transform', 'rotate(25)'); // rotate so a chain doesn't overlap on a small screen.
+      .style('text-anchor', 'start');
 
     const focus = (d: any) => {
       let datum = d3.select(d3.event.target).datum() as d3Node;
@@ -284,7 +283,7 @@ export class BlockDAG extends React.Component<Props, {}> {
         .selectAll('text.node-label')
         .attr('x', (d: any) => x(d.x) + 5)
         .attr('y', (d: any) => y(d.y) + 25)
-        .style('transform-origin', (d: any) => `${x(d.x)}px ${y(d.y)}px`);
+        .attr('transform', (d: any) => `rotate(25 ${x(d.x)} ${y(d.y)})`); // rotate so a chain doesn't overlap on a small screen.
 
       // update positions of line
       container


### PR DESCRIPTION
### Overview
`transform origin` doesn't work in SVG in Safari, so these labels doesn't rotate against the center of itself. 
Use rotate(degree, x, y) instead, it works well in Safari, Edge, Firefox, Chrome. 

Demo: 
Before: 
![image](https://user-images.githubusercontent.com/7604540/75660644-ebe1ed00-5ca6-11ea-9249-5d9b30596386.png)

After:
![image](https://user-images.githubusercontent.com/7604540/75660477-d1a80f00-5ca6-11ea-8b61-4aa3ea51d533.png)

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-340

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
