### PR TITLE
NODE-1291: Disable validations in Synchronizer. Added some metrics.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -468,7 +468,8 @@ object GossipServiceCasperTestNodeFactory {
                          maxPossibleDepth = Int.MaxValue,
                          minBlockCountToCheckWidth = Int.MaxValue,
                          maxBondingRate = 1.0,
-                         maxDepthAncestorsRequest = 1 // Just so we don't see the full DAG being synced all the time. We should have justifications for early stop.
+                         maxDepthAncestorsRequest = 1, // Just so we don't see the full DAG being synced all the time. We should have justifications for early stop.
+                         disableValidations = false    // See any problems in testing.
                        )
 
         server <- GossipServiceServer[F](

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerSpec.scala
@@ -500,7 +500,8 @@ object SynchronizerSpec {
         maxPossibleDepth = maxPossibleDepth,
         minBlockCountToCheckWidth = minBlockCountToCheckWidth,
         maxBondingRate = maxBondingRate,
-        maxDepthAncestorsRequest = maxDepthAncestorsRequest
+        maxDepthAncestorsRequest = maxDepthAncestorsRequest,
+        disableValidations = false
       ).flatMap { synchronizer =>
           test(synchronizer, TestVariables(requestsCounter, requestsGauge, knownHashes))
         }

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -82,6 +82,9 @@ sync-max-bonding-rate = 1.0
 # Maximum DAG depth to ask in iterative requests during syncing.
 sync-max-depth-ancestors-request = 5
 
+# Disable DAG shape validations during synchronization.
+sync-disable-validations = true
+
 # Maximum number of nodes to try to sync with initially in a round.
 init-sync-max-nodes = 5
 

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -456,7 +456,8 @@ package object gossiping {
                        maxPossibleDepth = conf.server.syncMaxPossibleDepth,
                        minBlockCountToCheckWidth = conf.server.syncMinBlockCountToCheckWidth,
                        maxBondingRate = conf.server.syncMaxBondingRate,
-                       maxDepthAncestorsRequest = conf.server.syncMaxDepthAncestorsRequest
+                       maxDepthAncestorsRequest = conf.server.syncMaxDepthAncestorsRequest,
+                       disableValidations = conf.server.syncDisableValidations
                      )
     } yield synchronizer
   }

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -81,6 +81,7 @@ object Configuration extends ParserImplicits {
       syncMinBlockCountToCheckWidth: Int Refined NonNegative,
       syncMaxBondingRate: Double Refined GreaterEqual[W.`0.0`.T],
       syncMaxDepthAncestorsRequest: Int Refined Positive,
+      syncDisableValidations: Boolean,
       initSyncMaxNodes: Int,
       initSyncMinSuccessful: Int Refined Positive,
       initSyncMemoizeNodes: Boolean,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -361,6 +361,10 @@ private[configuration] final case class Options private (
       gen[Int]("Maximum DAG depth to ask in iterative requests during syncing.")
 
     @scallop
+    val serverSyncDisableValidations =
+      gen[Flag]("Disable DAG shape validations during synchronization.")
+
+    @scallop
     val serverInitSyncMaxNodes =
       gen[Int]("Maximum number of nodes to try to sync with initially in a round.")
 

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -32,6 +32,7 @@ sync-max-possible-depth = 1
 sync-min-block-count-to-check-width = 1
 sync-max-bonding-rate = 1.0
 sync-max-depth-ancestors-request = 1
+sync-disable-validations = false
 init-sync-max-nodes = 1
 init-sync-min-successful = 1
 init-sync-memoize-nodes = false

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -85,6 +85,7 @@ class ConfigurationSpec
       syncMinBlockCountToCheckWidth = 1,
       syncMaxBondingRate = 1.0,
       syncMaxDepthAncestorsRequest = 1,
+      syncDisableValidations = false,
       initSyncMaxNodes = 1,
       initSyncMinSuccessful = 1,
       initSyncMemoizeNodes = false,


### PR DESCRIPTION
### Overview
Disables the DAG shape validations during gossiping synchronization to find out whether they are the cause of the stucked syncs on LRT. Also adding some tracking around looping and traversal, and the size of the synchronized DAG.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1291

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
