### PR TITLE
EE-906: Grow map size

### DIFF
--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -55,10 +55,10 @@ const ARG_PAGES_SHORT: &str = "p";
 const ARG_PAGES_VALUE: &str = "NUM";
 const ARG_PAGES_HELP: &str = "Sets the max number of pages to use for lmdb's mmap";
 const GET_PAGES_EXPECT: &str = "Could not parse pages argument";
-// 750 GiB = 805306368000 bytes
+// 10 MiB = 10485760 bytes
 // page size on x86_64 linux = 4096 bytes
-// 805306368000 / 4096 = 196608000
-const DEFAULT_PAGES: usize = 196_608_000;
+// 10485760 / 4096 = 2560
+const DEFAULT_PAGES: usize = 2560;
 
 // socket
 const ARG_SOCKET: &str = "socket";

--- a/execution-engine/engine-shared/Cargo.toml
+++ b/execution-engine/engine-shared/Cargo.toml
@@ -18,6 +18,8 @@ engine-wasm-prep = { version = "0.2.0", path = "../engine-wasm-prep", package = 
 hostname = "0.3.0"
 lazy_static = "1.4.0"
 libc = "0.2.66"
+lmdb = "0.8.0"
+lmdb-sys = "0.8.0"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
 num = { version = "0.2.0", default-features = false }
 parity-wasm = "0.31.3"
@@ -27,6 +29,9 @@ serde_json = "1"
 types = { version = "0.2.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wabt = "0.9.2"
+
+[dev-dependencies]
+tempfile = "3"
 
 [[test]]
 name = "trace-level-metrics-disabled"

--- a/execution-engine/engine-shared/src/lib.rs
+++ b/execution-engine/engine-shared/src/lib.rs
@@ -5,6 +5,7 @@ pub mod additive_map;
 pub mod gas;
 pub mod account;
 pub mod contract;
+pub mod lmdb_ext;
 pub mod logging;
 pub mod motes;
 pub mod newtypes;

--- a/execution-engine/engine-shared/src/lmdb_ext.rs
+++ b/execution-engine/engine-shared/src/lmdb_ext.rs
@@ -1,0 +1,129 @@
+use std::mem;
+
+use lmdb::{Environment, Error};
+use lmdb_sys::{self, MDB_env, MDB_SUCCESS};
+
+pub struct EnvInfo(lmdb_sys::MDB_envinfo);
+
+impl EnvInfo {
+    pub fn get_map_size(&self) -> usize {
+        self.0.me_mapsize
+    }
+}
+
+pub trait EnvironmentExt {
+    fn get_env_info(&self) -> Result<EnvInfo, lmdb::Error>;
+
+    fn get_map_size(&self) -> Result<usize, lmdb::Error> {
+        let env_info = self.get_env_info()?;
+        Ok(env_info.get_map_size())
+    }
+
+    fn set_map_size(&self, map_size: usize) -> Result<(), lmdb::Error>;
+}
+
+fn lmdb_result(err_code: i32) -> Result<(), Error> {
+    if err_code == MDB_SUCCESS {
+        Ok(())
+    } else {
+        Err(Error::from_err_code(err_code))
+    }
+}
+
+impl EnvironmentExt for Environment {
+    fn get_env_info(&self) -> Result<EnvInfo, lmdb::Error> {
+        let env: *mut MDB_env = self.env();
+        let e = mem::MaybeUninit::uninit();
+        unsafe {
+            let mut env_info = EnvInfo(e.assume_init());
+            lmdb_result(lmdb_sys::mdb_env_info(env, &mut env_info.0))?;
+            Ok(env_info)
+        }
+    }
+
+    fn set_map_size(&self, map_size: usize) -> Result<(), Error> {
+        let env: *mut MDB_env = self.env();
+        unsafe { lmdb_result(lmdb_sys::mdb_env_set_mapsize(env, map_size)) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lmdb::{Environment, Transaction, WriteFlags};
+    use tempfile;
+
+    use super::*;
+    use crate::os;
+
+    const DEFAULT_MAP_SIZE: usize = 10485760;
+    const GARBAGE: usize = 16392;
+
+    #[test]
+    fn should_resize_map() {
+        let mut map_size = 68719476736;
+
+        let tmp_dir = tempfile::tempdir().unwrap();
+
+        println!("tmp_dir: {:?}", tmp_dir.path());
+
+        {
+            let env = Environment::new()
+                .set_map_size(map_size)
+                .open(tmp_dir.path())
+                .unwrap();
+
+            let db = env.open_db(None).unwrap();
+
+            let test_val = vec![1u8; 2147467256];
+
+            let mut i: u8 = 1;
+
+            loop {
+                println!("i {:?}", i);
+                let test_key = vec![i; TEST_KEY_LENGTH];
+
+                let mut txn = env.begin_rw_txn().unwrap();
+                match txn.put(db, &test_key, &test_val, WriteFlags::empty()) {
+                    Ok(_) => {
+                        txn.commit().unwrap();
+                    }
+                    Err(lmdb::Error::MapFull) => {
+                        txn.abort();
+                        map_size = map_size * 2;
+                        env.set_map_size(map_size).unwrap();
+                        println!("resized: {:?}", map_size);
+                        i += 1;
+                        break;
+                    }
+                    e => {
+                        txn.abort();
+                        e.unwrap()
+                    }
+                }
+                i += 1;
+            }
+
+            println!("i {:?}", i);
+            let test_key = vec![i; TEST_KEY_LENGTH];
+
+            let mut txn = env.begin_rw_txn().unwrap();
+            txn.put(db, &test_key, &test_val, WriteFlags::empty())
+                .unwrap();
+            txn.commit().unwrap();
+
+            let map_size_actual = env.get_map_size().unwrap();
+            println!("map_size_actual: {}", map_size_actual);
+            assert_eq!(map_size_actual, map_size);
+        }
+
+        {
+            let env = Environment::new().open(tmp_dir.path()).unwrap();
+
+            let _db = env.open_db(None).unwrap();
+
+            let map_size_actual = env.get_map_size().unwrap();
+            println!("map_size_actual: {}", map_size_actual);
+            assert_eq!(map_size_actual, map_size);
+        }
+    }
+}

--- a/execution-engine/engine-storage/Cargo.toml
+++ b/execution-engine/engine-storage/Cargo.toml
@@ -15,6 +15,7 @@ engine-shared = { version = "0.3.0", path = "../engine-shared", package = "caspe
 engine-wasm-prep = { version = "0.2.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 failure = "0.1.6"
 lmdb = "0.8.0"
+lmdb-sys = "0.8.0"
 parking_lot = "0.10.0"
 types = { version = "0.2.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 wasmi = "0.4.2"

--- a/execution-engine/engine-storage/src/error/in_memory.rs
+++ b/execution-engine/engine-storage/src/error/in_memory.rs
@@ -2,21 +2,10 @@ use std::sync;
 
 use failure::Fail;
 
-use types::bytesrepr;
-
-#[derive(Debug, Fail, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Fail, PartialEq, Eq)]
 pub enum Error {
-    #[fail(display = "{}", _0)]
-    BytesRepr(#[fail(cause)] bytesrepr::Error),
-
     #[fail(display = "Another thread panicked while holding a lock")]
     Poison,
-}
-
-impl From<bytesrepr::Error> for Error {
-    fn from(error: bytesrepr::Error) -> Self {
-        Error::BytesRepr(error)
-    }
 }
 
 impl<T> From<sync::PoisonError<T>> for Error {

--- a/execution-engine/engine-storage/src/error/lmdb.rs
+++ b/execution-engine/engine-storage/src/error/lmdb.rs
@@ -1,49 +1,23 @@
-use std::sync;
-
 use failure::Fail;
 use lmdb as lmdb_external;
-
-use types::bytesrepr;
-
-use super::in_memory;
 
 #[derive(Debug, Clone, Fail, PartialEq, Eq)]
 pub enum Error {
     #[fail(display = "{}", _0)]
     Lmdb(#[fail(cause)] lmdb_external::Error),
-
-    #[fail(display = "{}", _0)]
-    BytesRepr(#[fail(cause)] bytesrepr::Error),
-
-    #[fail(display = "Another thread panicked while holding a lock")]
-    Poison,
 }
 
-impl wasmi::HostError for Error {}
+impl Error {
+    pub fn is_map_full(&self) -> bool {
+        match self {
+            Error::Lmdb(lmdb_external::Error::MapFull) => true,
+            _ => false,
+        }
+    }
+}
 
 impl From<lmdb_external::Error> for Error {
     fn from(error: lmdb_external::Error) -> Self {
         Error::Lmdb(error)
-    }
-}
-
-impl From<bytesrepr::Error> for Error {
-    fn from(error: bytesrepr::Error) -> Self {
-        Error::BytesRepr(error)
-    }
-}
-
-impl<T> From<sync::PoisonError<T>> for Error {
-    fn from(_error: sync::PoisonError<T>) -> Self {
-        Error::Poison
-    }
-}
-
-impl From<in_memory::Error> for Error {
-    fn from(error: in_memory::Error) -> Self {
-        match error {
-            in_memory::Error::BytesRepr(error) => Error::BytesRepr(error),
-            in_memory::Error::Poison => Error::Poison,
-        }
     }
 }

--- a/execution-engine/engine-storage/src/error/mod.rs
+++ b/execution-engine/engine-storage/src/error/mod.rs
@@ -1,4 +1,38 @@
 pub mod in_memory;
 pub mod lmdb;
 
-pub use self::lmdb::Error;
+use failure::Fail;
+
+use types::bytesrepr;
+
+#[derive(Debug, Clone, Fail, PartialEq, Eq)]
+pub enum Error {
+    #[fail(display = "{}", _0)]
+    Lmdb(#[fail(cause)] lmdb::Error),
+
+    #[fail(display = "{}", _0)]
+    InMemory(#[fail(cause)] in_memory::Error),
+
+    #[fail(display = "{}", _0)]
+    BytesRepr(#[fail(cause)] bytesrepr::Error),
+}
+
+impl wasmi::HostError for Error {}
+
+impl From<lmdb::Error> for Error {
+    fn from(error: lmdb::Error) -> Error {
+        Error::Lmdb(error)
+    }
+}
+
+impl From<in_memory::Error> for Error {
+    fn from(error: in_memory::Error) -> Error {
+        Error::InMemory(error)
+    }
+}
+
+impl From<bytesrepr::Error> for Error {
+    fn from(error: bytesrepr::Error) -> Error {
+        Error::BytesRepr(error)
+    }
+}

--- a/execution-engine/engine-storage/src/lib.rs
+++ b/execution-engine/engine-storage/src/lib.rs
@@ -18,11 +18,10 @@ const MAX_DBS: u32 = 2;
 
 #[cfg(test)]
 lazy_static! {
-    // 50 MiB = 52428800 bytes
-    // page size on x86_64 linux = 4096 bytes
-    // 52428800 / 4096 = 12800
     static ref TEST_MAP_SIZE: usize = {
+        // Default test map size should be around ~1MiB which is also default uses LMDB by default.
+        // We choose this default value to also be able to observe MapFull/MapResized error conditions under a load.
         let page_size = engine_shared::os::get_page_size().unwrap();
-        page_size * 12800
+        page_size * 256
     };
 }

--- a/execution-engine/engine-storage/src/lib.rs
+++ b/execution-engine/engine-storage/src/lib.rs
@@ -19,9 +19,9 @@ const MAX_DBS: u32 = 2;
 #[cfg(test)]
 lazy_static! {
     static ref TEST_MAP_SIZE: usize = {
-        // Default test map size should be around ~1MiB which is also default uses LMDB by default.
+        // Default test map size should be around ~10MiB which is also default uses LMDB by default.
         // We choose this default value to also be able to observe MapFull/MapResized error conditions under a load.
         let page_size = engine_shared::os::get_page_size().unwrap();
-        page_size * 256
+        page_size * 2560
     };
 }

--- a/execution-engine/engine-storage/src/protocol_data_store/in_memory.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/in_memory.rs
@@ -1,7 +1,6 @@
 use types::ProtocolVersion;
 
 use crate::{
-    error::in_memory::Error,
     protocol_data::ProtocolData,
     protocol_data_store::{self, ProtocolDataStore},
     store::Store,
@@ -25,7 +24,6 @@ impl InMemoryProtocolDataStore {
 }
 
 impl Store<ProtocolVersion, ProtocolData> for InMemoryProtocolDataStore {
-    type Error = Error;
     type Handle = Option<String>;
 
     fn handle(&self) -> Self::Handle {

--- a/execution-engine/engine-storage/src/protocol_data_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/protocol_data_store/lmdb.rs
@@ -24,13 +24,13 @@ impl LmdbProtocolDataStore {
         flags: DatabaseFlags,
     ) -> Result<Self, error::Error> {
         let name = Self::name(maybe_name);
-        let db = env.env().create_db(Some(&name), flags)?;
+        let db = env.create_db(Some(&name), flags)?;
         Ok(LmdbProtocolDataStore { db })
     }
 
     pub fn open(env: &LmdbEnvironment, maybe_name: Option<&str>) -> Result<Self, error::Error> {
         let name = Self::name(maybe_name);
-        let db = env.env().open_db(Some(&name))?;
+        let db = env.open_db(Some(&name))?;
         Ok(LmdbProtocolDataStore { db })
     }
 
@@ -42,8 +42,6 @@ impl LmdbProtocolDataStore {
 }
 
 impl Store<ProtocolVersion, ProtocolData> for LmdbProtocolDataStore {
-    type Error = error::Error;
-
     type Handle = Database;
 
     fn handle(&self) -> Self::Handle {

--- a/execution-engine/engine-storage/src/store/mod.rs
+++ b/execution-engine/engine-storage/src/store/mod.rs
@@ -5,21 +5,24 @@ pub(crate) mod tests;
 use types::bytesrepr::{self, FromBytes, ToBytes};
 
 pub use self::store_ext::StoreExt;
-use crate::transaction_source::{Readable, Writable};
+
+use crate::{
+    error,
+    transaction_source::{Readable, Writable},
+};
 
 pub trait Store<K, V> {
-    type Error: From<bytesrepr::Error>;
-
     type Handle;
 
     fn handle(&self) -> Self::Handle;
 
-    fn get<T>(&self, txn: &T, key: &K) -> Result<Option<V>, Self::Error>
+    fn get<T>(&self, txn: &T, key: &K) -> Result<Option<V>, error::Error>
     where
         T: Readable<Handle = Self::Handle>,
+        T::Error: Into<error::Error>,
+        error::Error: From<T::Error>,
         K: ToBytes,
         V: FromBytes,
-        Self::Error: From<T::Error>,
     {
         let handle = self.handle();
         match txn.read(handle, &key.to_bytes()?)? {
@@ -31,15 +34,15 @@ pub trait Store<K, V> {
         }
     }
 
-    fn put<T>(&self, txn: &mut T, key: &K, value: &V) -> Result<(), Self::Error>
+    fn put<T>(&self, txn: &mut T, key: &K, value: &V) -> Result<(), error::Error>
     where
         T: Writable<Handle = Self::Handle>,
+        T::Error: Into<error::Error>,
+        error::Error: From<T::Error>,
         K: ToBytes,
         V: ToBytes,
-        Self::Error: From<T::Error>,
     {
         let handle = self.handle();
-        txn.write(handle, &key.to_bytes()?, &value.to_bytes()?)
-            .map_err(Into::into)
+        Ok(txn.write(handle, &key.to_bytes()?, &value.to_bytes()?)?)
     }
 }

--- a/execution-engine/engine-storage/src/store/store_ext.rs
+++ b/execution-engine/engine-storage/src/store/store_ext.rs
@@ -1,6 +1,7 @@
 use types::bytesrepr::{FromBytes, ToBytes};
 
 use crate::{
+    error,
     store::Store,
     transaction_source::{Readable, Writable},
 };
@@ -10,12 +11,12 @@ pub trait StoreExt<K, V>: Store<K, V> {
         &self,
         txn: &T,
         keys: impl Iterator<Item = &'a K>,
-    ) -> Result<Vec<Option<V>>, Self::Error>
+    ) -> Result<Vec<Option<V>>, error::Error>
     where
         T: Readable<Handle = Self::Handle>,
+        error::Error: From<T::Error>,
         K: ToBytes + 'a,
         V: FromBytes,
-        Self::Error: From<T::Error>,
     {
         let mut ret: Vec<Option<V>> = Vec::new();
         for key in keys {
@@ -29,12 +30,12 @@ pub trait StoreExt<K, V>: Store<K, V> {
         &self,
         txn: &mut T,
         pairs: impl Iterator<Item = (&'a K, &'a V)>,
-    ) -> Result<(), Self::Error>
+    ) -> Result<(), error::Error>
     where
         T: Writable<Handle = Self::Handle>,
+        error::Error: From<T::Error>,
         K: ToBytes + 'a,
         V: ToBytes + 'a,
-        Self::Error: From<T::Error>,
     {
         for (key, value) in pairs {
             self.put(txn, key, value)?;

--- a/execution-engine/engine-storage/src/store/tests.rs
+++ b/execution-engine/engine-storage/src/store/tests.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use types::bytesrepr::{FromBytes, ToBytes};
 
 use crate::{
+    error,
     store::{Store, StoreExt},
     transaction_source::{Transaction, TransactionSource},
 };
@@ -12,19 +13,36 @@ fn roundtrip<'a, K, V, X, S>(
     transaction_source: &'a X,
     store: &S,
     items: &BTreeMap<K, V>,
-) -> Result<Vec<Option<V>>, S::Error>
+) -> Result<Vec<Option<V>>, error::Error>
 where
     K: ToBytes,
     V: ToBytes + FromBytes,
     X: TransactionSource<'a, Handle = S::Handle>,
     S: Store<K, V>,
-    S::Error: From<X::Error>,
+    error::Error: From<X::Error>,
 {
-    let mut txn: X::ReadWriteTransaction = transaction_source.create_read_write_txn()?;
-    store.put_many(&mut txn, items.iter())?;
-    let result = store.get_many(&txn, items.keys());
-    txn.commit()?;
-    result
+    loop {
+        let mut txn = transaction_source.create_read_write_txn()?;
+        match store.put_many(&mut txn, items.iter()) {
+            Ok(_) => {}
+            Err(error::Error::Lmdb(e)) if e.is_map_full() => {
+                txn.abort();
+                transaction_source.grow_map_size()?;
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+        let result = store.get_many(&txn, items.keys())?;
+
+        match txn.commit().map_err(error::Error::from) {
+            Ok(_) => return Ok(result),
+            Err(error::Error::Lmdb(e)) if e.is_map_full() => {
+                transaction_source.grow_map_size()?;
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
 }
 
 // should be moved to the `store` module
@@ -32,13 +50,13 @@ pub fn roundtrip_succeeds<'a, K, V, X, S>(
     transaction_source: &'a X,
     store: &S,
     items: BTreeMap<K, V>,
-) -> Result<bool, S::Error>
+) -> Result<bool, error::Error>
 where
     K: ToBytes,
     V: ToBytes + FromBytes + Clone + PartialEq,
     X: TransactionSource<'a, Handle = S::Handle>,
+    error::Error: From<X::Error>,
     S: Store<K, V>,
-    S::Error: From<X::Error>,
 {
     let maybe_values: Vec<Option<V>> = roundtrip(transaction_source, store, &items)?;
     let values = match maybe_values.into_iter().collect::<Option<Vec<V>>>() {

--- a/execution-engine/engine-storage/src/transaction_source/in_memory.rs
+++ b/execution-engine/engine-storage/src/transaction_source/in_memory.rs
@@ -163,4 +163,8 @@ impl<'a> TransactionSource<'a> for InMemoryEnvironment {
     fn create_read_write_txn(&'a self) -> Result<InMemoryReadWriteTransaction<'a>, Self::Error> {
         InMemoryReadWriteTransaction::new(self).map_err(Into::into)
     }
+
+    fn grow_map_size(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }

--- a/execution-engine/engine-storage/src/transaction_source/lmdb.rs
+++ b/execution-engine/engine-storage/src/transaction_source/lmdb.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
-use engine_shared::lmdb_ext::EnvironmentExt;
 use lmdb::{
     self as lmdb_external, Database, DatabaseFlags, Environment, RoTransaction, RwTransaction,
     WriteFlags,
 };
+
+use engine_shared::lmdb_ext::EnvironmentExt;
 
 use crate::{
     error::lmdb::Error,

--- a/execution-engine/engine-storage/src/transaction_source/mod.rs
+++ b/execution-engine/engine-storage/src/transaction_source/mod.rs
@@ -55,7 +55,5 @@ pub trait TransactionSource<'a> {
     fn create_read_write_txn(&'a self) -> Result<Self::ReadWriteTransaction, Self::Error>;
 
     /// Grows map size
-    fn grow_map_size(&self) -> Result<(), Self::Error> {
-        unimplemented!();
-    }
+    fn grow_map_size(&self) -> Result<(), Self::Error>;
 }

--- a/execution-engine/engine-storage/src/transaction_source/mod.rs
+++ b/execution-engine/engine-storage/src/transaction_source/mod.rs
@@ -16,9 +16,7 @@ pub trait Transaction: Sized {
     /// Aborts the transaction.
     ///
     /// Any pending operations will not be saved.
-    fn abort(self) {
-        unimplemented!("Abort operations should be performed in Drop implementations.")
-    }
+    fn abort(self) {}
 }
 
 /// A transaction with the capability to read from a given [`Handle`](Transaction::Handle).
@@ -55,4 +53,9 @@ pub trait TransactionSource<'a> {
 
     /// Creates a read-write transaction.
     fn create_read_write_txn(&'a self) -> Result<Self::ReadWriteTransaction, Self::Error>;
+
+    /// Grows map size
+    fn grow_map_size(&self) -> Result<(), Self::Error> {
+        unimplemented!();
+    }
 }

--- a/execution-engine/engine-storage/src/trie_store/in_memory.rs
+++ b/execution-engine/engine-storage/src/trie_store/in_memory.rs
@@ -99,9 +99,7 @@
 //! ```
 
 use super::*;
-use crate::{
-    error::in_memory::Error, transaction_source::in_memory::InMemoryEnvironment, trie_store,
-};
+use crate::{transaction_source::in_memory::InMemoryEnvironment, trie_store};
 
 /// An in-memory trie store.
 pub struct InMemoryTrieStore {
@@ -120,8 +118,6 @@ impl InMemoryTrieStore {
 }
 
 impl<K, V> Store<Blake2bHash, Trie<K, V>> for InMemoryTrieStore {
-    type Error = Error;
-
     type Handle = Option<String>;
 
     fn handle(&self) -> Self::Handle {

--- a/execution-engine/engine-storage/src/trie_store/lmdb.rs
+++ b/execution-engine/engine-storage/src/trie_store/lmdb.rs
@@ -131,13 +131,13 @@ impl LmdbTrieStore {
         flags: DatabaseFlags,
     ) -> Result<Self, error::Error> {
         let name = Self::name(maybe_name);
-        let db = env.env().create_db(Some(&name), flags)?;
+        let db = env.create_db(Some(&name), flags)?;
         Ok(LmdbTrieStore { db })
     }
 
     pub fn open(env: &LmdbEnvironment, maybe_name: Option<&str>) -> Result<Self, error::Error> {
         let name = Self::name(maybe_name);
-        let db = env.env().open_db(Some(&name))?;
+        let db = env.open_db(Some(&name))?;
         Ok(LmdbTrieStore { db })
     }
 
@@ -149,8 +149,6 @@ impl LmdbTrieStore {
 }
 
 impl<K, V> Store<Blake2bHash, Trie<K, V>> for LmdbTrieStore {
-    type Error = error::Error;
-
     type Handle = Database;
 
     fn handle(&self) -> Self::Handle {

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
@@ -307,10 +307,7 @@ mod empty_tries {
     use engine_shared::newtypes::CorrelationId;
 
     use super::*;
-    use crate::{
-        error::in_memory,
-        trie_store::operations::tests::{self, InMemoryTestContext},
-    };
+    use crate::trie_store::operations::tests::{self, InMemoryTestContext};
 
     #[test]
     fn in_memory_writes_to_n_leaf_empty_trie_had_expected_results() {
@@ -319,13 +316,7 @@ mod empty_tries {
         let context = InMemoryTestContext::new(&tries).unwrap();
         let initial_states = vec![root_hash];
 
-        let _states = tests::writes_to_n_leaf_empty_trie_had_expected_results::<
-            _,
-            _,
-            _,
-            _,
-            in_memory::Error,
-        >(
+        let _states = tests::writes_to_n_leaf_empty_trie_had_expected_results(
             correlation_id,
             &context.environment,
             &context.store,
@@ -355,10 +346,7 @@ mod proptests {
     }
 
     use super::*;
-    use crate::{
-        error::{self, in_memory},
-        trie_store::operations::tests::{self, InMemoryTestContext, LmdbTestContext},
-    };
+    use crate::trie_store::operations::tests::{self, InMemoryTestContext, LmdbTestContext};
     use std::ops::RangeInclusive;
 
     fn lmdb_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
@@ -367,7 +355,7 @@ mod proptests {
         let context = LmdbTestContext::new(&tries).unwrap();
         let mut states_to_check = vec![];
 
-        let root_hashes = tests::write_pairs::<_, _, _, _, error::Error>(
+        let root_hashes = tests::write_pairs(
             correlation_id,
             &context.environment,
             &context.store,
@@ -378,7 +366,7 @@ mod proptests {
 
         states_to_check.extend(root_hashes);
 
-        tests::check_pairs::<_, _, _, _, error::Error>(
+        tests::check_pairs(
             correlation_id,
             &context.environment,
             &context.store,
@@ -394,7 +382,7 @@ mod proptests {
         let context = InMemoryTestContext::new(&tries).unwrap();
         let mut states_to_check = vec![];
 
-        let root_hashes = tests::write_pairs::<_, _, _, _, in_memory::Error>(
+        let root_hashes = tests::write_pairs(
             correlation_id,
             &context.environment,
             &context.store,
@@ -405,7 +393,7 @@ mod proptests {
 
         states_to_check.extend(root_hashes);
 
-        tests::check_pairs::<_, _, _, _, in_memory::Error>(
+        tests::check_pairs(
             correlation_id,
             &context.environment,
             &context.store,

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/mod.rs
@@ -698,11 +698,7 @@ where
     'outer: loop {
         let mut results = Vec::new();
         let mut current_root_hash = root_hash.to_owned();
-        let res = environment.create_read_write_txn();
-        let mut txn = match res {
-            Ok(txn) => txn,
-            Err(e) => return Err(e.into()),
-        };
+        let mut txn = environment.create_read_write_txn()?;
 
         for leaf in leaves.iter() {
             if let Trie::Leaf { key, value } = leaf {

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/proptests.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/proptests.rs
@@ -28,7 +28,7 @@ fn lmdb_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
     let context = LmdbTestContext::new(&tries).unwrap();
     let mut states_to_check = vec![];
 
-    let root_hashes = write_pairs::<_, _, _, _, error::Error>(
+    let root_hashes = write_pairs(
         correlation_id,
         &context.environment,
         &context.store,
@@ -39,7 +39,7 @@ fn lmdb_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
 
     states_to_check.extend(root_hashes);
 
-    check_pairs::<_, _, _, _, error::Error>(
+    check_pairs(
         correlation_id,
         &context.environment,
         &context.store,
@@ -55,7 +55,7 @@ fn in_memory_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
     let context = InMemoryTestContext::new(&tries).unwrap();
     let mut states_to_check = vec![];
 
-    let root_hashes = write_pairs::<_, _, _, _, in_memory::Error>(
+    let root_hashes = write_pairs(
         correlation_id,
         &context.environment,
         &context.store,
@@ -66,7 +66,7 @@ fn in_memory_roundtrip_succeeds(pairs: &[(TestKey, TestValue)]) -> bool {
 
     states_to_check.extend(root_hashes);
 
-    check_pairs::<_, _, _, _, in_memory::Error>(
+    check_pairs(
         correlation_id,
         &context.environment,
         &context.store,

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/read.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/read.rs
@@ -9,7 +9,6 @@
 //! [`full_tries`] modules for more info.
 
 use super::*;
-use crate::error::{self, in_memory};
 
 mod partial_tries {
     //! Here we construct 6 separate "partial" tries, increasing in size
@@ -28,7 +27,7 @@ mod partial_tries {
             let test_leaves = TEST_LEAVES;
             let (used, unused) = test_leaves.split_at(num_leaves);
 
-            check_leaves::<_, _, _, _, error::Error>(
+            check_leaves(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -49,7 +48,7 @@ mod partial_tries {
             let test_leaves = TEST_LEAVES;
             let (used, unused) = test_leaves.split_at(num_leaves);
 
-            check_leaves::<_, _, _, _, in_memory::Error>(
+            check_leaves(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -86,7 +85,7 @@ mod full_tries {
             for (num_leaves, state) in states[..state_index].iter().enumerate() {
                 let test_leaves = TEST_LEAVES;
                 let (used, unused) = test_leaves.split_at(num_leaves);
-                check_leaves::<_, _, _, _, error::Error>(
+                check_leaves(
                     correlation_id,
                     &context.environment,
                     &context.store,
@@ -113,7 +112,7 @@ mod full_tries {
             for (num_leaves, state) in states[..state_index].iter().enumerate() {
                 let test_leaves = TEST_LEAVES;
                 let (used, unused) = test_leaves.split_at(num_leaves);
-                check_leaves::<_, _, _, _, in_memory::Error>(
+                check_leaves(
                     correlation_id,
                     &context.environment,
                     &context.store,

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/write.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/write.rs
@@ -13,7 +13,7 @@ mod empty_tries {
             let context = LmdbTestContext::new(&tries).unwrap();
             let initial_states = vec![root_hash];
 
-            writes_to_n_leaf_empty_trie_had_expected_results::<_, _, _, _, error::Error>(
+            writes_to_n_leaf_empty_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -32,7 +32,7 @@ mod empty_tries {
             let context = InMemoryTestContext::new(&tries).unwrap();
             let initial_states = vec![root_hash];
 
-            writes_to_n_leaf_empty_trie_had_expected_results::<_, _, _, _, in_memory::Error>(
+            writes_to_n_leaf_empty_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -51,7 +51,7 @@ mod empty_tries {
             let context = LmdbTestContext::new(&tries).unwrap();
             let initial_states = vec![root_hash];
 
-            writes_to_n_leaf_empty_trie_had_expected_results::<_, _, _, _, error::Error>(
+            writes_to_n_leaf_empty_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -70,7 +70,7 @@ mod empty_tries {
             let context = InMemoryTestContext::new(&tries).unwrap();
             let initial_states = vec![root_hash];
 
-            writes_to_n_leaf_empty_trie_had_expected_results::<_, _, _, _, in_memory::Error>(
+            writes_to_n_leaf_empty_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -99,7 +99,7 @@ mod empty_tries {
             let (root_hash, tries) = TEST_TRIE_GENERATORS[0]().unwrap();
             let context = InMemoryTestContext::new(&tries).unwrap();
 
-            write_leaves::<_, _, _, _, in_memory::Error>(
+            write_leaves(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -118,21 +118,20 @@ mod empty_tries {
 mod partial_tries {
     use super::*;
 
-    fn noop_writes_to_n_leaf_partial_trie_had_expected_results<'a, R, S, E>(
+    fn noop_writes_to_n_leaf_partial_trie_had_expected_results<'a, R, S>(
         correlation_id: CorrelationId,
         environment: &'a R,
         store: &S,
         states: &[Blake2bHash],
         num_leaves: usize,
-    ) -> Result<(), E>
+    ) -> Result<(), error::Error>
     where
         R: TransactionSource<'a, Handle = S::Handle>,
+        error::Error: From<R::Error>,
         S: TrieStore<TestKey, TestValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<types::bytesrepr::Error>,
     {
         // Check that the expected set of leaves is in the trie
-        check_leaves::<_, _, _, _, E>(
+        check_leaves(
             correlation_id,
             environment,
             store,
@@ -142,7 +141,7 @@ mod partial_tries {
         )?;
 
         // Rewrite that set of leaves
-        let write_results = write_leaves::<_, _, _, _, E>(
+        let write_results = write_leaves(
             correlation_id,
             environment,
             store,
@@ -155,7 +154,7 @@ mod partial_tries {
             .all(|result| *result == WriteResult::AlreadyExists));
 
         // Check that the expected set of leaves is in the trie
-        check_leaves::<_, _, _, _, E>(
+        check_leaves(
             correlation_id,
             environment,
             store,
@@ -173,7 +172,7 @@ mod partial_tries {
             let context = LmdbTestContext::new(&tries).unwrap();
             let states = vec![root_hash];
 
-            noop_writes_to_n_leaf_partial_trie_had_expected_results::<_, _, error::Error>(
+            noop_writes_to_n_leaf_partial_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -192,7 +191,7 @@ mod partial_tries {
             let context = InMemoryTestContext::new(&tries).unwrap();
             let states = vec![root_hash];
 
-            noop_writes_to_n_leaf_partial_trie_had_expected_results::<_, _, in_memory::Error>(
+            noop_writes_to_n_leaf_partial_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -203,23 +202,22 @@ mod partial_tries {
         }
     }
 
-    fn update_writes_to_n_leaf_partial_trie_had_expected_results<'a, R, S, E>(
+    fn update_writes_to_n_leaf_partial_trie_had_expected_results<'a, R, S>(
         correlation_id: CorrelationId,
         environment: &'a R,
         store: &S,
         states: &[Blake2bHash],
         num_leaves: usize,
-    ) -> Result<(), E>
+    ) -> Result<(), error::Error>
     where
         R: TransactionSource<'a, Handle = S::Handle>,
+        error::Error: From<R::Error>,
         S: TrieStore<TestKey, TestValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<types::bytesrepr::Error>,
     {
         let mut states = states.to_owned();
 
         // Check that the expected set of leaves is in the trie
-        check_leaves::<_, _, _, _, E>(
+        check_leaves(
             correlation_id,
             environment,
             store,
@@ -241,7 +239,7 @@ mod partial_tries {
 
             let root_hash = {
                 let current_root = states.last().unwrap();
-                let results = write_leaves::<_, _, _, _, E>(
+                let results = write_leaves(
                     correlation_id,
                     environment,
                     store,
@@ -258,7 +256,7 @@ mod partial_tries {
             states.push(root_hash);
 
             // Check that the expected set of leaves is in the trie
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -279,7 +277,7 @@ mod partial_tries {
             let context = LmdbTestContext::new(&tries).unwrap();
             let initial_states = vec![root_hash];
 
-            update_writes_to_n_leaf_partial_trie_had_expected_results::<_, _, error::Error>(
+            update_writes_to_n_leaf_partial_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -298,7 +296,7 @@ mod partial_tries {
             let context = InMemoryTestContext::new(&tries).unwrap();
             let states = vec![root_hash];
 
-            update_writes_to_n_leaf_partial_trie_had_expected_results::<_, _, in_memory::Error>(
+            update_writes_to_n_leaf_partial_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -313,22 +311,21 @@ mod partial_tries {
 mod full_tries {
     use super::*;
 
-    fn noop_writes_to_n_leaf_full_trie_had_expected_results<'a, R, S, E>(
+    fn noop_writes_to_n_leaf_full_trie_had_expected_results<'a, R, S>(
         correlation_id: CorrelationId,
         environment: &'a R,
         store: &S,
         states: &[Blake2bHash],
         index: usize,
-    ) -> Result<(), E>
+    ) -> Result<(), error::Error>
     where
         R: TransactionSource<'a, Handle = S::Handle>,
+        error::Error: From<R::Error>,
         S: TrieStore<TestKey, TestValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<types::bytesrepr::Error>,
     {
         // Check that the expected set of leaves is in the trie at every state reference
         for (num_leaves, state) in states[..index].iter().enumerate() {
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -339,7 +336,7 @@ mod full_tries {
         }
 
         // Rewrite that set of leaves
-        let write_results = write_leaves::<_, _, _, _, E>(
+        let write_results = write_leaves(
             correlation_id,
             environment,
             store,
@@ -353,7 +350,7 @@ mod full_tries {
 
         // Check that the expected set of leaves is in the trie at every state reference
         for (num_leaves, state) in states[..index].iter().enumerate() {
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -377,7 +374,7 @@ mod full_tries {
             context.update(&tries).unwrap();
             states.push(root_hash);
 
-            noop_writes_to_n_leaf_full_trie_had_expected_results::<_, _, error::Error>(
+            noop_writes_to_n_leaf_full_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -399,7 +396,7 @@ mod full_tries {
             context.update(&tries).unwrap();
             states.push(root_hash);
 
-            noop_writes_to_n_leaf_full_trie_had_expected_results::<_, _, in_memory::Error>(
+            noop_writes_to_n_leaf_full_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -410,24 +407,23 @@ mod full_tries {
         }
     }
 
-    fn update_writes_to_n_leaf_full_trie_had_expected_results<'a, R, S, E>(
+    fn update_writes_to_n_leaf_full_trie_had_expected_results<'a, R, S>(
         correlation_id: CorrelationId,
         environment: &'a R,
         store: &S,
         states: &[Blake2bHash],
         num_leaves: usize,
-    ) -> Result<(), E>
+    ) -> Result<(), error::Error>
     where
         R: TransactionSource<'a, Handle = S::Handle>,
+        error::Error: From<R::Error>,
         S: TrieStore<TestKey, TestValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<types::bytesrepr::Error>,
     {
         let mut states = states.to_vec();
 
         // Check that the expected set of leaves is in the trie at every state reference
         for (state_index, state) in states.iter().enumerate() {
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -438,19 +434,20 @@ mod full_tries {
         }
 
         // Write set of leaves to the trie
-        let hashes = write_leaves::<_, _, _, _, E>(
+        let write_leaves_res = write_leaves(
             correlation_id,
             environment,
             store,
             states.last().unwrap(),
             &TEST_LEAVES_UPDATED[..num_leaves],
-        )?
-        .iter()
-        .map(|result| match result {
-            WriteResult::Written(root_hash) => *root_hash,
-            _ => panic!("write_leaves resulted in non-write"),
-        })
-        .collect::<Vec<Blake2bHash>>();
+        );
+        let hashes = write_leaves_res?
+            .iter()
+            .map(|result| match result {
+                WriteResult::Written(root_hash) => *root_hash,
+                _ => panic!("write_leaves resulted in non-write"),
+            })
+            .collect::<Vec<Blake2bHash>>();
 
         states.extend(hashes);
 
@@ -477,7 +474,7 @@ mod full_tries {
 
         // Check that the expected set of leaves is in the trie at every state reference
         for (state_index, state) in states.iter().enumerate() {
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -501,7 +498,7 @@ mod full_tries {
             context.update(&tries).unwrap();
             states.push(root_hash);
 
-            update_writes_to_n_leaf_full_trie_had_expected_results::<_, _, error::Error>(
+            update_writes_to_n_leaf_full_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -523,7 +520,7 @@ mod full_tries {
             context.update(&tries).unwrap();
             states.push(root_hash);
 
-            update_writes_to_n_leaf_full_trie_had_expected_results::<_, _, in_memory::Error>(
+            update_writes_to_n_leaf_full_trie_had_expected_results(
                 correlation_id,
                 &context.environment,
                 &context.store,
@@ -534,24 +531,23 @@ mod full_tries {
         }
     }
 
-    fn node_writes_to_5_leaf_full_trie_had_expected_results<'a, R, S, E>(
+    fn node_writes_to_5_leaf_full_trie_had_expected_results<'a, R, S>(
         correlation_id: CorrelationId,
         environment: &'a R,
         store: &S,
         states: &[Blake2bHash],
-    ) -> Result<(), E>
+    ) -> Result<(), error::Error>
     where
         R: TransactionSource<'a, Handle = S::Handle>,
+        error::Error: From<R::Error>,
         S: TrieStore<TestKey, TestValue>,
-        S::Error: From<R::Error>,
-        E: From<R::Error> + From<S::Error> + From<types::bytesrepr::Error>,
     {
         let mut states = states.to_vec();
         let num_leaves = TEST_LEAVES_LENGTH;
 
         // Check that the expected set of leaves is in the trie at every state reference
         for (state_index, state) in states.iter().enumerate() {
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -562,7 +558,7 @@ mod full_tries {
         }
 
         // Write set of leaves to the trie
-        let hashes = write_leaves::<_, _, _, _, E>(
+        let hashes = write_leaves(
             correlation_id,
             environment,
             store,
@@ -601,7 +597,7 @@ mod full_tries {
 
         // Check that the expected set of leaves is in the trie at every state reference
         for (state_index, state) in states.iter().enumerate() {
-            check_leaves::<_, _, _, _, E>(
+            check_leaves(
                 correlation_id,
                 environment,
                 store,
@@ -625,7 +621,7 @@ mod full_tries {
             states.push(root_hash);
         }
 
-        node_writes_to_5_leaf_full_trie_had_expected_results::<_, _, error::Error>(
+        node_writes_to_5_leaf_full_trie_had_expected_results(
             correlation_id,
             &context.environment,
             &context.store,
@@ -646,7 +642,7 @@ mod full_tries {
             states.push(root_hash);
         }
 
-        node_writes_to_5_leaf_full_trie_had_expected_results::<_, _, in_memory::Error>(
+        node_writes_to_5_leaf_full_trie_had_expected_results(
             correlation_id,
             &context.environment,
             &context.store,

--- a/execution-engine/engine-storage/src/trie_store/tests/concurrent.rs
+++ b/execution-engine/engine-storage/src/trie_store/tests/concurrent.rs
@@ -84,7 +84,7 @@ fn lmdb_writer_mutex_does_not_collide_with_readers() {
 fn in_memory_writer_mutex_does_not_collide_with_readers() {
     let env = Arc::new(InMemoryEnvironment::new());
     let store = Arc::new(InMemoryTrieStore::new(&env, None));
-    let num_threads = 1;
+    let num_threads = 10;
     let barrier = Arc::new(Barrier::new(num_threads + 1));
     let mut handles = Vec::new();
     let TestData(ref leaf_1_hash, ref leaf_1) = &super::create_data()[0..1][0];

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -55,8 +55,8 @@ use crate::internal::utils;
 
 /// LMDB initial map size is calculated based on DEFAULT_LMDB_PAGES and systems page size.
 ///
-/// This default value should give 50MiB initial map size by default.
-const DEFAULT_LMDB_PAGES: usize = 128_000;
+/// This default value should give 1MiB initial map size by default.
+const DEFAULT_LMDB_PAGES: usize = 256;
 
 /// This is appended to the data dir path provided to the `LmdbWasmTestBuilder` in order to match
 /// the behavior of `get_data_dir()` in "engine-grpc-server/src/main.rs".
@@ -184,7 +184,7 @@ impl LmdbWasmTestBuilder {
         let page_size = get_page_size().expect("should get page size");
         let global_state_dir = Self::create_and_get_global_state_dir(data_dir);
         let environment = Arc::new(
-            LmdbEnvironment::new(&global_state_dir, page_size * DEFAULT_LMDB_PAGES)
+            LmdbEnvironment::new(&global_state_dir, page_size)
                 .expect("should create LmdbEnvironment"),
         );
         let trie_store = Arc::new(

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -55,8 +55,8 @@ use crate::internal::utils;
 
 /// LMDB initial map size is calculated based on DEFAULT_LMDB_PAGES and systems page size.
 ///
-/// This default value should give 1MiB initial map size by default.
-const DEFAULT_LMDB_PAGES: usize = 256;
+/// This default value should give 10MiB initial map size by default.
+const DEFAULT_LMDB_PAGES: usize = 2560;
 
 /// This is appended to the data dir path provided to the `LmdbWasmTestBuilder` in order to match
 /// the behavior of `get_data_dir()` in "engine-grpc-server/src/main.rs".
@@ -184,7 +184,7 @@ impl LmdbWasmTestBuilder {
         let page_size = get_page_size().expect("should get page size");
         let global_state_dir = Self::create_and_get_global_state_dir(data_dir);
         let environment = Arc::new(
-            LmdbEnvironment::new(&global_state_dir, page_size)
+            LmdbEnvironment::new(&global_state_dir, page_size * DEFAULT_LMDB_PAGES)
                 .expect("should create LmdbEnvironment"),
         );
         let trie_store = Arc::new(

--- a/execution-engine/types/src/bytesrepr.rs
+++ b/execution-engine/types/src/bytesrepr.rs
@@ -80,7 +80,7 @@ pub fn allocate_buffer<T: ToBytes>(to_be_serialized: &T) -> Result<Vec<u8>, Erro
 }
 
 /// Serialization and deserialization errors.
-#[derive(Debug, Fail, PartialEq, Eq, Clone)]
+#[derive(Debug, Fail, PartialEq, Eq, Clone, Copy)]
 #[repr(u8)]
 pub enum Error {
     /// Early end of stream while deserializing.


### PR DESCRIPTION
### Overview

Turns out to be much verbose than I initially thought, but now MapFull/MapResized are properly handled.

- Removes `E` generic parameter from calls and `storage::Error` is exposed that gathers impl specific errors
- Lowers default page size to 10MiB which is also lmdb's default value. I observed _slight_ performance increase using 10MiB over previous default values in benchmarks, 100MiB/1000MiB was very similar in throughput compared to 10MiB, but YMMV
- Handles MapResized internally when starting new transaction http://www.lmdb.tech/doc/group__mdb.html#gad7ea55da06b77513609efebd44b26920
- Handles MapFull case when writing/comitting data to the database

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-906

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
