### PR TITLE
NODE-1298: Fix default values of stream_events keyword parameters

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -650,20 +650,25 @@ class CasperLabsClient:
     @api
     def stream_events(
         self,
-        all: bool = True,
-        block_added: bool = True,
-        block_finalized: bool = True,
-        deploy_added: bool = True,
-        deploy_discarded: bool = True,
-        deploy_requeued: bool = True,
-        deploy_processed: bool = True,
-        deploy_finalized: bool = True,
-        deploy_orphaned: bool = True,
+        all: bool = False,
+        block_added: bool = False,
+        block_finalized: bool = False,
+        deploy_added: bool = False,
+        deploy_discarded: bool = False,
+        deploy_requeued: bool = False,
+        deploy_processed: bool = False,
+        deploy_finalized: bool = False,
+        deploy_orphaned: bool = False,
         account_public_keys=None,
         deploy_hashes=None,
     ):
         """
-        See StreamEventsRequest in ~/CasperLabs/protobuf/io/casperlabs/node/api/casper.proto
+        See StreamEventsRequest in
+            ~/CasperLabs/protobuf/io/casperlabs/node/api/casper.proto
+        for description of types of events.
+
+        Note, you must subscribe to some events (pass True to some keywords other than account_public_keys or deploy_hashes)
+        otherwise this generator will block forever.
         """
         if all:
             block_added = True

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -365,7 +365,7 @@ def show_peers_command(casperlabs_client, args):
 
 @guarded_command
 def stream_events_command(casperlabs_client, args):
-    kwargs = dict(
+    subscribed_events = dict(
         all=args.all,
         block_added=args.block_added,
         block_finalized=args.block_finalized,
@@ -375,12 +375,14 @@ def stream_events_command(casperlabs_client, args):
         deploy_processed=args.deploy_processed,
         deploy_finalized=args.deploy_finalized,
         deploy_orphaned=args.deploy_orphaned,
+    )
+    if not any(subscribed_events.values()):
+        raise argparse.ArgumentTypeError("No events chosen")
+    stream = casperlabs_client.stream_events(
         account_public_keys=args.account_public_key,
         deploy_hashes=args.deploy_hash,
+        **subscribed_events,
     )
-    if not any(kwargs.values()):
-        raise argparse.ArgumentTypeError("No events chosen")
-    stream = casperlabs_client.stream_events(**kwargs)
     for event in stream:
         now = datetime.datetime.now()
         print(f"------------- {now.strftime('%Y-%m-%d %H:%M:%S')} -------------")


### PR DESCRIPTION
### Overview
This PR fixes default values of Python client API `stream_events` keyword arguments, representing types of events to subsrcibe to. They were all set to `True`, so when user called, e.g.: `stream_events(block_added=True)` he was actually subscribing to all possible events. The bug did not affect CLI `stream-events` because the CLI args had correct defaults (`False`). 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1298

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
