### PR TITLE
EE-932: implement Integer trait for U512

### DIFF
--- a/execution-engine/types/Cargo.toml
+++ b/execution-engine/types/Cargo.toml
@@ -22,6 +22,7 @@ blake2 = { version = "0.8.1", default-features = false }
 failure = { version = "0.1.6", default-features = false, features = ["failure_derive"] }
 hex_fmt = "0.3.0"
 num-derive = { version = "0.3.0", default-features = false }
+num-integer = { version = "0.1.42", default-features = false }
 num-traits = { version = "0.2.10", default-features = false }
 proptest = { version = "0.9.4", optional = true }
 uint = { version = "0.8.2", default-features = false, features = [] }

--- a/execution-engine/types/src/uint.rs
+++ b/execution-engine/types/src/uint.rs
@@ -366,9 +366,19 @@ macro_rules! impl_traits_for_uint {
 
             #[test]
             #[should_panic]
-            fn overflow_and_underflow_test() {
+            fn overflow_mul_test() {
                 let _ = $type::MAX * $type::from(2);
+            }
+
+            #[test]
+            #[should_panic]
+            fn overflow_add_test() {
                 let _ = $type::MAX + $type::from(1);
+            }
+
+            #[test]
+            #[should_panic]
+            fn underflow_sub_test() {
                 let _ = $type::zero() - $type::from(1);
             }
         }

--- a/execution-engine/types/src/uint.rs
+++ b/execution-engine/types/src/uint.rs
@@ -1,5 +1,6 @@
 use alloc::vec::Vec;
 
+use num_integer::Integer;
 use num_traits::{AsPrimitive, Bounded, Num, One, Unsigned, WrappingAdd, WrappingSub, Zero};
 
 use crate::bytesrepr::{self, Error, FromBytes, ToBytes};
@@ -37,8 +38,8 @@ pub enum UIntParseError {
     InvalidRadix,
 }
 
-macro_rules! ser_and_num_impls {
-    ($type:ident, $total_bytes:expr) => {
+macro_rules! impl_traits_for_uint {
+    ($type:ident, $total_bytes:expr, $test_mod:ident) => {
         impl ToBytes for $type {
             fn to_bytes(&self) -> Result<Vec<u8>, Error> {
                 let mut buf = [0u8; $total_bytes];
@@ -124,6 +125,98 @@ macro_rules! ser_and_num_impls {
             }
         }
 
+        impl Integer for $type {
+            /// Unsigned integer division. Returns the same result as `div` (`/`).
+            #[inline]
+            fn div_floor(&self, other: &Self) -> Self {
+                *self / *other
+            }
+
+            /// Unsigned integer modulo operation. Returns the same result as `rem` (`%`).
+            #[inline]
+            fn mod_floor(&self, other: &Self) -> Self {
+                *self % *other
+            }
+
+            /// Calculates the Greatest Common Divisor (GCD) of the number and `other`
+            #[inline]
+            fn gcd(&self, other: &Self) -> Self {
+                let zero = Self::zero();
+                // Use Stein's algorithm
+                let mut m = *self;
+                let mut n = *other;
+                if m == zero || n == zero {
+                    return m | n;
+                }
+
+                // find common factors of 2
+                let shift = (m | n).trailing_zeros();
+
+                // divide n and m by 2 until odd
+                m >>= m.trailing_zeros();
+                n >>= n.trailing_zeros();
+
+                while m != n {
+                    if m > n {
+                        m -= n;
+                        m >>= m.trailing_zeros();
+                    } else {
+                        n -= m;
+                        n >>= n.trailing_zeros();
+                    }
+                }
+                m << shift
+            }
+
+            /// Calculates the Lowest Common Multiple (LCM) of the number and `other`.
+            #[inline]
+            fn lcm(&self, other: &Self) -> Self {
+                self.gcd_lcm(other).1
+            }
+
+            /// Calculates the Greatest Common Divisor (GCD) and
+            /// Lowest Common Multiple (LCM) of the number and `other`.
+            #[inline]
+            fn gcd_lcm(&self, other: &Self) -> (Self, Self) {
+                if self.is_zero() && other.is_zero() {
+                    return (Self::zero(), Self::zero());
+                }
+                let gcd = self.gcd(other);
+                let lcm = *self * (*other / gcd);
+                (gcd, lcm)
+            }
+
+            /// Deprecated, use `is_multiple_of` instead.
+            #[inline]
+            fn divides(&self, other: &Self) -> bool {
+                self.is_multiple_of(other)
+            }
+
+            /// Returns `true` if the number is a multiple of `other`.
+            #[inline]
+            fn is_multiple_of(&self, other: &Self) -> bool {
+                *self % *other == $type::zero()
+            }
+
+            /// Returns `true` if the number is divisible by `2`.
+            #[inline]
+            fn is_even(&self) -> bool {
+                (self.0[0]) & 1 == 0
+            }
+
+            /// Returns `true` if the number is not divisible by `2`.
+            #[inline]
+            fn is_odd(&self) -> bool {
+                !self.is_even()
+            }
+
+            /// Simultaneous truncated integer division and modulus.
+            #[inline]
+            fn div_rem(&self, other: &Self) -> (Self, Self) {
+                (*self / *other, *self % *other)
+            }
+        }
+
         impl AsPrimitive<$type> for i32 {
             fn as_(self) -> $type {
                 if self >= 0 {
@@ -193,12 +286,88 @@ macro_rules! ser_and_num_impls {
                 self.0[0]
             }
         }
+
+        #[cfg(test)]
+        mod $test_mod {
+            use super::*;
+
+            #[test]
+            fn test_div_mod_floor() {
+                assert_eq!($type::from(10).div_floor(&$type::from(3)), $type::from(3));
+                assert_eq!($type::from(10).mod_floor(&$type::from(3)), $type::from(1));
+                assert_eq!(
+                    $type::from(10).div_mod_floor(&$type::from(3)),
+                    ($type::from(3), $type::from(1))
+                );
+                assert_eq!($type::from(5).div_floor(&$type::from(5)), $type::from(1));
+                assert_eq!($type::from(5).mod_floor(&$type::from(5)), $type::from(0));
+                assert_eq!(
+                    $type::from(5).div_mod_floor(&$type::from(5)),
+                    ($type::from(1), $type::from(0))
+                );
+                assert_eq!($type::from(3).div_floor(&$type::from(7)), $type::from(0));
+                assert_eq!($type::from(3).mod_floor(&$type::from(7)), $type::from(3));
+                assert_eq!(
+                    $type::from(3).div_mod_floor(&$type::from(7)),
+                    ($type::from(0), $type::from(3))
+                );
+            }
+
+            #[test]
+            fn test_gcd() {
+                assert_eq!($type::from(10).gcd(&$type::from(2)), $type::from(2));
+                assert_eq!($type::from(10).gcd(&$type::from(3)), $type::from(1));
+                assert_eq!($type::from(0).gcd(&$type::from(3)), $type::from(3));
+                assert_eq!($type::from(3).gcd(&$type::from(3)), $type::from(3));
+                assert_eq!($type::from(56).gcd(&$type::from(42)), $type::from(14));
+                assert_eq!(
+                    $type::MAX.gcd(&($type::MAX / $type::from(2))),
+                    $type::from(1)
+                );
+                assert_eq!($type::from(15).gcd(&$type::from(17)), $type::from(1));
+            }
+
+            #[test]
+            fn test_lcm() {
+                assert_eq!($type::from(1).lcm(&$type::from(0)), $type::from(0));
+                assert_eq!($type::from(0).lcm(&$type::from(1)), $type::from(0));
+                assert_eq!($type::from(1).lcm(&$type::from(1)), $type::from(1));
+                assert_eq!($type::from(8).lcm(&$type::from(9)), $type::from(72));
+                assert_eq!($type::from(11).lcm(&$type::from(5)), $type::from(55));
+                assert_eq!($type::from(15).lcm(&$type::from(17)), $type::from(255));
+            }
+
+            #[test]
+            fn test_is_multiple_of() {
+                assert!($type::from(6).is_multiple_of(&$type::from(6)));
+                assert!($type::from(6).is_multiple_of(&$type::from(3)));
+                assert!($type::from(6).is_multiple_of(&$type::from(1)));
+            }
+
+            #[test]
+            fn is_even() {
+                assert_eq!($type::from(0).is_even(), true);
+                assert_eq!($type::from(1).is_even(), false);
+                assert_eq!($type::from(2).is_even(), true);
+                assert_eq!($type::from(3).is_even(), false);
+                assert_eq!($type::from(4).is_even(), true);
+            }
+
+            #[test]
+            fn is_odd() {
+                assert_eq!($type::from(0).is_odd(), false);
+                assert_eq!($type::from(1).is_odd(), true);
+                assert_eq!($type::from(2).is_odd(), false);
+                assert_eq!($type::from(3).is_odd(), true);
+                assert_eq!($type::from(4).is_odd(), false);
+            }
+        }
     };
 }
 
-ser_and_num_impls!(U128, 16);
-ser_and_num_impls!(U256, 32);
-ser_and_num_impls!(U512, 64);
+impl_traits_for_uint!(U128, 16, u128_test);
+impl_traits_for_uint!(U256, 32, u256_test);
+impl_traits_for_uint!(U512, 64, u512_test);
 
 impl AsPrimitive<U128> for U128 {
     fn as_(self) -> U128 {

--- a/execution-engine/types/src/uint.rs
+++ b/execution-engine/types/src/uint.rs
@@ -335,6 +335,7 @@ macro_rules! impl_traits_for_uint {
                 assert_eq!($type::from(8).lcm(&$type::from(9)), $type::from(72));
                 assert_eq!($type::from(11).lcm(&$type::from(5)), $type::from(55));
                 assert_eq!($type::from(15).lcm(&$type::from(17)), $type::from(255));
+                assert_eq!($type::from(4).lcm(&$type::from(8)), $type::from(8));
             }
 
             #[test]
@@ -342,6 +343,7 @@ macro_rules! impl_traits_for_uint {
                 assert!($type::from(6).is_multiple_of(&$type::from(6)));
                 assert!($type::from(6).is_multiple_of(&$type::from(3)));
                 assert!($type::from(6).is_multiple_of(&$type::from(1)));
+                assert!(!$type::from(3).is_multiple_of(&$type::from(5)))
             }
 
             #[test]
@@ -360,6 +362,14 @@ macro_rules! impl_traits_for_uint {
                 assert_eq!($type::from(2).is_odd(), false);
                 assert_eq!($type::from(3).is_odd(), true);
                 assert_eq!($type::from(4).is_odd(), false);
+            }
+
+            #[test]
+            #[should_panic]
+            fn overflow_and_underflow_test() {
+                let _ = $type::MAX * $type::from(2);
+                let _ = $type::MAX + $type::from(1);
+                let _ = $type::zero() - $type::from(1);
             }
         }
     };


### PR DESCRIPTION
### Overview
The `Integer` trait gives us `div_rem` (aka "divmod"), and also enables us to use `num-rational`'s `Ratio` type, which will likely help us writing cleaner seigniorage distribution code.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-932

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
