### PR TITLE
NO-TICKET: implement To/FromBytes for Vec<T: To/FromBytes>

### DIFF
--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -172,7 +172,7 @@ pub fn get_phase() -> Phase {
 /// currently-executing module is a direct call or a sub-call respectively.
 pub fn get_key(name: &str) -> Option<Key> {
     let (name_ptr, name_size, _bytes) = contract_api::to_ptr(name);
-    let mut key_bytes = vec![0u8; Key::serialized_size_hint()];
+    let mut key_bytes = vec![0u8; Key::max_serialized_length()];
     let mut total_bytes: usize = 0;
     let ret = unsafe {
         ext_ffi::get_key(

--- a/execution-engine/contract/src/contract_api/storage.rs
+++ b/execution-engine/contract/src/contract_api/storage.rs
@@ -140,7 +140,7 @@ pub fn store_function_at_hash(name: &str, named_keys: BTreeMap<String, Key>) -> 
 
 /// Returns a new unforgeable pointer, where the value is initialized to `init`.
 pub fn new_uref<T: CLTyped + ToBytes>(init: T) -> URef {
-    let key_ptr = contract_api::alloc_bytes(Key::serialized_size_hint());
+    let key_ptr = contract_api::alloc_bytes(Key::max_serialized_length());
     let cl_value = CLValue::from_t(init).unwrap_or_revert();
     let (cl_value_ptr, cl_value_size, _cl_value_bytes) = contract_api::to_ptr(cl_value);
     let bytes = unsafe {

--- a/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/player_data.rs
+++ b/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/player_data.rs
@@ -71,6 +71,10 @@ impl ToBytes for PlayerData {
 
         Ok(result)
     }
+
+    fn serialized_length(&self) -> usize {
+        PLAYER_DATA_BYTES_SIZE
+    }
 }
 
 impl FromBytes for PlayerData {
@@ -98,11 +102,7 @@ impl FromBytes for PlayerData {
 #[cfg(test)]
 mod tests {
     use super::PlayerData;
-    use types::{
-        account::PublicKey,
-        bytesrepr::{FromBytes, ToBytes},
-        AccessRights, URef,
-    };
+    use types::{account::PublicKey, bytesrepr, AccessRights, URef};
 
     use tic_tac_toe_logic::player::Player;
 
@@ -113,9 +113,6 @@ mod tests {
             opponent: PublicKey::ed25519_from([3u8; 32]),
             status_key: URef::new([5u8; 32], AccessRights::READ_ADD_WRITE),
         };
-        let value = player_data.to_bytes().expect("Should serialize");
-        let player_data_2: (PlayerData, &[u8]) =
-            PlayerData::from_bytes(&value).expect("Should deserialize");
-        assert_eq!(player_data, player_data_2.0);
+        bytesrepr::test_serialization_roundtrip(&player_data);
     }
 }

--- a/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/state_key.rs
+++ b/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/state_key.rs
@@ -24,6 +24,10 @@ impl StateKey {
 
 impl ToBytes for StateKey {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        Ok(self.0.to_vec())
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
     }
 }

--- a/execution-engine/engine-core/src/tracking_copy/byte_size.rs
+++ b/execution-engine/engine-core/src/tracking_copy/byte_size.rs
@@ -47,7 +47,7 @@ impl ByteSize for StoredValue {
     fn byte_size(&self) -> usize {
         mem::size_of::<Self>()
             + match self {
-                StoredValue::CLValue(cl_value) => cl_value.serialized_len(),
+                StoredValue::CLValue(cl_value) => cl_value.serialized_length(),
                 StoredValue::Account(account) => account.heap_size(),
                 StoredValue::Contract(contract) => contract.heap_size(),
             }

--- a/execution-engine/engine-shared/src/account/action_thresholds.rs
+++ b/execution-engine/engine-shared/src/account/action_thresholds.rs
@@ -1,6 +1,6 @@
 use types::{
     account::{ActionType, SetThresholdFailure, Weight, WEIGHT_SERIALIZED_LENGTH},
-    bytesrepr::{Error, FromBytes, ToBytes},
+    bytesrepr::{self, Error, FromBytes, ToBytes},
 };
 
 /// Thresholds that have to be met when executing an action of a certain type.
@@ -91,17 +91,21 @@ impl Default for ActionThresholds {
 
 impl ToBytes for ActionThresholds {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        let mut result = Vec::with_capacity(2 * WEIGHT_SERIALIZED_LENGTH);
-        result.extend(&self.deployment.to_bytes()?);
-        result.extend(&self.key_management.to_bytes()?);
+        let mut result = bytesrepr::unchecked_allocate_buffer(self);
+        result.append(&mut self.deployment.to_bytes()?);
+        result.append(&mut self.key_management.to_bytes()?);
         Ok(result)
+    }
+
+    fn serialized_length(&self) -> usize {
+        2 * WEIGHT_SERIALIZED_LENGTH
     }
 }
 
 impl FromBytes for ActionThresholds {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (deployment, rem): (Weight, &[u8]) = FromBytes::from_bytes(&bytes)?;
-        let (key_management, rem): (Weight, &[u8]) = FromBytes::from_bytes(&rem)?;
+        let (deployment, rem) = Weight::from_bytes(&bytes)?;
+        let (key_management, rem) = Weight::from_bytes(&rem)?;
         let ret = ActionThresholds {
             deployment,
             key_management,
@@ -135,5 +139,11 @@ mod tests {
     fn should_not_create_action_thresholds_with_invalid_deployment_threshold() {
         // deployment cant be greater than key management
         assert!(ActionThresholds::new(Weight::new(5), Weight::new(1)).is_err());
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let action_thresholds = ActionThresholds::new(Weight::new(1), Weight::new(42)).unwrap();
+        bytesrepr::test_serialization_roundtrip(&action_thresholds);
     }
 }

--- a/execution-engine/engine-shared/src/newtypes/macros.rs
+++ b/execution-engine/engine-shared/src/newtypes/macros.rs
@@ -102,6 +102,10 @@ macro_rules! make_array_newtype {
             fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
                 self.0.to_bytes()
             }
+
+            fn serialized_length(&self) -> usize {
+                self.0.serialized_length()
+            }
         }
 
         impl bytesrepr::FromBytes for $name {

--- a/execution-engine/engine-shared/src/newtypes/mod.rs
+++ b/execution-engine/engine-shared/src/newtypes/mod.rs
@@ -97,7 +97,11 @@ impl Into<[u8; BLAKE2B_DIGEST_LENGTH]> for Blake2bHash {
 
 impl ToBytes for Blake2bHash {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        ToBytes::to_bytes(&self.0)
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.0.serialized_length()
     }
 }
 

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -347,8 +347,8 @@ mod tests {
     fn initial_state_has_the_expected_hash() {
         let correlation_id = CorrelationId::new();
         let expected_bytes = vec![
-            243, 47, 248, 24, 18, 220, 95, 83, 103, 81, 100, 141, 145, 156, 26, 225, 23, 211, 126,
-            219, 65, 215, 200, 175, 255, 183, 116, 198, 144, 222, 99, 246,
+            197, 117, 38, 12, 241, 62, 54, 241, 121, 165, 11, 8, 130, 189, 100, 252, 4, 102, 236,
+            210, 91, 221, 123, 200, 135, 102, 194, 204, 46, 76, 13, 254,
         ];
         let (_, root_hash) = InMemoryGlobalState::from_pairs(correlation_id, &[]).unwrap();
         assert_eq!(expected_bytes, root_hash.to_vec())

--- a/execution-engine/engine-storage/src/protocol_data.rs
+++ b/execution-engine/engine-storage/src/protocol_data.rs
@@ -5,7 +5,7 @@ use types::{
 };
 
 const PROTOCOL_DATA_SERIALIZED_LENGTH: usize =
-    WASM_COSTS_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH + UREF_SERIALIZED_LENGTH;
+    WASM_COSTS_SERIALIZED_LENGTH + 3 * UREF_SERIALIZED_LENGTH;
 const DEFAULT_UREF_ADDRESS: [u8; 32] = [0; 32];
 
 /// Represents a protocol's data. Intended to be associated with a given protocol version.
@@ -110,12 +110,16 @@ impl ProtocolData {
 
 impl ToBytes for ProtocolData {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut ret: Vec<u8> = Vec::with_capacity(PROTOCOL_DATA_SERIALIZED_LENGTH);
+        let mut ret = bytesrepr::unchecked_allocate_buffer(self);
         ret.append(&mut self.wasm_costs.to_bytes()?);
         ret.append(&mut self.mint.to_bytes()?);
         ret.append(&mut self.proof_of_stake.to_bytes()?);
         ret.append(&mut self.standard_payment.to_bytes()?);
         Ok(ret)
+    }
+
+    fn serialized_length(&self) -> usize {
+        PROTOCOL_DATA_SERIALIZED_LENGTH
     }
 }
 

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -40,6 +40,10 @@ impl ToBytes for TestKey {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         Ok(self.0.to_vec())
     }
+
+    fn serialized_length(&self) -> usize {
+        TEST_KEY_LENGTH
+    }
 }
 
 impl FromBytes for TestKey {
@@ -60,6 +64,10 @@ struct TestValue([u8; TEST_VAL_LENGTH]);
 impl ToBytes for TestValue {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         Ok(self.0.to_vec())
+    }
+
+    fn serialized_length(&self) -> usize {
+        TEST_VAL_LENGTH
     }
 }
 

--- a/execution-engine/engine-wasm-prep/src/wasm_costs.rs
+++ b/execution-engine/engine-wasm-prep/src/wasm_costs.rs
@@ -53,7 +53,7 @@ impl WasmCosts {
 
 impl ToBytes for WasmCosts {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
-        let mut ret: Vec<u8> = Vec::with_capacity(WASM_COSTS_SERIALIZED_LENGTH);
+        let mut ret = bytesrepr::unchecked_allocate_buffer(self);
         ret.append(&mut self.regular.to_bytes()?);
         ret.append(&mut self.div.to_bytes()?);
         ret.append(&mut self.mul.to_bytes()?);
@@ -65,6 +65,10 @@ impl ToBytes for WasmCosts {
         ret.append(&mut self.opcodes_mul.to_bytes()?);
         ret.append(&mut self.opcodes_div.to_bytes()?);
         Ok(ret)
+    }
+
+    fn serialized_length(&self) -> usize {
+        WASM_COSTS_SERIALIZED_LENGTH
     }
 }
 

--- a/execution-engine/proof-of-stake/src/queue.rs
+++ b/execution-engine/proof-of-stake/src/queue.rs
@@ -3,7 +3,7 @@ use core::result;
 
 use types::{
     account::PublicKey,
-    bytesrepr::{self, FromBytes, ToBytes},
+    bytesrepr::{self, FromBytes, ToBytes, U64_SERIALIZED_LENGTH},
     system_contract_errors::pos::{Error, Result},
     BlockTime, CLType, CLTyped, U512,
 };
@@ -30,6 +30,22 @@ impl QueueEntry {
     }
 }
 
+impl ToBytes for QueueEntry {
+    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
+        let mut bytes = bytesrepr::allocate_buffer(self)?;
+        bytes.append(&mut self.validator.to_bytes()?);
+        bytes.append(&mut self.amount.to_bytes()?);
+        bytes.append(&mut self.timestamp.to_bytes()?);
+        Ok(bytes)
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.validator.serialized_length()
+            + self.amount.serialized_length()
+            + self.timestamp.serialized_length()
+    }
+}
+
 impl FromBytes for QueueEntry {
     fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
         let (validator, bytes) = PublicKey::from_bytes(bytes)?;
@@ -44,15 +60,6 @@ impl FromBytes for QueueEntry {
     }
 }
 
-impl ToBytes for QueueEntry {
-    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
-        Ok((self.validator.to_bytes()?.into_iter())
-            .chain(self.amount.to_bytes()?)
-            .chain(self.timestamp.to_bytes()?)
-            .collect())
-    }
-}
-
 impl CLTyped for QueueEntry {
     fn cl_type() -> CLType {
         CLType::Any
@@ -60,7 +67,7 @@ impl CLTyped for QueueEntry {
 }
 
 /// A queue of bonding or unbonding requests, sorted by timestamp in ascending order.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Queue(pub Vec<QueueEntry>);
 
 impl Queue {
@@ -91,6 +98,21 @@ impl Queue {
     }
 }
 
+impl ToBytes for Queue {
+    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
+        let mut bytes = bytesrepr::allocate_buffer(self)?;
+        bytes.append(&mut (self.0.len() as u64).to_bytes()?);
+        for entry in &self.0 {
+            bytes.append(&mut entry.to_bytes()?);
+        }
+        Ok(bytes)
+    }
+
+    fn serialized_length(&self) -> usize {
+        U64_SERIALIZED_LENGTH + self.0.iter().map(ToBytes::serialized_length).sum::<usize>()
+    }
+}
+
 impl FromBytes for Queue {
     fn from_bytes(bytes: &[u8]) -> result::Result<(Self, &[u8]), bytesrepr::Error> {
         let (len, mut bytes) = u64::from_bytes(bytes)?;
@@ -104,16 +126,6 @@ impl FromBytes for Queue {
     }
 }
 
-impl ToBytes for Queue {
-    fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
-        let mut bytes = (self.0.len() as u64).to_bytes()?; // TODO: Allocate correct capacity.
-        for entry in &self.0 {
-            bytes.append(&mut entry.to_bytes()?);
-        }
-        Ok(bytes)
-    }
-}
-
 impl CLTyped for Queue {
     fn cl_type() -> CLType {
         CLType::List(Box::new(QueueEntry::cl_type()))
@@ -124,7 +136,9 @@ impl CLTyped for Queue {
 mod tests {
     use alloc::vec;
 
-    use types::{account::PublicKey, system_contract_errors::pos::Error, BlockTime, U512};
+    use types::{
+        account::PublicKey, bytesrepr, system_contract_errors::pos::Error, BlockTime, U512,
+    };
 
     use super::{Queue, QueueEntry};
 
@@ -170,5 +184,17 @@ mod tests {
             vec![QueueEntry::new(val3, U512::from(7), BlockTime::new(102)),],
             queue.pop_due(BlockTime::new(105))
         );
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        let val1 = PublicKey::ed25519_from(KEY1);
+        let val2 = PublicKey::ed25519_from(KEY2);
+        let val3 = PublicKey::ed25519_from(KEY3);
+        let mut queue: Queue = Default::default();
+        queue.push(val1, U512::from(5), BlockTime::new(0)).unwrap();
+        queue.push(val2, U512::from(6), BlockTime::new(1)).unwrap();
+        queue.push(val3, U512::from(7), BlockTime::new(2)).unwrap();
+        bytesrepr::test_serialization_roundtrip(&queue);
     }
 }

--- a/execution-engine/types/benches/bytesrepr_bench.rs
+++ b/execution-engine/types/benches/bytesrepr_bench.rs
@@ -60,7 +60,7 @@ fn deserialize_vector_of_u8(b: &mut Bencher) {
         .collect::<Vec<_>>()
         .to_bytes()
         .unwrap();
-    b.iter(|| Vec::<i32>::from_bytes(&data))
+    b.iter(|| Vec::<u8>::from_bytes(&data))
 }
 
 #[bench]

--- a/execution-engine/types/src/access_rights.rs
+++ b/execution-engine/types/src/access_rights.rs
@@ -73,11 +73,15 @@ impl bytesrepr::ToBytes for AccessRights {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.bits.to_bytes()
     }
+
+    fn serialized_length(&self) -> usize {
+        ACCESS_RIGHTS_SERIALIZED_LENGTH
+    }
 }
 
 impl bytesrepr::FromBytes for AccessRights {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
-        let (id, rem): (u8, &[u8]) = bytesrepr::FromBytes::from_bytes(bytes)?;
+        let (id, rem) = u8::from_bytes(bytes)?;
         match AccessRights::from_bits(id) {
             Some(rights) => Ok((rights, rem)),
             None => Err(bytesrepr::Error::Formatting),
@@ -87,7 +91,7 @@ impl bytesrepr::FromBytes for AccessRights {
 
 #[cfg(test)]
 mod tests {
-    use super::AccessRights;
+    use super::*;
 
     fn test_readable(right: AccessRights, is_true: bool) {
         assert_eq!(right.is_readable(), is_true)

--- a/execution-engine/types/src/account.rs
+++ b/execution-engine/types/src/account.rs
@@ -123,13 +123,17 @@ impl Weight {
 
 impl ToBytes for Weight {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        ToBytes::to_bytes(&self.0)
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        WEIGHT_SERIALIZED_LENGTH
     }
 }
 
 impl FromBytes for Weight {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (byte, rem): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (byte, rem) = u8::from_bytes(bytes)?;
         Ok((Weight::new(byte), rem))
     }
 }
@@ -181,13 +185,17 @@ impl Display for Ed25519 {
 
 impl ToBytes for Ed25519 {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        ToBytes::to_bytes(&self.0)
+        self.0.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        ED25519_SERIALIZED_LENGTH
     }
 }
 
 impl FromBytes for Ed25519 {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (bytes, rem): ([u8; 32], &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (bytes, rem) = <[u8; 32]>::from_bytes(bytes)?;
         Ok((Ed25519::new(bytes), rem))
     }
 }
@@ -256,8 +264,12 @@ impl ToBytes for PublicKey {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let PublicKey::Ed25519(ed25519) = self;
         let mut bytes = Vec::with_capacity(PUBLIC_KEY_SERIALIZED_MAX_LENGTH);
-        bytes.extend(&ed25519.to_bytes()?);
+        bytes.append(&mut ed25519.to_bytes()?);
         Ok(bytes)
+    }
+
+    fn serialized_length(&self) -> usize {
+        PUBLIC_KEY_SERIALIZED_MAX_LENGTH
     }
 }
 

--- a/execution-engine/types/src/block_time.rs
+++ b/execution-engine/types/src/block_time.rs
@@ -32,6 +32,10 @@ impl ToBytes for BlockTime {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         self.0.to_bytes()
     }
+
+    fn serialized_length(&self) -> usize {
+        BLOCKTIME_SERIALIZED_LENGTH
+    }
 }
 
 impl FromBytes for BlockTime {

--- a/execution-engine/types/src/cl_type.rs
+++ b/execution-engine/types/src/cl_type.rs
@@ -92,7 +92,7 @@ pub enum CLType {
 
 impl CLType {
     /// The `len()` of the `Vec<u8>` resulting from `self.to_bytes()`.
-    pub fn serialized_len(&self) -> usize {
+    pub fn serialized_length(&self) -> usize {
         mem::size_of::<u8>()
             + match self {
                 CLType::Bool
@@ -109,15 +109,15 @@ impl CLType {
                 | CLType::Key
                 | CLType::URef
                 | CLType::Any => 0,
-                CLType::Option(cl_type) | CLType::List(cl_type) => cl_type.serialized_len(),
+                CLType::Option(cl_type) | CLType::List(cl_type) => cl_type.serialized_length(),
                 CLType::FixedList(cl_type, list_len) => {
-                    cl_type.serialized_len() + list_len.to_le_bytes().len()
+                    cl_type.serialized_length() + list_len.to_le_bytes().len()
                 }
-                CLType::Result { ok, err } => ok.serialized_len() + err.serialized_len(),
-                CLType::Map { key, value } => key.serialized_len() + value.serialized_len(),
-                CLType::Tuple1(cl_type_array) => serialized_len_of_cl_tuple_type(cl_type_array),
-                CLType::Tuple2(cl_type_array) => serialized_len_of_cl_tuple_type(cl_type_array),
-                CLType::Tuple3(cl_type_array) => serialized_len_of_cl_tuple_type(cl_type_array),
+                CLType::Result { ok, err } => ok.serialized_length() + err.serialized_length(),
+                CLType::Map { key, value } => key.serialized_length() + value.serialized_length(),
+                CLType::Tuple1(cl_type_array) => serialized_length_of_cl_tuple_type(cl_type_array),
+                CLType::Tuple2(cl_type_array) => serialized_length_of_cl_tuple_type(cl_type_array),
+                CLType::Tuple3(cl_type_array) => serialized_length_of_cl_tuple_type(cl_type_array),
             }
     }
 }
@@ -285,12 +285,12 @@ fn parse_cl_tuple_types(
     Ok((cl_types, bytes))
 }
 
-fn serialized_len_of_cl_tuple_type<'a, T: IntoIterator<Item = &'a Box<CLType>>>(
+fn serialized_length_of_cl_tuple_type<'a, T: IntoIterator<Item = &'a Box<CLType>>>(
     cl_type_array: T,
 ) -> usize {
     cl_type_array
         .into_iter()
-        .map(|cl_type| cl_type.serialized_len())
+        .map(|cl_type| cl_type.serialized_length())
         .sum()
 }
 
@@ -468,7 +468,7 @@ mod tests {
         let cl_value = CLValue::from_t(value.clone()).unwrap();
 
         let serialized_cl_value = cl_value.to_bytes().unwrap();
-        assert_eq!(serialized_cl_value.len(), cl_value.serialized_len());
+        assert_eq!(serialized_cl_value.len(), cl_value.serialized_length());
         let parsed_cl_value: CLValue = bytesrepr::deserialize(serialized_cl_value).unwrap();
         assert_eq!(cl_value, parsed_cl_value);
 
@@ -665,6 +665,10 @@ mod tests {
         impl ToBytes for Any {
             fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
                 self.0.to_bytes()
+            }
+
+            fn serialized_length(&self) -> usize {
+                self.0.serialized_length()
             }
         }
 

--- a/execution-engine/types/src/phase.rs
+++ b/execution-engine/types/src/phase.rs
@@ -34,11 +34,15 @@ impl ToBytes for Phase {
 
         Ok(vec![id])
     }
+
+    fn serialized_length(&self) -> usize {
+        PHASE_SERIALIZED_LENGTH
+    }
 }
 
 impl FromBytes for Phase {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (id, rest): (u8, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (id, rest) = u8::from_bytes(bytes)?;
         let phase = FromPrimitive::from_u8(id).ok_or(Error::Formatting)?;
         Ok((phase, rest))
     }

--- a/execution-engine/types/src/protocol_version.rs
+++ b/execution-engine/types/src/protocol_version.rs
@@ -121,14 +121,17 @@ impl ProtocolVersion {
 
 impl ToBytes for ProtocolVersion {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        let value_bytes = self.value().to_bytes()?;
-        Ok(value_bytes.to_vec())
+        self.value().to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        self.value().serialized_length()
     }
 }
 
 impl FromBytes for ProtocolVersion {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (version, rem): (SemVer, &[u8]) = FromBytes::from_bytes(bytes)?;
+        let (version, rem) = SemVer::from_bytes(bytes)?;
         let protocol_version = ProtocolVersion::new(version);
         Ok((protocol_version, rem))
     }

--- a/execution-engine/types/src/semver.rs
+++ b/execution-engine/types/src/semver.rs
@@ -1,9 +1,9 @@
 use alloc::vec::Vec;
 use core::fmt;
 
-use crate::bytesrepr::{Error, FromBytes, ToBytes};
+use crate::bytesrepr::{self, Error, FromBytes, ToBytes, U32_SERIALIZED_LENGTH};
 
-const SEM_VER_SERIALIZED_LENGTH: usize = 12;
+const SEM_VER_SERIALIZED_LENGTH: usize = 3 * U32_SERIALIZED_LENGTH;
 
 /// A struct for semantic versioning.
 #[derive(Copy, Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -36,11 +36,15 @@ impl SemVer {
 
 impl ToBytes for SemVer {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        let mut ret: Vec<u8> = Vec::with_capacity(SEM_VER_SERIALIZED_LENGTH);
+        let mut ret = bytesrepr::unchecked_allocate_buffer(self);
         ret.append(&mut self.major.to_bytes()?);
         ret.append(&mut self.minor.to_bytes()?);
         ret.append(&mut self.patch.to_bytes()?);
         Ok(ret)
+    }
+
+    fn serialized_length(&self) -> usize {
+        SEM_VER_SERIALIZED_LENGTH
     }
 }
 

--- a/execution-engine/types/src/system_contract_errors/mint.rs
+++ b/execution-engine/types/src/system_contract_errors/mint.rs
@@ -6,7 +6,7 @@ use core::convert::{TryFrom, TryInto};
 use failure::Fail;
 
 use crate::{
-    bytesrepr::{self, FromBytes, ToBytes},
+    bytesrepr::{self, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
     AccessRights, CLType, CLTyped,
 };
 
@@ -88,6 +88,10 @@ impl ToBytes for Error {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let value = *self as u8;
         value.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
     }
 }
 

--- a/execution-engine/types/src/system_contract_errors/pos.rs
+++ b/execution-engine/types/src/system_contract_errors/pos.rs
@@ -3,7 +3,10 @@
 use alloc::vec::Vec;
 use core::result;
 
-use crate::{bytesrepr, bytesrepr::ToBytes, CLType, CLTyped};
+use crate::{
+    bytesrepr::{self, ToBytes, U8_SERIALIZED_LENGTH},
+    CLType, CLTyped,
+};
 
 /// Errors which can occur while executing the Proof of Stake contract.
 // TODO: Split this up into user errors vs. system errors.
@@ -86,6 +89,10 @@ impl ToBytes for Error {
     fn to_bytes(&self) -> result::Result<Vec<u8>, bytesrepr::Error> {
         let value = *self as u8;
         value.to_bytes()
+    }
+
+    fn serialized_length(&self) -> usize {
+        U8_SERIALIZED_LENGTH
     }
 }
 

--- a/execution-engine/types/src/uint.rs
+++ b/execution-engine/types/src/uint.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use num_integer::Integer;
 use num_traits::{AsPrimitive, Bounded, Num, One, Unsigned, WrappingAdd, WrappingSub, Zero};
 
-use crate::bytesrepr::{self, Error, FromBytes, ToBytes};
+use crate::bytesrepr::{self, Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH};
 
 #[allow(
     clippy::assign_op_pattern,
@@ -50,6 +50,13 @@ macro_rules! impl_traits_for_uint {
                 non_zero_bytes.push(num_bytes);
                 non_zero_bytes.reverse();
                 Ok(non_zero_bytes)
+            }
+
+            fn serialized_length(&self) -> usize {
+                let mut buf = [0u8; $total_bytes];
+                self.to_little_endian(&mut buf);
+                let non_zero_bytes = buf.iter().rev().skip_while(|b| **b == 0).count();
+                U8_SERIALIZED_LENGTH + non_zero_bytes
             }
         }
 

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -74,8 +74,8 @@ class GrpcExecutionEngineService[F[_]: Defer: Concurrent: Log: TaskLift: Metrics
 
   override def emptyStateHash: ByteString = {
     val arr: Array[Byte] = Array(
-      197, 117, 38, 12, 241, 62, 54, 241, 121, 165, 11, 8, 130, 189, 100, 252, 4, 102, 236, 210,
-      91, 221, 123, 200, 135, 102, 194, 204, 46, 76, 13, 254
+      197, 117, 38, 12, 241, 62, 54, 241, 121, 165, 11, 8, 130, 189, 100, 252, 4, 102, 236, 210, 91,
+      221, 123, 200, 135, 102, 194, 204, 46, 76, 13, 254
     ).map(_.toByte)
     ByteString.copyFrom(arr)
   }

--- a/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
+++ b/smart-contracts/src/main/scala/io/casperlabs/smartcontracts/ExecutionEngineService.scala
@@ -74,8 +74,8 @@ class GrpcExecutionEngineService[F[_]: Defer: Concurrent: Log: TaskLift: Metrics
 
   override def emptyStateHash: ByteString = {
     val arr: Array[Byte] = Array(
-      243, 47, 248, 24, 18, 220, 95, 83, 103, 81, 100, 141, 145, 156, 26, 225, 23, 211, 126, 219,
-      65, 215, 200, 175, 255, 183, 116, 198, 144, 222, 99, 246
+      197, 117, 38, 12, 241, 62, 54, 241, 121, 165, 11, 8, 130, 189, 100, 252, 4, 102, 236, 210,
+      91, 221, 123, 200, 135, 102, 194, 204, 46, 76, 13, 254
     ).map(_.toByte)
     ByteString.copyFrom(arr)
   }


### PR DESCRIPTION
### Overview
This adds support for (de)serializing vectors of arbitrary (de)serializable types.

None of the binary formats have been altered with the exception of 2 tag types in `trie` which were changed from `u32` to `u8` to reduce storage overhead.

A method `serialized_length()` was added to the `ToBytes` trait.  This was required to enable checking for `OutOfMemory` error in `impl<T: ToBytes> ToBytes for Vec<T>`.  It proved to be useful in standardising checks for this error across many `impl ToBytes`.

The high-level engine-tests benchmarks show no overall change, the trie store show a couple of modest improvements, and the `types` benchmarks are mostly unchanged with the exception of the following ones:

| Test                                 | Dev                         | This PR                  |
|:-------------------------------------|:----------------------------|:-------------------------|
| deserialize_cl_value_listint32       |   1,967 ns/iter (+/- 40)    | 2,626 ns/iter (+/- 38)   |
| deserialize_vec_of_keys              |   1,421 ns/iter (+/- 18)    | 1,332 ns/iter (+/- 15)   |
| deserialize_vec_of_string            |     805 ns/iter (+/- 20)    | 766 ns/iter (+/- 7)      |
| deserialize_vector_of_i32s           |   6,935 ns/iter (+/- 47)    | 9,469 ns/iter (+/- 118)  |
| serialize_cl_value_bytearray         |     186 ns/iter (+/- 3)     | 210 ns/iter (+/- 3)      |
| serialize_cl_value_listint32         |  47,798 ns/iter (+/- 610)   | 18,760 ns/iter (+/- 270) |
| serialize_cl_value_liststring        |     360 ns/iter (+/- 3)     | 286 ns/iter (+/- 3)      |
| serialize_tree_map                   |     598 ns/iter (+/- 10)    | 306 ns/iter (+/- 4)      |
| serialize_vec_of_keys                |   5,775 ns/iter (+/- 102)   | 2,263 ns/iter (+/- 35)   |
| serialize_vec_of_string              |   1,390 ns/iter (+/- 29)    | 873 ns/iter (+/- 28)     |
| serialize_vector_of_i32s             | 207,626 ns/iter (+/- 1,503) | 73,278 ns/iter (+/- 971) |
| serialize_vector_of_u8               |      63 ns/iter (+/- 3)     | 93 ns/iter (+/- 1)       |
| serialize_vector_of_vector_of_u8     |      75 ns/iter (+/- 0)     | 141 ns/iter (+/- 5)      |

As well as allowing the removal of several specialisations of `impl To/FromBytes` for vecs, the `serialized_length()` in many cases returns the corresponding `XXX_SERIALIZED_LENGTH` const, and this is now tested for correctness in the `bytesrepr::test_serialization_roundtrip()` function.

### Which JIRA ticket does this PR relate to?
NO-TICKET

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
