### PR TITLE
CON-631: Orphaning flags and events

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/EventEmitter.scala
@@ -19,7 +19,8 @@ import simulacrum.typeclass
   def blockAdded(blockHash: BlockHash): F[Unit]
   def newLastFinalizedBlock(
       lfb: BlockHash,
-      indirectlyFinalized: Set[BlockHash]
+      indirectlyFinalized: Set[BlockHash],
+      indirectlyOrphaned: Set[BlockHash]
   ): F[Unit]
 }
 

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -174,20 +174,17 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
       for {
         result <- MultiParentFinalizer[F].onNewMessageAdded(message)
         _ <- result.traverse {
-              case fb @ FinalizedBlocks(mainParent, _, secondary, orphaned) => {
-                val mainParentFinalizedStr = PrettyPrinter.buildString(
-                  mainParent
-                )
-                val secondaryParentsFinalizedStr =
-                  secondary.map(PrettyPrinter.buildString).mkString("{", ", ", "}")
+              case fb @ FinalizedBlocks(newLFB, _, finalized, orphaned) => {
+                val lfbStr       = PrettyPrinter.buildString(newLFB)
+                val finalizedStr = finalized.map(PrettyPrinter.buildString).mkString("{", ", ", "}")
                 for {
                   _ <- Log[F].info(
-                        s"New last finalized block hashes are ${mainParentFinalizedStr -> null}, ${secondaryParentsFinalizedStr -> null}."
+                        s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}."
                       )
-                  _ <- lfbRef.set(mainParent)
-                  _ <- FinalityStorage[F].markAsFinalized(mainParent, secondary, orphaned)
-                  _ <- DeployBuffer[F].removeFinalizedDeploys(secondary + mainParent).forkAndLog
-                  _ <- BlockEventEmitter[F].newLastFinalizedBlock(mainParent, secondary, orphaned)
+                  _ <- lfbRef.set(newLFB)
+                  _ <- FinalityStorage[F].markAsFinalized(newLFB, finalized, orphaned)
+                  _ <- DeployBuffer[F].removeFinalizedDeploys(finalized + newLFB).forkAndLog
+                  _ <- BlockEventEmitter[F].newLastFinalizedBlock(newLFB, finalized, orphaned)
                 } yield ()
               }
             }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -189,7 +189,7 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
                   _ <- lfbRef.set(mainParent)
                   _ <- FinalityStorage[F].markAsFinalized(mainParent, secondary, orphaned)
                   _ <- DeployBuffer[F].removeFinalizedDeploys(secondary + mainParent).forkAndLog
-                  _ <- BlockEventEmitter[F].newLastFinalizedBlock(mainParent, secondary)
+                  _ <- BlockEventEmitter[F].newLastFinalizedBlock(mainParent, secondary, orphaned)
                 } yield ()
               }
             }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -174,14 +174,12 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
       for {
         result <- MultiParentFinalizer[F].onNewMessageAdded(message)
         _ <- result.traverse {
-              case fb @ FinalizedBlocks(mainParent, _, secondary) => {
+              case fb @ FinalizedBlocks(mainParent, _, secondary, orphaned) => {
                 val mainParentFinalizedStr = PrettyPrinter.buildString(
                   mainParent
                 )
                 val secondaryParentsFinalizedStr =
                   secondary.map(PrettyPrinter.buildString).mkString("{", ", ", "}")
-                // TODO (CON-631): Orphans.
-                val orphaned = Set.empty[BlockHash]
                 for {
                   _ <- Log[F].info(
                         s"New last finalized block hashes are ${mainParentFinalizedStr -> null}, ${secondaryParentsFinalizedStr -> null}."

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -46,7 +46,8 @@ object MultiParentFinalizer {
   final case class FinalizedBlocks(
       mainChain: BlockHash,
       quorum: BigInt,
-      secondaryParents: Set[BlockHash]
+      secondaryParents: Set[BlockHash],
+      orphaned: Set[BlockHash]
   ) {
     def finalizedBlocks: Set[BlockHash] = secondaryParents + mainChain
   }
@@ -75,7 +76,9 @@ object MultiParentFinalizer {
                                               newLFB,
                                               dag
                                             )
-                          } yield Some(FinalizedBlocks(newLFB, quorum, justFinalized))
+                          } yield Some(
+                            FinalizedBlocks(newLFB, quorum, justFinalized, orphaned = Set.empty)
+                          )
                       }
         } yield finalized)
     }

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -73,11 +73,16 @@ object MultiParentFinalizer {
                           for {
                             _ <- lfbCache.set(newLFB)
                             justFinalized <- FinalityDetectorUtil.finalizedIndirectly[F](
-                                              newLFB,
-                                              dag
+                                              dag,
+                                              newLFB
                                             )
+                            justOrphaned <- FinalityDetectorUtil.orphanedIndirectly(
+                                             dag,
+                                             newLFB,
+                                             justFinalized
+                                           )
                           } yield Some(
-                            FinalizedBlocks(newLFB, quorum, justFinalized, orphaned = Set.empty)
+                            FinalizedBlocks(newLFB, quorum, justFinalized, justOrphaned)
                           )
                       }
         } yield finalized)

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -44,12 +44,13 @@ object MultiParentFinalizer {
   }
 
   final case class FinalizedBlocks(
-      mainChain: BlockHash,
+      // New finalized block in the main chain.
+      newLFB: BlockHash,
       quorum: BigInt,
-      secondaryParents: Set[BlockHash],
-      orphaned: Set[BlockHash]
+      indirectlyFinalized: Set[BlockHash],
+      indirectlyOrphaned: Set[BlockHash]
   ) {
-    def finalizedBlocks: Set[BlockHash] = secondaryParents + mainChain
+    def finalizedBlocks: Set[BlockHash] = indirectlyFinalized + newLFB
   }
 
   def create[F[_]: Concurrent: FinalityStorage](

--- a/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/genesis/Genesis.scala
@@ -98,6 +98,10 @@ object Genesis {
 
       // And store the block as well since we won't have any other means of retrieving its effects.
       _ <- BlockStorage[F].put(genesis)
-      _ <- FinalityStorage[F].markAsFinalized(genesis.getBlockMessage.blockHash, Set.empty)
+      _ <- FinalityStorage[F].markAsFinalized(
+            genesis.getBlockMessage.blockHash,
+            Set.empty,
+            Set.empty
+          )
     } yield genesis
 }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -103,12 +103,10 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
       result <- MultiParentFinalizer[F]
                  .onNewMessageAdded(message)
       w <- result.traverse {
-            case MultiParentFinalizer.FinalizedBlocks(mainParent, _, secondary) => {
+            case MultiParentFinalizer.FinalizedBlocks(mainParent, _, secondary, orphaned) => {
               val mainParentFinalizedStr = mainParent.show
               val secondaryParentsFinalizedStr =
                 secondary.map(_.show).mkString("{", ", ", "}")
-              // TODO (CON-631): Orphans.
-              val orphaned = Set.empty[BlockHash]
               for {
                 _ <- Log[F].info(
                       s"New last finalized block hashes are ${mainParentFinalizedStr -> null}, ${secondaryParentsFinalizedStr -> null}."

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -116,7 +116,7 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
                 _  <- FinalityStorage[F].markAsFinalized(mainParent, secondary, orphaned)
                 w1 <- DeployBuffer[F].removeFinalizedDeploys(secondary + mainParent).forkAndLog
                 w2 <- BlockEventEmitter[F]
-                       .newLastFinalizedBlock(mainParent, secondary)
+                       .newLastFinalizedBlock(mainParent, secondary, orphaned)
                        .timer("emitNewLFB")
                        .forkAndLog
               } yield w1 *> w2

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -50,8 +50,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
                                                                 Seq(genesis.blockHash, a.blockHash): _*
                                                               )
           finalizedIndirectly <- FinalityDetectorUtil.finalizedIndirectly[Task](
-                                  b.blockHash,
-                                  dag
+                                  dag,
+                                  b.blockHash
                                 )
         } yield assert(finalizedIndirectly == Set(a1.blockHash))
   }
@@ -95,8 +95,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
                                                          ).runA(Map.empty)
         _ <- FinalityDetectorUtil
               .finalizedIndirectly[G](
-                c.blockHash,
-                stateTDag
+                stateTDag,
+                c.blockHash
               )
               .run(Map.empty) shouldBeF ((expectedNodesVisitedA, Set(a.blockHash)))
         d <- createAndStoreBlockFull[Task](v1, Seq(a), Seq.empty, bonds)
@@ -114,8 +114,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
               .run(Map.empty)
         _ <- FinalityDetectorUtil
               .finalizedIndirectly[G](
-                f.blockHash,
-                stateTDag
+                stateTDag,
+                f.blockHash
               )
               .run(Map.empty) shouldBeF (
               (

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -109,7 +109,9 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
           e -> 1,
           b -> 1
         ).map(p => (p._1.blockHash, p._2))
-        _ <- finalityStorage.markAsFinalized(c.blockHash, Set(a.blockHash)).run(Map.empty)
+        _ <- finalityStorage
+              .markAsFinalized(c.blockHash, Set(a.blockHash), Set.empty)
+              .run(Map.empty)
         _ <- FinalityDetectorUtil
               .finalizedIndirectly[G](
                 f.blockHash,

--- a/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
@@ -55,7 +55,8 @@ class MultiParentFinalizerTest extends FlatSpec with BlockGenerator with Storage
         )
         _ <- fs.markAsFinalized(
               newlyFinalizedBlocksA.mainChain,
-              newlyFinalizedBlocksA.secondaryParents
+              newlyFinalizedBlocksA.secondaryParents,
+              Set.empty
             )
         c    <- createAndStoreBlockFull[Task](v1, Seq(b, a), Seq.empty, bonds)
         cMsg <- Task.fromTry(Message.fromBlock(c))

--- a/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/NoOpsEventEmitter.scala
@@ -21,7 +21,8 @@ object NoOpsEventEmitter {
 
       override def newLastFinalizedBlock(
           lfb: BlockHash,
-          indirectlyFinalized: Set[BlockHash]
+          indirectlyFinalized: Set[BlockHash],
+          indirectlyOrphaned: Set[BlockHash]
       ): F[Unit] = ().pure[F]
 
       override def deployAdded(deploy: Deploy): F[Unit] =

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -1078,7 +1078,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
 
             val switch = insert(makeBlock("Alice", runtime.era, runtime.endTick))
             fc.set(switch)
-            fs.markAsFinalized(switch.messageHash, secondary = Set.empty)
+            fs.markAsFinalized(switch.messageHash, secondary = Set.empty, orphaned = Set.empty)
 
             val agenda = runtime.handleAgenda(Agenda.StartRound(Ticks(runtime.endTick))).value
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -1078,7 +1078,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
 
             val switch = insert(makeBlock("Alice", runtime.era, runtime.endTick))
             fc.set(switch)
-            fs.markAsFinalized(switch.messageHash, secondary = Set.empty, orphaned = Set.empty)
+            fs.markAsFinalized(switch.messageHash, finalized = Set.empty, orphaned = Set.empty)
 
             val agenda = runtime.handleAgenda(Agenda.StartRound(Ticks(runtime.endTick))).value
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
@@ -372,7 +372,8 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
             .set(Some(message))
             .as(
               Some(
-                MultiParentFinalizer.FinalizedBlocks(message.messageHash, BigInt(0), Set.empty)
+                MultiParentFinalizer
+                  .FinalizedBlocks(message.messageHash, BigInt(0), Set.empty, Set.empty)
               )
             )
       }

--- a/casper/src/test/scala/io/casperlabs/casper/mocks/MockEventEmitter.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/mocks/MockEventEmitter.scala
@@ -26,9 +26,14 @@ class MockEventEmitter[F[_]: Applicative](
 
   override def newLastFinalizedBlock(
       lfb: BlockHash,
-      indirectlyFinalized: Set[BlockHash]
+      indirectlyFinalized: Set[BlockHash],
+      indirectlyOrphaned: Set[BlockHash]
   ): F[Unit] =
-    add(Event().withNewFinalizedBlock(Event.NewFinalizedBlock(lfb, indirectlyFinalized.toSeq)))
+    add(
+      Event().withNewFinalizedBlock(
+        Event.NewFinalizedBlock(lfb, indirectlyFinalized.toSeq, indirectlyOrphaned.toSeq)
+      )
+    )
 
   override def deployAdded(deploy: Deploy): F[Unit] =
     add(Event().withDeployAdded(Event.DeployAdded().withDeploy(deploy)))

--- a/casper/src/test/scala/io/casperlabs/casper/mocks/MockFinalityStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/mocks/MockFinalityStorage.scala
@@ -20,13 +20,13 @@ class MockFinalityStorage[F[_]: Monad](
     }
 
   override def markAsFinalized(
-      mainParent: BlockHash,
-      secondary: Set[BlockHash],
+      lfb: BlockHash,
+      finalized: Set[BlockHash],
       orphaned: Set[BlockHash]
   ): F[Unit] =
-    lastFinalizedRef.set(mainParent) >> finalizedRef.update {
+    lastFinalizedRef.set(lfb) >> finalizedRef.update {
       case (fd, od) =>
-        (fd ++ secondary + mainParent, od ++ orphaned)
+        (fd ++ finalized + lfb, od ++ orphaned)
     }
 }
 

--- a/casper/src/test/scala/io/casperlabs/casper/mocks/MockFinalityStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/mocks/MockFinalityStorage.scala
@@ -6,6 +6,7 @@ import cats.effect._
 import cats.effect.concurrent.Ref
 import io.casperlabs.storage.BlockHash
 import io.casperlabs.storage.dag.FinalityStorage
+import io.casperlabs.casper.consensus.info.BlockInfo.Status.Finality
 
 class MockFinalityStorage[F[_]: Monad](
     lastFinalizedRef: Ref[F, BlockHash],

--- a/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
+++ b/client/src/main/scala/io/casperlabs/client/GraphzGenerator.scala
@@ -67,7 +67,7 @@ object GraphzGenerator {
 
     val lastFinalizedBlockHash =
       blockInfos
-        .find(_.getStatus.isFinalized)
+        .find(_.getStatus.finality.isFinalized)
         .map(x => hexShort(x.getSummary.blockHash))
         .getOrElse("")
 

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -482,7 +482,7 @@ const isBallot = (block: BlockInfo) =>
   !isBlock(block)
 
 const isFinalized = (block: BlockInfo) =>
-  block.getStatus()!.getIsFinalized()
+  block.getStatus()!.getFinality() === BlockInfo.Status.Finality.FINALIZED
 
 const validatorHash = (block: BlockInfo) =>
   encodeBase16(

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -235,17 +235,9 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
     ['Deploy Gas Price Average', stats.getDeployGasPriceAvg().toLocaleString()],
     ['Block Size (bytes)', stats.getBlockSizeBytes().toLocaleString()],
     [
-      'Is Finalized',
-      block
-        .getStatus()!
-        .getIsFinalized().toString()
+      'Finality',
+      <FinalityIcon finality={block.getStatus()!.getFinality()} />
     ],
-    [
-      'Is Orphaned',
-      block
-        .getStatus()!
-        .getIsOrphaned().toString()
-    ]
   ];
 };
 
@@ -267,6 +259,16 @@ export const BlockType = (props: { header: Block.Header }) => {
   let typ = props.header.getMessageType();
   let lbl = typ === Block.MessageType.BLOCK ? "Block" : typ === Block.MessageType.BALLOT ? "Ballot" : "n/a"
   return <span>{lbl}</span>;
+}
+
+export const FinalityIcon = (props: { finality: BlockInfo.Status.FinalityMap[keyof BlockInfo.Status.FinalityMap] }) => {
+  if (props.finality === BlockInfo.Status.Finality.FINALIZED) {
+    return <Icon name="check-circle" color="green" />
+  } else if (props.finality === BlockInfo.Status.Finality.ORPHANED)
+    return <Icon name="times-circle" color="red" />
+  else {
+    return <Icon name="clock" />
+  }
 }
 
 export default BlockDetails;

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -239,6 +239,12 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
       block
         .getStatus()!
         .getIsFinalized().toString()
+    ],
+    [
+      'Is Orphaned',
+      block
+        .getStatus()!
+        .getIsOrphaned().toString()
     ]
   ];
 };

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -236,7 +236,7 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
     ['Block Size (bytes)', stats.getBlockSizeBytes().toLocaleString()],
     [
       'Finality',
-      <FinalityIcon finality={block.getStatus()!.getFinality()} />
+      <FinalityIcon block={block} />
     ],
   ];
 };
@@ -261,10 +261,14 @@ export const BlockType = (props: { header: Block.Header }) => {
   return <span>{lbl}</span>;
 }
 
-export const FinalityIcon = (props: { finality: BlockInfo.Status.FinalityMap[keyof BlockInfo.Status.FinalityMap] }) => {
-  if (props.finality === BlockInfo.Status.Finality.FINALIZED) {
+export const FinalityIcon = (props: { block: BlockInfo }) => {
+  if (props.block.getSummary()?.getHeader()!.getMessageType() === Block.MessageType.BALLOT)
+    return null;
+
+  let finality = props.block.getStatus()!.getFinality();
+  if (finality === BlockInfo.Status.Finality.FINALIZED) {
     return <Icon name="check-circle" color="green" />
-  } else if (props.finality === BlockInfo.Status.Finality.ORPHANED)
+  } else if (finality === BlockInfo.Status.Finality.ORPHANED)
     return <Icon name="times-circle" color="red" />
   else {
     return <Icon name="clock" />

--- a/explorer/ui/src/components/DeployDetails.tsx
+++ b/explorer/ui/src/components/DeployDetails.tsx
@@ -119,7 +119,7 @@ const ResultsTable = observer(
                 <Link to={Pages.block(id)}>{shortHash(id)}</Link>
               </td>
               <td>
-                <FinalityIcon finality={proc.getBlockInfo()!.getStatus()!.getFinality()} />
+                <FinalityIcon block={proc.getBlockInfo()!} />
               </td>
               <td className="text-right">{proc.getCost().toLocaleString()}</td>
               <td className="text-right">

--- a/explorer/ui/src/components/DeployDetails.tsx
+++ b/explorer/ui/src/components/DeployDetails.tsx
@@ -99,7 +99,7 @@ const ResultsTable = observer(
         title={`Results for deploy ${props.deployHashBase16}`}
         headers={[
           'Block Hash',
-          'Is Finalized',
+          'Finality',
           'Cost',
           'Remaining Balance',
           'Result',
@@ -113,17 +113,19 @@ const ResultsTable = observer(
               .getSummary()!
               .getBlockHash_asU8()
           );
+          const isFinalized = proc.getBlockInfo()!.getStatus()!.getIsFinalized()
+          const isOrphaned = proc.getBlockInfo()!.getStatus()!.getIsOrphaned()
           return (
             <tr key={i}>
               <td>
                 <Link to={Pages.block(id)}>{shortHash(id)}</Link>
               </td>
               <td>
-                {proc
-                  .getBlockInfo()!
-                  .getStatus()!
-                  .getIsFinalized()
-                  .toString()}
+                {
+                  isFinalized ? (<Icon name="check-circle" color="green" />) :
+                    isOrphaned ? (<Icon name="times-circle" color="red" />) :
+                      (<Icon name="clock" />)
+                }
               </td>
               <td className="text-right">{proc.getCost().toLocaleString()}</td>
               <td className="text-right">

--- a/explorer/ui/src/components/DeployDetails.tsx
+++ b/explorer/ui/src/components/DeployDetails.tsx
@@ -7,7 +7,7 @@ import { DeployInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_
 import Pages from './Pages';
 import { RefreshableComponent, Icon, shortHash } from './Utils';
 import ObservableValueMap from '../lib/ObservableValueMap';
-import { Balance } from './BlockDetails';
+import { Balance, FinalityIcon } from './BlockDetails';
 import { decodeBase16, encodeBase16 } from 'casperlabs-sdk';
 
 // URL parameter
@@ -113,19 +113,13 @@ const ResultsTable = observer(
               .getSummary()!
               .getBlockHash_asU8()
           );
-          const isFinalized = proc.getBlockInfo()!.getStatus()!.getIsFinalized()
-          const isOrphaned = proc.getBlockInfo()!.getStatus()!.getIsOrphaned()
           return (
             <tr key={i}>
               <td>
                 <Link to={Pages.block(id)}>{shortHash(id)}</Link>
               </td>
               <td>
-                {
-                  isFinalized ? (<Icon name="check-circle" color="green" />) :
-                    isOrphaned ? (<Icon name="times-circle" color="red" />) :
-                      (<Icon name="clock" />)
-                }
+                <FinalityIcon finality={proc.getBlockInfo()!.getStatus()!.getFinality()} />
               </td>
               <td className="text-right">{proc.getCost().toLocaleString()}</td>
               <td className="text-right">

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -214,6 +214,12 @@ class BlockDetails extends React.Component<
             .getStatus()!
             .getIsFinalized().toString()
         ],
+        [
+          'Is Orphaned',
+          block
+            .getStatus()!
+            .getIsOrphaned().toString()
+        ],
       ];
     return (
       <div

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -16,7 +16,7 @@ import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
 import { BondedValidatorsTable } from './BondedValidatorsTable';
 import { ToggleButton } from './ToggleButton';
-import { BlockType } from './BlockDetails';
+import { BlockType, FinalityIcon } from './BlockDetails';
 
 /** Show the tips of the DAG. */
 @observer
@@ -209,17 +209,9 @@ class BlockDetails extends React.Component<
           })()
         ],
         [
-          'Is Finalized',
-          block
-            .getStatus()!
-            .getIsFinalized().toString()
-        ],
-        [
-          'Is Orphaned',
-          block
-            .getStatus()!
-            .getIsOrphaned().toString()
-        ],
+          'Finality',
+          <FinalityIcon finality={block.getStatus()!.getFinality()} />
+        ]
       ];
     return (
       <div

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -210,7 +210,7 @@ class BlockDetails extends React.Component<
         ],
         [
           'Finality',
-          <FinalityIcon finality={block.getStatus()!.getFinality()} />
+          <FinalityIcon block={block} />
         ]
       ];
     return (

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -195,7 +195,7 @@ export class DagContainer {
               this.blocks?.forEach(block => {
                 let bh = block.getSummary()!.getBlockHash_asB64();
                 if (finalizedBlocks.has(bh)) {
-                  block.getStatus()?.setIsFinalized(true);
+                  block.getStatus()?.setFinality(BlockInfo.Status.Finality.FINALIZED)
                 }
                 if (!updatedLastFinalizedBlock && bh === directFinalizedBlockHash) {
                   this.lastFinalizedBlock = block;

--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -119,11 +119,12 @@ object EventStream {
 
       override def newLastFinalizedBlock(
           lfb: BlockHash,
-          indirectlyFinalized: Set[BlockHash]
+          indirectlyFinalized: Set[BlockHash],
+          indirectlyOrphaned: Set[BlockHash]
       ): F[Unit] =
         emit {
           Event().withNewFinalizedBlock(
-            NewFinalizedBlock(lfb, indirectlyFinalized.toSeq)
+            NewFinalizedBlock(lfb, indirectlyFinalized.toSeq, indirectlyOrphaned.toSeq)
           )
         } >> {
           (lfb +: indirectlyFinalized.toList).traverse { blockHash =>

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/GraphQLBlockTypes.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/GraphQLBlockTypes.scala
@@ -306,9 +306,10 @@ class GraphQLBlockTypes(
           resolve = c => c.value._2.get.map(_.asLeft[ProcessingResult])
         ),
         Field(
-          "isFinalized",
-          BooleanType,
-          resolve = c => c.value._1.getStatus.isFinalized
+          "finality",
+          StringType,
+          "Indicate whether the block has been finalized or orphaned yet.".some,
+          resolve = c => c.value._1.getStatus.finality.toString
         ),
         Field(
           "blockSizeBytes",

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -20,6 +20,8 @@ message BlockInfo {
         Stats stats = 2;
         repeated bytes child_hashes = 3;
 
+        // Indicate the finality status of the block, i.e. whether it's in the p-past cone
+        // of the last finalized block. Doesn't apply to ballots, those never get finalized.
         Finality finality = 5;
 
         // Statistics derived from the full block.

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -139,7 +139,6 @@ message Event {
         io.casperlabs.casper.consensus.Block.ProcessedDeploy processed_deploy = 2;
     }
 
-    // TODO (CON-631): Emit the anti-finalization event (currently just a placeholder).
     // A block the deploy was included in has been anti-finalized, i.e. orphaned by the LFB.
     // The deploy can still be finalized in a different block, if it was requeued or re-sent.
     message DeployOrphaned {

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -98,7 +98,8 @@ message Event {
         bytes block_hash = 1;
         // Set of blocks that were finalized indirectly (secondary parents of the new main-chain LFB).
         repeated bytes indirectly_finalized_block_hashes = 2;
-        // TODO (CON-631): Add `orphaned_block_hashes`.
+        // Set of blocks which are never going to be finalized now.
+        repeated bytes indirectly_orphaned_block_hashes = 3;
     }
 
     // A deploy was added to the local buffer.

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -22,6 +22,9 @@ message BlockInfo {
         // Indicate that this block has reached k=1 summit level and has appeared in the finalized block stream.
         bool is_finalized = 4;
 
+        // Indicate that this block was bypassed by the Last Finalized Block without being finalized, i.e. it will never be finalized now.
+        bool is_orphaned = 5;
+
         // Statistics derived from the full block.
         message Stats {
             uint32 block_size_bytes = 1;

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -16,14 +16,11 @@ message BlockInfo {
 
     message Status {
         reserved 1; // fault_tolerance;
+        reserved 4; // is_finalized;
         Stats stats = 2;
         repeated bytes child_hashes = 3;
 
-        // Indicate that this block has reached k=1 summit level and has appeared in the finalized block stream.
-        bool is_finalized = 4;
-
-        // Indicate that this block was bypassed by the Last Finalized Block without being finalized, i.e. it will never be finalized now.
-        bool is_orphaned = 5;
+        Finality finality = 5;
 
         // Statistics derived from the full block.
         message Stats {
@@ -32,6 +29,15 @@ message BlockInfo {
             uint64 deploy_cost_total = 3;
             // Average gas price across all deploys in the block weighted by the gas cost of the deploys.
             uint64 deploy_gas_price_avg = 4;
+        }
+
+        enum Finality {
+            // The fate of the block hasn't been decided yet.
+            UNDECIDED = 0;
+            // The block has reached k=1 summit level and has appeared in the finalized block stream.
+            FINALIZED = 1;
+            // The block was bypassed by the Last Finalized Block without being finalized, i.e. it will never be finalized now.
+            ORPHANED = 2;
         }
     }
 }

--- a/storage/src/main/resources/db/migration/V20201316_631__Add_lfb_chain_indirectly_orphaned.sql
+++ b/storage/src/main/resources/db/migration/V20201316_631__Add_lfb_chain_indirectly_orphaned.sql
@@ -1,0 +1,3 @@
+ALTER TABLE lfb_chain ADD COLUMN indirectly_orphaned BLOB NOT NULL DEFAULT x'';
+
+ALTER TABLE block_metadata ADD COLUMN is_orphaned BOOLEAN NOT NULL DEFAULT FALSE;

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -185,11 +185,11 @@ object SQLiteStorage {
       override def getChildlessEras               = eraStorage.getChildlessEras
 
       override def markAsFinalized(
-          mainParent: BlockHash,
-          secondary: Set[BlockHash],
+          lfb: BlockHash,
+          finalized: Set[BlockHash],
           orphaned: Set[BlockHash]
       ): F[Unit] =
-        dagStorage.markAsFinalized(mainParent, secondary, orphaned)
+        dagStorage.markAsFinalized(lfb, finalized, orphaned)
 
       override def getLastFinalizedBlock: F[BlockHash] = dagStorage.getLastFinalizedBlock
 

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -186,14 +186,15 @@ object SQLiteStorage {
 
       override def markAsFinalized(
           mainParent: BlockHash,
-          secondary: Set[BlockHash]
+          secondary: Set[BlockHash],
+          orphaned: Set[BlockHash]
       ): F[Unit] =
-        dagStorage.markAsFinalized(mainParent, secondary)
+        dagStorage.markAsFinalized(mainParent, secondary, orphaned)
 
       override def getLastFinalizedBlock: F[BlockHash] = dagStorage.getLastFinalizedBlock
 
-      override def isFinalized(block: BlockHash): F[Boolean] =
-        dagStorage.isFinalized(block)
+      override def getFinalityStatus(block: BlockHash): F[FinalityStorage.FinalityStatus] =
+        dagStorage.getFinalityStatus(block)
 
       override implicit val MT: MonadThrowable[F] = Sync[F]
 

--- a/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/SQLiteBlockStorage.scala
@@ -237,7 +237,8 @@ object SQLiteBlockStorage {
         "deploy_error_count",
         "deploy_cost_total",
         "deploy_gas_price_avg",
-        "is_finalized"
+        "is_finalized",
+        "is_orphaned"
       )
     Fragment.const(cols.map(col => if (alias.isEmpty) col else s"${alias}.${col}").mkString(", "))
   }

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -177,12 +177,13 @@ class CachingDagStorage[F[_]: Concurrent](
 
   override def markAsFinalized(
       mainParent: BlockHash,
-      secondary: Set[BlockHash]
+      secondary: Set[BlockHash],
+      orphaned: Set[BlockHash]
   ): F[Unit] =
-    underlying.markAsFinalized(mainParent, secondary)
+    underlying.markAsFinalized(mainParent, secondary, orphaned)
 
-  override def isFinalized(block: BlockHash): F[Boolean] =
-    underlying.isFinalized(block)
+  override def getFinalityStatus(block: BlockHash): F[FinalityStorage.FinalityStatus] =
+    underlying.getFinalityStatus(block)
 
   override def getLastFinalizedBlock: F[BlockHash] = underlying.getLastFinalizedBlock
 }

--- a/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
@@ -34,7 +34,9 @@ object FinalityStorage {
   case class FinalityStatus(
       isFinalized: Boolean,
       isOrphaned: Boolean
-  )
+  ) {
+    def isEmpty = !(isFinalized || isOrphaned)
+  }
 
   trait MeteredFinalityStorage[F[_]] extends FinalityStorage[F] with Metered[F] {
     abstract override def markAsFinalized(

--- a/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
@@ -1,11 +1,18 @@
 package io.casperlabs.storage.dag
 
+import cats.Applicative
+import cats.implicits._
 import io.casperlabs.metrics.Metered
 import io.casperlabs.storage.BlockHash
 import simulacrum.typeclass
 
 @typeclass trait FinalityStorageReader[F[_]] {
-  def isFinalized(block: BlockHash): F[Boolean]
+  def getFinalityStatus(block: BlockHash): F[FinalityStorage.FinalityStatus]
+
+  def isFinalized(block: BlockHash)(implicit A: Applicative[F]): F[Boolean] =
+    getFinalityStatus(block).map(_.isFinalized)
+  def isOrphaned(block: BlockHash)(implicit A: Applicative[F]): F[Boolean] =
+    getFinalityStatus(block).map(_.isOrphaned)
 
   /** Returns last finalized block.
     *
@@ -15,20 +22,30 @@ import simulacrum.typeclass
 }
 
 @typeclass trait FinalityStorage[F[_]] extends FinalityStorageReader[F] {
-  def markAsFinalized(mainParent: BlockHash, secondary: Set[BlockHash]): F[Unit]
+  def markAsFinalized(
+      mainParent: BlockHash,
+      secondary: Set[BlockHash],
+      orphaned: Set[BlockHash]
+  ): F[Unit]
 }
 
 object FinalityStorage {
 
+  case class FinalityStatus(
+      isFinalized: Boolean,
+      isOrphaned: Boolean
+  )
+
   trait MeteredFinalityStorage[F[_]] extends FinalityStorage[F] with Metered[F] {
     abstract override def markAsFinalized(
         mainParent: BlockHash,
-        secondary: Set[BlockHash]
+        secondary: Set[BlockHash],
+        orphaned: Set[BlockHash]
     ): F[Unit] =
-      incAndMeasure("markAsFinalized", super.markAsFinalized(mainParent, secondary))
+      incAndMeasure("markAsFinalized", super.markAsFinalized(mainParent, secondary, orphaned))
 
-    abstract override def isFinalized(block: BlockHash): F[Boolean] =
-      incAndMeasure("isFinalized", super.isFinalized(block))
+    abstract override def getFinalityStatus(block: BlockHash): F[FinalityStorage.FinalityStatus] =
+      incAndMeasure("getFinalityStatus", super.getFinalityStatus(block))
 
     abstract override def getLastFinalizedBlock: F[BlockHash] =
       incAndMeasure("getLastFinalizedBlock", super.getLastFinalizedBlock)

--- a/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/FinalityStorage.scala
@@ -23,8 +23,11 @@ import simulacrum.typeclass
 
 @typeclass trait FinalityStorage[F[_]] extends FinalityStorageReader[F] {
   def markAsFinalized(
-      mainParent: BlockHash,
-      secondary: Set[BlockHash],
+      // The Last Finalized Block, i.e. the block in the main chain that got finalized.
+      lfb: BlockHash,
+      // Secondary parents that got finalized implicitly by the LFB.
+      finalized: Set[BlockHash],
+      // Blocks in the j-past cone of the LFB that _didn't_ get finalized.
       orphaned: Set[BlockHash]
   ): F[Unit]
 }

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -61,6 +61,7 @@ class SQLiteDagStorage[F[_]: Sync](
     val mainRank = block.getHeader.mainRank
 
     val isFinalized = false
+    val isOrphaned  = false
     val insertBlockMetadata =
       (fr"""INSERT OR IGNORE INTO block_metadata
             (block_hash, validator, j_rank, main_rank, create_time_millis, """ ++ blockInfoCols() ++ fr""")
@@ -75,7 +76,8 @@ class SQLiteDagStorage[F[_]: Sync](
               $deployErrorCount,
               $deployCostTotal,
               $deployGasPriceAvg,
-              $isFinalized
+              $isFinalized,
+              $isOrphaned
             )
             """).update.run
 

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -480,7 +480,10 @@ class SQLiteDagStorage[F[_]: Sync](
     sql"""SELECT is_finalized, is_orphaned FROM block_metadata WHERE block_hash=$block"""
       .query[(Boolean, Boolean)]
       .unique
-      .map(FinalityStorage.FinalityStatus.tupled)
+      .map {
+        case (isFinalized, isOrphaned) =>
+          FinalityStorage.FinalityStatus(isFinalized, isOrphaned)
+      }
       .transact(readXa)
 
   override def getLastFinalizedBlock: F[BlockHash] =

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -7,6 +7,7 @@ import io.casperlabs.casper.consensus.{BlockSummary, Deploy, Era}
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
 import io.casperlabs.casper.consensus.info.BlockInfo
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
+import io.casperlabs.storage.dag.FinalityStorage.FinalityStatus
 import io.casperlabs.ipc.TransformEntry
 
 trait DoobieCodecs {
@@ -59,14 +60,15 @@ trait DoobieCodecs {
   }
 
   protected implicit val readBlockInfo: Read[BlockInfo] = {
-    Read[(Array[Byte], Int, Int, Long, Long, Boolean)].map {
+    Read[(Array[Byte], Int, Int, Long, Long, Boolean, Boolean)].map {
       case (
           blockSummaryData,
           blockSize,
           deployErrorCount,
           deployCostTotal,
           deployGasPriceAvg,
-          isFinalized
+          isFinalized,
+          isOrphaned
           ) =>
         val blockSummary = BlockSummary.parseFrom(blockSummaryData)
         val blockStatus = BlockInfo
@@ -79,7 +81,7 @@ trait DoobieCodecs {
               .withDeployCostTotal(deployCostTotal)
               .withDeployGasPriceAvg(deployGasPriceAvg)
           )
-          .withIsFinalized(isFinalized)
+          .withFinality(FinalityStatus(isFinalized, isOrphaned))
         BlockInfo()
           .withSummary(blockSummary)
           .withStatus(blockStatus)

--- a/storage/src/test/scala/io/casperlabs/storage/dag/FinalityStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/FinalityStorageTest.scala
@@ -35,14 +35,20 @@ class FinalityStorageTest
       : Task[BlockStorage[Task] with DagStorage[Task] with FinalityStorage[Task]] =
     SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
 
-  def finalityStatus(storage: FinalityStorage[Task], hashes: Seq[BlockHash]): Task[List[Boolean]] =
-    hashes.toList.traverse(storage.isFinalized(_))
+  def finalityStatus(
+      storage: FinalityStorage[Task],
+      hashes: Seq[BlockHash]
+  ): Task[List[FinalityStorage.FinalityStatus]] =
+    hashes.toList.traverse(storage.getFinalityStatus(_))
 
   def assertNotFinalized(storage: FinalityStorage[Task], hashes: BlockHash*): Task[Assertion] =
-    finalityStatus(storage, hashes).map(results => assert(results.forall(!_)))
+    finalityStatus(storage, hashes).map(results => assert(results.forall(!_.isFinalized)))
 
   def assertFinalized(storage: FinalityStorage[Task], hashes: BlockHash*): Task[Assertion] =
-    finalityStatus(storage, hashes).map(results => assert(results.forall(identity)))
+    finalityStatus(storage, hashes).map(results => assert(results.forall(_.isFinalized)))
+
+  def assertOrphaned(storage: FinalityStorage[Task], hashes: BlockHash*): Task[Assertion] =
+    finalityStatus(storage, hashes).map(results => assert(results.forall(_.isOrphaned)))
 
   "FinalityStorage" should "mark blocks as finalized" in withFinalityStorage { storage =>
     val sampleBlock = sample(arbBlock.arbitrary)
@@ -50,23 +56,25 @@ class FinalityStorageTest
     for {
       _    <- storage.insert(sampleBlock)
       _    <- assertNotFinalized(storage, sampleBlock.blockHash)
-      _    <- storage.markAsFinalized(sampleBlock.blockHash, Set.empty)
+      _    <- storage.markAsFinalized(sampleBlock.blockHash, Set.empty, Set.empty)
       _    <- assertFinalized(storage, sampleBlock.blockHash)
       info <- storage.getBlockInfo(sampleBlock.blockHash)
       _    = info.get.getStatus.isFinalized shouldBe true
     } yield ()
   }
 
-  it should "mark blocks as finalized in batches" in withFinalityStorage { storage =>
+  it should "mark blocks as finalized/orphaned in batches" in withFinalityStorage { storage =>
     val blocks           = List.fill(10)(sample(arbBlock.arbitrary))
     val mainParent       = blocks.head.blockHash
-    val secondaryParents = blocks.tail.map(_.blockHash).toSet
+    val secondaryParents = blocks.tail.take(4).map(_.blockHash).toSet
+    val orphanedParents  = blocks.tail.drop(4).map(_.blockHash).toSet
 
     for {
       _ <- blocks.traverse_(storage.insert(_))
       _ <- assertNotFinalized(storage, blocks.map(_.blockHash): _*)
-      _ <- storage.markAsFinalized(mainParent, secondaryParents)
-      _ <- assertFinalized(storage, blocks.map(_.blockHash): _*)
+      _ <- storage.markAsFinalized(mainParent, secondaryParents, orphanedParents)
+      _ <- assertFinalized(storage, blocks.take(5).map(_.blockHash): _*)
+      _ <- assertOrphaned(storage, blocks.drop(5).map(_.blockHash): _*)
     } yield ()
   }
 
@@ -78,12 +86,14 @@ class FinalityStorageTest
       }
 
       for {
-        _   <- blocks.traverse_(storage.insert(_))
-        _   <- assertNotFinalized(storage, blocks.map(_.blockHash): _*)
-        _   <- blocks.traverse_(block => storage.markAsFinalized(block.blockHash, Set.empty))
+        _ <- blocks.traverse_(storage.insert(_))
+        _ <- assertNotFinalized(storage, blocks.map(_.blockHash): _*)
+        _ <- blocks.traverse_(
+              block => storage.markAsFinalized(block.blockHash, Set.empty, Set.empty)
+            )
         _   <- assertFinalized(storage, blocks.map(_.blockHash): _*)
         lfb <- storage.getLastFinalizedBlock
       } yield assert(lfb == blocks.last.blockHash)
-
   }
+
 }

--- a/storage/src/test/scala/io/casperlabs/storage/dag/FinalityStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/FinalityStorageTest.scala
@@ -59,7 +59,7 @@ class FinalityStorageTest
       _    <- storage.markAsFinalized(sampleBlock.blockHash, Set.empty, Set.empty)
       _    <- assertFinalized(storage, sampleBlock.blockHash)
       info <- storage.getBlockInfo(sampleBlock.blockHash)
-      _    = info.get.getStatus.isFinalized shouldBe true
+      _    = info.get.getStatus.finality.isFinalized shouldBe true
     } yield ()
   }
 


### PR DESCRIPTION
### Overview
* Adds a `Finality` enum to `BlockInfo` to show that a block has not been finalized and will never be (unless there's an equivocation catastrophe) because the Last Finalized Block has gone past it without finalizing it.
* Adds the `indirectly_orphaned_block_hashes` list to `NewFinalizedBlock` in the event stream.
* Emits `DeployOrphaned` events for the deploys included in these blocks.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-631

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Still need to add a test to `FinalityDetectorUtil`.
