### PR TITLE
NODE-1293: Fix syncedSummariesRef memory leak

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
@@ -16,8 +16,9 @@ import io.casperlabs.comm.gossiping.synchronization.Synchronizer.SyncError
 import io.casperlabs.comm.gossiping.synchronization.Synchronizer.SyncError._
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.shared.Log
-import scala.util.control.NonFatal
 import io.casperlabs.shared.Sorting.{catsOrder, jRankOrdering}
+import scala.util.control.NonFatal
+import scala.collection.immutable.Queue
 
 class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     connectToGossip: Node => F[GossipService[F]],
@@ -38,7 +39,7 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
   // This is supposed to be called every time a scheduled download is finished,
   // even when the resolution is that we already had it, so there should be no leaks.
   override def downloaded(blockHash: ByteString) =
-    syncedSummariesRef.update(_ - blockHash)
+    removeSynced(blockHash)
 
   override def syncDag(
       source: Node,
@@ -163,12 +164,36 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     * so next time we don't have to travel that far back in their DAG. */
   private def addSynced(source: Node, syncState: SyncState): F[Unit] =
     syncedSummariesRef.update { syncedSummaries =>
+      // We could filter with `backend.notInDag` to never add ones that have perhaps been
+      // downloaded in the meantime, but that would be a lot of database queries.
+      // Instead, `removeSynced` will clear the dependencies recursively,
+      // so if any descendants gets downloaded it will remove any leftovers.
       syncState.summaries.values.foldLeft(syncedSummaries) {
         case (syncedSummaries, summary) =>
           val ss = syncedSummaries.getOrElse(summary.blockHash, SyncedSummary(summary))
           syncedSummaries + (summary.blockHash -> ss.addSource(source))
       }
-    }
+    } >> recordSyncedSummaries
+
+  /** Recursively clear out summaries and their dependencies from the cache. */
+  private def removeSynced(blockHash: ByteString): F[Unit] = {
+    def remove(queue: Queue[ByteString]): F[Unit] =
+      queue.dequeueOption.fold(().pure[F]) {
+        case (blockHash, queue) =>
+          syncedSummariesRef.modify { ss =>
+            (ss - blockHash) -> ss.get(blockHash)
+          } flatMap {
+            case None =>
+              remove(queue)
+            case Some(s) =>
+              remove(queue.enqueue(dependencies(s.summary)))
+          }
+      }
+    remove(Queue(blockHash)) >> recordSyncedSummaries
+  }
+
+  private def recordSyncedSummaries =
+    syncedSummariesRef.get.flatMap(ss => Metrics[F].setGauge("synced_summaries", ss.size.toLong))
 
   /** Ask the source to traverse back from whatever our last unknown blocks were. */
   private def traverse(


### PR DESCRIPTION
### Overview
The `SynchronizerImpl` keeps a map of summaries that have been synced before, per source, so that it can stop traversing backwards early. It's notified of downloads, which is when that map should be cleared. However I forgot that when we do syncing we get more than what we asked for due to the fixed page sizes, so entries got re-added and never cleared. 

The PR adds a recursive mechanism so that when a download happens all its dependencies are cleared from this map.

Verified with the new metric:
```console
$ make node-0/metrics | grep synced_summaries
# TYPE casperlabs_comm_gossiping_Synchronizer_synced_summaries gauge
casperlabs_comm_gossiping_Synchronizer_synced_summaries 0.0
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1293

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
