### PR TITLE
NO-TICKET: transfer stored U512

### DIFF
--- a/execution-engine/contracts/client/transfer-to-account-u512-stored/Cargo.toml
+++ b/execution-engine/contracts/client/transfer-to-account-u512-stored/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
-name = "transfer-to-account-u512"
+name = "transfer-to-account-u512-stored"
 version = "0.1.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 
 [lib]
-crate-type = ["lib", "cdylib"]
+crate-type = ["cdylib"]
 bench = false
 doctest = false
 test = false
 
 [features]
 std = ["contract/std", "types/std"]
-lib = []
 
 [dependencies]
 contract = { path = "../../../contract", package = "casperlabs-contract" }
+transfer-to-account = { path = "../transfer-to-account-u512", package = "transfer-to-account-u512",  default-features = false, features = ["lib"] }
 types = { path = "../../../types", package = "casperlabs-types" }

--- a/execution-engine/contracts/client/transfer-to-account-u512-stored/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account-u512-stored/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, string::String};
+
+use contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use types::{ApiError, Key};
+
+const CONTRACT_NAME: &str = "transfer_to_account";
+const DESTINATION_HASH: &str = "hash";
+const DESTINATION_UREF: &str = "uref";
+const FUNCTION_NAME: &str = "transfer";
+
+enum Arg {
+    Destination = 0,
+}
+
+#[repr(u16)]
+enum Error {
+    UnknownDestination = 1,
+}
+
+#[no_mangle]
+pub extern "C" fn transfer() {
+    transfer_to_account::delegate();
+}
+
+fn store_at_hash() -> Key {
+    let named_keys: BTreeMap<String, Key> = BTreeMap::new();
+    let pointer = storage::store_function_at_hash(FUNCTION_NAME, named_keys);
+    pointer.into()
+}
+
+fn store_at_uref() -> Key {
+    let named_keys: BTreeMap<String, Key> = BTreeMap::new();
+    storage::store_function(FUNCTION_NAME, named_keys)
+        .into_uref()
+        .unwrap_or_revert_with(ApiError::UnexpectedContractRefVariant)
+        .into()
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let destination: String = runtime::get_arg(Arg::Destination as u32)
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
+
+    let key = match destination.as_str() {
+        DESTINATION_HASH => store_at_hash(),
+        DESTINATION_UREF => store_at_uref(),
+        _ => runtime::revert(ApiError::User(Error::UnknownDestination as u16)),
+    };
+    runtime::put_key(CONTRACT_NAME, key);
+}

--- a/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
@@ -23,7 +23,7 @@ enum CustomError {
 /// Executes mote transfer to supplied public key.
 /// Transfers the requested amount.
 #[no_mangle]
-pub extern "C" fn call() {
+pub fn delegate() {
     let public_key: PublicKey = runtime::get_arg(Args::AccountPublicKey as u32)
         .unwrap_or_revert_with(ApiError::User(CustomError::MissingAccountPublicKey as u16))
         .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAccountPublicKey as u16));
@@ -31,4 +31,10 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::User(CustomError::MissingAmount as u16))
         .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAmount as u16));
     system::transfer_to_account(public_key, transfer_amount).unwrap_or_revert();
+}
+
+#[cfg(not(feature = "lib"))]
+#[no_mangle]
+pub extern "C" fn call() {
+    delegate();
 }

--- a/execution-engine/engine-tests/src/test/contract_api/mod.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/mod.rs
@@ -14,3 +14,4 @@ mod transfer;
 mod transfer_purse_to_account;
 mod transfer_purse_to_purse;
 mod transfer_stored;
+mod transfer_u512_stored;

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_u512_stored.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_u512_stored.rs
@@ -87,10 +87,8 @@ fn should_transfer_to_account_stored() {
     let gas = result.cost();
     let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
-    let tally = motes_alpha.value()
-        + motes_bravo.value()
-        + U512::from(transferred_amount)
-        + modified_balance_bravo;
+    let tally =
+        motes_alpha.value() + motes_bravo.value() + transferred_amount + modified_balance_bravo;
 
     assert!(
         modified_balance_alpha < initial_balance,

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_u512_stored.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_u512_stored.rs
@@ -1,0 +1,109 @@
+use engine_core::engine_state::CONV_RATE;
+use engine_shared::motes::Motes;
+use engine_test_support::{
+    internal::{
+        utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
+        DEFAULT_ACCOUNT_KEY, DEFAULT_GENESIS_CONFIG,
+    },
+    DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
+};
+use types::{account::PublicKey, U512};
+
+const CONTRACT_KEY_NAME: &str = "transfer_to_account";
+const CONTRACT_TRANSFER_TO_ACCOUNT_NAME: &str = "transfer_to_account_u512";
+const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";
+const STORE_AT_HASH: &str = "hash";
+const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const TRANSFER_AMOUNT: u64 = 1;
+
+#[ignore]
+#[test]
+fn should_transfer_to_account_stored() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+    {
+        // first, store transfer contract
+        let exec_request = ExecuteRequestBuilder::standard(
+            DEFAULT_ACCOUNT_ADDR,
+            &format!("{}_stored.wasm", CONTRACT_TRANSFER_TO_ACCOUNT_NAME),
+            (STORE_AT_HASH.to_string(),),
+        )
+        .build();
+        builder.run_genesis(&*DEFAULT_GENESIS_CONFIG);
+        builder.exec_commit_finish(exec_request);
+    }
+
+    let default_account = builder
+        .get_account(DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+
+    let contract_hash = default_account
+        .named_keys()
+        .get(CONTRACT_KEY_NAME)
+        .expect("contract_hash should exist")
+        .into_hash()
+        .expect("should be a hash");
+
+    let response = builder
+        .get_exec_response(0)
+        .expect("there should be a response")
+        .clone();
+    let mut result = utils::get_success_result(&response);
+    let gas = result.cost();
+    let motes_alpha = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
+
+    let modified_balance_alpha: U512 = builder.get_purse_balance(default_account.main_purse());
+
+    let transferred_amount: U512 = U512::from(TRANSFER_AMOUNT);
+    let payment_purse_amount = 10_000_000;
+
+    // next make another deploy that USES stored payment logic
+    let exec_request = {
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_session_hash(contract_hash.to_vec(), (ACCOUNT_1_ADDR, transferred_amount))
+            .with_payment_code(
+                &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
+                (U512::from(payment_purse_amount),),
+            )
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
+            .with_deploy_hash([2; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec_commit_finish(exec_request);
+
+    let modified_balance_bravo: U512 = builder.get_purse_balance(default_account.main_purse());
+
+    let initial_balance: U512 = U512::from(DEFAULT_ACCOUNT_INITIAL_BALANCE);
+
+    let response = builder
+        .get_exec_response(1)
+        .expect("there should be a response")
+        .clone();
+
+    result = utils::get_success_result(&response);
+    let gas = result.cost();
+    let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
+
+    let tally = motes_alpha.value()
+        + motes_bravo.value()
+        + U512::from(transferred_amount)
+        + modified_balance_bravo;
+
+    assert!(
+        modified_balance_alpha < initial_balance,
+        "balance should be less than initial balance"
+    );
+
+    assert!(
+        modified_balance_bravo < modified_balance_alpha,
+        "second modified balance should be less than first modified balance"
+    );
+
+    assert_eq!(
+        initial_balance, tally,
+        "no net resources should be gained or lost post-distribution"
+    );
+}


### PR DESCRIPTION
This PR adds a stored version of the client/transfer_to_account_u512 smart contract named client/transfer_to_account_u512_stored 

This PR is unticketed.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR includes an engine-test.
- [X] This PR is assigned.

### Notes
The immediate use for the stored version of this contract is for SRE testing purposes / max # of transfers per second metric.
