### PR TITLE
EE-949: add highway feature flag

### DIFF
--- a/execution-engine/engine-core/src/engine_state/engine_config.rs
+++ b/execution-engine/engine-core/src/engine_state/engine_config.rs
@@ -3,6 +3,7 @@
 pub struct EngineConfig {
     // feature flags go here
     use_system_contracts: bool,
+    highway: bool,
 }
 
 impl EngineConfig {
@@ -17,6 +18,15 @@ impl EngineConfig {
 
     pub fn with_use_system_contracts(mut self, use_system_contracts: bool) -> EngineConfig {
         self.use_system_contracts = use_system_contracts;
+        self
+    }
+
+    pub fn highway(self) -> bool {
+        self.highway
+    }
+
+    pub fn with_highway(mut self, highway: bool) -> EngineConfig {
+        self.highway = highway;
         self
     }
 }

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -26,7 +26,7 @@ use std::{
     time::Instant,
 };
 
-use grpc::{RequestOptions, ServerBuilder, SingleResponse};
+use grpc::{Error as GrpcError, RequestOptions, ServerBuilder, SingleResponse};
 use log::{info, warn, Level};
 
 use engine_core::engine_state::{
@@ -65,6 +65,8 @@ const TAG_RESPONSE_EXEC: &str = "exec_response";
 const TAG_RESPONSE_QUERY: &str = "query_response";
 const TAG_RESPONSE_GENESIS: &str = "genesis_response";
 const TAG_RESPONSE_UPGRADE: &str = "upgrade_response";
+
+const UNIMPLEMENTED: &str = "unimplemented";
 
 const DEFAULT_PROTOCOL_VERSION: ProtocolVersion = ProtocolVersion::V1_0_0;
 
@@ -448,6 +450,9 @@ where
         _request_options: RequestOptions,
         _bid_state_request: BidStateRequest,
     ) -> SingleResponse<BidStateResponse> {
+        if !self.config().highway() {
+            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
+        }
         let response = BidStateResponse::new();
         SingleResponse::completed(response)
     }
@@ -457,6 +462,9 @@ where
         _request_options: RequestOptions,
         _distribute_rewards_request: DistributeRewardsRequest,
     ) -> SingleResponse<DistributeRewardsResponse> {
+        if !self.config().highway() {
+            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
+        }
         let response = DistributeRewardsResponse::new();
         SingleResponse::completed(response)
     }
@@ -466,6 +474,9 @@ where
         _request_options: RequestOptions,
         _slash_request: SlashRequest,
     ) -> SingleResponse<SlashResponse> {
+        if !self.config().highway() {
+            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
+        }
         let response = SlashResponse::new();
         SingleResponse::completed(response)
     }
@@ -475,6 +486,9 @@ where
         _request_options: RequestOptions,
         _unbond_payout_request: UnbondPayoutRequest,
     ) -> SingleResponse<UnbondPayoutResponse> {
+        if !self.config().highway() {
+            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
+        }
         let response = UnbondPayoutResponse::new();
         SingleResponse::completed(response)
     }

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -102,6 +102,11 @@ const ARG_USE_SYSTEM_CONTRACTS_SHORT: &str = "z";
 const ARG_USE_SYSTEM_CONTRACTS_HELP: &str =
     "Use system contracts instead of host-side logic for Mint, Proof of Stake and Standard Payment";
 
+// Highway
+const ARG_HIGHWAY: &str = "highway";
+const ARG_HIGHWAY_SHORT: &str = "h";
+const ARG_HIGHWAY_HELP: &str = "Highway consensus mode";
+
 // runnable
 const SIGINT_HANDLE_EXPECT: &str = "Error setting Ctrl-C handler";
 const RUNNABLE_CHECK_INTERVAL_SECONDS: u64 = 3;
@@ -228,6 +233,11 @@ fn get_args() -> ArgMatches<'static> {
                 .help(ARG_USE_SYSTEM_CONTRACTS_HELP),
         )
         .arg(
+            Arg::with_name(ARG_HIGHWAY)
+                .short(ARG_HIGHWAY_SHORT)
+                .help(ARG_HIGHWAY_HELP),
+        )
+        .arg(
             Arg::with_name(ARG_SOCKET)
                 .required(true)
                 .help(ARG_SOCKET_HELP)
@@ -291,7 +301,10 @@ fn get_thread_count(arg_matches: &ArgMatches) -> usize {
 fn get_engine_config(arg_matches: &ArgMatches) -> EngineConfig {
     // feature flags go here
     let use_system_contracts = arg_matches.is_present(ARG_USE_SYSTEM_CONTRACTS);
-    EngineConfig::new().with_use_system_contracts(use_system_contracts)
+    let highway = arg_matches.is_present(ARG_HIGHWAY);
+    EngineConfig::new()
+        .with_use_system_contracts(use_system_contracts)
+        .with_highway(highway)
 }
 
 /// Builds and returns a gRPC server.

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -104,7 +104,7 @@ const ARG_USE_SYSTEM_CONTRACTS_HELP: &str =
 
 // Highway
 const ARG_HIGHWAY: &str = "highway";
-const ARG_HIGHWAY_SHORT: &str = "h";
+const ARG_HIGHWAY_SHORT: &str = "w";
 const ARG_HIGHWAY_HELP: &str = "Highway consensus mode";
 
 // runnable

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -30,5 +30,6 @@ types = { version = "0.2.0", path = "../types", package = "casperlabs-types", fe
 version-sync = "0.8"
 
 [features]
+highway = []
 use-as-wasm = []
 use-system-contracts = []

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -100,8 +100,9 @@ impl<S> WasmTestBuilder<S> {
 impl Default for InMemoryWasmTestBuilder {
     fn default() -> Self {
         Self::initialize_logging();
-        let engine_config =
-            EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
+        let engine_config = EngineConfig::new()
+            .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
+            .with_highway(cfg!(feature = "highway"));
 
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
         let engine_state = EngineState::new(global_state, engine_config);

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -29,6 +29,7 @@ tempfile = "3"
 wabt = "0.9.2"
 
 [features]
+highway = ["engine-test-support/highway"]
 use-as-wasm = ["engine-test-support/use-as-wasm"]
 use-system-contracts = ["engine-test-support/use-system-contracts"]
 

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -47,8 +47,9 @@ fn bootstrap(data_dir: &Path, accounts: &[PublicKey], amount: U512) -> LmdbWasmT
     )
     .build();
 
-    let engine_config =
-        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
+    let engine_config = EngineConfig::new()
+        .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
+        .with_highway(cfg!(feature = "highway"));
 
     let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir, engine_config);
 

--- a/execution-engine/engine-tests/src/profiling/simple_transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple_transfer.rs
@@ -112,8 +112,9 @@ fn main() {
         ExecuteRequestBuilder::new().push_deploy(deploy).build()
     };
 
-    let engine_config =
-        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
+    let engine_config = EngineConfig::new()
+        .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
+        .with_highway(cfg!(feature = "highway"));
 
     let mut test_builder = LmdbWasmTestBuilder::open(&args.data_dir, engine_config, root_hash);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
@@ -12,8 +12,9 @@ const DEPLOY_HASH_1: [u8; 32] = [1u8; 32];
 #[test]
 fn should_run_mint_install_contract() {
     let mut builder = WasmTestBuilder::default();
-    let engine_config =
-        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
+    let engine_config = EngineConfig::new()
+        .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
+        .with_highway(cfg!(feature = "highway"));
 
     builder.run_genesis(&DEFAULT_GENESIS_CONFIG);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -27,8 +27,9 @@ const POS_REWARDS_PURSE: &str = "pos_rewards_purse";
 #[test]
 fn should_run_pos_install_contract() {
     let mut builder = WasmTestBuilder::default();
-    let engine_config =
-        EngineConfig::new().with_use_system_contracts(cfg!(feature = "use-system-contracts"));
+    let engine_config = EngineConfig::new()
+        .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
+        .with_highway(cfg!(feature = "highway"));
 
     let exec_request = ExecuteRequestBuilder::standard(
         DEFAULT_ACCOUNT_ADDR,


### PR DESCRIPTION
### Overview
We plan to disable bonding and unbonding, but would like to do this under a "highway" feature flag as to minimize breakage of existing tests.  This PR introduces the flag.  A subsequent PR will disable bonding and unbonding.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-949

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
