### PR TITLE
NODE-1296: Change sync traversal

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/util/ByteStringPrettifier.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/ByteStringPrettifier.scala
@@ -2,6 +2,7 @@ package io.casperlabs.casper.util
 
 import org.scalactic.Prettifier
 import io.casperlabs.casper.PrettyPrinter
+import io.casperlabs.models.PartialPrettifier
 import com.google.protobuf.ByteString
 import scala.util.Success
 import scala.collection.{mutable, GenMap}
@@ -10,66 +11,8 @@ import _root_.cats.instances.`package`.byte
 
 trait ByteStringPrettifier {
   // Shameless copy-paste of Scalactic's Prettifier that injects special pretty-printer for ByteString.
-  implicit val byteStringPrettifier: Prettifier = Prettifier {
-    case bs: ByteString    => PrettyPrinter.buildString(bs)
-    case Some(e)           => "Some(" + byteStringPrettifier(e) + ")"
-    case Success(e)        => "Success(" + byteStringPrettifier(e) + ")"
-    case Left(e)           => "Left(" + byteStringPrettifier(e) + ")"
-    case Right(e)          => "Right(" + byteStringPrettifier(e) + ")"
-    case anArray: Array[_] => "Array(" + (anArray.map(byteStringPrettifier(_))).mkString(", ") + ")"
-    case aWrappedArray: mutable.WrappedArray[_] =>
-      "Array(" + (aWrappedArray.map(byteStringPrettifier(_))).mkString(", ") + ")"
-    case anArrayOps: mutable.ArrayOps[_] =>
-      "Array(" + (anArrayOps.map(byteStringPrettifier(_))).mkString(", ") + ")"
-    case aGenMap: GenMap[_, _] =>
-      aGenMap.stringPrefix + "(" +
-        (aGenMap.toIterator
-          .map {
-            case (key, value) => // toIterator is needed for consistent ordering
-              byteStringPrettifier(key) + " -> " + byteStringPrettifier(value)
-          })
-          .mkString(", ") + ")"
-    case aGenTraversable: GenTraversable[_] =>
-      val isSelf =
-        if (aGenTraversable.size == 1) {
-          aGenTraversable.head match {
-            case ref: AnyRef => ref eq aGenTraversable
-            case other       => other == aGenTraversable
-          }
-        } else
-          false
-      if (isSelf)
-        aGenTraversable.toString
-      else
-        aGenTraversable.stringPrefix + "(" + aGenTraversable.toIterator
-          .map(byteStringPrettifier(_))
-          .mkString(", ") + ")" // toIterator is needed for consistent ordering
-    // SKIP-SCALATESTJS-START
-    case javaCol: java.util.Collection[_] =>
-      // By default java collection follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractCollection.html#toString()
-      // let's do our best to prettify its element when it is not overriden
-      import scala.collection.JavaConverters._
-      val theToString = javaCol.toString
-      if (theToString.startsWith("[") && theToString.endsWith("]"))
-        "[" + javaCol.iterator().asScala.map(byteStringPrettifier(_)).mkString(", ") + "]"
-      else
-        theToString
-    case javaMap: java.util.Map[_, _] =>
-      // By default java map follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractMap.html#toString()
-      // let's do our best to prettify its element when it is not overriden
-      import scala.collection.JavaConverters._
-      val theToString = javaMap.toString
-      if (theToString.startsWith("{") && theToString.endsWith("}"))
-        "{" + javaMap.entrySet.iterator.asScala
-          .map { entry =>
-            byteStringPrettifier(entry.getKey) + "=" + byteStringPrettifier(entry.getValue)
-          }
-          .mkString(", ") + "}"
-      else
-        theToString
-    case tuple2: Tuple2[_, _] =>
-      "(" ++ byteStringPrettifier(tuple2._1) ++ ", " ++ byteStringPrettifier(tuple2._2) ++ ")"
-    case other => Prettifier.default(other)
+  implicit val byteStringPrettifier: Prettifier = PartialPrettifier {
+    case bs: ByteString => PrettyPrinter.buildString(bs)
   }
 }
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
@@ -404,6 +404,7 @@ object SynchronizerImpl {
     for {
       semaphoreMap       <- SemaphoreMap[F, Node](1)
       syncedSummariesRef <- Ref[F].of(Map.empty[ByteString, SyncedSummary])
+      _                  <- Log[F].warn("Not going to perform DAG shape validations.").whenA(disableValidations)
     } yield {
       new SynchronizerImpl[F](
         connectToGossip,

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -19,6 +19,7 @@ import io.casperlabs.crypto.codec.Base16
 import io.casperlabs.crypto.util.{CertificateHelper, CertificatePrinter}
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.BlockImplicits._
+import io.casperlabs.models.PartialPrettifier
 import io.casperlabs.shared.Sorting._
 import io.casperlabs.shared.{Compression, Log}
 import io.grpc.netty.{NegotiationType, NettyChannelBuilder}
@@ -35,6 +36,7 @@ import org.scalatest.concurrent._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks.{forAll, PropertyCheckConfiguration}
 
 import scala.concurrent.duration._
+import org.scalactic.Prettifier
 
 class GrpcGossipServiceSpec
     extends refspec.RefSpecLike
@@ -67,7 +69,7 @@ class GrpcGossipServiceSpec
   override def afterAll() =
     shutdown.runSyncUnsafe(10.seconds)
 
-  def runTestUnsafe(testData: TestData, timeout: FiniteDuration = 5.seconds)(
+  def runTestUnsafe(testData: TestData, timeout: FiniteDuration = 10.seconds)(
       test: Task[Unit]
   ): Unit = {
     testDataRef.set(testData)
@@ -734,20 +736,22 @@ class GrpcGossipServiceSpec
         target: ByteString,
         maxDepth: Int
     ): Map[ByteString, Int] = {
-      def loop(visited: Map[ByteString, Int], hash: ByteString, depth: Int): Map[ByteString, Int] =
-        if (depth > maxDepth)
-          visited
-        else {
-          val summary     = summaries(hash)
-          val nextVisited = visited + (summary.blockHash -> depth)
-          elders(summary).foldLeft(nextVisited) {
-            case (visited, hash) if visited.contains(hash) && visited(hash) <= depth + 1 =>
+      val targetSummary = summaries(target)
+      def loop(visited: Map[ByteString, Int], summary: BlockSummary): Map[ByteString, Int] =
+        elders(summary)
+          .map(summaries.get)
+          .flatten
+          .map(dep => dep -> (targetSummary.getHeader.jRank - dep.getHeader.jRank).toInt)
+          .foldLeft(visited) {
+            case (visited, (_, dist)) if dist > maxDepth =>
               visited
-            case (visited, hash) =>
-              loop(visited, hash, depth + 1)
+            case (visited, (dep, dist))
+                if visited.contains(dep.blockHash) && visited(dep.blockHash) <= dist =>
+              visited
+            case (visited, (dep, dist)) =>
+              loop(visited.updated(dep.blockHash, dist), dep)
           }
-        }
-      loop(Map.empty, target, 0)
+      loop(Map(target -> 0), targetSummary)
     }
 
     /** Collect the ancestors of all targets and return the minimum distance to the nearest target. */
@@ -796,6 +800,11 @@ class GrpcGossipServiceSpec
         new TestFixture[T](gen, test)
     }
 
+    implicit val prettifier: Prettifier = PartialPrettifier {
+      case bs: ByteString   => hex(bs)
+      case bs: BlockSummary => s"BlockSummary(${hex(bs)})"
+    }
+
     "streamAncestorBlockSummaries" when {
       "called with unknown target hashes" should {
         "return an empty stream" in {
@@ -836,17 +845,20 @@ class GrpcGossipServiceSpec
           )
         } yield TestCase(dag, req)
 
-        "return the targets and their parents + justifications" in TestFixture(genTestCase) {
+        "return the targets and their parents + justifications within 1 rank" in TestFixture(
+          genTestCase
+        ) {
           case tc @ TestCase(_, req) =>
+            val targets = req.targetBlockHashes.map(tc.summaries)
             val expected = (
-              req.targetBlockHashes ++
-                req.targetBlockHashes.flatMap { t =>
-                  elders(tc.summaries(t))
+              targets ++
+                targets.flatMap { t =>
+                  elders(t).map(tc.summaries).filterNot(_.jRank < t.jRank - 1)
                 }
             ).toSet
 
             stub.streamAncestorBlockSummaries(req).toListL.map { ancestors =>
-              ancestors.map(_.blockHash) should contain theSameElementsAs expected
+              ancestors should contain theSameElementsAs expected
             }
         }
       }
@@ -880,7 +892,7 @@ class GrpcGossipServiceSpec
           )
         } yield TestCase(dag, req)
 
-        "return all ancestors of the target up to that depth in reverse breadth first order" in TestFixture(
+        "return all ancestors of the target up to that depth in reverse topological order" in TestFixture(
           genTestCase
         ) {
           case tc @ TestCase(_, req) =>
@@ -909,7 +921,8 @@ class GrpcGossipServiceSpec
       "called with many targets and maximum depth" should {
         val genTestCase = for {
           dag      <- genSummaryDagFromGenesis
-          targets  <- Gen.someOf(dag)
+          targetN  <- Gen.choose(1, math.min(5, dag.size))
+          targets  <- Gen.pick(targetN, dag)
           maxDepth <- Gen.choose(0, dag.size)
           req = StreamAncestorBlockSummariesRequest(
             targetBlockHashes = targets.map(_.blockHash),
@@ -917,12 +930,16 @@ class GrpcGossipServiceSpec
           )
         } yield TestCase(dag, req)
 
-        "start with the targets" in TestFixture(genTestCase) {
-          case TestCase(_, req) =>
+        "start with the target having the highest j-rank" in TestFixture(genTestCase) {
+          case tc @ TestCase(_, req) =>
             stub.streamAncestorBlockSummaries(req).toListL.map { ancestors =>
-              val targetHashes   = req.targetBlockHashes
-              val startingHashes = ancestors.map(_.blockHash).take(targetHashes.size)
-              startingHashes should contain theSameElementsAs targetHashes
+              val targetHashes = req.targetBlockHashes
+              if (targetHashes.isEmpty) ancestors shouldBe empty
+              else {
+                targetHashes should contain(ancestors.head.blockHash)
+                val maxRank = targetHashes.map(tc.summaries).map(_.getHeader.jRank).max
+                ancestors.head.getHeader.jRank shouldBe maxRank
+              }
             }
         }
 
@@ -948,7 +965,9 @@ class GrpcGossipServiceSpec
             }
         }
 
-        "return all ancestors up to that depth from any of the targets" in TestFixture(genTestCase) {
+        "return all ancestors up to that depth from any of the targets" in TestFixture(
+          genTestCase
+        ) {
           case tc @ TestCase(_, req) =>
             stub.streamAncestorBlockSummaries(req).toListL.map { ancestors =>
               val ancestorHashes = ancestors.map(_.blockHash)
@@ -961,10 +980,10 @@ class GrpcGossipServiceSpec
 
               ancestorHashes should contain theSameElementsAs depthsFromNearest.keySet
               // Check partial ordering
-              if (ancestorHashes.nonEmpty) {
-                Inspectors.forAll(ancestorHashes.init zip ancestorHashes.tail) {
+              if (ancestors.nonEmpty) {
+                Inspectors.forAll(ancestors.init zip ancestors.tail) {
                   case (a, b) =>
-                    depthsFromNearest(a) should be <= depthsFromNearest(b)
+                    a.jRank should be >= b.jRank
                 }
               }
             }
@@ -1014,7 +1033,9 @@ class GrpcGossipServiceSpec
             }
         }
 
-        "return the known blocks if they are within the maximum depth" in TestFixture(genTestCase) {
+        "return the known blocks if they are within the maximum depth" in TestFixture(
+          genTestCase
+        ) {
           case tc @ TestCase(_, req0) =>
             // Just using 1 known so we know that we won't stop before reaching it due to
             // other known ancestors on the path.

--- a/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
+++ b/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
@@ -266,7 +266,7 @@ trait ArbitraryConsensus {
                 validatorPublicKey = j.validatorPublicKey
               )
             })
-            .withJRank(parents.map(_.jRank).max + 1)
+            .withJRank((parents ++ justifications).map(_.jRank).max + 1)
             .withMainRank(parents.head.mainRank + 1)
           block.withHeader(header)
         }

--- a/models/src/test/scala/io/casperlabs/models/PartialPrettifier.scala
+++ b/models/src/test/scala/io/casperlabs/models/PartialPrettifier.scala
@@ -1,0 +1,73 @@
+package io.casperlabs.models
+
+import org.scalactic.Prettifier
+import com.google.protobuf.ByteString
+import scala.util.Success
+import scala.collection.{mutable, GenMap}
+import scala.collection.GenTraversable
+import _root_.cats.instances.`package`.byte
+
+object PartialPrettifier {
+  // Shameless copy-paste of Scalactic's Prettifier that injects special pretty-printer for ByteString.
+  def apply(pp: PartialFunction[Any, String]): Prettifier = Prettifier {
+    case x if pp.isDefinedAt(x) => pp(x)
+    case Some(e)                => "Some(" + apply(pp)(e) + ")"
+    case Success(e)             => "Success(" + apply(pp)(e) + ")"
+    case Left(e)                => "Left(" + apply(pp)(e) + ")"
+    case Right(e)               => "Right(" + apply(pp)(e) + ")"
+    case anArray: Array[_]      => "Array(" + (anArray.map(apply(pp)(_))).mkString(", ") + ")"
+    case aWrappedArray: mutable.WrappedArray[_] =>
+      "Array(" + (aWrappedArray.map(apply(pp)(_))).mkString(", ") + ")"
+    case anArrayOps: mutable.ArrayOps[_] =>
+      "Array(" + (anArrayOps.map(apply(pp)(_))).mkString(", ") + ")"
+    case aGenMap: GenMap[_, _] =>
+      aGenMap.stringPrefix + "(" +
+        (aGenMap.toIterator
+          .map {
+            case (key, value) => // toIterator is needed for consistent ordering
+              apply(pp)(key) + " -> " + apply(pp)(value)
+          })
+          .mkString(", ") + ")"
+    case aGenTraversable: GenTraversable[_] =>
+      val isSelf =
+        if (aGenTraversable.size == 1) {
+          aGenTraversable.head match {
+            case ref: AnyRef => ref eq aGenTraversable
+            case other       => other == aGenTraversable
+          }
+        } else
+          false
+      if (isSelf)
+        aGenTraversable.toString
+      else
+        aGenTraversable.stringPrefix + "(" + aGenTraversable.toIterator
+          .map(apply(pp)(_))
+          .mkString(", ") + ")" // toIterator is needed for consistent ordering
+    // SKIP-SCALATESTJS-START
+    case javaCol: java.util.Collection[_] =>
+      // By default java collection follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractCollection.html#toString()
+      // let's do our best to prettify its element when it is not overriden
+      import scala.collection.JavaConverters._
+      val theToString = javaCol.toString
+      if (theToString.startsWith("[") && theToString.endsWith("]"))
+        "[" + javaCol.iterator().asScala.map(apply(pp)(_)).mkString(", ") + "]"
+      else
+        theToString
+    case javaMap: java.util.Map[_, _] =>
+      // By default java map follows http://download.java.net/jdk7/archive/b123/docs/api/java/util/AbstractMap.html#toString()
+      // let's do our best to prettify its element when it is not overriden
+      import scala.collection.JavaConverters._
+      val theToString = javaMap.toString
+      if (theToString.startsWith("{") && theToString.endsWith("}"))
+        "{" + javaMap.entrySet.iterator.asScala
+          .map { entry =>
+            apply(pp)(entry.getKey) + "=" + apply(pp)(entry.getValue)
+          }
+          .mkString(", ") + "}"
+      else
+        theToString
+    case tuple2: Tuple2[_, _] =>
+      "(" ++ apply(pp)(tuple2._1) ++ ", " ++ apply(pp)(tuple2._2) ++ ")"
+    case other => Prettifier.default(other)
+  }
+}


### PR DESCRIPTION
### Overview
Changes `GossipService.StreamAncestorBlockSummaries` to return the target blocks' j-DAG with up to `maxDepth` distance from any of the targets, instead of doing a Breadth First traversal. This way we should avoid travelling into grandparent eras, because those will have much lower j-Rank values, even if they are referenced directly.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1296

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
