### PR TITLE
CON-640: Swimlane check

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/dag/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/dag/DagOperations.scala
@@ -73,7 +73,7 @@ object DagOperations {
   def swimlaneV[F[_]: MonadThrowable](
       validator: ByteString,
       message: Message,
-      dag: DagRepresentation[F]
+      dag: DagLookup[F]
   ): StreamT[F, Message] = {
     // Messages visible in the direct justifications of the block.
     val messagePanorama =

--- a/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/validation/ValidationImpl.scala
@@ -130,8 +130,7 @@ abstract class ValidationImpl[F[_]: Sync: FunctorRaise[*[_], InvalidBlock]: Log:
       _ <- Validation.blockRank[F](summary, dag)
       _ <- Validation.validatorPrevBlockHash[F](summary, dag, isHighway)
       _ <- Validation.sequenceNumber[F](summary, dag)
-      // TODO (CON-640): A voting ballot appears to be merging swimlanes in the child era.
-      _ <- Validation.swimlane[F](summary, dag).whenA(!isHighway)
+      _ <- Validation.swimlane[F](summary, dag, isHighway)
       // TODO: Validate that blocks only have block parents and ballots have a single parent which is a block.
       // Checks that need the body.
       _ <- Validation.blockHash[F](block)

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -199,7 +199,7 @@ class ValidationTest
   implicit def `Block => BlockSummary`(b: Block) =
     BlockSummary(b.blockHash, b.header, b.signature)
 
-  "Block signature validation" should "return false on unknown algorithms" in withStorage {
+  "Block signature validation" should "return false on unknown algorithms" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _                <- createChain[Task](2)
@@ -223,7 +223,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return false on invalid ed25519 signatures" in withStorage {
+  it should "return false on invalid ed25519 signatures" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       implicit val (sk, _) = Ed25519.newKeyPair
       for {
@@ -244,7 +244,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return true on valid ed25519 signatures" in withStorage { _ => _ => _ => _ =>
+  it should "return true on valid ed25519 signatures" ignore withStorage { _ => _ => _ => _ =>
     implicit val (sk, pk) = Ed25519.newKeyPair
     val block = ProtoUtil.block(
       Seq.empty,
@@ -394,7 +394,7 @@ class ValidationTest
     )
   }
 
-  "Timestamp validation" should "not accept blocks with future time" in withStorage {
+  "Timestamp validation" should "not accept blocks with future time" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _                       <- createChain[Task](1)
@@ -411,7 +411,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "not accept blocks that were published before parent time" in withStorage {
+  it should "not accept blocks that were published before parent time" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _                       <- createChain[Task](2)
@@ -428,7 +428,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "not accept blocks that were published before justification time" in withStorage {
+  it should "not accept blocks that were published before justification time" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _       <- createChain[Task](3, creator = ByteString.copyFrom(Array[Byte](1)))
@@ -452,7 +452,7 @@ class ValidationTest
       } yield result
   }
 
-  "Block rank validation" should "only accept 0 as the number for a block with no parents" in withStorage {
+  "Block rank validation" should "only accept 0 as the number for a block with no parents" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _     <- createChain[Task](1)
@@ -469,7 +469,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return true for sequential numbering" in withStorage {
+  it should "return true for sequential numbering" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val n         = 6
       val validator = generateValidator("Validator")
@@ -491,7 +491,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "correctly validate a multiparent block where the parents have different block numbers" in withStorage {
+  it should "correctly validate a multiparent block where the parents have different block numbers" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       def createBlockWithNumber(
           n: Long,
@@ -521,7 +521,7 @@ class ValidationTest
       } yield result
   }
 
-  "Sequence number validation" should "only accept 0 as the number for a block with no parents" in withStorage {
+  "Sequence number validation" should "only accept 0 as the number for a block with no parents" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _     <- createChain[Task](1)
@@ -546,7 +546,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "return false for non-sequential numbering" in withStorage {
+  it should "return false for non-sequential numbering" ignore withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
       for {
         _     <- createChainWithRoundRobinValidators[Task](2, 2)
@@ -564,7 +564,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return true for sequential numbering" in withStorage {
+  it should "return true for sequential numbering" ignore withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
       val n              = 20
       val validatorCount = 3
@@ -585,7 +585,7 @@ class ValidationTest
       } yield result
   }
 
-  "Previous block hash validation" should "pass if the hash is in the j-past-cone" in withStorage {
+  "Previous block hash validation" should "pass if the hash is in the j-past-cone" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val List(v1, v2) = List(1, 2).map(i => generateValidator(s"v$i"))
       for {
@@ -597,7 +597,7 @@ class ValidationTest
         _   <- Validation.validatorPrevBlockHash[Task](b2.getSummary, dag, isHighway = false)
       } yield ()
   }
-  it should "pass if the hash is in the justifications" in withStorage {
+  it should "pass if the hash is in the justifications" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v1 = generateValidator("v1")
       for {
@@ -608,7 +608,7 @@ class ValidationTest
         _   <- Validation.validatorPrevBlockHash[Task](b1.getSummary, dag, isHighway = false)
       } yield ()
   }
-  it should "fail if the hash belongs to somebody else" in withStorage {
+  it should "fail if the hash belongs to somebody else" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val List(v1, v2) = List(1, 2).map(i => generateValidator(s"v$i"))
       for {
@@ -629,7 +629,7 @@ class ValidationTest
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
   }
-  it should "fail if the hash is not in the j-past-cone" in withStorage {
+  it should "fail if the hash is not in the j-past-cone" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val List(v1, v2) = List(1, 2).map(i => generateValidator(s"v$i"))
       for {
@@ -651,7 +651,7 @@ class ValidationTest
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
   }
-  it should "fail if the hash does not exist" in withStorage {
+  it should "fail if the hash does not exist" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v1 = generateValidator("v1")
       val bx = generateHash("non-existent")
@@ -719,7 +719,7 @@ class ValidationTest
       } yield ()
   }
 
-  "Sender validation" should "return true for genesis and blocks from bonded validators and false otherwise" in withStorage {
+  "Sender validation" should "return true for genesis and blocks from bonded validators and false otherwise" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val validator = generateValidator("Validator")
       val impostor  = generateValidator("Impostor")
@@ -763,7 +763,7 @@ class ValidationTest
               )
     } yield block
 
-  "Parent validation" should "return true for proper justifications and false otherwise" in withStorage {
+  "Parent validation" should "return true for proper justifications and false otherwise" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("V1")
       val v1 = generateValidator("V2")
@@ -847,7 +847,7 @@ class ValidationTest
   }
 
   // See [[/resources/casper/localDetectedForeignDidnt.jpg]]
-  it should "use only j-past-cone of the block when detecting equivocators" in withStorage {
+  it should "use only j-past-cone of the block when detecting equivocators" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
@@ -884,7 +884,7 @@ class ValidationTest
   }
 
   // Creates a block with an invalid block number and sequence number
-  "Block validation" should "short circuit after first invalidity" in withStorage {
+  "Block validation" should "short circuit after first invalidity" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _        <- createChain[Task](2)
@@ -911,7 +911,7 @@ class ValidationTest
       } yield ()
   }
 
-  "Bonds cache validation" should "succeed on a valid block and fail on modified bonds" in withStorage {
+  "Bonds cache validation" should "succeed on a valid block and fail on modified bonds" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val (_, validators)                         = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
       val bonds                                   = HashSetCasperTest.createBonds(validators)
@@ -937,7 +937,7 @@ class ValidationTest
       } yield result
   }
 
-  "Field format validation" should "succeed on a valid block and fail on empty fields" in withStorage {
+  "Field format validation" should "succeed on a valid block and fail on empty fields" ignore withStorage {
     _ => _ => _ => _ =>
       implicit val log                          = LogStub[Task]()
       val (sk, pk)                              = Ed25519.newKeyPair
@@ -986,7 +986,7 @@ class ValidationTest
     Validation.deployHash[Task](deploy) shouldBeF true
   }
 
-  "Processed deploy validation" should "fail a block with a deploy having an invalid hash" in withStorage {
+  "Processed deploy validation" should "fail a block with a deploy having an invalid hash" ignore withStorage {
     _ => _ => _ => _ =>
       val block = sample {
         for {
@@ -1005,26 +1005,27 @@ class ValidationTest
       } yield ()
   }
 
-  it should "fail a block with a deploy having no signature" in withStorage { _ => _ => _ => _ =>
-    val block = sample {
-      for {
-        b <- arbitrary[consensus.Block]
-      } yield b.withBody(
-        b.getBody.withDeploys(
-          b.getBody.deploys
-            .take(1)
-            .map(x => x.withDeploy(x.getDeploy.withApprovals(Seq.empty))) ++
-            b.getBody.deploys.tail
+  it should "fail a block with a deploy having no signature" ignore withStorage {
+    _ => _ => _ => _ =>
+      val block = sample {
+        for {
+          b <- arbitrary[consensus.Block]
+        } yield b.withBody(
+          b.getBody.withDeploys(
+            b.getBody.deploys
+              .take(1)
+              .map(x => x.withDeploy(x.getDeploy.withApprovals(Seq.empty))) ++
+              b.getBody.deploys.tail
+          )
         )
-      )
-    }
-    for {
-      result <- Validation.deploySignatures[Task](block).attempt
-      _      = result shouldBe Left(ValidateErrorWrapper(InvalidDeploySignature))
-    } yield ()
+      }
+      for {
+        result <- Validation.deploySignatures[Task](block).attempt
+        _      = result shouldBe Left(ValidateErrorWrapper(InvalidDeploySignature))
+      } yield ()
   }
 
-  it should "fail a block with a deploy having an invalid signature" in withStorage {
+  it should "fail a block with a deploy having an invalid signature" ignore withStorage {
     _ => _ => _ => _ =>
       val block = sample {
         for {
@@ -1052,7 +1053,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "fail a block with a deploy having an foreign chain name" in withStorage {
+  it should "fail a block with a deploy having an foreign chain name" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val block = sample {
         arbitrary[consensus.Block] map { block =>
@@ -1077,7 +1078,7 @@ class ValidationTest
       }
   }
 
-  it should "pass a block with a deploy having no chain name" in withStorage {
+  it should "pass a block with a deploy having no chain name" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val block = sample {
         arbitrary[consensus.Block] map { b =>
@@ -1100,22 +1101,23 @@ class ValidationTest
       } yield ()
   }
 
-  "Block hash format validation" should "fail on invalid hash" in withStorage { _ => _ => _ => _ =>
-    val (sk, pk) = Ed25519.newKeyPair
-    val BlockMsgWithTransform(Some(block), _) =
-      HashSetCasperTest.createGenesis(Map(pk -> 1))
-    val signedBlock = ProtoUtil.signBlock(block, sk, Ed25519)
-    for {
-      _ <- Validation.blockHash[Task](signedBlock) shouldBeF Unit
-      result <- Validation
-                 .blockHash[Task](
-                   signedBlock.withBlockHash(ByteString.copyFromUtf8("123"))
-                 )
-                 .attempt shouldBeF Left(InvalidBlockHash)
-    } yield result
+  "Block hash format validation" should "fail on invalid hash" ignore withStorage {
+    _ => _ => _ => _ =>
+      val (sk, pk) = Ed25519.newKeyPair
+      val BlockMsgWithTransform(Some(block), _) =
+        HashSetCasperTest.createGenesis(Map(pk -> 1))
+      val signedBlock = ProtoUtil.signBlock(block, sk, Ed25519)
+      for {
+        _ <- Validation.blockHash[Task](signedBlock) shouldBeF Unit
+        result <- Validation
+                   .blockHash[Task](
+                     signedBlock.withBlockHash(ByteString.copyFromUtf8("123"))
+                   )
+                   .attempt shouldBeF Left(InvalidBlockHash)
+      } yield result
   }
 
-  "Block deploy count validation" should "fail on invalid number of deploys" in withStorage {
+  "Block deploy count validation" should "fail on invalid number of deploys" ignore withStorage {
     _ => _ => _ => _ =>
       val (sk, pk) = Ed25519.newKeyPair
       val BlockMsgWithTransform(Some(block), _) =
@@ -1131,7 +1133,7 @@ class ValidationTest
       } yield result
   }
 
-  "Block version validation" should "work" in withStorage { _ => _ => _ => _ =>
+  "Block version validation" should "work" ignore withStorage { _ => _ => _ => _ =>
     val (sk, pk)                              = Ed25519.newKeyPair
     val BlockMsgWithTransform(Some(block), _) = HashSetCasperTest.createGenesis(Map(pk -> 1))
     // Genesis' block version is 1.  `missingProtocolVersionForBlock` will fail ProtocolVersion lookup
@@ -1156,7 +1158,7 @@ class ValidationTest
     } yield result
   }
 
-  "validateTransactions" should "return InvalidPreStateHash when preStateHash of block is not correct" in withStorage {
+  "validateTransactions" should "return InvalidPreStateHash when preStateHash of block is not correct" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       implicit val executionEngineService: ExecutionEngineService[Task] =
         HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
@@ -1213,7 +1215,7 @@ class ValidationTest
     shouldBeInvalidDeployHeader(DeployOps.randomInvalidDependency())
   }
 
-  it should "return DeployFromFuture when a deploy timestamp is later than the block timestamp" in withStorage {
+  it should "return DeployFromFuture when a deploy timestamp is later than the block timestamp" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val deploy         = DeployOps.randomNonzeroTTL()
       val blockTimestamp = deploy.getHeader.timestamp - 1
@@ -1226,7 +1228,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(DeployFromFuture))
   }
 
-  it should "return DeployExpired when a deploy is past its TTL" in withStorage {
+  it should "return DeployExpired when a deploy is past its TTL" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val deploy         = DeployOps.randomNonzeroTTL()
       val blockTimestamp = deploy.getHeader.timestamp + deploy.getHeader.ttlMillis + 1
@@ -1239,7 +1241,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(DeployExpired))
   }
 
-  it should "return DeployDependencyNotMet when a deploy has a dependency not in the p-past cone" in withStorage {
+  it should "return DeployDependencyNotMet when a deploy has a dependency not in the p-past cone" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val deployA        = DeployOps.randomNonzeroTTL()
       val deployB        = deployA.withDependencies(List(deployA.deployHash))
@@ -1253,7 +1255,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(DeployDependencyNotMet))
   }
 
-  it should "work for valid deploys" in withStorage {
+  it should "work for valid deploys" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ =>
       _ =>
         // The last validation would fail if the deploy timestamp was in the future,
@@ -1291,7 +1293,7 @@ class ValidationTest
         } yield result shouldBe Right(())
   }
 
-  "deployUniqueness" should "return InvalidRepeatDeploy when a deploy is present in an ancestor" in withStorage {
+  "deployUniqueness" should "return InvalidRepeatDeploy when a deploy is present in an ancestor" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val contract        = ByteString.copyFromUtf8("some contract")
       val deploysWithCost = prepareDeploys(Vector(contract), 1)
@@ -1303,7 +1305,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(InvalidRepeatDeploy))
   }
 
-  it should "return InvalidRepeatDeploy when a deploy is present in the body twice" in withStorage {
+  it should "return InvalidRepeatDeploy when a deploy is present in the body twice" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val contract        = ByteString.copyFromUtf8("some contract")
       val deploysWithCost = prepareDeploys(Vector(contract), 1)
@@ -1317,7 +1319,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(InvalidRepeatDeploy))
   }
 
-  it should "return InvalidPostStateHash when postStateHash of block is not correct" in withStorage {
+  it should "return InvalidPostStateHash when postStateHash of block is not correct" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       implicit val executionEngineService: ExecutionEngineService[Task] =
         HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
@@ -1346,7 +1348,7 @@ class ValidationTest
       }
   }
 
-  it should "return a checkpoint with the right hash for a valid block" in withStorage {
+  it should "return a checkpoint with the right hash for a valid block" ignore withStorage {
     implicit val executionEngineService: ExecutionEngineService[Task] =
       HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
@@ -1394,7 +1396,7 @@ class ValidationTest
       } yield postStateHash should be(computedPostStateHash)
   }
 
-  "swimlane validation" should "not allow merging equivocator's swimlane" in withStorage {
+  "swimlane validation" should "not allow merging equivocator's swimlane" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
@@ -1419,7 +1421,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "not raise errors when j-past-cone does not merge a swmilane" in withStorage {
+  it should "not raise errors when j-past-cone does not merge a swmilane" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
@@ -1442,7 +1444,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "not raise when the j-past-cone contain blocks and ballots across eras" in withStorage {
+  it should "not raise when the j-past-cone contain blocks and ballots across eras" ignore withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v1 = generateValidator("v1")
       // era-0: G - B0 - B1 - B2
@@ -1466,7 +1468,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "raise when the j-past-cone an equivocation in an era" in withStorage {
+  it should "raise when the j-past-cone contains an equivocation in an era" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v1 = generateValidator("v1")
       // era-0: G - B0 - B1 - B2

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -1475,7 +1475,7 @@ class ValidationTest
                keyBlockHash = e1.keyBlockHash
              )
         dag <- dagStorage.getRepresentation
-        _   <- Validation.swimlane[Task](b3, dag, isHighway = true)
+        _   <- Validation.swimlane[Task](b3, dag, isHighway = true).attempt shouldBeF Right(())
       } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -49,6 +49,7 @@ import io.casperlabs.storage.BlockMsgWithTransform
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.dag._
 import io.casperlabs.storage.deploy.DeployStorage
+import io.casperlabs.storage.SQLiteStorage.CombinedStorage
 import io.casperlabs.casper.validation.NCBValidationImpl
 import monix.eval.Task
 import monix.execution.Scheduler
@@ -99,6 +100,15 @@ class ValidationTest
     import Scheduler.Implicits.global
     t.runSyncUnsafe(5.seconds)
   }
+
+  def withCombinedStorageIndexed(
+      f: CombinedStorage[Task] => IndexedDagStorage[Task] => Task[_]
+  ): Unit =
+    withCombinedStorage() { db =>
+      IndexedDagStorage.create[Task](db).flatMap { ids =>
+        f(db)(ids)
+      }
+    }
 
   def createChain[F[_]: MonadThrowable: Time: BlockStorage: IndexedDagStorage](
       length: Int,
@@ -199,7 +209,7 @@ class ValidationTest
   implicit def `Block => BlockSummary`(b: Block) =
     BlockSummary(b.blockHash, b.header, b.signature)
 
-  "Block signature validation" should "return false on unknown algorithms" ignore withStorage {
+  "Block signature validation" should "return false on unknown algorithms" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _                <- createChain[Task](2)
@@ -223,7 +233,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return false on invalid ed25519 signatures" ignore withStorage {
+  it should "return false on invalid ed25519 signatures" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       implicit val (sk, _) = Ed25519.newKeyPair
       for {
@@ -244,7 +254,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return true on valid ed25519 signatures" ignore withStorage { _ => _ => _ => _ =>
+  it should "return true on valid ed25519 signatures" in withStorage { _ => _ => _ => _ =>
     implicit val (sk, pk) = Ed25519.newKeyPair
     val block = ProtoUtil.block(
       Seq.empty,
@@ -394,7 +404,7 @@ class ValidationTest
     )
   }
 
-  "Timestamp validation" should "not accept blocks with future time" ignore withStorage {
+  "Timestamp validation" should "not accept blocks with future time" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _                       <- createChain[Task](1)
@@ -411,7 +421,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "not accept blocks that were published before parent time" ignore withStorage {
+  it should "not accept blocks that were published before parent time" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _                       <- createChain[Task](2)
@@ -428,7 +438,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "not accept blocks that were published before justification time" ignore withStorage {
+  it should "not accept blocks that were published before justification time" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _       <- createChain[Task](3, creator = ByteString.copyFrom(Array[Byte](1)))
@@ -452,7 +462,7 @@ class ValidationTest
       } yield result
   }
 
-  "Block rank validation" should "only accept 0 as the number for a block with no parents" ignore withStorage {
+  "Block rank validation" should "only accept 0 as the number for a block with no parents" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _     <- createChain[Task](1)
@@ -469,7 +479,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return true for sequential numbering" ignore withStorage {
+  it should "return true for sequential numbering" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val n         = 6
       val validator = generateValidator("Validator")
@@ -491,7 +501,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "correctly validate a multiparent block where the parents have different block numbers" ignore withStorage {
+  it should "correctly validate a multiparent block where the parents have different block numbers" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       def createBlockWithNumber(
           n: Long,
@@ -521,7 +531,7 @@ class ValidationTest
       } yield result
   }
 
-  "Sequence number validation" should "only accept 0 as the number for a block with no parents" ignore withStorage {
+  "Sequence number validation" should "only accept 0 as the number for a block with no parents" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _     <- createChain[Task](1)
@@ -546,7 +556,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "return false for non-sequential numbering" ignore withStorage {
+  it should "return false for non-sequential numbering" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
       for {
         _     <- createChainWithRoundRobinValidators[Task](2, 2)
@@ -564,7 +574,7 @@ class ValidationTest
       } yield result
   }
 
-  it should "return true for sequential numbering" ignore withStorage {
+  it should "return true for sequential numbering" in withStorage {
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
       val n              = 20
       val validatorCount = 3
@@ -585,7 +595,7 @@ class ValidationTest
       } yield result
   }
 
-  "Previous block hash validation" should "pass if the hash is in the j-past-cone" ignore withStorage {
+  "Previous block hash validation" should "pass if the hash is in the j-past-cone" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val List(v1, v2) = List(1, 2).map(i => generateValidator(s"v$i"))
       for {
@@ -597,7 +607,7 @@ class ValidationTest
         _   <- Validation.validatorPrevBlockHash[Task](b2.getSummary, dag, isHighway = false)
       } yield ()
   }
-  it should "pass if the hash is in the justifications" ignore withStorage {
+  it should "pass if the hash is in the justifications" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v1 = generateValidator("v1")
       for {
@@ -608,7 +618,7 @@ class ValidationTest
         _   <- Validation.validatorPrevBlockHash[Task](b1.getSummary, dag, isHighway = false)
       } yield ()
   }
-  it should "fail if the hash belongs to somebody else" ignore withStorage {
+  it should "fail if the hash belongs to somebody else" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val List(v1, v2) = List(1, 2).map(i => generateValidator(s"v$i"))
       for {
@@ -629,7 +639,7 @@ class ValidationTest
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
   }
-  it should "fail if the hash is not in the j-past-cone" ignore withStorage {
+  it should "fail if the hash is not in the j-past-cone" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val List(v1, v2) = List(1, 2).map(i => generateValidator(s"v$i"))
       for {
@@ -651,7 +661,7 @@ class ValidationTest
         result shouldBe Left(ValidateErrorWrapper(InvalidPrevBlockHash))
       }
   }
-  it should "fail if the hash does not exist" ignore withStorage {
+  it should "fail if the hash does not exist" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v1 = generateValidator("v1")
       val bx = generateHash("non-existent")
@@ -719,7 +729,7 @@ class ValidationTest
       } yield ()
   }
 
-  "Sender validation" should "return true for genesis and blocks from bonded validators and false otherwise" ignore withStorage {
+  "Sender validation" should "return true for genesis and blocks from bonded validators and false otherwise" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val validator = generateValidator("Validator")
       val impostor  = generateValidator("Impostor")
@@ -763,7 +773,7 @@ class ValidationTest
               )
     } yield block
 
-  "Parent validation" should "return true for proper justifications and false otherwise" ignore withStorage {
+  "Parent validation" should "return true for proper justifications and false otherwise" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("V1")
       val v1 = generateValidator("V2")
@@ -847,7 +857,7 @@ class ValidationTest
   }
 
   // See [[/resources/casper/localDetectedForeignDidnt.jpg]]
-  it should "use only j-past-cone of the block when detecting equivocators" ignore withStorage {
+  it should "use only j-past-cone of the block when detecting equivocators" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
@@ -884,7 +894,7 @@ class ValidationTest
   }
 
   // Creates a block with an invalid block number and sequence number
-  "Block validation" should "short circuit after first invalidity" ignore withStorage {
+  "Block validation" should "short circuit after first invalidity" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       for {
         _        <- createChain[Task](2)
@@ -911,7 +921,7 @@ class ValidationTest
       } yield ()
   }
 
-  "Bonds cache validation" should "succeed on a valid block and fail on modified bonds" ignore withStorage {
+  "Bonds cache validation" should "succeed on a valid block and fail on modified bonds" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val (_, validators)                         = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
       val bonds                                   = HashSetCasperTest.createBonds(validators)
@@ -937,7 +947,7 @@ class ValidationTest
       } yield result
   }
 
-  "Field format validation" should "succeed on a valid block and fail on empty fields" ignore withStorage {
+  "Field format validation" should "succeed on a valid block and fail on empty fields" in withStorage {
     _ => _ => _ => _ =>
       implicit val log                          = LogStub[Task]()
       val (sk, pk)                              = Ed25519.newKeyPair
@@ -986,7 +996,7 @@ class ValidationTest
     Validation.deployHash[Task](deploy) shouldBeF true
   }
 
-  "Processed deploy validation" should "fail a block with a deploy having an invalid hash" ignore withStorage {
+  "Processed deploy validation" should "fail a block with a deploy having an invalid hash" in withStorage {
     _ => _ => _ => _ =>
       val block = sample {
         for {
@@ -1005,27 +1015,26 @@ class ValidationTest
       } yield ()
   }
 
-  it should "fail a block with a deploy having no signature" ignore withStorage {
-    _ => _ => _ => _ =>
-      val block = sample {
-        for {
-          b <- arbitrary[consensus.Block]
-        } yield b.withBody(
-          b.getBody.withDeploys(
-            b.getBody.deploys
-              .take(1)
-              .map(x => x.withDeploy(x.getDeploy.withApprovals(Seq.empty))) ++
-              b.getBody.deploys.tail
-          )
-        )
-      }
+  it should "fail a block with a deploy having no signature" in withStorage { _ => _ => _ => _ =>
+    val block = sample {
       for {
-        result <- Validation.deploySignatures[Task](block).attempt
-        _      = result shouldBe Left(ValidateErrorWrapper(InvalidDeploySignature))
-      } yield ()
+        b <- arbitrary[consensus.Block]
+      } yield b.withBody(
+        b.getBody.withDeploys(
+          b.getBody.deploys
+            .take(1)
+            .map(x => x.withDeploy(x.getDeploy.withApprovals(Seq.empty))) ++
+            b.getBody.deploys.tail
+        )
+      )
+    }
+    for {
+      result <- Validation.deploySignatures[Task](block).attempt
+      _      = result shouldBe Left(ValidateErrorWrapper(InvalidDeploySignature))
+    } yield ()
   }
 
-  it should "fail a block with a deploy having an invalid signature" ignore withStorage {
+  it should "fail a block with a deploy having an invalid signature" in withStorage {
     _ => _ => _ => _ =>
       val block = sample {
         for {
@@ -1053,7 +1062,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "fail a block with a deploy having an foreign chain name" ignore withStorage {
+  it should "fail a block with a deploy having an foreign chain name" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val block = sample {
         arbitrary[consensus.Block] map { block =>
@@ -1078,7 +1087,7 @@ class ValidationTest
       }
   }
 
-  it should "pass a block with a deploy having no chain name" ignore withStorage {
+  it should "pass a block with a deploy having no chain name" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val block = sample {
         arbitrary[consensus.Block] map { b =>
@@ -1101,23 +1110,22 @@ class ValidationTest
       } yield ()
   }
 
-  "Block hash format validation" should "fail on invalid hash" ignore withStorage {
-    _ => _ => _ => _ =>
-      val (sk, pk) = Ed25519.newKeyPair
-      val BlockMsgWithTransform(Some(block), _) =
-        HashSetCasperTest.createGenesis(Map(pk -> 1))
-      val signedBlock = ProtoUtil.signBlock(block, sk, Ed25519)
-      for {
-        _ <- Validation.blockHash[Task](signedBlock) shouldBeF Unit
-        result <- Validation
-                   .blockHash[Task](
-                     signedBlock.withBlockHash(ByteString.copyFromUtf8("123"))
-                   )
-                   .attempt shouldBeF Left(InvalidBlockHash)
-      } yield result
+  "Block hash format validation" should "fail on invalid hash" in withStorage { _ => _ => _ => _ =>
+    val (sk, pk) = Ed25519.newKeyPair
+    val BlockMsgWithTransform(Some(block), _) =
+      HashSetCasperTest.createGenesis(Map(pk -> 1))
+    val signedBlock = ProtoUtil.signBlock(block, sk, Ed25519)
+    for {
+      _ <- Validation.blockHash[Task](signedBlock) shouldBeF Unit
+      result <- Validation
+                 .blockHash[Task](
+                   signedBlock.withBlockHash(ByteString.copyFromUtf8("123"))
+                 )
+                 .attempt shouldBeF Left(InvalidBlockHash)
+    } yield result
   }
 
-  "Block deploy count validation" should "fail on invalid number of deploys" ignore withStorage {
+  "Block deploy count validation" should "fail on invalid number of deploys" in withStorage {
     _ => _ => _ => _ =>
       val (sk, pk) = Ed25519.newKeyPair
       val BlockMsgWithTransform(Some(block), _) =
@@ -1133,7 +1141,7 @@ class ValidationTest
       } yield result
   }
 
-  "Block version validation" should "work" ignore withStorage { _ => _ => _ => _ =>
+  "Block version validation" should "work" in withStorage { _ => _ => _ => _ =>
     val (sk, pk)                              = Ed25519.newKeyPair
     val BlockMsgWithTransform(Some(block), _) = HashSetCasperTest.createGenesis(Map(pk -> 1))
     // Genesis' block version is 1.  `missingProtocolVersionForBlock` will fail ProtocolVersion lookup
@@ -1158,7 +1166,7 @@ class ValidationTest
     } yield result
   }
 
-  "validateTransactions" should "return InvalidPreStateHash when preStateHash of block is not correct" ignore withStorage {
+  "validateTransactions" should "return InvalidPreStateHash when preStateHash of block is not correct" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       implicit val executionEngineService: ExecutionEngineService[Task] =
         HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
@@ -1215,7 +1223,7 @@ class ValidationTest
     shouldBeInvalidDeployHeader(DeployOps.randomInvalidDependency())
   }
 
-  it should "return DeployFromFuture when a deploy timestamp is later than the block timestamp" ignore withStorage {
+  it should "return DeployFromFuture when a deploy timestamp is later than the block timestamp" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val deploy         = DeployOps.randomNonzeroTTL()
       val blockTimestamp = deploy.getHeader.timestamp - 1
@@ -1228,7 +1236,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(DeployFromFuture))
   }
 
-  it should "return DeployExpired when a deploy is past its TTL" ignore withStorage {
+  it should "return DeployExpired when a deploy is past its TTL" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val deploy         = DeployOps.randomNonzeroTTL()
       val blockTimestamp = deploy.getHeader.timestamp + deploy.getHeader.ttlMillis + 1
@@ -1241,7 +1249,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(DeployExpired))
   }
 
-  it should "return DeployDependencyNotMet when a deploy has a dependency not in the p-past cone" ignore withStorage {
+  it should "return DeployDependencyNotMet when a deploy has a dependency not in the p-past cone" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val deployA        = DeployOps.randomNonzeroTTL()
       val deployB        = deployA.withDependencies(List(deployA.deployHash))
@@ -1255,7 +1263,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(DeployDependencyNotMet))
   }
 
-  it should "work for valid deploys" ignore withStorage {
+  it should "work for valid deploys" in withStorage {
     implicit blockStorage => implicit dagStorage => _ =>
       _ =>
         // The last validation would fail if the deploy timestamp was in the future,
@@ -1293,7 +1301,7 @@ class ValidationTest
         } yield result shouldBe Right(())
   }
 
-  "deployUniqueness" should "return InvalidRepeatDeploy when a deploy is present in an ancestor" ignore withStorage {
+  "deployUniqueness" should "return InvalidRepeatDeploy when a deploy is present in an ancestor" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val contract        = ByteString.copyFromUtf8("some contract")
       val deploysWithCost = prepareDeploys(Vector(contract), 1)
@@ -1305,7 +1313,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(InvalidRepeatDeploy))
   }
 
-  it should "return InvalidRepeatDeploy when a deploy is present in the body twice" ignore withStorage {
+  it should "return InvalidRepeatDeploy when a deploy is present in the body twice" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val contract        = ByteString.copyFromUtf8("some contract")
       val deploysWithCost = prepareDeploys(Vector(contract), 1)
@@ -1319,7 +1327,7 @@ class ValidationTest
       } yield result shouldBe Left(ValidateErrorWrapper(InvalidRepeatDeploy))
   }
 
-  it should "return InvalidPostStateHash when postStateHash of block is not correct" ignore withStorage {
+  it should "return InvalidPostStateHash when postStateHash of block is not correct" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       implicit val executionEngineService: ExecutionEngineService[Task] =
         HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
@@ -1348,7 +1356,7 @@ class ValidationTest
       }
   }
 
-  it should "return a checkpoint with the right hash for a valid block" ignore withStorage {
+  it should "return a checkpoint with the right hash for a valid block" in withStorage {
     implicit val executionEngineService: ExecutionEngineService[Task] =
       HashSetCasperTestNode.simpleEEApi[Task](Map.empty)
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
@@ -1396,7 +1404,7 @@ class ValidationTest
       } yield postStateHash should be(computedPostStateHash)
   }
 
-  "swimlane validation" should "not allow merging equivocator's swimlane" ignore withStorage {
+  "swimlane validation" should "not allow merging equivocator's swimlane" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
@@ -1421,7 +1429,7 @@ class ValidationTest
       } yield ()
   }
 
-  it should "not raise errors when j-past-cone does not merge a swmilane" ignore withStorage {
+  it should "not raise errors when j-past-cone does not merge a swmilane" in withStorage {
     implicit blockStorage => implicit dagStorage => _ => _ =>
       val v0 = generateValidator("v0")
       val v1 = generateValidator("v1")
@@ -1444,32 +1452,35 @@ class ValidationTest
       } yield ()
   }
 
-  it should "not raise when the j-past-cone contain blocks and ballots across eras" ignore withStorage {
-    implicit blockStorage => implicit dagStorage => _ => _ =>
+  it should "not raise when the j-past-cone contain blocks and ballots across eras" in withCombinedStorageIndexed {
+    implicit db => implicit dagStorage =>
       val v1 = generateValidator("v1")
       // era-0: G - B0 - B1 - B2
       //                   \
       // era-1:             B3
       for {
         g  <- createAndStoreMessage[Task](Nil)
-        b0 <- createAndStoreBlockFull[Task](v1, List(g), Nil)
-        b1 <- createAndStoreBlockFull[Task](v1, List(b0), List(b0), keyBlockHash = b0.blockHash)
-        b2 <- createAndStoreBlockFull[Task](v1, List(b1), List(b1), keyBlockHash = b0.blockHash)
+        eg <- createAndStoreEra[Task](g.blockHash)
+        b0 <- createAndStoreBlockFull[Task](v1, List(g), Nil, keyBlockHash = eg.keyBlockHash)
+        e0 <- createAndStoreEra[Task](b0.blockHash)
+        b1 <- createAndStoreBlockFull[Task](v1, List(b0), List(b0), keyBlockHash = e0.keyBlockHash)
+        b2 <- createAndStoreBlockFull[Task](v1, List(b1), List(b1), keyBlockHash = e0.keyBlockHash)
+        e1 <- createAndStoreEra[Task](b1.blockHash)
         b3 <- createAndStoreBlockFull[Task](
                v1,
                List(b1),
                List(b1, b2),
                maybeValidatorPrevBlockHash = Some(ByteString.EMPTY),
                maybeValidatorBlockSeqNum = Some(0),
-               keyBlockHash = b1.blockHash
+               keyBlockHash = e1.keyBlockHash
              )
         dag <- dagStorage.getRepresentation
         _   <- Validation.swimlane[Task](b3, dag, isHighway = true)
       } yield ()
   }
 
-  it should "raise when the j-past-cone contains an equivocation in an era" in withStorage {
-    implicit blockStorage => implicit dagStorage => _ => _ =>
+  it should "raise when the j-past-cone contains an equivocation in an era" in withCombinedStorageIndexed {
+    implicit db => implicit dagStorage =>
       val v1 = generateValidator("v1")
       // era-0: G - B0 - B1 - B2
       //                   \    \
@@ -1478,19 +1489,27 @@ class ValidationTest
       // era-1:                B4 - B5
       for {
         g  <- createAndStoreMessage[Task](Nil)
-        b0 <- createAndStoreBlockFull[Task](v1, List(g), Nil)
-        b1 <- createAndStoreBlockFull[Task](v1, List(b0), List(b0), keyBlockHash = b0.blockHash)
-        b2 <- createAndStoreBlockFull[Task](v1, List(b1), List(b1), keyBlockHash = b0.blockHash)
-        b3 <- createAndStoreBlockFull[Task](v1, List(b1), List(b1), keyBlockHash = b0.blockHash)
+        eg <- createAndStoreEra[Task](g.blockHash)
+        b0 <- createAndStoreBlockFull[Task](v1, List(g), Nil, keyBlockHash = eg.keyBlockHash)
+        e0 <- createAndStoreEra[Task](b0.blockHash)
+        b1 <- createAndStoreBlockFull[Task](v1, List(b0), List(b0), keyBlockHash = e0.keyBlockHash)
+        b2 <- createAndStoreBlockFull[Task](v1, List(b1), List(b1), keyBlockHash = e0.keyBlockHash)
+        b3 <- createAndStoreBlockFull[Task](v1, List(b1), List(b1), keyBlockHash = e0.keyBlockHash)
+        e1 <- createAndStoreEra[Task](b1.blockHash)
         b4 <- createAndStoreBlockFull[Task](
                v1,
                List(b3),
                List(b3),
                maybeValidatorPrevBlockHash = Some(ByteString.EMPTY),
                maybeValidatorBlockSeqNum = Some(0),
-               keyBlockHash = b1.blockHash
+               keyBlockHash = e1.keyBlockHash
              )
-        b5  <- createAndStoreBlockFull[Task](v1, List(b4), List(b4, b2), keyBlockHash = b1.blockHash)
+        b5 <- createAndStoreBlockFull[Task](
+               v1,
+               List(b4),
+               List(b4, b2),
+               keyBlockHash = e1.keyBlockHash
+             )
         dag <- dagStorage.getRepresentation
         _ <- Validation.swimlane[Task](b5, dag, isHighway = true).attempt shouldBeF Left(
               ValidateErrorWrapper(SwimlaneMerged)

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -16,7 +16,7 @@ import io.casperlabs.storage.dag.{
   DagRepresentation,
   EraTipRepresentation,
   FinalityStorage,
-  TipRepresentation
+  GlobalTipRepresentation
 }
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.casper.mocks.MockFinalityStorage
@@ -172,8 +172,9 @@ object FinalityDetectorUtilTest {
           lastBlockHash: BlockHash
       ) = ???
 
-      override def latestGlobal
-          : StateT[F, Map[BlockHash, Int], TipRepresentation[StateT[F, Map[BlockHash, Int], *]]] =
+      override def latestGlobal: StateT[F, Map[BlockHash, Int], GlobalTipRepresentation[
+        StateT[F, Map[BlockHash, Int], *]
+      ]] =
         ???
       override def latestInEra(
           keyBlockHash: BlockHash

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -26,6 +26,7 @@ import io.casperlabs.smartcontracts.ExecutionEngineService
 import io.casperlabs.storage.block.BlockStorage
 import io.casperlabs.storage.dag.{DagRepresentation, IndexedDagStorage}
 import io.casperlabs.storage.deploy.{DeployStorage, DeployStorageWriter}
+import io.casperlabs.storage.era.EraStorage
 import monix.eval.Task
 import io.casperlabs.shared.Sorting._
 
@@ -310,4 +311,10 @@ trait BlockGenerator {
       maybeValidatorBlockSeqNum = maybeValidatorBlockSeqNum,
       keyBlockHash = keyBlockHash
     )
+
+  /** Insert an era so we get the behaviour where latest messages are stored per key block hash. */
+  def createAndStoreEra[F[_]: Applicative: EraStorage](keyBlockHash: ByteString): F[Era] = {
+    val era = Era(keyBlockHash)
+    EraStorage[F].addEra(era).as(era)
+  }
 }

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -141,9 +141,7 @@ trait EraTipRepresentation[F[_]] extends TipRepresentation[F] {
 trait GlobalTipRepresentation[F[_]] extends TipRepresentation[F] {
 
   /** Get the equivocations across all eras. */
-  def getEquivocations(
-      implicit A: Applicative[F]
-  ): F[Map[Validator, Map[BlockHash, Set[Message]]]]
+  def getEquivocations: F[Map[Validator, Map[BlockHash, Set[Message]]]]
 
   /** Get the equivocators across all eras. */
   def getEquivocators(implicit A: Applicative[F]): F[Set[Validator]] =

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -129,11 +129,25 @@ trait EraTipRepresentation[F[_]] extends TipRepresentation[F] {
   // * the parent block candidate hashes, and
   // * the justifications of the parent block candidates.
 
+  /** Get the equivocators in *this* era. */
   def getEquivocators(implicit A: Applicative[F]): F[Set[Validator]] =
     getEquivocations.map(_.keySet)
 
+  /** Get the equivocations in *this* era. */
   def getEquivocations(implicit A: Applicative[F]): F[Map[Validator, Set[Message]]] =
     latestMessages.map(_.filter(_._2.size > 1))
+}
+
+trait GlobalTipRepresentation[F[_]] extends TipRepresentation[F] {
+
+  /** Get the equivocations across all eras. */
+  def getEquivocations(
+      implicit A: Applicative[F]
+  ): F[Map[Validator, Map[BlockHash, Set[Message]]]]
+
+  /** Get the equivocators across all eras. */
+  def getEquivocators(implicit A: Applicative[F]): F[Set[Validator]] =
+    getEquivocations.map(_.keySet)
 }
 
 @typeclass trait DagLookup[F[_]] {
@@ -205,7 +219,7 @@ trait DagRepresentation[F[_]] extends DagLookup[F] {
     *
     * Doesn't guarantee to return immutable representation.
     */
-  def latestGlobal: F[TipRepresentation[F]]
+  def latestGlobal: F[GlobalTipRepresentation[F]]
 
   /** Get a representation restricted to a given era, which mean anyone
     * with more than 1 entry in their latest messages must have equivocated

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -364,12 +364,10 @@ class SQLiteDagStorage[F[_]: Sync](
           // be set to false prematurely.
           sql"""
           SELECT
-            case when exists(select 1 from validator_latest_messages where key_block_hash = x'')
-                 then true else false end
-              as has_empty,
-            case when exists(select 1 from validator_latest_messages where key_block_hash != x'')
-                 then true else false end
-              as has_defined
+            EXISTS(SELECT 1 FROM validator_latest_messages WHERE key_block_hash = x'')
+              AS has_empty,
+            EXISTS(SELECT 1 FROM validator_latest_messages WHERE key_block_hash != x'')
+              AS has_defined
           """
             .query[(Boolean, Boolean)]
             .unique


### PR DESCRIPTION
### Overview
We validate that a new block from a validator doesn't merge equivocating blocks from them in their j-past-cone (we don't check that they don't merge other people's equivocations). This didn't take into account the fact that in Highway you produce messages in the parent era and the child era at the same time, which on its own looks like an equivocation.

The PR changes the swimlane check so that it looks for equivocations on a per-era basis and check if the j-past-cone contains any such pairs. Added a new database query to retrieve all equivocations.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-640

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
