### PR TITLE
NODE-1288: Add `ftt` to the Genesis chainspec.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/Casper.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/Casper.scala
@@ -71,7 +71,8 @@ sealed abstract class MultiParentCasperInstances {
       genesisEffects: ExecEngineUtil.TransformMap,
       chainName: String,
       minTtl: FiniteDuration,
-      upgrades: Seq[ipc.ChainSpec.UpgradePoint]
+      upgrades: Seq[ipc.ChainSpec.UpgradePoint],
+      rFTT: Double
   ): F[MultiParentCasper[F]] =
     for {
       lfbHash <- FinalityStorage[F].getLastFinalizedBlock
@@ -93,7 +94,8 @@ sealed abstract class MultiParentCasperInstances {
                  chainName,
                  minTtl,
                  upgrades,
-                 lfbRef = lfbRef
+                 lfbRef = lfbRef,
+                 faultToleranceThreshold = rFTT
                )
     } yield casper
 }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -532,7 +532,7 @@ object MultiParentCasperImpl {
       chainName: String,
       minTtl: FiniteDuration,
       upgrades: Seq[ipc.ChainSpec.UpgradePoint],
-      faultToleranceThreshold: Double = 0.1,
+      faultToleranceThreshold: Double,
       lfbRef: Ref[F, BlockHash]
   ): F[MultiParentCasper[F]] =
     for {

--- a/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
@@ -83,8 +83,9 @@ class MultiParentFinalizerTest extends FlatSpec with BlockGenerator with Storage
         genesis                                  <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
         implicit0(fs: MockFinalityStorage[Task]) <- MockFinalityStorage[Task](genesis.blockHash)
         dag                                      <- dagStorage.getRepresentation
+        fft                                      = 0.1
         finalizer <- FinalityDetectorVotingMatrix
-                      .of[Task](dag, genesis.blockHash, 0.1, isHighway = false)
+                      .of[Task](dag, genesis.blockHash, fft, isHighway = false)
         implicit0(multiParentFinalizer: MultiParentFinalizer[Task]) <- MultiParentFinalizer
                                                                         .create[Task](
                                                                           dag,

--- a/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
@@ -27,6 +27,8 @@ voting-period-duration = "2days"
 
 voting-period-summit-level = 0
 
+ftt = 0.1
+
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10

--- a/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
@@ -27,6 +27,8 @@ voting-period-duration = "2days"
 
 voting-period-summit-level = 0
 
+ftt = 0.1
+
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10

--- a/integration-testing/resources/test-chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec/genesis/manifest.toml
@@ -27,6 +27,8 @@ voting-period-duration = "2days"
 
 voting-period-summit-level = 0
 
+ftt = 0.1
+
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10

--- a/node/src/main/resources/chainspec/genesis/manifest.toml
+++ b/node/src/main/resources/chainspec/genesis/manifest.toml
@@ -48,6 +48,10 @@ voting-period-duration = "2days"
 # Alternative voting duration based on the finality level of the switch block; effective if it's non-zero.
 voting-period-summit-level = 0
 
+# Relative fault tolerance thresholds used by the internal finalizer.
+# Has to be between 0 and 0.5
+ftt = 0.1
+
 [deploys]
 # 1 day
 max-ttl-millis = 86400000

--- a/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
@@ -246,7 +246,7 @@ object Highway {
   ): Resource[F, Consensus[F]] = {
     val chainName               = chainSpec.getGenesis.name
     val hc                      = chainSpec.getGenesis.getHighwayConfig
-    val faultToleranceThreshold = 0.1
+    val faultToleranceThreshold = chainSpec.getGenesis.getHighwayConfig.ftt
 
     for {
       implicit0(finalizer: MultiParentFinalizer[F]) <- {

--- a/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
@@ -178,7 +178,8 @@ object NCB {
                      transforms,
                      genesis.getHeader.chainName,
                      conf.casper.minTtl,
-                     chainSpec.upgrades
+                     chainSpec.upgrades,
+                     rFTT = chainSpec.getGenesis.getHighwayConfig.ftt
                    )
           _ <- MultiParentCasperRef[F].set(casper)
           _ <- Log[F].info(s"Making the transition to block processing.")

--- a/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
@@ -116,7 +116,8 @@ object ChainSpec extends ParserImplicits {
       bookingDuration: FiniteDuration,
       entropyDuration: FiniteDuration,
       votingPeriodDuration: FiniteDuration,
-      votingPeriodSummitLevel: Int Refined Interval.Closed[W.`0`.T, W.`1`.T]
+      votingPeriodSummitLevel: Int Refined Interval.Closed[W.`0`.T, W.`1`.T],
+      ftt: Double Refined Interval.OpenClosed[W.`0.0`.T, W.`0.5`.T]
   )
 
   final case class Upgrade(
@@ -418,7 +419,8 @@ object ChainSpecReader {
       highwayConfig.bookingDuration.toMillis,
       highwayConfig.entropyDuration.toMillis,
       highwayConfig.votingPeriodDuration.toMillis,
-      highwayConfig.votingPeriodSummitLevel.value
+      highwayConfig.votingPeriodSummitLevel.value,
+      highwayConfig.ftt.value
     )
 
   private def withManifest[A, B](dir: Path, parseManifest: (=> Source) => ValidatedNel[String, A])(

--- a/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Parser.scala
@@ -97,6 +97,14 @@ private[configuration] trait ParserImplicits {
         w <- refineV[Interval.OpenClosed[W.`0.0`.T, W.`1.0`.T]](d)
       } yield w
 
+  implicit val gt0lte05DoubleParser
+      : Parser[Refined[Double, Interval.OpenClosed[W.`0.0`.T, W.`0.5`.T]]] =
+    s =>
+      for {
+        d <- Try(s.toDouble).toEither.leftMap(_.getMessage)
+        w <- refineV[Interval.OpenClosed[W.`0.0`.T, W.`0.5`.T]](d)
+      } yield w
+
   implicit val gte0lte1IntParser: Parser[Refined[Int, Interval.Closed[W.`0`.T, W.`1`.T]]] =
     s =>
       for {

--- a/node/src/test/resources/test-chainspec/genesis/manifest.toml
+++ b/node/src/test/resources/test-chainspec/genesis/manifest.toml
@@ -27,6 +27,8 @@ voting-period-duration = "2days"
 
 voting-period-summit-level = 0
 
+ftt = 0.1
+
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -278,6 +278,10 @@ message ChainSpec {
         uint64 voting_period_duration_millis = 5;
         // Stop the post-era voting period when the switch block reaches a certain summit level; when 0 use the duration instead.
         uint32 voting_period_summit_level = 6;
+        // Relative fault tolerance threshold value used by the internal finalizer.
+        // Has to be between 0 and 0.5 .
+        double ftt = 7;
+
     }
 
     message CostTable {


### PR DESCRIPTION
### Overview
Since `ftt` (fault tolerance threshold) has to be the same on every node to produce the same results, it has to be part of the Genesis chainspec.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1288

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
