### PR TITLE
NODE-1276: 'make clean' needs the highway.env file as well.

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -64,7 +64,7 @@ node-%/up: node-% .make/docker/network maybe-reset-highway-env
 	$(REFRESH_TARGETS)
 
 # Tear down node. Using docker to delete logs owned by root for now.
-node-%/down:
+node-%/down: $(HIGHWAY_ENV)
 	if [ -d node-$* ]; then \
 		cd node-$* && docker-compose down && cd - && \
 		docker run -it --rm \


### PR DESCRIPTION
### Overview
The following resulted in an error:
```console
$ make node-0
$ make clean
ERROR: Couldn't find env file: /home/aakoshh/projects/CasperLabs/hack/docker/.casperlabs/chainspec/genesis/highway.env
```
The reason is that `highway.env` was only created during `make node-0/up`, but `docker-compose` needs it even for the teardown of a system that never was up. The PR makes sure the file is established when `make node-0/down` is called.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
