### PR TITLE
NODE-1268: Catch exceptions in docker tear down and log a warning

### DIFF
--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -5,6 +5,7 @@ import os
 import pytest
 import shutil
 import logging
+import time
 
 from docker.client import DockerClient
 
@@ -32,6 +33,10 @@ from casperlabs_local_net.casperlabs_network import (
 )
 
 
+NUMBER_OF_DOCKER_PRUNE_RETRIES = 10
+DOCKER_PRUNE_RETRY_DELAY_SECONDS = 2
+
+
 @pytest.fixture(scope="session")
 def unique_run_num(pytestconfig):
     try:
@@ -55,12 +60,29 @@ def docker_client_fixture(unique_run_num) -> Generator[DockerClient, None, None]
     try:
         yield docker_client
     finally:
-        try:
-            docker_client.containers.prune()
-            docker_client.volumes.prune()
-            docker_client.networks.prune()
-        except Exception as e:
-            logging.warning("Exception in docker_client_fixture tear down.", exc_info=e)
+        # Prunning may fail with a docker.errors.APIError: "a prune operation is already running".
+        # So, we will catch exceptions here and retry few times.
+        all_pruned = False
+        number_of_retries = 0
+        while not all_pruned and number_of_retries < NUMBER_OF_DOCKER_PRUNE_RETRIES:
+            try:
+                docker_client.containers.prune()
+                docker_client.volumes.prune()
+                docker_client.networks.prune()
+                all_pruned = True
+            except Exception as e:
+                logging.warning(
+                    "Exception in docker_client_fixture tear down.", exc_info=e
+                )
+                number_of_retries += 1
+                logging.info(
+                    f"Retrying tear down of docker_client_fixture in {DOCKER_PRUNE_RETRY_DELAY_SECONDS} seconds..."
+                )
+                time.sleep(DOCKER_PRUNE_RETRY_DELAY_SECONDS)
+        if not all_pruned:
+            logging.warning(
+                f"docker_client_fixture tear down failed despite {number_of_retries} retries"
+            )
 
 
 @pytest.fixture(scope="module")

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -56,9 +56,9 @@ def docker_client_fixture(unique_run_num) -> Generator[DockerClient, None, None]
         yield docker_client
     finally:
         try:
-            docker_client.networks.prune()
-            docker_client.volumes.prune()
             docker_client.containers.prune()
+            docker_client.volumes.prune()
+            docker_client.networks.prune()
         except Exception as e:
             logging.warning("Exception in docker_client_fixture tear down.", exc_info=e)
 

--- a/integration-testing/test/conftest.py
+++ b/integration-testing/test/conftest.py
@@ -4,6 +4,7 @@ import docker as docker_py
 import os
 import pytest
 import shutil
+import logging
 
 from docker.client import DockerClient
 
@@ -54,9 +55,12 @@ def docker_client_fixture(unique_run_num) -> Generator[DockerClient, None, None]
     try:
         yield docker_client
     finally:
-        docker_client.networks.prune()
-        docker_client.volumes.prune()
-        docker_client.containers.prune()
+        try:
+            docker_client.networks.prune()
+            docker_client.volumes.prune()
+            docker_client.containers.prune()
+        except Exception as e:
+            logging.warning("Exception in docker_client_fixture tear down.", exc_info=e)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Overview
It could occasionally happen in the parallel drone integration testing tasks that docker network and container pruning executed in pytest fixture tear down code was executed by two tests at the same time, which was resulting in a test failure with `docker.errors.APIError: 409 Client Error: Conflict ("a prune operation is already running")`.

The fix is about catching the above exception and just logging a warning, preventing the test from reporting a failure.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1268

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
