### PR TITLE
EE-933: update concurrent-executor script and README for turbo mode

### DIFF
--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -411,7 +411,7 @@ where
                 genesis_config.standard_payment_installer_bytes()
             };
 
-            if !self.config.use_system_contracts() && standard_payment_installer_bytes.is_empty() {
+            if !self.config.use_system_contracts() {
                 store_do_nothing_contract()?
             } else {
                 let standard_payment_installer_module =

--- a/execution-engine/engine-tests/src/profiling/README.md
+++ b/execution-engine/engine-tests/src/profiling/README.md
@@ -85,7 +85,7 @@ First build the contracts and run `state-initializer`:
 
 ```bash
 cd CasperLabs/execution-engine/
-make build-contracts
+make build-contracts-rs
 cd engine-tests/
 HASH=$(cargo run --release --bin=state-initializer -- --data-dir=/tmp/CasperLabs/DataDir)
 ```
@@ -98,6 +98,8 @@ cargo run --release --bin=casperlabs-engine-grpc-server -- \
     /tmp/CasperLabs/Socket --data-dir=/tmp/CasperLabs/DataDir --threads=8
 ```
 
+**Note: to tell the server to use Wasm system contracts rather than host-side implementations, append ` -z` to the above command.**
+
 Then in the first terminal, run the client:
 
 ```bash
@@ -105,11 +107,12 @@ RUST_LOG=concurrent_executor=info cargo run --release --bin=concurrent-executor 
     --socket=/tmp/CasperLabs/Socket --pre-state-hash=$HASH --threads=8 --requests=200
 ```
 
-There is a bash script which automates this process, and which allows specifying the number of server threadpool threads, the number of client threadpool threads, and the number of messages the client should send.
+There is a bash script which automates this process, and which allows specifying the number of server threadpool threads, the number of client threadpool threads, the number of messages the client should send, and whether to use system contracts or not.
 
 ```bash
 cd CasperLabs/execution-engine/engine-tests/src/profiling/
-./concurrent_executor.sh 8 8 200
+./concurrent_executor.sh 8 8 200     # without system contracts
+./concurrent_executor.sh 8 8 200 -z  # using system contracts
 ```
 
 For logging, again set the `RUST_LOG` env var:

--- a/execution-engine/engine-tests/src/profiling/concurrent_executor.sh
+++ b/execution-engine/engine-tests/src/profiling/concurrent_executor.sh
@@ -16,11 +16,13 @@ MAX_MESSAGES=1000000
 
 print_usage_and_exit() {
     printf "USAGE:\n"
-    printf "    %s <SERVER-THREAD-COUNT> <CLIENT-THREAD-COUNT> <MESSAGE-COUNT>\n\n" "$THIS_SCRIPT"
+    printf "    %s <SERVER-THREAD-COUNT> <CLIENT-THREAD-COUNT> <MESSAGE-COUNT> [FLAGS]\n\n" "$THIS_SCRIPT"
     printf "ARGS:\n"
     printf "    <SERVER-THREAD-COUNT>   Number of threads for the server threadpool [%d-%d]\n" $MIN_THREADS $MAX_THREADS
     printf "    <CLIENT-THREAD-COUNT>   Number of threads for the client threadpool [%d-%d]\n" $MIN_THREADS $MAX_THREADS
     printf "    <MESSAGE-COUNT>         Total number of messages the client should send [%d-%d]\n\n" $MIN_MESSAGES $MAX_MESSAGES
+    printf "FLAGS:\n"
+    printf "    -z   Use system contracts instead of host-side logic for Mint, Proof of Stake and Standard Payment\n\n"
     exit 127
 }
 
@@ -33,9 +35,16 @@ validate_and_assign_arg() {
     OUT_VAR=$ARG
 }
 
+validate_and_assign_flag() {
+    local ARG=$1
+    local -n OUT_VAR=$2
+    [[ $1 == "-z" ]] || print_usage_and_exit
+    OUT_VAR=$ARG
+}
+
 build_contracts_and_run_state_initializer() {
     cd $EE_DIR
-    make build-contracts
+    make build-contracts-rs
     cd engine-tests/
     PRE_STATE_HASH=$(cargo run --release --bin=state-initializer -- --data-dir=$DATA_DIR)
 }
@@ -43,7 +52,7 @@ build_contracts_and_run_state_initializer() {
 run_server() {
     cd $EE_DIR
     cargo build --release --bin=$SERVER
-    target/release/$SERVER $SOCKET --data-dir=$DATA_DIR --threads=$SERVER_THREAD_COUNT &
+    target/release/$SERVER $SOCKET --data-dir=$DATA_DIR --threads=$SERVER_THREAD_COUNT $USE_SYSTEM_CONTRACTS &
     SERVER_PID=$!
 }
 
@@ -68,6 +77,12 @@ if [[ $# -eq 3 ]]; then
     validate_and_assign_arg $1 $MIN_THREADS  $MAX_THREADS  SERVER_THREAD_COUNT
     validate_and_assign_arg $2 $MIN_THREADS  $MAX_THREADS  CLIENT_THREAD_COUNT
     validate_and_assign_arg $3 $MIN_MESSAGES $MAX_MESSAGES MESSAGE_COUNT
+    USE_SYSTEM_CONTRACTS=
+elif [[ $# -eq 4 ]]; then
+    validate_and_assign_arg $1 $MIN_THREADS  $MAX_THREADS  SERVER_THREAD_COUNT
+    validate_and_assign_arg $2 $MIN_THREADS  $MAX_THREADS  CLIENT_THREAD_COUNT
+    validate_and_assign_arg $3 $MIN_MESSAGES $MAX_MESSAGES MESSAGE_COUNT
+    validate_and_assign_flag $4 USE_SYSTEM_CONTRACTS
 else
     print_usage_and_exit
 fi

--- a/execution-engine/engine-tests/src/profiling/state_initializer.rs
+++ b/execution-engine/engine-tests/src/profiling/state_initializer.rs
@@ -6,10 +6,13 @@ use std::{env, path::PathBuf};
 
 use clap::{crate_version, App};
 
+use engine_core::engine_state::{engine_config::EngineConfig, genesis::GenesisConfig};
 use engine_test_support::{
     internal::{
-        DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_GENESIS_CONFIG,
-        DEFAULT_PAYMENT,
+        utils, DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder, DEFAULT_ACCOUNTS,
+        DEFAULT_CHAIN_NAME, DEFAULT_GENESIS_TIMESTAMP, DEFAULT_PAYMENT, DEFAULT_PROTOCOL_VERSION,
+        DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT, POS_INSTALL_CONTRACT, STANDARD_PAYMENT_CONTRACT,
+        STANDARD_PAYMENT_INSTALL_CONTRACT,
     },
     DEFAULT_ACCOUNT_ADDR,
 };
@@ -18,7 +21,7 @@ use casperlabs_engine_tests::profiling;
 
 const ABOUT: &str = "Initializes global state in preparation for profiling runs. Outputs the root \
                      hash from the commit response.";
-const STANDARD_PAYMENT_WASM: &str = "standard_payment.wasm";
+const STATE_INITIALIZER_CONTRACT: &str = "state_initializer.wasm";
 
 fn data_dir() -> PathBuf {
     let exe_name = profiling::exe_name();
@@ -44,24 +47,40 @@ fn main() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_deploy_hash([1; 32])
             .with_session_code(
-                "state_initializer.wasm",
+                STATE_INITIALIZER_CONTRACT,
                 (
                     account_1_public_key,
                     account_1_initial_amount,
                     account_2_public_key,
                 ),
             )
-            .with_payment_code(STANDARD_PAYMENT_WASM, (*DEFAULT_PAYMENT,))
+            .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,))
             .with_authorization_keys(&[genesis_public_key])
             .build();
 
         ExecuteRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let mut builder = LmdbWasmTestBuilder::new(&data_dir);
+    let engine_config = EngineConfig::new().with_use_system_contracts(true);
+    let mut builder = LmdbWasmTestBuilder::new_with_config(&data_dir, engine_config);
+
+    let mint_installer_bytes = utils::read_wasm_file_bytes(MINT_INSTALL_CONTRACT);
+    let pos_installer_bytes = utils::read_wasm_file_bytes(POS_INSTALL_CONTRACT);
+    let standard_payment_installer_bytes =
+        utils::read_wasm_file_bytes(STANDARD_PAYMENT_INSTALL_CONTRACT);
+    let genesis_config = GenesisConfig::new(
+        DEFAULT_CHAIN_NAME.to_string(),
+        DEFAULT_GENESIS_TIMESTAMP,
+        *DEFAULT_PROTOCOL_VERSION,
+        mint_installer_bytes,
+        pos_installer_bytes,
+        standard_payment_installer_bytes,
+        DEFAULT_ACCOUNTS.clone(),
+        *DEFAULT_WASM_COSTS,
+    );
 
     let post_state_hash = builder
-        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .run_genesis(&genesis_config)
         .exec(exec_request)
         .expect_success()
         .commit()


### PR DESCRIPTION
### Overview
This PR adds an option to use system contracts (rather than executing in default "turbo mode") to the concurrent-executor script and documents this in the README.

Supporting this required the state-initializer tool to be updated to always use system contracts, so that subsequent execution of the server has the choice to use these or not.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-933

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
