### PR TITLE
NODE-1266: No stacktrace for validation errors.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -22,6 +22,7 @@ import io.casperlabs.storage.era.EraStorage
 import io.casperlabs.shared.SemaphoreMap
 
 import scala.util.Random
+import scala.util.control.NoStackTrace
 
 /** Class to encapsulate the message handling logic of messages in an era.
   *
@@ -511,7 +512,8 @@ class EraRuntime[F[_]: Sync: Clock: Metrics: EraStorage: FinalityStorageReader: 
     */
   def handleMessage(message: ValidatedMessage): HWL[Unit] = {
     def check(ok: Boolean, error: String) =
-      if (ok) noop else MonadThrowable[HWL].raiseError[Unit](new IllegalStateException(error))
+      if (ok) noop
+      else MonadThrowable[HWL].raiseError[Unit](new IllegalStateException(error) with NoStackTrace)
 
     for {
       _ <- check(

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -10,6 +10,7 @@ import java.time.Instant
 
 import io.casperlabs.casper.consensus.{Block, BlockSummary, Era}
 import io.casperlabs.casper.dag.DagOperations
+import io.casperlabs.casper.validation.Errors.ErrorMessageWrapper
 import io.casperlabs.catscontrib.{MakeSemaphore, MonadThrowable}
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.models.Message
@@ -619,7 +620,9 @@ class EraRuntime[F[_]: Sync: Clock: Metrics: EraStorage: FinalityStorageReader: 
               // and not stop processing, so we'll need to return more detailed statuses from
               // validate to decide what to do, whether to react or not.
               MonadThrowable[F].raiseError[Unit](
-                new IllegalArgumentException(s"Could not validate block against era: $error")
+                new ErrorMessageWrapper(
+                  s"Could not validate block ${block.blockHash.show} against era ${era.keyBlockHash.show}: $error"
+                )
               ),
             _ => ().pure[F]
           )

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -22,6 +22,7 @@ import io.casperlabs.crypto.Keys.PublicKeyBS
 import io.casperlabs.ipc
 import io.casperlabs.mempool.DeployBuffer
 import io.casperlabs.models.Message
+import io.casperlabs.models.BlockImplicits._
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.metrics.implicits._ // for .timer syntax
 import io.casperlabs.shared.{FatalError, Log, Time}
@@ -30,7 +31,7 @@ import io.casperlabs.storage.deploy.{DeployStorage, DeployStorageWriter}
 import io.casperlabs.storage.dag.{DagStorage, FinalityStorage}
 import io.casperlabs.smartcontracts.ExecutionEngineService
 import scala.util.control.NonFatal
-import io.casperlabs.models.BlockImplicits._
+import scala.util.control.NoStackTrace
 
 /** A stateless class to encapsulate the steps to validate, execute and store a block. */
 class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagStorage: DeployStorage: BlockEventEmitter: Validation: CasperLabsProtocol: ExecutionEngineService: Fs2Compiler: MultiParentFinalizer: FinalityStorage: DeployBuffer](
@@ -157,6 +158,7 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
       case Processing | Processed =>
         Sync[F].raiseError(
           new IllegalStateException("A block should not be processing at this stage.")
+            with NoStackTrace
         )
 
       case UnexpectedBlockException(ex) =>

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -155,7 +155,9 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
           functorRaiseInvalidBlock.raise(status)
 
       case Processing | Processed =>
-        Sync[F].raiseError(new RuntimeException("A block should not be processing at this stage."))
+        Sync[F].raiseError(
+          new IllegalStateException("A block should not be processing at this stage.")
+        )
 
       case UnexpectedBlockException(ex) =>
         Log[F].error(

--- a/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/Errors.scala
@@ -6,14 +6,17 @@ import com.google.protobuf.ByteString
 import io.casperlabs.casper.InvalidBlock
 import io.casperlabs.casper.PrettyPrinter
 import io.casperlabs.shared.Log
-
+import scala.util.control.NoStackTrace
 import scala.concurrent.duration.FiniteDuration
 
 object Errors {
   // Wrapper for the tests that were originally outside the `attemptAdd` method
   // and meant the block was not getting saved.
-  final case class DropErrorWrapper(status: InvalidBlock)     extends Exception
-  final case class ValidateErrorWrapper(status: InvalidBlock) extends Exception(status.toString)
+  final case class DropErrorWrapper(status: InvalidBlock) extends Exception with NoStackTrace
+  final case class ValidateErrorWrapper(status: InvalidBlock)
+      extends Exception(status.toString)
+      with NoStackTrace
+  final case class ErrorMessageWrapper(message: String) extends Exception(message) with NoStackTrace
 
   sealed trait DeployHeaderError { self =>
     val deployHash: ByteString


### PR DESCRIPTION
### Overview
The stack traces are largely useless, but for the kind of validation errors we raise there's no need to log a lengthy stack trace at all.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1266

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
