### PR TITLE
NODE-1275: Add build-client, build-node and build-python-client to (default) target all in main Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ all: \
 	docker-build-all \
 	cargo-package-all \
     build-client \
-    build-node
+    build-node \
+    build-python-client \
 
 # Push the local artifacts to repositories.
 publish: docker-push-all
@@ -299,6 +300,9 @@ explorer/contracts/%.wasm: .make/contracts/%
 
 build-client: \
 	.make/sbt-stage/client
+
+build-python-client:
+	integration-testing/client/CasperLabsClient/build.sh
 
 build-client-contracts: \
 	client/src/main/resources/bonding.wasm \

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ $(eval DOCKER_TEST_TAG = $(shell if [ -z ${DRONE_BUILD_NUMBER} ]; then echo test
 all: \
 	docker-build-all \
 	cargo-package-all \
-    build-client \
-    build-node \
-    build-python-client \
+	build-client \
+	build-node \
+	build-python-client 
+
 
 # Push the local artifacts to repositories.
 publish: docker-push-all
@@ -301,7 +302,8 @@ explorer/contracts/%.wasm: .make/contracts/%
 build-client: \
 	.make/sbt-stage/client
 
-build-python-client: build-client-contracts \
+build-python-client: 
+	build-client-contracts \
 	$(shell find ./protobuf) \
 	$(shell find ./integration-testing/client/CasperLabsClient/ -name "*.py"|grep -v _grpc.py)
 	cd integration-testing && pipenv run client/CasperLabsClient/build.sh

--- a/Makefile
+++ b/Makefile
@@ -301,8 +301,10 @@ explorer/contracts/%.wasm: .make/contracts/%
 build-client: \
 	.make/sbt-stage/client
 
-build-python-client:
-	integration-testing/client/CasperLabsClient/build.sh
+build-python-client: build-client-contracts \
+	$(shell find ./protobuf) \
+	$(shell find ./integration-testing/client/CasperLabsClient/ -name "*.py"|grep -v _grpc.py)
+	cd integration-testing && pipenv run client/CasperLabsClient/build.sh
 
 build-client-contracts: \
 	client/src/main/resources/bonding.wasm \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,9 @@ $(eval DOCKER_TEST_TAG = $(shell if [ -z ${DRONE_BUILD_NUMBER} ]; then echo test
 # Build all artifacts locally.
 all: \
 	docker-build-all \
-	cargo-package-all
+	cargo-package-all \
+    build-client \
+    build-node
 
 # Push the local artifacts to repositories.
 publish: docker-push-all

--- a/Makefile
+++ b/Makefile
@@ -304,7 +304,7 @@ build-client: \
 
 build-python-client: 
 	build-client-contracts \
-	$(shell find ./protobuf) \
+	$(PROTO_SRC) \
 	$(shell find ./integration-testing/client/CasperLabsClient/ -name "*.py"|grep -v _grpc.py)
 	cd integration-testing && pipenv run client/CasperLabsClient/build.sh
 

--- a/integration-testing/client/CasperLabsClient/build.sh
+++ b/integration-testing/client/CasperLabsClient/build.sh
@@ -7,4 +7,4 @@ cd ${DIR}
 
 rm -rf dist/*
 python setup.py sdist
-pip install dist/casperlabs_client-*
+# pip install dist/casperlabs_client-*

--- a/integration-testing/client/CasperLabsClient/install.sh
+++ b/integration-testing/client/CasperLabsClient/install.sh
@@ -5,5 +5,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd ${DIR}
 
-rm -rf dist/*
-python setup.py sdist
+pip install dist/casperlabs_client-*

--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -21,6 +21,7 @@ fi
 
 pip install pipenv
 pipenv sync
+pipenv run client/CasperLabsClient/build.sh
 pipenv run client/CasperLabsClient/install.sh
 
 # Cannot get the quoted -k arguments passed in via variable replacement.


### PR DESCRIPTION
### Overview
Fix Makefile and add build-client and build-node to the default target all.
Also, add new target build-python-client.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1275

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
