### PR TITLE
EE-904: implement host-side standard payment logic

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "engine-wasm-prep",
     "mint",
     "proof-of-stake",
+    "standard-payment",
     "types"
 ]
 exclude = [
@@ -33,6 +34,7 @@ default-members = [
     "engine-wasm-prep",
     "mint",
     "proof-of-stake",
+    "standard-payment",
     "types"
 ]
 

--- a/execution-engine/contracts/system/standard-payment/Cargo.toml
+++ b/execution-engine/contracts/system/standard-payment/Cargo.toml
@@ -11,9 +11,11 @@ doctest = false
 test = false
 
 [features]
-std = ["contract/std", "types/std"]
+std = ["casperlabs-standard-payment/std", "contract/std", "types/std"]
 lib = []
 
 [dependencies]
+casperlabs-standard-payment = { path = "../../../standard-payment" }
 contract = { path = "../../../contract", package = "casperlabs-contract" }
+proof-of-stake = { path = "../../../proof-of-stake", package = "casperlabs-proof-of-stake" }
 types = { path = "../../../types", package = "casperlabs-types" }

--- a/execution-engine/contracts/system/standard-payment/src/lib.rs
+++ b/execution-engine/contracts/system/standard-payment/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 
+use casperlabs_standard_payment::{
+    AccountProvider, MintProvider, ProofOfStakeProvider, StandardPayment,
+};
 use contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
@@ -8,22 +11,43 @@ use types::{ApiError, URef, U512};
 
 const GET_PAYMENT_PURSE: &str = "get_payment_purse";
 
-enum Arg {
-    Amount = 0,
+struct StandardPaymentContract;
+
+impl AccountProvider for StandardPaymentContract {
+    fn get_main_purse(&self) -> Result<URef, ApiError> {
+        Ok(account::get_main_purse())
+    }
 }
 
+impl MintProvider for StandardPaymentContract {
+    fn transfer_purse_to_purse(
+        &mut self,
+        source: URef,
+        target: URef,
+        amount: U512,
+    ) -> Result<(), ApiError> {
+        system::transfer_from_purse_to_purse(source, target, amount)
+    }
+}
+
+impl ProofOfStakeProvider for StandardPaymentContract {
+    fn get_payment_purse(&mut self) -> Result<URef, ApiError> {
+        let pos_pointer = system::get_proof_of_stake();
+        let payment_purse = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,));
+        Ok(payment_purse)
+    }
+}
+
+impl StandardPayment for StandardPaymentContract {}
+
 pub fn delegate() {
-    let amount: U512 = runtime::get_arg(Arg::Amount as u32)
+    let mut standard_payment_contract = StandardPaymentContract;
+
+    let amount: U512 = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
-    let main_purse = account::get_main_purse();
-
-    let pos_pointer = system::get_proof_of_stake();
-
-    let payment_purse: URef = runtime::call_contract(pos_pointer, (GET_PAYMENT_PURSE,));
-
-    system::transfer_from_purse_to_purse(main_purse, payment_purse, amount).unwrap_or_revert();
+    standard_payment_contract.pay(amount).unwrap_or_revert();
 }
 
 #[cfg(not(feature = "lib"))]

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -20,6 +20,7 @@ engine-wasm-prep = { version = "0.2.0", path = "../engine-wasm-prep", package = 
 failure = "0.1.6"
 hex_fmt = "0.3.0"
 itertools = "0.8.2"
+lazy_static = "1.4.0"
 linked-hash-map = "0.5.2"
 log = "0.4.8"
 mint = { path = "../mint", package = "casperlabs-mint" }
@@ -30,6 +31,7 @@ parity-wasm = "0.31.3"
 pwasm-utils = "0.6.2"
 rand = "0.7.2"
 rand_chacha = "0.2.1"
+standard-payment = { path = "../standard-payment", package = "casperlabs-standard-payment" }
 types = { version = "0.2.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 wasmi = "0.4.2"
 

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -44,26 +44,23 @@ use types::{
     Key, Phase, ProtocolVersion, URef, KEY_HASH_LENGTH, U512, UREF_ADDR_LENGTH,
 };
 
-use self::{
-    deploy_item::DeployItem,
-    executable_deploy_item::ExecutableDeployItem,
-    execution_result::{ExecutionResult, ForcedTransferResult},
-    genesis::{
-        GenesisAccount, GenesisConfig, GenesisResult, PLACEHOLDER_KEY, POS_PAYMENT_PURSE,
-        POS_REWARDS_PURSE,
-    },
-    system_contract_cache::SystemContractCache,
-};
 pub use self::{
     engine_config::EngineConfig,
     error::{Error, RootNotFound},
 };
 use crate::{
     engine_state::{
+        deploy_item::DeployItem,
         error::Error::MissingSystemContract,
+        executable_deploy_item::ExecutableDeployItem,
         execute_request::ExecuteRequest,
-        genesis::POS_BONDING_PURSE,
+        execution_result::{ExecutionResult, ForcedTransferResult},
+        genesis::{
+            GenesisAccount, GenesisConfig, GenesisResult, PLACEHOLDER_KEY, POS_BONDING_PURSE,
+            POS_PAYMENT_PURSE, POS_REWARDS_PURSE,
+        },
         query::{QueryRequest, QueryResult},
+        system_contract_cache::SystemContractCache,
         upgrade::{UpgradeConfig, UpgradeResult},
     },
     execution::{self, AddressGenerator, Executor, MINT_NAME, POS_NAME},
@@ -193,29 +190,34 @@ where
             Rc::new(RefCell::new(generator))
         };
 
+        // Closure used to store a contract with no named keys and which does nothing.  Used in
+        // place of the mint and standard payment contracts when these system contracts aren't
+        // required (turbo mode).
+        let store_do_nothing_contract = || -> Result<URef, Error> {
+            let uref = {
+                let addr = address_generator.borrow_mut().create_address();
+                URef::new(addr, AccessRights::READ_ADD_WRITE)
+            };
+            let contract = {
+                let do_nothing = {
+                    let do_nothing_bytes = wasm::do_nothing_bytes();
+                    preprocessor.preprocess(&do_nothing_bytes)?
+                };
+                let bytes = parity_wasm::serialize(do_nothing).expect("failed to serialize");
+                Contract::new(bytes, BTreeMap::default(), protocol_version)
+            };
+            let key = Key::URef(uref);
+            let value = StoredValue::Contract(contract);
+            tracking_copy.borrow_mut().write(key, value);
+            Ok(uref)
+        };
+
         // Spec #5: Execute the wasm code from the mint installer bytes
         let mint_reference: URef = {
             let mint_installer_bytes = genesis_config.mint_installer_bytes();
 
             if self.config.turbo() && mint_installer_bytes.is_empty() {
-                let tracking_copy = Rc::clone(&tracking_copy);
-                let uref = {
-                    let address_generator = Rc::clone(&address_generator);
-                    let addr = address_generator.borrow_mut().create_address();
-                    URef::new(addr, AccessRights::READ_ADD_WRITE)
-                };
-                let contract = {
-                    let do_nothing = {
-                        let do_nothing_bytes = wasm::do_nothing_bytes();
-                        preprocessor.preprocess(&do_nothing_bytes)?
-                    };
-                    let bytes = parity_wasm::serialize(do_nothing).expect("failed to serialize");
-                    Contract::new(bytes, BTreeMap::default(), protocol_version)
-                };
-                let key = Key::URef(uref);
-                let value = StoredValue::Contract(contract);
-                tracking_copy.borrow_mut().write(key, value);
-                uref
+                store_do_nothing_contract()?
             } else {
                 let mint_installer_module = preprocessor.preprocess(mint_installer_bytes)?;
                 let args = Vec::new();
@@ -399,44 +401,49 @@ where
         );
 
         let standard_payment_reference: URef = {
-            let standard_payment_installer_bytes =
-                if genesis_config.standard_payment_installer_bytes().is_empty() {
-                    // TODO - remove this once Node has been updated to pass the required bytes
-                    include_bytes!(
+            let standard_payment_installer_bytes = if !self.config.turbo()
+                && genesis_config.standard_payment_installer_bytes().is_empty()
+            {
+                // TODO - remove this once Node has been updated to pass the required bytes
+                include_bytes!(
                     "../../../target/wasm32-unknown-unknown/release/standard_payment_install.wasm"
                 )
-                } else {
-                    genesis_config.standard_payment_installer_bytes()
-                };
+            } else {
+                genesis_config.standard_payment_installer_bytes()
+            };
 
-            let standard_payment_installer_module =
-                preprocessor.preprocess(standard_payment_installer_bytes)?;
-            let args = Vec::new();
-            let mut named_keys = BTreeMap::new();
-            let authorization_keys = BTreeSet::new();
-            let install_deploy_hash = install_deploy_hash.into();
-            let address_generator = Rc::clone(&address_generator);
-            let tracking_copy = Rc::clone(&tracking_copy);
-            let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
+            if self.config.turbo() && standard_payment_installer_bytes.is_empty() {
+                store_do_nothing_contract()?
+            } else {
+                let standard_payment_installer_module =
+                    preprocessor.preprocess(standard_payment_installer_bytes)?;
+                let args = Vec::new();
+                let mut named_keys = BTreeMap::new();
+                let authorization_keys = BTreeSet::new();
+                let install_deploy_hash = install_deploy_hash.into();
+                let address_generator = Rc::clone(&address_generator);
+                let tracking_copy = Rc::clone(&tracking_copy);
+                let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
 
-            executor.exec_system(
-                standard_payment_installer_module,
-                args,
-                &mut named_keys,
-                initial_base_key,
-                &virtual_system_account,
-                authorization_keys,
-                blocktime,
-                install_deploy_hash,
-                gas_limit,
-                address_generator,
-                protocol_version,
-                correlation_id,
-                tracking_copy,
-                phase,
-                protocol_data,
-                system_contract_cache,
-            )?
+                executor.exec_system(
+                    standard_payment_installer_module,
+                    args,
+                    &mut named_keys,
+                    initial_base_key,
+                    &virtual_system_account,
+                    authorization_keys,
+                    blocktime,
+                    install_deploy_hash,
+                    gas_limit,
+                    address_generator,
+                    protocol_version,
+                    correlation_id,
+                    tracking_copy,
+                    phase,
+                    protocol_data,
+                    system_contract_cache,
+                )?
+            }
         };
 
         // Spec #2: Associate given CostTable with given ProtocolVersion.
@@ -1203,6 +1210,7 @@ where
                     }
                     Err(_) => return Ok(ExecutionResult::precondition_failure(Error::Deploy)),
                 };
+                // If in turbo mode, the returned module is the "do_nothing" Wasm.
                 self.get_module_from_key(
                     Rc::clone(&tracking_copy),
                     standard_payment,
@@ -1229,22 +1237,65 @@ where
             let system_contract_cache = SystemContractCache::clone(&self.system_contract_cache);
 
             // payment_code_spec_2: execute payment code
-            executor.exec(
-                payment_module,
-                payment.take_args(),
-                address,
-                &account,
-                authorization_keys.clone(),
-                blocktime,
-                deploy_hash,
-                pay_gas_limit,
-                protocol_version,
-                correlation_id,
-                Rc::clone(&tracking_copy),
-                Phase::Payment,
-                protocol_data,
-                system_contract_cache,
-            )
+            let phase = Phase::Payment;
+            if self.config.turbo() && module_bytes_is_empty {
+                let mut named_keys = account.named_keys().clone();
+                let address_generator = AddressGenerator::new(&deploy_hash, phase);
+
+                let mut runtime = match executor.create_runtime(
+                    payment_module,
+                    payment.take_args(),
+                    &mut named_keys,
+                    address,
+                    &account,
+                    authorization_keys.clone(),
+                    blocktime,
+                    deploy_hash,
+                    pay_gas_limit,
+                    Rc::new(RefCell::new(address_generator)),
+                    protocol_version,
+                    correlation_id,
+                    Rc::clone(&tracking_copy),
+                    phase,
+                    protocol_data,
+                    system_contract_cache,
+                ) {
+                    Ok((_instance, runtime)) => runtime,
+                    Err(error) => {
+                        return Ok(ExecutionResult::precondition_failure(Error::Exec(error)))
+                    }
+                };
+
+                let effects_snapshot = tracking_copy.borrow().effect();
+                match runtime.call_host_standard_payment() {
+                    Ok(()) => ExecutionResult::Success {
+                        effect: runtime.context().effect(),
+                        cost: runtime.context().gas_counter(),
+                    },
+                    Err(error) => ExecutionResult::Failure {
+                        error: error.into(),
+                        effect: effects_snapshot,
+                        cost: runtime.context().gas_counter(),
+                    },
+                }
+            } else {
+                executor.exec(
+                    payment_module,
+                    payment.take_args(),
+                    address,
+                    &account,
+                    authorization_keys.clone(),
+                    blocktime,
+                    deploy_hash,
+                    pay_gas_limit,
+                    protocol_version,
+                    correlation_id,
+                    Rc::clone(&tracking_copy),
+                    phase,
+                    protocol_data,
+                    system_contract_cache,
+                )
+            }
         };
 
         let payment_result_cost = payment_result.cost();

--- a/execution-engine/engine-core/src/runtime/proof_of_stake_internal.rs
+++ b/execution-engine/engine-core/src/runtime/proof_of_stake_internal.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Write,
+};
 
 use engine_shared::stored_value::StoredValue;
 use engine_storage::global_state::StateReader;
@@ -11,7 +14,6 @@ use types::{
 };
 
 use crate::{execution, runtime::Runtime};
-use std::fmt::Write;
 
 const BONDING_KEY: u8 = 1;
 const UNBONDING_KEY: u8 = 2;

--- a/execution-engine/engine-core/src/runtime/standard_payment_internal.rs
+++ b/execution-engine/engine-core/src/runtime/standard_payment_internal.rs
@@ -1,0 +1,78 @@
+use lazy_static::lazy_static;
+
+use contract::args_parser::ArgsParser;
+use engine_shared::stored_value::StoredValue;
+use engine_storage::global_state::StateReader;
+use standard_payment::{AccountProvider, MintProvider, ProofOfStakeProvider, StandardPayment};
+use types::{bytesrepr::ToBytes, system_contract_errors, ApiError, Key, URef, U512};
+
+use crate::{execution, runtime::Runtime};
+
+lazy_static! {
+    static ref SERIALIZED_GET_PAYMENT_PURSE: Vec<u8> = ArgsParser::parse(("get_payment_purse",))
+        .expect("args should convert to `Vec<CLValue>`")
+        .into_bytes()
+        .expect("args should serialize");
+}
+
+impl<'a, R> AccountProvider for Runtime<'a, R>
+where
+    R: StateReader<Key, StoredValue>,
+    R::Error: Into<execution::Error>,
+{
+    fn get_main_purse(&self) -> Result<URef, ApiError> {
+        self.context
+            .get_main_purse()
+            .map_err(|_| ApiError::InvalidPurse)
+    }
+}
+
+impl<'a, R> MintProvider for Runtime<'a, R>
+where
+    R: StateReader<Key, StoredValue>,
+    R::Error: Into<execution::Error>,
+{
+    fn transfer_purse_to_purse(
+        &mut self,
+        source: URef,
+        target: URef,
+        amount: U512,
+    ) -> Result<(), ApiError> {
+        let mint_contract_key = Key::from(self.get_mint_contract_uref());
+        self.mint_transfer(mint_contract_key, source, target, amount)
+            .map_err(|error| match error {
+                execution::Error::SystemContract(system_contract_errors::Error::Mint(
+                    mint_error,
+                )) => ApiError::from(mint_error),
+                _ => ApiError::Unhandled,
+            })
+    }
+}
+
+impl<'a, R> ProofOfStakeProvider for Runtime<'a, R>
+where
+    R: StateReader<Key, StoredValue>,
+    R::Error: Into<execution::Error>,
+{
+    fn get_payment_purse(&mut self) -> Result<URef, ApiError> {
+        let pos_contract_key = Key::from(self.get_pos_contract_uref());
+
+        let cl_value = self
+            .call_contract(pos_contract_key, SERIALIZED_GET_PAYMENT_PURSE.clone())
+            .map_err(|_| {
+                ApiError::ProofOfStake(
+                    system_contract_errors::pos::Error::PaymentPurseNotFound as u8,
+                )
+            })?;
+
+        let payment_purse_ref: URef = cl_value.into_t()?;
+        Ok(payment_purse_ref)
+    }
+}
+
+impl<'a, R> StandardPayment for Runtime<'a, R>
+where
+    R: StateReader<Key, StoredValue>,
+    R::Error: Into<execution::Error>,
+{
+}

--- a/execution-engine/engine-test-support/src/internal/mod.rs
+++ b/execution-engine/engine-test-support/src/internal/mod.rs
@@ -52,16 +52,18 @@ lazy_static! {
     pub static ref DEFAULT_GENESIS_CONFIG: GenesisConfig = {
         let mint_installer_bytes;
         let pos_installer_bytes;
+        let standard_payment_installer_bytes;
         if cfg!(feature = "turbo") {
             mint_installer_bytes = Vec::new();
             pos_installer_bytes = Vec::new();
+            standard_payment_installer_bytes = Vec::new();
         } else {
             mint_installer_bytes = utils::read_wasm_file_bytes(MINT_INSTALL_CONTRACT);
             pos_installer_bytes = utils::read_wasm_file_bytes(POS_INSTALL_CONTRACT);
+            standard_payment_installer_bytes =
+                utils::read_wasm_file_bytes(STANDARD_PAYMENT_INSTALL_CONTRACT);
         };
-        // TODO - make this an empty vec for cfg!(feature = "turbo")
-        let standard_payment_installer_bytes =
-            utils::read_wasm_file_bytes(STANDARD_PAYMENT_INSTALL_CONTRACT);
+
         GenesisConfig::new(
             DEFAULT_CHAIN_NAME.to_string(),
             DEFAULT_GENESIS_TIMESTAMP,

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -55,8 +55,8 @@ use crate::internal::utils;
 
 /// LMDB initial map size is calculated based on DEFAULT_LMDB_PAGES and systems page size.
 ///
-/// This default value should give 1MiB initial map size by default.
-const DEFAULT_LMDB_PAGES: usize = 2560;
+/// This default value should give 50MiB initial map size by default.
+const DEFAULT_LMDB_PAGES: usize = 128_000;
 
 /// This is appended to the data dir path provided to the `LmdbWasmTestBuilder` in order to match
 /// the behavior of `get_data_dir()` in "engine-grpc-server/src/main.rs".

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -9,7 +9,7 @@ use engine_core::engine_state::EngineConfig;
 use engine_test_support::{
     internal::{
         DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_GENESIS_CONFIG,
-        DEFAULT_PAYMENT, STANDARD_PAYMENT_CONTRACT,
+        DEFAULT_PAYMENT,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
@@ -135,7 +135,7 @@ fn transfer_to_account_multiple_deploys(
     for i in 0..TRANSFER_BATCH_SIZE {
         let deploy = DeployItemBuilder::default()
             .with_address(DEFAULT_ACCOUNT_ADDR)
-            .with_payment_code(STANDARD_PAYMENT_CONTRACT, (U512::from(PER_RUN_FUNDING),))
+            .with_empty_payment_bytes((U512::from(PER_RUN_FUNDING),))
             .with_session_code(
                 CONTRACT_TRANSFER_TO_EXISTING_ACCOUNT,
                 (account, U512::one()),
@@ -189,7 +189,7 @@ fn transfer_to_purse_multiple_deploys(
     for i in 0..TRANSFER_BATCH_SIZE {
         let deploy = DeployItemBuilder::default()
             .with_address(TARGET_ADDR)
-            .with_payment_code(STANDARD_PAYMENT_CONTRACT, (U512::from(PER_RUN_FUNDING),))
+            .with_empty_payment_bytes((U512::from(PER_RUN_FUNDING),))
             .with_session_code(CONTRACT_TRANSFER_TO_PURSE, (purse, U512::one()))
             .with_authorization_keys(&[TARGET_ADDR])
             .with_deploy_hash(make_deploy_hash(i)) // deploy_hash

--- a/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
@@ -66,6 +66,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
     );
 }
 
+#[cfg(not(feature = "turbo"))]
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
@@ -134,6 +135,7 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
     );
 }
 
+#[cfg(not(feature = "turbo"))]
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_error_when_out_of_gas() {

--- a/execution-engine/proof-of-stake/src/lib.rs
+++ b/execution-engine/proof-of-stake/src/lib.rs
@@ -219,7 +219,7 @@ mod internal {
             })
     }
 
-    /// Returns the purse for accepting payment for tranasactions.
+    /// Returns the purse for accepting payment for transactions.
     pub fn get_payment_purse<R: RuntimeProvider>(runtime_provider: &R) -> Result<URef> {
         get_purse::<R>(runtime_provider, PAYMENT_PURSE_KEY).map_err(PurseLookupError::payment)
     }

--- a/execution-engine/standard-payment/Cargo.toml
+++ b/execution-engine/standard-payment/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "casperlabs-standard-payment"
+version = "0.1.0"
+authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
+edition = "2018"
+
+[features]
+std = []
+
+[dependencies]
+types = { path = "../types", package = "casperlabs-types" }

--- a/execution-engine/standard-payment/src/account_provider.rs
+++ b/execution-engine/standard-payment/src/account_provider.rs
@@ -1,0 +1,5 @@
+use types::{ApiError, URef};
+
+pub trait AccountProvider {
+    fn get_main_purse(&self) -> Result<URef, ApiError>;
+}

--- a/execution-engine/standard-payment/src/lib.rs
+++ b/execution-engine/standard-payment/src/lib.rs
@@ -1,0 +1,23 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+mod account_provider;
+mod mint_provider;
+mod proof_of_stake_provider;
+
+use core::marker::Sized;
+
+use types::{ApiError, U512};
+
+pub use crate::{
+    account_provider::AccountProvider, mint_provider::MintProvider,
+    proof_of_stake_provider::ProofOfStakeProvider,
+};
+
+pub trait StandardPayment: AccountProvider + MintProvider + ProofOfStakeProvider + Sized {
+    fn pay(&mut self, amount: U512) -> Result<(), ApiError> {
+        let main_purse = self.get_main_purse()?;
+        let payment_purse = self.get_payment_purse()?;
+        self.transfer_purse_to_purse(main_purse, payment_purse, amount)
+            .map_err(|_| ApiError::Transfer)
+    }
+}

--- a/execution-engine/standard-payment/src/mint_provider.rs
+++ b/execution-engine/standard-payment/src/mint_provider.rs
@@ -1,0 +1,10 @@
+use types::{ApiError, URef, U512};
+
+pub trait MintProvider {
+    fn transfer_purse_to_purse(
+        &mut self,
+        source: URef,
+        target: URef,
+        amount: U512,
+    ) -> Result<(), ApiError>;
+}

--- a/execution-engine/standard-payment/src/proof_of_stake_provider.rs
+++ b/execution-engine/standard-payment/src/proof_of_stake_provider.rs
@@ -1,0 +1,5 @@
+use types::{ApiError, URef};
+
+pub trait ProofOfStakeProvider {
+    fn get_payment_purse(&mut self) -> Result<URef, ApiError>;
+}


### PR DESCRIPTION
### Overview
This implements host-side logic to replace execution of the standard payment contract when running in turbo mode.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-904

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Two tests were disabled in turbo mode for this PR (    `should_raise_insufficient_payment_error_when_out_of_gas` and `should_raise_insufficient_payment_when_payment_code_does_not_pay_enough`).  These both fail since executing the host-side standard payment logic incurs no gas costs.

We could consider adding a nominal amount to charge for executing host-side standard payment logic which would then keep the two flows more similar.  For example, we could define `const TURBO_PAYMENT_COST: u64 = 193_278;` which for me is the current cost of executing the actual standard payment contract.  If we do this, then these two tests can be re-enabled.