### PR TITLE
NODE-1276: hack/docker multi bootstrap

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -20,10 +20,15 @@ clean: down $(shell find . -type d -name "node-*" | grep -v .casperlabs | grep -
 node-%: .casperlabs
 	$(eval N = $*)
 	$(eval ENV = node-$(N)/.env)
+
+	@# Collect existing nodes before making the newest one. We'll bootstrap from them.
+	$(eval NODES = $(shell find . -maxdepth 1 -type d -name "node-*" | sed 's/.\///'))
+
 	mkdir node-$(N)
 
 	@# Create an .env file to hold template variables for docker-compose.
 	echo NODE_NUMBER=$(N) >> $(ENV)
+	echo BOOTSTRAP_HOSTNAMES=$(NODES) >> $(ENV)
 
 	# Set default env values. Create overrides with `export CL_<name>=<value>` before running `make node-X/up` commands,
 	# or override them for individual nodes e.g. `CL_VERSION=0.1.2 make node-0/up`

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -121,7 +121,7 @@ slow:
 
 # Generate keys and bonds.
 .casperlabs:
-	mkdir -p .casperlabs/bootstrap
+	mkdir -p .casperlabs/nodes
 	mkdir -p .casperlabs/chainspec/genesis
 
 	@# Create a `facet-account` to hold some initial tokens to distribute.
@@ -132,21 +132,17 @@ slow:
 	@# Create bonded validators with 0 balance.
 	bash -c 'i=0 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \
 		echo Generating validator $$i / $(CL_CASPER_NUM_VALIDATORS) ; \
-		mkdir -p .casperlabs/node-$$i ; \
+		mkdir -p .casperlabs/nodes/node-$$i ; \
 		mkdir -p keys/account-$$i ; \
-		../key-management/docker-gen-keys.sh .casperlabs/node-$$i ; \
+		../key-management/docker-gen-keys.sh .casperlabs/nodes/node-$$i ; \
 		../key-management/docker-gen-account-keys.sh keys/account-$$i ; \
 		BOND=$$(( $(CL_CASPER_NUM_VALIDATORS)*10+$$i )) ; \
-		(cat .casperlabs/node-$$i/validator-id; echo ",0,$$BOND") >> .casperlabs/chainspec/genesis/accounts.csv ; \
+		(cat .casperlabs/nodes/node-$$i/validator-id; echo ",0,$$BOND") >> .casperlabs/chainspec/genesis/accounts.csv ; \
 		((i = i + 1)) ; \
 	done'
 
-	@# Copy the bootstrap node to a place where every node can read it from.
-	cp -r .casperlabs/node-0/node-id .casperlabs/bootstrap/node-id
-
 	@# Check that the files we wanted exist and aren't empty.
 	[ -s .casperlabs/chainspec/genesis/accounts.csv ]
-	[ -s .casperlabs/bootstrap/node-id ]
 
 
 # Create common Highway environment overrides for the chainspec defaults,

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -154,7 +154,7 @@ for example:
 ```bash
 # Get the node-id for TLS.
 NODE=0
-NODE_ID=$(cat $DIR/.casperlabs/node-$NODE/node-id)
+NODE_ID=$(cat $DIR/.casperlabs/nodes/node-$NODE/node-id)
 casperlabs-client --host localhost --port 404${NODE}1 --node-id $NODE_ID show-blocks --depth 10
 ```
 

--- a/hack/docker/template/docker-compose.yml
+++ b/hack/docker/template/docker-compose.yml
@@ -36,10 +36,10 @@ services:
       - socketvolume:/root/.casperlabs/sockets
       # Common bonds file
       - $PWD/../.casperlabs/chainspec:/root/.casperlabs/chainspec
-      # Bootstrap node ID
-      - $PWD/../.casperlabs/bootstrap:/root/.casperlabs/bootstrap
+      # Bootstrap node IDs
+      - $PWD/../.casperlabs/nodes:/root/.casperlabs/nodes
       # Node keys
-      - $PWD/../.casperlabs/node-${NODE_NUMBER}:/root/.casperlabs/node
+      - $PWD/../.casperlabs/nodes/node-${NODE_NUMBER}:/root/.casperlabs/node
       - $PWD/../template/start-node.sh:/opt/docker/start-node.sh
       # Make logs available in JSON, stack traces are only available there.
       - $PWD/logs:/var/logs/casperlabs
@@ -47,7 +47,6 @@ services:
       - casperlabs
     environment:
       HOME: /root
-      BOOTSTRAP_HOSTNAME: node-0
       CL_GRPC_SOCKET: /root/.casperlabs/sockets/.casper-node.sock
       CL_SERVER_RELAY_FACTOR: 1
       CL_SERVER_NO_UPNP: "true"
@@ -59,6 +58,7 @@ services:
       CL_TLS_API_KEY: /root/.casperlabs/node/node.key.pem
       CL_GRPC_USE_TLS: "false"
       CL_METRICS_PROMETHEUS: "true"
+      CL_SERVER_ALIVE_PEERS_CACHE_EXPIRATION_PERIOD: 15second
       # TODO: The log written is owned by root, can't remove.
       CL_LOG_JSON_PATH: /var/logs/casperlabs
     env_file:

--- a/hack/docker/template/docker-compose.yml
+++ b/hack/docker/template/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - casperlabs
     environment:
       HOME: /root
+      BOOTSTRAP_HOSTNAMES: ${BOOTSTRAP_HOSTNAMES}
       CL_GRPC_SOCKET: /root/.casperlabs/sockets/.casper-node.sock
       CL_SERVER_RELAY_FACTOR: 1
       CL_SERVER_NO_UPNP: "true"
@@ -59,7 +60,6 @@ services:
       CL_GRPC_USE_TLS: "false"
       CL_METRICS_PROMETHEUS: "true"
       CL_SERVER_ALIVE_PEERS_CACHE_EXPIRATION_PERIOD: 15second
-      # TODO: The log written is owned by root, can't remove.
       CL_LOG_JSON_PATH: /var/logs/casperlabs
     env_file:
       - .env

--- a/hack/docker/template/start-node.sh
+++ b/hack/docker/template/start-node.sh
@@ -3,21 +3,23 @@
 set -e
 
 CL_SERVER_BOOTSTRAP=${CL_SERVER_BOOTSTRAP:-""}
+BOOTSTRAP_HOSTNAMES=${BOOTSTRAP_HOSTNAMES:-""}
 
 # Unless specified, connect to each other node, so there's no specific bootstrap,
 # therefore we can restart any node without worrying that it will not try to reconnect.
 if [ -z "$CL_SERVER_BOOTSTRAP" ]; then
-    cd $HOME/.casperlabs/nodes
-    while read -r BOOTSTRAP_HOSTNAME ; do
+    for BOOTSTRAP_HOSTNAME in $BOOTSTRAP_HOSTNAMES; do
         if [ "$BOOTSTRAP_HOSTNAME" != "$HOSTNAME" ]; then
-            BOOTSTRAP_ID=$(cat $BOOTSTRAP_HOSTNAME/node-id)
+            BOOTSTRAP_ID=$(cat $HOME/.casperlabs/nodes/$BOOTSTRAP_HOSTNAME/node-id)
             BOOTSTRAP="casperlabs://${BOOTSTRAP_ID}@${BOOTSTRAP_HOSTNAME}?protocol=40400&discovery=40404"
             export CL_SERVER_BOOTSTRAP="$BOOTSTRAP $CL_SERVER_BOOTSTRAP"
+            export CL_CASPER_STANDALONE=false
         fi
-    done < <(ls)
-    cd -
+    done
+else
+    export CL_CASPER_STANDALONE=false
 fi
 
-echo CL_SERVER_BOOTSTRAP = $CL_SERVER_BOOTSTRAP
+export CL_CASPER_STANDALONE=${CL_CASPER_STANDALONE:-true}
 
 exec /usr/bin/casperlabs-node run --server-host $HOSTNAME

--- a/hack/docker/template/start-node.sh
+++ b/hack/docker/template/start-node.sh
@@ -2,14 +2,22 @@
 
 set -e
 
-if [ "$HOSTNAME" = "$BOOTSTRAP_HOSTNAME" ]; then
-    # Start the bootstrap node with a fixed key to get a deterministic ID.
-    exec /usr/bin/casperlabs-node run -s \
-        --server-host $HOSTNAME
-else
-    # Connect to the bootstrap node.
-    BOOTSTRAP_ID=$(cat $HOME/.casperlabs/bootstrap/node-id)
-    exec /usr/bin/casperlabs-node run \
-        --server-host $HOSTNAME \
-        --server-bootstrap "casperlabs://${BOOTSTRAP_ID}@${BOOTSTRAP_HOSTNAME}?protocol=40400&discovery=40404"
+CL_SERVER_BOOTSTRAP=${CL_SERVER_BOOTSTRAP:-""}
+
+# Unless specified, connect to each other node, so there's no specific bootstrap,
+# therefore we can restart any node without worrying that it will not try to reconnect.
+if [ -z "$CL_SERVER_BOOTSTRAP" ]; then
+    cd $HOME/.casperlabs/nodes
+    while read -r BOOTSTRAP_HOSTNAME ; do
+        if [ "$BOOTSTRAP_HOSTNAME" != "$HOSTNAME" ]; then
+            BOOTSTRAP_ID=$(cat $BOOTSTRAP_HOSTNAME/node-id)
+            BOOTSTRAP="casperlabs://${BOOTSTRAP_ID}@${BOOTSTRAP_HOSTNAME}?protocol=40400&discovery=40404"
+            export CL_SERVER_BOOTSTRAP="$BOOTSTRAP $CL_SERVER_BOOTSTRAP"
+        fi
+    done < <(ls)
+    cd -
 fi
+
+echo CL_SERVER_BOOTSTRAP = $CL_SERVER_BOOTSTRAP
+
+exec /usr/bin/casperlabs-node run --server-host $HOSTNAME

--- a/hack/docker/template/start-node.sh
+++ b/hack/docker/template/start-node.sh
@@ -2,23 +2,17 @@
 
 set -e
 
-CL_SERVER_BOOTSTRAP=${CL_SERVER_BOOTSTRAP:-""}
+export CL_SERVER_BOOTSTRAP=""
 BOOTSTRAP_HOSTNAMES=${BOOTSTRAP_HOSTNAMES:-""}
 
-# Unless specified, connect to each other node, so there's no specific bootstrap,
-# therefore we can restart any node without worrying that it will not try to reconnect.
-if [ -z "$CL_SERVER_BOOTSTRAP" ]; then
-    for BOOTSTRAP_HOSTNAME in $BOOTSTRAP_HOSTNAMES; do
-        if [ "$BOOTSTRAP_HOSTNAME" != "$HOSTNAME" ]; then
-            BOOTSTRAP_ID=$(cat $HOME/.casperlabs/nodes/$BOOTSTRAP_HOSTNAME/node-id)
-            BOOTSTRAP="casperlabs://${BOOTSTRAP_ID}@${BOOTSTRAP_HOSTNAME}?protocol=40400&discovery=40404"
-            export CL_SERVER_BOOTSTRAP="$BOOTSTRAP $CL_SERVER_BOOTSTRAP"
-            export CL_CASPER_STANDALONE=false
-        fi
-    done
-else
-    export CL_CASPER_STANDALONE=false
-fi
+for BOOTSTRAP_HOSTNAME in $BOOTSTRAP_HOSTNAMES; do
+    if [ "$BOOTSTRAP_HOSTNAME" != "$HOSTNAME" ]; then
+        BOOTSTRAP_ID=$(cat $HOME/.casperlabs/nodes/$BOOTSTRAP_HOSTNAME/node-id)
+        BOOTSTRAP="casperlabs://${BOOTSTRAP_ID}@${BOOTSTRAP_HOSTNAME}?protocol=40400&discovery=40404"
+        export CL_SERVER_BOOTSTRAP="$BOOTSTRAP $CL_SERVER_BOOTSTRAP"
+        export CL_CASPER_STANDALONE=false
+    fi
+done
 
 export CL_CASPER_STANDALONE=${CL_CASPER_STANDALONE:-true}
 

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -68,7 +68,7 @@ approval-relay-factor = 10
 approval-poll-interval = "30second"
 
 # Time to cache live peers for and to ban unresponsive ones.
-alive-peers-cache-expiration-period = "5minute"
+alive-peers-cache-expiration-period = "1minute"
 
 # Maximum DAG depth to allow when syncing after a new block notification.
 sync-max-possible-depth = 1000


### PR DESCRIPTION
### Overview
Currently every node bootstrapped from `node-0`, which had the unfortunate effect that if we destroyed and recreated `node-0` itself, it didn't try to rejoin the network.

The PR changes this so that the bootstrap nodes depend on the order of creation: node N bootstraps from node 0, 1, ... N-1. This is determined when the `node-$i` directory is created, so if later we do a `make node-0/down` followed by `make node-0/up` then `node-0` will at that point bootstrap from `node-1` and `node-2`, but by default it will start in standalone mode.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1276

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
