### PR TITLE
NODE-1258: Fix fork choice children check

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -12,6 +12,8 @@ import io.casperlabs.casper.util.DagOperations
 import io.casperlabs.catscontrib.{MakeSemaphore, MonadThrowable}
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.models.Message
+import io.casperlabs.metrics.implicits._
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.{DagRepresentation, DagStorage, FinalityStorageReader}
 import io.casperlabs.storage.era.EraStorage
@@ -35,7 +37,7 @@ import scala.util.Random
   *
   * This should make testing easier: the return values are not opaque.
   */
-class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader: ForkChoice](
+class EraRuntime[F[_]: Sync: Clock: Metrics: EraStorage: FinalityStorageReader: ForkChoice](
     conf: HighwayConf,
     val era: Era,
     leaderFunction: LeaderFunction,
@@ -62,6 +64,8 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
 ) {
   import EraRuntime._, Agenda._
   import HighwayConf.VotingDuration
+
+  implicit val metricsSource = HighwayMetricsSource / "EraRuntime"
 
   type HWL[A] = HighwayLog[F, A]
   private val noop = HighwayLog.unit[F]
@@ -152,12 +156,15 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
         tick =>
           if (tick < endTick) false.pure[F]
           else {
-            ForkChoice[F].fromKeyBlock(era.keyBlockHash).flatMap { choice =>
-              choice.block.isSwitchBlock.ifM(
-                FinalityStorageReader[F].isFinalized(choice.block.messageHash),
-                false.pure[F]
-              )
-            }
+            ForkChoice[F]
+              .fromKeyBlock(era.keyBlockHash)
+              .timerGauge("is_over_forkchoice")
+              .flatMap { choice =>
+                choice.block.isSwitchBlock.ifM(
+                  FinalityStorageReader[F].isFinalized(choice.block.messageHash),
+                  false.pure[F]
+                )
+              }
           }
 
       case VotingDuration.SummitLevel(_) =>
@@ -211,34 +218,39 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
   ): HWL[Unit] = ifSynced {
     for {
       m <- HighwayLog.liftF {
-            messageProducer.withPermit {
-              for {
-                // We need to cite the lambda message, and our own latest message.
-                // NOTE: The latter will be empty until the validator produces something in this era.
-                tips              <- dag.latestInEra(era.keyBlockHash)
-                ownLatestMessages <- tips.latestMessageHash(messageProducer.validatorId)
-                justifications = List(
-                  PublicKey(lambdaMessage.validatorId) -> Set(lambdaMessage.messageHash),
-                  messageProducer.validatorId          -> ownLatestMessages
-                ).filterNot(_._2.isEmpty).toMap
-                // See what the fork choice is, given the lambda and our own latest message, that is our target.
-                // In the voting period the lambda message is a ballot, so can't be a target,
-                // but in any case our own latest message might point at something with more weight already.
-                choice <- ForkChoice[F].fromJustifications(
-                           lambdaMessage.eraId,
-                           justifications.values.flatten.toSet
-                         )
-                maybeMessage <- ifCanBuildOn(choice) {
-                                 messageProducer
-                                   .ballot(
-                                     keyBlockHash = era.keyBlockHash,
-                                     roundId = Ticks(lambdaMessage.roundId),
-                                     target = choice.block.messageHash,
-                                     justifications = choice.justificationsMap
-                                   )
-                               }
-              } yield maybeMessage
-            }
+            messageProducer
+              .withPermit {
+                for {
+                  // We need to cite the lambda message, and our own latest message.
+                  // NOTE: The latter will be empty until the validator produces something in this era.
+                  tips              <- dag.latestInEra(era.keyBlockHash)
+                  ownLatestMessages <- tips.latestMessageHash(messageProducer.validatorId)
+                  justifications = List(
+                    PublicKey(lambdaMessage.validatorId) -> Set(lambdaMessage.messageHash),
+                    messageProducer.validatorId          -> ownLatestMessages
+                  ).filterNot(_._2.isEmpty).toMap
+                  // See what the fork choice is, given the lambda and our own latest message, that is our target.
+                  // In the voting period the lambda message is a ballot, so can't be a target,
+                  // but in any case our own latest message might point at something with more weight already.
+                  choice <- ForkChoice[F]
+                             .fromJustifications(
+                               lambdaMessage.eraId,
+                               justifications.values.flatten.toSet
+                             )
+                             .timerGauge("response_forkchoice")
+                  maybeMessage <- ifCanBuildOn(choice) {
+                                   messageProducer
+                                     .ballot(
+                                       keyBlockHash = era.keyBlockHash,
+                                       roundId = Ticks(lambdaMessage.roundId),
+                                       target = choice.block.messageHash,
+                                       justifications = choice.justificationsMap
+                                     )
+                                     .timerGauge("response_ballot")
+                                 }
+                } yield maybeMessage
+              }
+              .timerGauge("create_response")
           }
       _ <- m.fold(noop) { msg =>
             HighwayLog.tell[F](HighwayEvent.CreatedLambdaResponse(msg))
@@ -252,41 +264,48 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
   ): HWL[Unit] = ifSynced {
     for {
       m <- HighwayLog.liftF {
-            messageProducer.withPermit {
-              ForkChoice[F].fromKeyBlock(era.keyBlockHash) flatMap { choice =>
-                ifCanBuildOn(choice) {
-                  // In the active period we create a block, but during voting
-                  // it can only be a ballot, after the switch block has been created.
-                  val block = messageProducer
-                    .block(
-                      keyBlockHash = era.keyBlockHash,
-                      roundId = roundId,
-                      mainParent = choice.block.messageHash,
-                      justifications = choice.justificationsMap,
-                      isBookingBlock = isBookingBoundary(
-                        choice.block.roundInstant,
-                        conf.toInstant(roundId)
-                      )
-                    )
-                    .widen[Message]
+            messageProducer
+              .withPermit {
+                ForkChoice[F]
+                  .fromKeyBlock(era.keyBlockHash)
+                  .timerGauge("lambda_forkchoice")
+                  .flatMap { choice =>
+                    ifCanBuildOn(choice) {
+                      // In the active period we create a block, but during voting
+                      // it can only be a ballot, after the switch block has been created.
+                      val block = messageProducer
+                        .block(
+                          keyBlockHash = era.keyBlockHash,
+                          roundId = roundId,
+                          mainParent = choice.block.messageHash,
+                          justifications = choice.justificationsMap,
+                          isBookingBlock = isBookingBoundary(
+                            choice.block.roundInstant,
+                            conf.toInstant(roundId)
+                          )
+                        )
+                        .timerGauge("lambda_block")
+                        .widen[Message]
 
-                  val ballot = messageProducer
-                    .ballot(
-                      keyBlockHash = era.keyBlockHash,
-                      roundId = roundId,
-                      target = choice.block.messageHash,
-                      justifications = choice.justificationsMap
-                    )
-                    .widen[Message]
+                      val ballot = messageProducer
+                        .ballot(
+                          keyBlockHash = era.keyBlockHash,
+                          roundId = roundId,
+                          target = choice.block.messageHash,
+                          justifications = choice.justificationsMap
+                        )
+                        .timerGauge("lambda_ballot")
+                        .widen[Message]
 
-                  if (roundId < endTick) {
-                    block
-                  } else {
-                    choice.block.isSwitchBlock.ifM(ballot, block)
+                      if (roundId < endTick) {
+                        block
+                      } else {
+                        choice.block.isSwitchBlock.ifM(ballot, block)
+                      }
+                    }
                   }
-                }
               }
-            }
+              .timerGauge("create_lambda")
           }
       _ <- m.fold(noop) { msg =>
             HighwayLog.tell[F](HighwayEvent.CreatedLambdaMessage(msg)) >>
@@ -301,18 +320,25 @@ class EraRuntime[F[_]: MonadThrowable: Clock: EraStorage: FinalityStorageReader:
   ): HWL[Unit] = ifSynced {
     for {
       m <- HighwayLog.liftF {
-            messageProducer.withPermit {
-              ForkChoice[F].fromKeyBlock(era.keyBlockHash) flatMap { choice =>
-                ifCanBuildOn(choice) {
-                  messageProducer.ballot(
-                    keyBlockHash = era.keyBlockHash,
-                    roundId = roundId,
-                    target = choice.block.messageHash,
-                    justifications = choice.justificationsMap
-                  )
-                }
+            messageProducer
+              .withPermit {
+                ForkChoice[F]
+                  .fromKeyBlock(era.keyBlockHash)
+                  .timerGauge("omega_forkchoice")
+                  .flatMap { choice =>
+                    ifCanBuildOn(choice) {
+                      messageProducer
+                        .ballot(
+                          keyBlockHash = era.keyBlockHash,
+                          roundId = roundId,
+                          target = choice.block.messageHash,
+                          justifications = choice.justificationsMap
+                        )
+                        .timerGauge("omega_ballot")
+                    }
+                  }
               }
-            }
+              .timerGauge("create_omega")
           }
       _ <- m.fold(noop) { msg =>
             HighwayLog.tell[F](HighwayEvent.CreatedOmegaMessage(msg))
@@ -614,7 +640,7 @@ object EraRuntime {
     bonds = genesis.getHeader.getState.bonds
   )
 
-  def fromGenesis[F[_]: Sync: MakeSemaphore: Clock: DagStorage: EraStorage: FinalityStorageReader: ForkChoice](
+  def fromGenesis[F[_]: Sync: MakeSemaphore: Clock: Metrics: DagStorage: EraStorage: FinalityStorageReader: ForkChoice](
       conf: HighwayConf,
       genesis: BlockSummary,
       maybeMessageProducer: Option[MessageProducer[F]],
@@ -626,7 +652,7 @@ object EraRuntime {
     fromEra[F](conf, era, maybeMessageProducer, initRoundExponent, isSynced, leaderSequencer)
   }
 
-  def fromEra[F[_]: Sync: MakeSemaphore: Clock: DagStorage: EraStorage: FinalityStorageReader: ForkChoice](
+  def fromEra[F[_]: Sync: MakeSemaphore: Clock: Metrics: DagStorage: EraStorage: FinalityStorageReader: ForkChoice](
       conf: HighwayConf,
       era: Era,
       maybeMessageProducer: Option[MessageProducer[F]],

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -10,6 +10,7 @@ import io.casperlabs.casper.util.DagOperations, DagOperations.Key
 import io.casperlabs.casper.highway.EraRuntime.Agenda
 import io.casperlabs.comm.gossiping.Relaying
 import io.casperlabs.metrics.Metrics
+import io.casperlabs.metrics.implicits._
 import io.casperlabs.models.Message
 import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockHash
@@ -36,6 +37,8 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
 ) {
   import EraSupervisor.Entry
 
+  implicit val metricsSource = HighwayMetricsSource / "EraSupervisor"
+
   private def shutdown(): F[Unit] =
     for {
       _        <- isShutdownRef.set(true)
@@ -49,12 +52,19 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
     for {
       _      <- ensureNotShutdown
       header = block.getHeader
+      hash   = block.blockHash.show
       _ <- Log[F].info(
-            s"Handling incoming ${block.blockHash.show -> "message"} from ${header.validatorPublicKey.show -> "validator"} in ${header.roundId -> "round"} ${header.keyBlockHash.show -> "era"}"
+            s"Handling incoming ${hash -> "message"} from ${header.validatorPublicKey.show -> "validator"} in ${header.roundId -> "round"} ${header.keyBlockHash.show -> "era"}"
           )
-      entry   <- load(header.keyBlockHash)
-      message <- entry.runtime.validateAndAddBlock(messageExecutor, block)
-      _       <- messageExecutor.effectsAfterAdded(message)
+      entry <- load(header.keyBlockHash)
+
+      message <- entry.runtime
+                  .validateAndAddBlock(messageExecutor, block)
+                  .timerGauge("incoming_validateAndAddBlock")
+
+      _ <- messageExecutor
+            .effectsAfterAdded(message)
+            .timerGauge("incoming_effectsAfterAdded")
 
       // Tell descendant eras for the next time they create a block that this era received a message.
       // NOTE: If the events create an era it will only be loaded later, so the first time
@@ -62,12 +72,18 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
       // this message. The fork choice manager should load the latest messages from the
       // parent era the first time it's asked, and only rely on incremental updates later.
       _ <- propagateLatestMessageToDescendantEras(message)
+            .timerGauge("incoming_propagateLatestMessage")
 
       // See what reactions the protocol dictates.
-      (events, ()) <- entry.runtime.handleMessage(message).run
-      _            <- handleEvents(events)
+      (events, ()) <- entry.runtime
+                       .handleMessage(message)
+                       .run
+                       .timerGauge("incoming_handleMessage")
 
-      _ <- Log[F].info(s"Finished handling ${block.blockHash.show -> "message"}")
+      _ <- handleEvents(events)
+            .timerGauge("incoming_handleEvents")
+
+      _ <- Log[F].info(s"Finished handling ${hash -> "message"}")
     } yield ()
 
   private def ensureNotShutdown: F[Unit] =
@@ -125,11 +141,14 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
           fiber <- scheduleAt(tick) {
                     val era = runtime.era.keyBlockHash.show
                     val exec = for {
-                      _                <- Log[F].debug(s"Executing $action in $era")
-                      (events, agenda) <- runtime.handleAgenda(action).run
-                      _                <- scheduleRef.update(_ - key)
-                      _                <- schedule(runtime, agenda)
-                      _                <- handleEvents(events)
+                      _ <- Log[F].debug(s"Executing $action in $era")
+                      (events, agenda) <- runtime
+                                           .handleAgenda(action)
+                                           .run
+                                           .timerGauge("schedule_handleAgenda")
+                      _ <- scheduleRef.update(_ - key)
+                      _ <- schedule(runtime, agenda)
+                      _ <- handleEvents(events).timerGauge("schedule_handleEvents")
                     } yield ()
 
                     exec.recoverWith {
@@ -164,9 +183,14 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
         _ <- Log[F].info(
               s"Created $kind ${message.messageHash.show -> "message"} in ${message.roundId -> "round"} ${message.eraId.show -> "era"} child of ${message.parentBlock.show -> "parent"}"
             )
-        _ <- messageExecutor.effectsAfterAdded(Validated(message))
-        _ <- Relaying[F].relay(List(message.messageHash))
+        _ <- messageExecutor
+              .effectsAfterAdded(Validated(message))
+              .timerGauge("created_effectsAfterAdded")
+        _ <- Relaying[F]
+              .relay(List(message.messageHash))
+              .timerGauge("created_relay")
         _ <- propagateLatestMessageToDescendantEras(message)
+              .timerGauge("created_propagateLatestMessage")
       } yield ()
 
     events.traverse {

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -9,6 +9,7 @@ import io.casperlabs.casper.consensus.{Block, BlockSummary, Era}
 import io.casperlabs.casper.util.DagOperations, DagOperations.Key
 import io.casperlabs.casper.highway.EraRuntime.Agenda
 import io.casperlabs.comm.gossiping.Relaying
+import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Message
 import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockHash
@@ -23,7 +24,7 @@ import scala.util.control.NonFatal
   * - manages the scheduling of the agendas of the eras by acting as a trampoline for them
   * - propagates messages received or created by parent eras to the descendants to keep the latest messsages up to date.
   */
-class EraSupervisor[F[_]: Concurrent: Timer: Log: EraStorage: Relaying: ForkChoiceManager](
+class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying: ForkChoiceManager](
     conf: HighwayConf,
     // Once the supervisor is shut down, reject incoming messages.
     isShutdownRef: Ref[F, Boolean],
@@ -238,7 +239,7 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: EraStorage: Relaying: ForkChoi
 
 object EraSupervisor {
 
-  def apply[F[_]: Concurrent: Timer: Log: EraStorage: DagStorage: FinalityStorageReader: Relaying: ForkChoiceManager](
+  def apply[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: DagStorage: FinalityStorageReader: Relaying: ForkChoiceManager](
       conf: HighwayConf,
       genesis: BlockSummary,
       maybeMessageProducer: Option[MessageProducer[F]],

--- a/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/ForkChoice.scala
@@ -126,7 +126,9 @@ object ForkChoice {
                        val noChildren = DagOperations
                          .bfToposortTraverseF[F](
                            latestHonestMessages.values.toList
-                         )(m => dag.lookupUnsafe(m.parentBlock).map(List(_)))
+                         ) { m =>
+                           List(m.parentBlock).filterNot(_.isEmpty).traverse(dag.lookupUnsafe)
+                         }
                          .takeWhile(_.mainRank > startBlock.mainRank)
                          .find { x =>
                            x.parentBlock == startBlock.messageHash && x.isBlock && x.eraId == keyBlock.messageHash

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -22,6 +22,8 @@ package highway {
 
 package object highway {
 
+  val HighwayMetricsSource = CasperMetricsSource / "highway"
+
   /** Time since Unix epoch in milliseconds. */
   type Timestamp = Long @@ TimestampTag
   def Timestamp(t: Long) = t.asInstanceOf[Timestamp]

--- a/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/DagOperations.scala
@@ -137,6 +137,11 @@ object DagOperations {
   val blockTopoOrderingDesc: Ordering[Message] =
     Ordering.by[Message, (Long, ByteString)](m => (m.jRank, m.messageHash))(longByteStringOrdering)
 
+  val blockMainRankOrderingDesc: Ordering[Message] =
+    Ordering.by[Message, (Long, ByteString)](m => (m.mainRank, m.messageHash))(
+      longByteStringOrdering
+    )
+
   def bfToposortTraverseF[F[_]: Monad](
       start: List[Message]
   )(

--- a/shared/src/main/scala/io/casperlabs/metrics/MetricsSyntax.scala
+++ b/shared/src/main/scala/io/casperlabs/metrics/MetricsSyntax.scala
@@ -14,6 +14,11 @@ trait MetricsBlockSyntax[A, F[_]] {
       delta: Long = 1
   )(implicit M: Metrics[F], ms: Metrics.Source, B: Bracket[F, Throwable]): F[A] =
     M.gauge(name, delta)(block)
+
+  def timerGauge(
+      name: String
+  )(implicit M: Metrics[F], ms: Metrics.Source, B: Bracket[F, Throwable]): F[A] =
+    M.gauge(s"${name}_ongoing")(M.timer(name)(block))
 }
 
 trait MetricsStreamSyntax[A, F[_]] {
@@ -27,6 +32,9 @@ trait MetricsStreamSyntax[A, F[_]] {
       delta: Long = 1
   )(implicit M: Metrics[F], ms: Metrics.Source): fs2.Stream[F, A] =
     M.gaugeS(name, delta)(stream)
+
+  def timerGauge(name: String)(implicit M: Metrics[F], ms: Metrics.Source): fs2.Stream[F, A] =
+    M.gaugeS(s"${name}_ongoing")(M.timerS(name)(stream))
 }
 
 package object implicits {


### PR DESCRIPTION
### Overview
Trying to replicate the issue like this:
```
cd hack/docker
export CL_HIGHWAY_ENABLED=true
make reset-highway-env
CL_HIGHWAY_INIT_ROUND_EXPONENT=14 make node-0/up
CL_HIGHWAY_INIT_ROUND_EXPONENT=12 make node-1/up
CL_HIGHWAY_INIT_ROUND_EXPONENT=10 make node-2/up
make up
```
Wait some time, then `docker stop node-1`, wait, then `docker start node-1`. The hypotheses is that if it builds on a block older than the LFB of `node-0`, then `node-0` can go into 100% CPU according to `docker stats`.

Added metrics to try to figure out where it's stuck:
```
make node-0/metrics | grep EraSupervisor | grep ongoing | grep -v TYPE
```

I think the reason for the hickup is that when the node stops, it becomes unresponsive and the others ban it for a while. It comes back, and syncs, but the others still don't send messages to them until the ban timeout expires. During that time it will build on old LFB. This effect can be made less prominent by adjusting the `alive-peers-cache-expiration-period` setting, 5 minutes by default.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1258

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
