### PR TITLE
EE-938: change and invert turbo flag to use-system-contracts

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -130,7 +130,7 @@ test: test-rs test-as
 .PHONY: test-contracts-rs
 test-contracts-rs: build-contracts-rs
 	$(CARGO) test $(CARGO_FLAGS) -p casperlabs-engine-tests -- --ignored --nocapture
-	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "turbo" -- --ignored --nocapture
+	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "use-system-contracts" -- --ignored --nocapture
 
 .PHONY: test-contracts-as
 test-contracts-as: build-contracts-rs build-contracts-as

--- a/execution-engine/engine-core/src/engine_state/engine_config.rs
+++ b/execution-engine/engine-core/src/engine_state/engine_config.rs
@@ -1,8 +1,8 @@
 /// The runtime configuration of the execution engine
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub struct EngineConfig {
     // feature flags go here
-    turbo: bool,
+    use_system_contracts: bool,
 }
 
 impl EngineConfig {
@@ -11,18 +11,12 @@ impl EngineConfig {
         Default::default()
     }
 
-    pub fn turbo(self) -> bool {
-        self.turbo
+    pub fn use_system_contracts(self) -> bool {
+        self.use_system_contracts
     }
 
-    pub fn with_turbo(mut self, turbo: bool) -> EngineConfig {
-        self.turbo = turbo;
+    pub fn with_use_system_contracts(mut self, use_system_contracts: bool) -> EngineConfig {
+        self.use_system_contracts = use_system_contracts;
         self
-    }
-}
-
-impl Default for EngineConfig {
-    fn default() -> Self {
-        EngineConfig { turbo: false }
     }
 }

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -161,7 +161,7 @@ impl Executor {
             context,
         );
 
-        if self.config.turbo() {
+        if !self.config.use_system_contracts() {
             if runtime.is_mint(base_key) {
                 match runtime.call_host_mint(
                     protocol_version,
@@ -303,7 +303,7 @@ impl Executor {
             context,
         );
 
-        if self.config.turbo() {
+        if !self.config.use_system_contracts() {
             match runtime.call_host_proof_of_stake(
                 protocol_version,
                 runtime.context().named_keys().to_owned(),

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -1931,7 +1931,7 @@ where
             self.context.validate_key(key)?;
         }
 
-        if self.config.turbo() {
+        if !self.config.use_system_contracts() {
             if self.is_mint(key) {
                 return self.call_host_mint(
                     self.context.protocol_version(),

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -96,10 +96,11 @@ const ARG_THREAD_COUNT_VALUE: &str = "NUM";
 const ARG_THREAD_COUNT_HELP: &str = "Worker thread count";
 const ARG_THREAD_COUNT_EXPECT: &str = "expected valid thread count";
 
-// turbo
-const ARG_TURBO: &str = "turbo";
-const ARG_TURBO_SHORT: &str = "z";
-const ARG_TURBO_HELP: &str = "Turbo mode";
+// use system contracts
+const ARG_USE_SYSTEM_CONTRACTS: &str = "use-system-contracts";
+const ARG_USE_SYSTEM_CONTRACTS_SHORT: &str = "z";
+const ARG_USE_SYSTEM_CONTRACTS_HELP: &str =
+    "Use system contracts instead of host-side logic for Mint, Proof of Stake and Standard Payment";
 
 // runnable
 const SIGINT_HANDLE_EXPECT: &str = "Error setting Ctrl-C handler";
@@ -222,9 +223,9 @@ fn get_args() -> ArgMatches<'static> {
                 .help(ARG_THREAD_COUNT_HELP),
         )
         .arg(
-            Arg::with_name(ARG_TURBO)
-                .short(ARG_TURBO_SHORT)
-                .help(ARG_TURBO_HELP),
+            Arg::with_name(ARG_USE_SYSTEM_CONTRACTS)
+                .short(ARG_USE_SYSTEM_CONTRACTS_SHORT)
+                .help(ARG_USE_SYSTEM_CONTRACTS_HELP),
         )
         .arg(
             Arg::with_name(ARG_SOCKET)
@@ -289,8 +290,8 @@ fn get_thread_count(arg_matches: &ArgMatches) -> usize {
 /// Returns an [`EngineConfig`].
 fn get_engine_config(arg_matches: &ArgMatches) -> EngineConfig {
     // feature flags go here
-    let turbo = arg_matches.occurrences_of(ARG_TURBO) > 0;
-    EngineConfig::new().with_turbo(turbo)
+    let use_system_contracts = arg_matches.is_present(ARG_USE_SYSTEM_CONTRACTS);
+    EngineConfig::new().with_use_system_contracts(use_system_contracts)
 }
 
 /// Builds and returns a gRPC server.

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -31,4 +31,4 @@ version-sync = "0.8"
 
 [features]
 use-as-wasm = []
-turbo = []
+use-system-contracts = []

--- a/execution-engine/engine-test-support/src/internal/mod.rs
+++ b/execution-engine/engine-test-support/src/internal/mod.rs
@@ -53,15 +53,15 @@ lazy_static! {
         let mint_installer_bytes;
         let pos_installer_bytes;
         let standard_payment_installer_bytes;
-        if cfg!(feature = "turbo") {
-            mint_installer_bytes = Vec::new();
-            pos_installer_bytes = Vec::new();
-            standard_payment_installer_bytes = Vec::new();
-        } else {
+        if cfg!(feature = "use-system-contracts") {
             mint_installer_bytes = utils::read_wasm_file_bytes(MINT_INSTALL_CONTRACT);
             pos_installer_bytes = utils::read_wasm_file_bytes(POS_INSTALL_CONTRACT);
             standard_payment_installer_bytes =
                 utils::read_wasm_file_bytes(STANDARD_PAYMENT_INSTALL_CONTRACT);
+        } else {
+            mint_installer_bytes = Vec::new();
+            pos_installer_bytes = Vec::new();
+            standard_payment_installer_bytes = Vec::new();
         };
 
         GenesisConfig::new(

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -100,11 +100,8 @@ impl<S> WasmTestBuilder<S> {
 impl Default for InMemoryWasmTestBuilder {
     fn default() -> Self {
         Self::initialize_logging();
-        let engine_config = if cfg!(feature = "turbo") {
-            EngineConfig::new().with_turbo(true)
-        } else {
-            EngineConfig::new()
-        };
+        let engine_config =
+            EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
 
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
         let engine_state = EngineState::new(global_state, engine_config);

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -30,7 +30,7 @@ wabt = "0.9.2"
 
 [features]
 use-as-wasm = ["engine-test-support/use-as-wasm"]
-turbo = ["engine-test-support/turbo"]
+use-system-contracts = ["engine-test-support/use-system-contracts"]
 
 [lib]
 bench = false

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -47,11 +47,8 @@ fn bootstrap(data_dir: &Path, accounts: &[PublicKey], amount: U512) -> LmdbWasmT
     )
     .build();
 
-    let engine_config = if cfg!(feature = "turbo") {
-        EngineConfig::new().with_turbo(true)
-    } else {
-        EngineConfig::new()
-    };
+    let engine_config =
+        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
 
     let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir, engine_config);
 

--- a/execution-engine/engine-tests/src/profiling/simple_transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple_transfer.rs
@@ -112,11 +112,8 @@ fn main() {
         ExecuteRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let engine_config = if cfg!(feature = "turbo") {
-        EngineConfig::new().with_turbo(true)
-    } else {
-        EngineConfig::new()
-    };
+    let engine_config =
+        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
 
     let mut test_builder = LmdbWasmTestBuilder::open(&args.data_dir, engine_config, root_hash);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
@@ -12,11 +12,8 @@ const DEPLOY_HASH_1: [u8; 32] = [1u8; 32];
 #[test]
 fn should_run_mint_install_contract() {
     let mut builder = WasmTestBuilder::default();
-    let engine_config = if cfg!(feature = "turbo") {
-        EngineConfig::new().with_turbo(true)
-    } else {
-        EngineConfig::new()
-    };
+    let engine_config =
+        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
 
     builder.run_genesis(&DEFAULT_GENESIS_CONFIG);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -27,11 +27,8 @@ const POS_REWARDS_PURSE: &str = "pos_rewards_purse";
 #[test]
 fn should_run_pos_install_contract() {
     let mut builder = WasmTestBuilder::default();
-    let engine_config = if cfg!(feature = "turbo") {
-        EngineConfig::new().with_turbo(true)
-    } else {
-        EngineConfig::new()
-    };
+    let engine_config =
+        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
 
     let exec_request = ExecuteRequestBuilder::standard(
         DEFAULT_ACCOUNT_ADDR,

--- a/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
@@ -66,7 +66,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
     );
 }
 
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
@@ -135,7 +135,7 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
     );
 }
 
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_error_when_out_of_gas() {

--- a/execution-engine/engine-tests/src/test/system_contracts/standard_payment_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/standard_payment_install.rs
@@ -12,11 +12,8 @@ const DEPLOY_HASH_1: [u8; 32] = [1u8; 32];
 #[test]
 fn should_run_standard_payment_install_contract() {
     let mut builder = WasmTestBuilder::default();
-    let engine_config = if cfg!(feature = "turbo") {
-        EngineConfig::new().with_turbo(true)
-    } else {
-        EngineConfig::new()
-    };
+    let engine_config =
+        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
 
     builder.run_genesis(&DEFAULT_GENESIS_CONFIG);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/upgrade.rs
@@ -1,24 +1,24 @@
 use engine_core::engine_state::{upgrade::ActivationPoint, Error};
 use engine_grpc_server::engine_server::ipc::DeployCode;
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 use engine_shared::{stored_value::StoredValue, transform::Transform};
 use engine_test_support::internal::{
     utils, InMemoryWasmTestBuilder, UpgradeRequestBuilder, DEFAULT_GENESIS_CONFIG,
     DEFAULT_WASM_COSTS,
 };
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 use engine_test_support::{internal::ExecuteRequestBuilder, DEFAULT_ACCOUNT_ADDR};
 use engine_wasm_prep::wasm_costs::WasmCosts;
 use types::ProtocolVersion;
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 use types::{CLValue, Key, U512};
 
 const PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
 const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;
 const MODIFIED_SYSTEM_UPGRADER_CONTRACT_NAME: &str = "modified_system_upgrader.wasm";
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 const MODIFIED_MINT_CALLER_CONTRACT_NAME: &str = "modified_mint_caller.wasm";
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 const PAYMENT_AMOUNT: u64 = 200_000_000;
 
 fn get_upgraded_wasm_costs() -> WasmCosts {
@@ -75,7 +75,7 @@ fn should_upgrade_only_protocol_version() {
     );
 }
 
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[test]
 fn should_upgrade_system_contract() {
@@ -151,7 +151,7 @@ fn should_upgrade_system_contract() {
     );
 }
 
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[test]
 fn should_upgrade_system_contract_on_patch_bump() {
@@ -230,7 +230,7 @@ fn should_upgrade_system_contract_on_patch_bump() {
     );
 }
 
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[test]
 fn should_upgrade_system_contract_on_minor_bump() {
@@ -397,7 +397,7 @@ fn should_allow_only_wasm_costs_minor_version() {
     );
 }
 
-#[cfg(not(feature = "turbo"))]
+#[cfg(feature = "use-system-contracts")]
 #[ignore]
 #[test]
 fn should_upgrade_system_contract_and_wasm_costs_major() {


### PR DESCRIPTION
### Overview
This inverts the turbo mode so that it's enabled by default.  It's therefore renamed to `use-system-contracts`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-938

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
