### PR TITLE
NODE-1287: Fix stake persistence

### DIFF
--- a/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
+++ b/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
@@ -219,10 +219,12 @@ trait ArbitraryConsensus {
         deploy  <- arbitrary[Deploy]
         isError <- arbitrary[Boolean]
         cost    <- arbitrary[Long]
+        stage   <- Gen.choose(0, 5)
       } yield {
         Block
           .ProcessedDeploy()
           .withDeploy(deploy)
+          .withStage(stage)
           .withCost(cost)
           .withIsError(isError)
           .withErrorMessage(if (isError) "Kaboom!" else "")

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -45,6 +45,7 @@ message DeployInfo {
         uint64 cost = 2;
         bool is_error = 3;
         string error_message = 4;
+        uint32 stage = 5;
     }
 
     enum View {

--- a/storage/src/main/resources/db/migration/V20200311_1287__Add_deploy_process_results_stage.sql
+++ b/storage/src/main/resources/db/migration/V20200311_1287__Add_deploy_process_results_stage.sql
@@ -1,0 +1,1 @@
+ALTER TABLE deploy_process_results ADD COLUMN stage INT NOT NULL DEFAULT 0;

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -29,6 +29,22 @@ trait DoobieCodecs {
   protected implicit val readDeployHeader: Read[Deploy.Header] =
     Read[Array[Byte]].map(Deploy.Header.parseFrom)
 
+  protected implicit val readProcessingResult: Read[(ByteString, ProcessedDeploy)] = {
+    Read[(Array[Byte], Long, Option[String], Int)].map {
+      case (blockHash, cost, maybeError, stage) =>
+        (
+          ByteString.copyFrom(blockHash),
+          ProcessedDeploy(
+            deploy = None,
+            cost = cost,
+            isError = maybeError.nonEmpty,
+            errorMessage = maybeError.getOrElse(""),
+            stage = stage
+          )
+        )
+    }
+  }
+
   protected implicit val readProcessedDeploy: Read[ProcessedDeploy] = {
     Read[(Deploy, Long, Option[String], Int)].map {
       case (deploy, cost, maybeError, stage) =>

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -29,22 +29,6 @@ trait DoobieCodecs {
   protected implicit val readDeployHeader: Read[Deploy.Header] =
     Read[Array[Byte]].map(Deploy.Header.parseFrom)
 
-  protected implicit val readProcessingResult: Read[(ByteString, ProcessedDeploy)] = {
-    Read[(Array[Byte], Long, Option[String], Int)].map {
-      case (blockHash, cost, maybeError, stage) =>
-        (
-          ByteString.copyFrom(blockHash),
-          ProcessedDeploy(
-            deploy = None,
-            cost = cost,
-            isError = maybeError.nonEmpty,
-            errorMessage = maybeError.getOrElse(""),
-            stage = stage
-          )
-        )
-    }
-  }
-
   protected implicit val readProcessedDeploy: Read[ProcessedDeploy] = {
     Read[(Deploy, Long, Option[String], Int)].map {
       case (deploy, cost, maybeError, stage) =>
@@ -87,12 +71,13 @@ trait DoobieCodecs {
   }
 
   protected implicit val readDeployAndProcessingResult: Read[ProcessingResult] = {
-    Read[(Long, Option[String], BlockInfo)].map {
-      case (cost, maybeError, blockInfo) =>
+    Read[(Long, Option[String], Int, BlockInfo)].map {
+      case (cost, maybeError, stage, blockInfo) =>
         ProcessingResult(
           cost = cost,
           isError = maybeError.nonEmpty,
-          errorMessage = maybeError.getOrElse("")
+          errorMessage = maybeError.getOrElse(""),
+          stage = stage
         ).withBlockInfo(blockInfo)
     }
   }

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -30,28 +30,30 @@ trait DoobieCodecs {
     Read[Array[Byte]].map(Deploy.Header.parseFrom)
 
   protected implicit val readProcessingResult: Read[(ByteString, ProcessedDeploy)] = {
-    Read[(Array[Byte], Long, Option[String])].map {
-      case (blockHash, cost, maybeError) =>
+    Read[(Array[Byte], Long, Option[String], Int)].map {
+      case (blockHash, cost, maybeError, stage) =>
         (
           ByteString.copyFrom(blockHash),
           ProcessedDeploy(
             deploy = None,
             cost = cost,
             isError = maybeError.nonEmpty,
-            errorMessage = maybeError.getOrElse("")
+            errorMessage = maybeError.getOrElse(""),
+            stage = stage
           )
         )
     }
   }
 
   protected implicit val readProcessedDeploy: Read[ProcessedDeploy] = {
-    Read[(Deploy, Long, Option[String])].map {
-      case (deploy, cost, maybeError) =>
+    Read[(Deploy, Long, Option[String], Int)].map {
+      case (deploy, cost, maybeError, stage) =>
         ProcessedDeploy(
           deploy = Option(deploy),
           cost = cost,
           isError = maybeError.nonEmpty,
-          errorMessage = maybeError.getOrElse("")
+          errorMessage = maybeError.getOrElse(""),
+          stage = stage
         )
     }
   }

--- a/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/BlockStorageTest.scala
@@ -156,12 +156,12 @@ trait BlockStorageTest
         for {
           _          <- storage.put(b)
           maybeBlock <- storage.get(b.getBlockMessage.blockHash)
-          _ <- Task {
-                maybeBlock should not be None
-                val got = maybeBlock.get.toByteArray
-                assert(before.sameElements(got))
-              }
-        } yield ()
+        } yield {
+          maybeBlock should not be None
+          maybeBlock.get shouldBe b
+          val got = maybeBlock.get.toByteArray
+          assert(before.sameElements(got))
+        }
       }
     }
   }


### PR DESCRIPTION
### Overview
We forgot to add `ProcessedDeploy.stage` to the persistence layer and also the random date generators. The result was that cached blocks were fine, but blocks retrieved from SQLite lost their `stage` information, which resulted in invalid body hashes. 

This only occurred for example if
1. node-0 was started
2. multiple deploys from the same account ended up in the same block
3. node-0 was restarted, its cached emptied
4. node-1 was started and tried to sync

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1287

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
