### PR TITLE
NO-TICK: remove channel override from drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -898,7 +898,6 @@ steps:
   settings:
     webhook:
       from_secret: slack_webhook
-    channel: alerts
     template:
     - |
       *{{ uppercasefirst build.status }}*
@@ -1210,7 +1209,6 @@ steps:
   settings:
     webhook:
       from_secret: slack_webhook
-    channel: alerts
     template:
     - |
       macOS Build Status: *{{ uppercasefirst build.status }}*


### PR DESCRIPTION
### Overview
Channel override from drone file - reason new alerts weren't triggered

### Which JIRA ticket does this PR relate to?
N/A

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

1. built https://github.com/drone-plugins/drone-slack.git locally and tested 
 
```
./drone-slack --webhook <url> --template '
*test*             
      Author: mal
      Drone Build: funct
      Commit Link: blabla'
```
https://casperlabs-team.slack.com/archives/CV33BQWVB/p1584026580001800

2. also tested at tested at https://casperlabs-team.slack.com/archives/CUSURQT0R/p1584027320002000 for a similar PR https://github.com/CasperLabs/website/pull/65
