### PR TITLE
NO-TICKET: temporarily add standard-payment-install dep to 'make build'

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -66,8 +66,9 @@ TOOL_WASM_DIR             = cargo-casperlabs/wasm
 .PHONY: all
 all: build build-contracts
 
+# TODO - remove dependency on standard-payment-install once Node is updated to pass this via GenesisConfig
 .PHONY: build
-build:
+build: build-contract-rs/standard-payment-install
 	$(CARGO) build $(CARGO_FLAGS)
 
 build-contract-rs/%:


### PR DESCRIPTION
### Overview
Causes `standard-payment-install` to be built as part of `make build` in EE.  This is a temporary workaround until Node is updated to pass this Wasm code via the `GenesisConfig`.

### Which JIRA ticket does this PR relate to?
NO-TICKET

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
