### PR TITLE
EE-950: disable bonding & unbonding in highway mode

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -10,24 +10,23 @@ IT_RES_DIR = $(realpath $(EE_DIR)/../integration-testing/resources)
 
 # Rust Contracts
 # Directory names should match crate names
-BENCH_CONTRACTS       = $(shell find ./contracts/bench       -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-CLIENT_CONTRACTS      = $(shell find ./contracts/client      -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-EXAMPLE_CONTRACTS     = $(shell find ./contracts/examples    -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-EXPLORER_CONTRACTS    = $(shell find ./contracts/explorer    -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-INTEGRATION_CONTRACTS = $(shell find ./contracts/integration -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-PROFILING_CONTRACTS   = $(shell find ./contracts/profiling   -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-SRE_CONTRACTS         = $(shell find ./contracts/SRE         -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-SYSTEM_CONTRACTS      = $(shell find ./contracts/system      -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
-TEST_CONTRACTS        = $(shell find ./contracts/test        -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+BENCH       = $(shell find ./contracts/bench       -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+CLIENT      = $(shell find ./contracts/client      -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+EXAMPLE     = $(shell find ./contracts/examples    -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+EXPLORER    = $(shell find ./contracts/explorer    -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+INTEGRATION = $(shell find ./contracts/integration -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+PROFILING   = $(shell find ./contracts/profiling   -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+SRE         = $(shell find ./contracts/SRE         -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+SYSTEM      = $(shell find ./contracts/system      -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+TEST        = $(shell find ./contracts/test        -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
 
-BENCH_CONTRACTS     := $(patsubst %, build-contract-rs/%, $(BENCH_CONTRACTS))
-CLIENT_CONTRACTS    := $(patsubst %, build-contract-rs/%, $(CLIENT_CONTRACTS))
-EXAMPLE_CONTRACTS   := $(patsubst %, build-contract-rs/%, $(EXAMPLE_CONTRACTS))
-EXPLORER_CONTRACTS  := $(patsubst %, build-contract-rs/%, $(EXPLORER_CONTRACTS))
-PROFILING_CONTRACTS := $(patsubst %, build-contract-rs/%, $(PROFILING_CONTRACTS))
-SRE_CONTRACTS       := $(patsubst %, build-contract-rs/%, $(SRE_CONTRACTS))
-SYSTEM_CONTRACTS    := $(patsubst %, build-contract-rs/%, $(SYSTEM_CONTRACTS))
-TEST_CONTRACTS      := $(patsubst %, build-contract-rs/%, $(TEST_CONTRACTS))
+BENCH_CONTRACTS     := $(patsubst %, build-contract-rs/%, $(BENCH))
+CLIENT_CONTRACTS    := $(patsubst %, build-contract-rs/%, $(CLIENT))
+EXAMPLE_CONTRACTS   := $(patsubst %, build-contract-rs/%, $(EXAMPLE))
+EXPLORER_CONTRACTS  := $(patsubst %, build-contract-rs/%, $(EXPLORER))
+PROFILING_CONTRACTS := $(patsubst %, build-contract-rs/%, $(PROFILING))
+SRE_CONTRACTS       := $(patsubst %, build-contract-rs/%, $(SRE))
+TEST_CONTRACTS      := $(patsubst %, build-contract-rs/%, $(TEST))
 
 # AssemblyScript Contracts
 CLIENT_CONTRACTS_AS  = $(shell find ./contracts-as/client   -mindepth 1 -maxdepth 1 -type d)
@@ -55,7 +54,13 @@ INTEGRATION_CONTRACTS += \
 	transfer-to-account-u512 \
 	unbonding-call
 
-INTEGRATION_CONTRACTS := $(patsubst %, build-integration-contract-rs/%, $(INTEGRATION_CONTRACTS))
+HIGHWAY_CONTRACTS += \
+	pos-install \
+	pos
+
+INTEGRATION_CONTRACTS     := $(patsubst %, build-integration-contract-rs/%,     $(INTEGRATION))
+SYSTEM_CONTRACTS          := $(patsubst %, build-contract-rs/%,                 $(SYSTEM))
+SYSTEM_CONTRACTS_FEATURED := $(patsubst %, build-system-contract-featured-rs/%, $(SYSTEM))
 
 CONTRACT_TARGET_DIR       = target/wasm32-unknown-unknown/release
 CONTRACT_TARGET_DIR_AS    = target-as
@@ -85,7 +90,12 @@ build-integration-contract-rs/%:
 	        --target wasm32-unknown-unknown \
 	        --out-dir $(IT_RES_DIR)
 
-.PHONY: build-contracts-rs
+build-system-contract-featured-rs/%:
+	$(CARGO) build \
+	        --release $(filter-out --release, $(CARGO_FLAGS)) \
+	        --manifest-path "contracts/system/$*/Cargo.toml" $(if $(FEATURES),$(if $(filter $(HIGHWAY_CONTRACTS), $*),--features $(FEATURES))) \
+	        --target wasm32-unknown-unknown
+
 build-contracts-rs: \
 	$(BENCH_CONTRACTS) \
 	$(CLIENT_CONTRACTS) \
@@ -97,11 +107,26 @@ build-contracts-rs: \
 	$(SYSTEM_CONTRACTS) \
 	$(TEST_CONTRACTS)
 
+build-contracts-highway-rs: FEATURES := highway
+build-contracts-highway-rs: \
+	$(BENCH_CONTRACTS) \
+	$(CLIENT_CONTRACTS) \
+	$(EXAMPLE_CONTRACTS) \
+	$(EXPLORER_CONTRACTS) \
+	$(INTEGRATION_CONTRACTS) \
+	$(PROFILING_CONTRACTS) \
+	$(SRE_CONTRACTS) \
+	$(SYSTEM_CONTRACTS_FEATURED) \
+	$(TEST_CONTRACTS)
+
 .PHONY: build-example-contracts
 build-example-contracts: $(EXAMPLE_CONTRACTS)
 
 .PHONY: build-integration-contracts
 build-integration-contracts: $(INTEGRATION_CONTRACTS)
+
+.PHONY: build-system-contracts
+build-system-contracts: $(SYSTEM_CONTRACTS)
 
 build-contract-as/%:
 	cd $* && $(NPM) run asbuild
@@ -131,6 +156,11 @@ test: test-rs test-as
 test-contracts-rs: build-contracts-rs
 	$(CARGO) test $(CARGO_FLAGS) -p casperlabs-engine-tests -- --ignored --nocapture
 	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "use-system-contracts" -- --ignored --nocapture
+
+.PHONY: test-contracts-highway-rs
+test-contracts-highway-rs: build-contracts-highway-rs
+	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "highway" -- --ignored --nocapture
+	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "highway,use-system-contracts" -- --ignored --nocapture
 
 .PHONY: test-contracts-as
 test-contracts-as: build-contracts-rs build-contracts-as
@@ -166,6 +196,7 @@ check-rs: \
 	audit \
 	test-rs \
 	test-contracts-rs \
+	test-contracts-highway-rs
 
 .PHONY: check
 check: \

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -37,7 +37,7 @@ CLIENT_CONTRACTS_AS  := $(patsubst %, build-contract-as/%, $(CLIENT_CONTRACTS_AS
 TEST_CONTRACTS_AS    := $(patsubst %, build-contract-as/%, $(TEST_CONTRACTS_AS))
 EXAMPLE_CONTRACTS_AS := $(patsubst %, build-contract-as/%, $(EXAMPLE_CONTRACTS_AS))
 
-INTEGRATION_CONTRACTS += \
+INTEGRATION += \
 	bonding-call \
 	counter-call \
 	counter-define \

--- a/execution-engine/contracts/system/pos-install/Cargo.toml
+++ b/execution-engine/contracts/system/pos-install/Cargo.toml
@@ -12,6 +12,7 @@ test = false
 
 [features]
 std = ["contract/std", "types/std"]
+highway = ["pos/highway"]
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }

--- a/execution-engine/contracts/system/pos/Cargo.toml
+++ b/execution-engine/contracts/system/pos/Cargo.toml
@@ -12,6 +12,7 @@ doctest = false
 [features]
 std = ["contract/std", "types/std"]
 lib = []
+highway = []
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -167,6 +167,10 @@ pub fn delegate() {
     match method_name.as_str() {
         // Type of this method: `fn bond(amount: U512, purse: URef)`
         METHOD_BOND => {
+            if cfg!(feature = "highway") {
+                runtime::revert(ApiError::Unhandled)
+            }
+
             let validator = runtime::get_caller();
             let amount: U512 = runtime::get_arg(1)
                 .unwrap_or_revert_with(ApiError::MissingArgument)
@@ -180,6 +184,10 @@ pub fn delegate() {
         }
         // Type of this method: `fn unbond(amount: Option<U512>)`
         METHOD_UNBOND => {
+            if cfg!(feature = "highway") {
+                runtime::revert(ApiError::Unhandled)
+            }
+
             let validator = runtime::get_caller();
             let maybe_amount = runtime::get_arg(1)
                 .unwrap_or_revert_with(ApiError::MissingArgument)

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -1838,6 +1838,11 @@ where
 
         let ret: CLValue = match method_name.as_str() {
             METHOD_BOND => {
+                if self.config.highway() {
+                    let err = Error::Revert(ApiError::Unhandled.into());
+                    return Err(err);
+                }
+
                 let validator: PublicKey = runtime.context.get_caller();
                 let amount: U512 = Self::get_argument(&args, 1)?;
                 let source_uref: URef = Self::get_argument(&args, 2)?;
@@ -1847,6 +1852,11 @@ where
                 CLValue::from_t(()).map_err(Self::reverter)?
             }
             METHOD_UNBOND => {
+                if self.config.highway() {
+                    let err = Error::Revert(ApiError::Unhandled.into());
+                    return Err(err);
+                }
+
                 let validator: PublicKey = runtime.context.get_caller();
                 let maybe_amount: Option<U512> = Self::get_argument(&args, 1)?;
                 runtime

--- a/execution-engine/engine-tests/src/test/regression/ee_597.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_597.rs
@@ -26,6 +26,13 @@ fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
         .to_owned();
 
     let error_message = utils::get_error_message(response);
-    // Error::BondTooSmall => 5,
-    assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(5)))));
+
+    if cfg!(feature = "highway") {
+        assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::Unhandled))));
+    } else {
+        // Error::BondTooSmall => 5,
+        assert!(
+            error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(5))))
+        );
+    }
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_598.rs
@@ -73,6 +73,13 @@ fn should_fail_unboding_more_than_it_was_staked_ee_598_regression() {
         .expect("should have a response")
         .to_owned();
     let error_message = utils::get_error_message(response);
-    // Error::UnbondTooLarge => 7,
-    assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(7)))));
+
+    if cfg!(feature = "highway") {
+        assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::Unhandled))));
+    } else {
+        // Error::UnbondTooLarge => 7,
+        assert!(
+            error_message.contains(&format!("Revert({})", u32::from(ApiError::ProofOfStake(7))))
+        );
+    }
 }


### PR DESCRIPTION
### Overview
This PR disables bonding and unbonding when the EE is run with the `--highway` flag.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-950

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The length and number of test runs is indeed an unfortunate tradeoff here.  I think we have been well aware of the scaling problems of this approach to testing, but it may be approaching the point that we need to step back and consider how we can improve this situation
