### PR TITLE
NODE-1284: Convenience bytes representation for List(U8) and FixedList(U8)

### DIFF
--- a/client/src/test/scala/io/casperlabs/client/configuration/ArgsSpec.scala
+++ b/client/src/test/scala/io/casperlabs/client/configuration/ArgsSpec.scala
@@ -151,13 +151,29 @@ class ArgsSpec extends FlatSpec with Matchers {
             "value_3" : {"u64" : $long}
           }}
         }
+      },
+
+      {
+        "name" : "raw_bytes",
+        "value" : {
+          "cl_type" : {"list_type" : {"inner" : {"simple_type" : "U8"}}},
+          "value" : {"bytes_value" : "$addressHex"}
+        }
+      },
+
+      {
+        "name" : "raw_bytes_fixed",
+        "value" : {
+          "cl_type" : {"fixed_list_type" : {"inner" : {"simple_type" : "U8"}, "len" : 32}},
+          "value" : {"bytes_value" : "$addressHex"}
+        }
       }
     ]
     """
 
     val args = Args.fromJson(json).fold(e => fail(e), identity)
 
-    args should have size 26
+    args should have size 28
     args(0) shouldBe Arg("bool").withValue(
       dsl.instances.bool(bool)
     )
@@ -280,6 +296,12 @@ class ArgsSpec extends FlatSpec with Matchers {
     )
     args(25) shouldBe Arg("tuple3").withValue(
       dsl.instances.tuple3(dsl.instances.u8(byte), dsl.instances.u32(int), dsl.instances.u64(long))
+    )
+    args(26) shouldBe Arg("raw_bytes").withValue(
+      dsl.instances.bytes(address)
+    )
+    args(27) shouldBe Arg("raw_bytes_fixed").withValue(
+      dsl.instances.bytesFixedLength(address)
     )
   }
 

--- a/models/src/main/scala/io/casperlabs/models/cltype/protobuf/dsl.scala
+++ b/models/src/main/scala/io/casperlabs/models/cltype/protobuf/dsl.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.models.cltype.protobuf
 
 import cats.syntax.option._
+import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.state.{CLType, CLValueInstance, Key, Unit}
 
 object dsl {
@@ -118,6 +119,10 @@ object dsl {
 
     def uref(u: Key.URef): CLValueInstance.Value = CLValueInstance.Value(
       value = CLValueInstance.Value.Value.Uref(u)
+    )
+
+    def bytes(bs: Seq[Byte]): CLValueInstance.Value = CLValueInstance.Value(
+      value = CLValueInstance.Value.Value.BytesValue(ByteString.copyFrom(bs.toArray))
     )
 
     def option(inner: Option[CLValueInstance.Value]): CLValueInstance.Value =
@@ -252,6 +257,16 @@ object dsl {
     def uref(u: Key.URef): CLValueInstance = CLValueInstance(
       clType = types.uref.some,
       value = values.uref(u).some
+    )
+
+    def bytes(bs: Seq[Byte]): CLValueInstance = CLValueInstance(
+      clType = types.list(types.u8).some,
+      value = values.bytes(bs).some
+    )
+
+    def bytesFixedLength(bs: Seq[Byte]): CLValueInstance = CLValueInstance(
+      clType = types.fixedList(types.u8, bs.size).some,
+      value = values.bytes(bs).some
     )
 
     object option {

--- a/models/src/test/scala/io/casperlabs/models/cltype/protobuf/MappingsTest.scala
+++ b/models/src/test/scala/io/casperlabs/models/cltype/protobuf/MappingsTest.scala
@@ -53,4 +53,14 @@ class MappingsTest extends FlatSpec with Matchers with PropertyChecks {
     val wideProto = Mappings.toProto(wideType)
     val _         = Mappings.fromProto(wideProto)
   }
+
+  "CLValueInstance.List(U8) and CLValueInstance.FixedList(U8)" should "convert into bytes" in {
+    val bytes          = Array.range(0, 32).map(_.toByte)
+    val bytesInstances = bytes.map(CLValueInstance.U8.apply)
+    val list           = CLValueInstance.List(bytesInstances, CLType.U8).right.get
+    val fixedList      = CLValueInstance.FixedList(bytesInstances, CLType.U8, bytes.length).right.get
+
+    Mappings.toProto(list) shouldBe dsl.instances.bytes(bytes)
+    Mappings.toProto(fixedList) shouldBe dsl.instances.bytesFixedLength(bytes)
+  }
 }

--- a/protobuf/io/casperlabs/casper/consensus/state.proto
+++ b/protobuf/io/casperlabs/casper/consensus/state.proto
@@ -109,6 +109,7 @@ message CLValueInstance {
             Tuple1 tuple1_value = 19;
             Tuple2 tuple2_value = 20;
             Tuple3 tuple3_value = 21;
+            bytes bytes_value = 22; // convenience for representing List(U8) / FixedList(U8)
         }
     }
 


### PR DESCRIPTION
### Overview
Let's clients specify bytes in base-16; also prints bytes as bytes when coming from query.

You still need to give the type, but we can smooth that out later with type inference and/or a better DSL for specifying arguments.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1284

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
