### PR TITLE
NO-TICK: Move logging of the last round into EraRuntime.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -14,6 +14,7 @@ import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.models.Message
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.catscontrib.{MakeSemaphore, MonadThrowable}
+import io.casperlabs.shared.Log
 import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.block.BlockStorageWriter
 import io.casperlabs.storage.dag.{DagStorage, FinalityStorage}
@@ -48,6 +49,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
   implicit def `Message => ValidatedMessage`(m: Message): ValidatedMessage = Validated(m)
 
   implicit val noMetrics = new Metrics.MetricsNOP[Id]
+  implicit val noLog     = Log.NOPLog[Id]
 
   val postEraVotingDuration = days(2)
 
@@ -167,6 +169,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       // Let's say we are right at the beginning of the era by default.
       C: Clock[Id] = TestClock.frozen[Id](date(2019, 12, 9)),
       M: Metrics[Id] = noMetrics,
+      L: Log[Id] = noLog,
       DS: BlockDagStorage[Id] = defaultBlockDagStorage,
       ES: EraStorage[Id] = MockEraStorage[Id],
       FS: FinalityStorage[Id] = defaultFinalityStorage,
@@ -179,7 +182,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       roundExponent,
       isSyncedRef.get,
       leaderSequencer
-    )(syncId, makeSemaphoreId, C, M, DS, ES, FS, FC)
+    )(syncId, makeSemaphoreId, C, M, L, DS, ES, FS, FC)
 
   /** Create a runtime given an era that's supposedly the child era of another one;
     * otherwise we should be using `genesisEraRuntime` instead. For the same reason
@@ -198,6 +201,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       implicit
       C: Clock[Id],
       M: Metrics[Id],
+      L: Log[Id],
       DS: BlockDagStorage[Id],
       ES: EraStorage[Id],
       FS: FinalityStorage[Id],
@@ -210,7 +214,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       roundExponent,
       isSyncedRef.get,
       leaderSequencer
-    )(syncId, makeSemaphoreId, C, M, DS, ES, FS, FC)
+    )(syncId, makeSemaphoreId, C, M, L, DS, ES, FS, FC)
 
   // Make it easier to share common dependencies.
   // TODO (NODE-1199): Use HighwayFixture instead for all tests.


### PR DESCRIPTION
### Overview
Moves the logging of the last round in the era into `EraRuntime` form `EraSupervisor` so the supervisor doesn't have to know how the action logic works.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
