### PR TITLE
EE-908: Add a keys iterator that takes a prefix argument

### DIFF
--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -877,6 +877,57 @@ impl<E> From<E> for KeysWithPrefixError<E> {
     }
 }
 
+impl<E> PartialEq for KeysWithPrefixError<E>
+where
+    E: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (KeysWithPrefixError::HashNotFound(h1), KeysWithPrefixError::HashNotFound(h2)) => {
+                h1 == h2
+            }
+            (
+                KeysWithPrefixError::PrefixRootNotFound(pfx1),
+                KeysWithPrefixError::PrefixRootNotFound(pfx2),
+            ) => pfx1 == pfx2,
+            (
+                KeysWithPrefixError::LeafNotMatchingPrefix {
+                    pfx: pfx1,
+                    key: key1,
+                },
+                KeysWithPrefixError::LeafNotMatchingPrefix {
+                    pfx: pfx2,
+                    key: key2,
+                },
+            ) => pfx1 == pfx2 && key1 == key2,
+            (KeysWithPrefixError::Store(err1), KeysWithPrefixError::Store(err2)) => err1 == err2,
+            _ => false,
+        }
+    }
+}
+
+impl<E> std::fmt::Debug for KeysWithPrefixError<E>
+where
+    E: std::fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            KeysWithPrefixError::HashNotFound(hash) => {
+                write!(formatter, "HashNotFound({:?})", hash)
+            }
+            KeysWithPrefixError::PrefixRootNotFound(pfx) => {
+                write!(formatter, "PrefixRootNotFound({:?})", pfx)
+            }
+            KeysWithPrefixError::LeafNotMatchingPrefix { pfx, key } => write!(
+                formatter,
+                "LeafNotMatchingPrefix {{ pfx: {:?}, key: {:?} }}",
+                pfx, key
+            ),
+            KeysWithPrefixError::Store(err) => write!(formatter, "Store({:?})", err),
+        }
+    }
+}
+
 /// Get the hash of the node that is the root of the subtrie matching the `prefix`
 fn get_prefix_root<'a, 'b, K, V, T, S>(
     _correlation_id: CorrelationId,

--- a/execution-engine/engine-storage/src/trie_store/operations/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/mod.rs
@@ -945,14 +945,14 @@ where
 {
     let mut traversed_prefix = vec![];
     let mut current_root = *root;
-    while prefix.len() > 0 {
+    while !prefix.is_empty() {
         match store.get(txn, &current_root)? {
             None => {
                 return Err(KeysWithPrefixError::HashNotFound(current_root));
             }
             Some(Trie::Leaf { key, .. }) => {
                 traversed_prefix.extend(prefix);
-                let key_bytes = key.to_bytes().map_err(|err| S::Error::from(err))?;
+                let key_bytes = key.to_bytes().map_err(S::Error::from)?;
                 if key_bytes.starts_with(&traversed_prefix) {
                     // the leaf is the root of the subtrie
                     return Ok((traversed_prefix, current_root));

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/keys.rs
@@ -7,8 +7,8 @@ mod partial_tries {
         trie_store::operations::{
             self,
             tests::{
-                InMemoryTestContext, LmdbTestContext, TestKey, TestValue, TEST_LEAVES,
-                TEST_LEAVES_PREFIXES, TEST_TRIE_GENERATORS,
+                InMemoryTestContext, LmdbTestContext, PrefixTestSpec, TestKey, TestValue,
+                TEST_LEAVES, TEST_LEAVES_PREFIXES, TEST_TRIE_GENERATORS,
             },
             KeysWithPrefixError,
         },
@@ -84,7 +84,11 @@ mod partial_tries {
             };
             assert_eq!(actual, expected);
 
-            for (prefix, expected_result) in TEST_LEAVES_PREFIXES.iter() {
+            for PrefixTestSpec {
+                prefix,
+                expected_result,
+            } in TEST_LEAVES_PREFIXES.iter()
+            {
                 let expected = expected_result.as_ref().map(|_| {
                     let mut tmp = used
                         .iter()

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -7,6 +7,7 @@ mod write;
 
 use std::{collections::HashMap, convert};
 
+use lazy_static::lazy_static;
 use lmdb::DatabaseFlags;
 use tempfile::{tempdir, TempDir};
 
@@ -24,7 +25,7 @@ use crate::{
         self,
         in_memory::InMemoryTrieStore,
         lmdb::LmdbTrieStore,
-        operations::{self, read, write, ReadResult, WriteResult},
+        operations::{self, read, write, KeysWithPrefixError, ReadResult, WriteResult},
         TrieStore,
     },
     TEST_MAP_SIZE,
@@ -123,6 +124,20 @@ const TEST_LEAVES: [TestTrie; TEST_LEAVES_LENGTH] = [
         value: TestValue(*b"value5"),
     },
 ];
+
+lazy_static! {
+    static ref TEST_LEAVES_PREFIXES: [(
+        &'static [u8],
+        Result<(), KeysWithPrefixError<error::in_memory::Error>>,
+    ); 3] = [
+        (&[0; 4], Ok(())),
+        (&[1], Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))),
+        (
+            &[1, 5, 4],
+            Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))
+        ),
+    ];
+}
 
 const TEST_LEAVES_UPDATED: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -125,17 +125,25 @@ const TEST_LEAVES: [TestTrie; TEST_LEAVES_LENGTH] = [
     },
 ];
 
+struct PrefixTestSpec {
+    pub prefix: &'static [u8],
+    pub expected_result: Result<(), KeysWithPrefixError<error::in_memory::Error>>,
+}
+
 lazy_static! {
-    static ref TEST_LEAVES_PREFIXES: [(
-        &'static [u8],
-        Result<(), KeysWithPrefixError<error::in_memory::Error>>,
-    ); 3] = [
-        (&[0; 4], Ok(())),
-        (&[1], Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))),
-        (
-            &[1, 5, 4],
-            Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))
-        ),
+    static ref TEST_LEAVES_PREFIXES: [PrefixTestSpec; 3] = [
+        PrefixTestSpec {
+            prefix: &[0; 4],
+            expected_result: Ok(())
+        },
+        PrefixTestSpec {
+            prefix: &[1],
+            expected_result: Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))
+        },
+        PrefixTestSpec {
+            prefix: &[1, 5, 4],
+            expected_result: Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))
+        },
     ];
 }
 

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -7,7 +7,6 @@ mod write;
 
 use std::{collections::HashMap, convert};
 
-use lazy_static::lazy_static;
 use lmdb::DatabaseFlags;
 use tempfile::{tempdir, TempDir};
 
@@ -25,7 +24,7 @@ use crate::{
         self,
         in_memory::InMemoryTrieStore,
         lmdb::LmdbTrieStore,
-        operations::{self, read, write, KeysWithPrefixError, ReadResult, WriteResult},
+        operations::{self, read, write, ReadResult, WriteResult},
         TrieStore,
     },
     TEST_MAP_SIZE,
@@ -125,27 +124,7 @@ const TEST_LEAVES: [TestTrie; TEST_LEAVES_LENGTH] = [
     },
 ];
 
-struct PrefixTestSpec {
-    pub prefix: &'static [u8],
-    pub expected_result: Result<(), KeysWithPrefixError<error::in_memory::Error>>,
-}
-
-lazy_static! {
-    static ref TEST_LEAVES_PREFIXES: [PrefixTestSpec; 3] = [
-        PrefixTestSpec {
-            prefix: &[0; 4],
-            expected_result: Ok(())
-        },
-        PrefixTestSpec {
-            prefix: &[1],
-            expected_result: Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))
-        },
-        PrefixTestSpec {
-            prefix: &[1, 5, 4],
-            expected_result: Err(KeysWithPrefixError::PrefixRootNotFound(vec![1]))
-        },
-    ];
-}
+const TEST_LEAVES_PREFIXES: [&[u8]; 3] = [&[0; 4], &[1], &[1, 5, 4]];
 
 const TEST_LEAVES_UPDATED: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -124,8 +124,6 @@ const TEST_LEAVES: [TestTrie; TEST_LEAVES_LENGTH] = [
     },
 ];
 
-const TEST_LEAVES_PREFIXES: [&[u8]; 3] = [&[0; 4], &[1], &[1, 5, 4]];
-
 const TEST_LEAVES_UPDATED: [TestTrie; TEST_LEAVES_LENGTH] = [
     Trie::Leaf {
         key: TestKey([0u8, 0, 0, 0, 0, 0, 0]),


### PR DESCRIPTION
### Overview
This PR adds a `keys_with_prefix` function that allows iterating over keys in a sub-trie defined by a common prefix. This will be useful for iterating over local keys.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-908

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The assertions in the tests are a bit ugly due to issues with the types and the borrow checker. I couldn't figure out how to make them prettier, but I'll welcome any suggestions in this regard.
