### PR TITLE
CON-641: Update prev message hash check for Highway

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -128,8 +128,7 @@ abstract class ValidationImpl[F[_]: Sync: FunctorRaise[*[_], InvalidBlock]: Log:
       _ <- Validation.missingBlocks[F](summary)
       _ <- Validation.timestamp[F](summary)
       _ <- Validation.blockRank[F](summary, dag)
-      // TODO (CON-641): Going on the j-DAG is not enough, it may lead to a ballot in the parent era.
-      _ <- Validation.validatorPrevBlockHash[F](summary, dag).whenA(!isHighway)
+      _ <- Validation.validatorPrevBlockHash[F](summary, dag, isHighway)
       _ <- Validation.sequenceNumber[F](summary, dag)
       // TODO (CON-640): A voting ballot appears to be merging swimlanes in the child era.
       _ <- Validation.swimlane[F](summary, dag).whenA(!isHighway)

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -594,7 +594,7 @@ class ValidationTest
         b1  <- createAndStoreBlockFull[Task](v2, List(b0), List(b0))
         b2  <- createAndStoreBlockFull[Task](v1, List(b1), List(b1))
         dag <- dagStorage.getRepresentation
-        _   <- Validation.validatorPrevBlockHash[Task](b2.getSummary, dag)
+        _   <- Validation.validatorPrevBlockHash[Task](b2.getSummary, dag, isHighway = false)
       } yield ()
   }
   it should "pass if the hash is in the justifications" in withStorage {
@@ -605,7 +605,7 @@ class ValidationTest
         b0  <- createAndStoreBlockFull[Task](v1, List(g), Nil)
         b1  <- createAndStoreBlockFull[Task](v1, List(b0), List(b0))
         dag <- dagStorage.getRepresentation
-        _   <- Validation.validatorPrevBlockHash[Task](b1.getSummary, dag)
+        _   <- Validation.validatorPrevBlockHash[Task](b1.getSummary, dag, isHighway = false)
       } yield ()
   }
   it should "fail if the hash belongs to somebody else" in withStorage {
@@ -621,8 +621,10 @@ class ValidationTest
                List(b1, b0),
                maybeValidatorPrevBlockHash = Some(b1.blockHash)
              )
-        dag    <- dagStorage.getRepresentation
-        result <- Validation.validatorPrevBlockHash[Task](b2.getSummary, dag).attempt
+        dag <- dagStorage.getRepresentation
+        result <- Validation
+                   .validatorPrevBlockHash[Task](b2.getSummary, dag, isHighway = false)
+                   .attempt
       } yield {
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
@@ -641,8 +643,10 @@ class ValidationTest
                List(b2),
                maybeValidatorPrevBlockHash = Some(b1.blockHash)
              )
-        dag    <- dagStorage.getRepresentation
-        result <- Validation.validatorPrevBlockHash[Task](b3.getSummary, dag).attempt
+        dag <- dagStorage.getRepresentation
+        result <- Validation
+                   .validatorPrevBlockHash[Task](b3.getSummary, dag, isHighway = false)
+                   .attempt
       } yield {
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
@@ -660,8 +664,10 @@ class ValidationTest
                maybeValidatorPrevBlockHash = Some(bx),
                maybeValidatorBlockSeqNum = Some(1)
              )
-        dag    <- dagStorage.getRepresentation
-        result <- Validation.validatorPrevBlockHash[Task](b0.getSummary, dag).attempt
+        dag <- dagStorage.getRepresentation
+        result <- Validation
+                   .validatorPrevBlockHash[Task](b0.getSummary, dag, isHighway = false)
+                   .attempt
       } yield {
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
@@ -708,8 +714,8 @@ class ValidationTest
                keyBlockHash = b1.blockHash
              )
         dag <- dagStorage.getRepresentation
-        _   <- Validation.validatorPrevBlockHash[Task](b3.getSummary, dag)
-        _   <- Validation.validatorPrevBlockHash[Task](b5.getSummary, dag)
+        _   <- Validation.validatorPrevBlockHash[Task](b3.getSummary, dag, isHighway = true)
+        _   <- Validation.validatorPrevBlockHash[Task](b5.getSummary, dag, isHighway = true)
       } yield ()
   }
 


### PR DESCRIPTION
### Overview
In Highway a message can cite a previous message from the validator in the parent era, which can be of higher j-rank then their previous message in the child era. The validation thought that was wrong, but it should just be ignored.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-641

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
