### PR TITLE
NODE-1289: Support replaying events

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -177,7 +177,7 @@ class NodeRuntime private[node] (
       implicit0(eventStream: EventStream[Task]) <- Resource.pure[Task, EventStream[Task]](
                                                     EventStream
                                                       .create[Task](
-                                                        ingressScheduler,
+                                                        egressScheduler,
                                                         conf.server.eventStreamBufferSize.value
                                                       )
                                                   )

--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -165,13 +165,11 @@ object EventStream {
                 processed <- rdr.getProcessedDeploys(blockHash)
                 deploys   = processed.map(_.getDeploy)
                 infos     <- rdr.getDeployInfos(deploys)
-                _ <- infos.traverse { info =>
-                      emit {
-                        Event().withDeployOrphaned(
-                          DeployOrphaned().withBlockHash(blockHash).withDeployInfo(info)
-                        )
-                      }
-                    }
+                _ <- emit(infos.map { info =>
+                      Value.DeployOrphaned(
+                        DeployOrphaned().withBlockHash(blockHash).withDeployInfo(info)
+                      )
+                    }: _*)
               } yield ()
             } void
         }

--- a/protobuf/io/casperlabs/casper/consensus/info.proto
+++ b/protobuf/io/casperlabs/casper/consensus/info.proto
@@ -89,6 +89,7 @@ message DeployInfo {
 }
 
 message Event {
+    uint64 event_id = 9;
     oneof value {
         BlockAdded block_added = 1;
         NewFinalizedBlock new_finalized_block = 2;

--- a/protobuf/io/casperlabs/node/api/casper.proto
+++ b/protobuf/io/casperlabs/node/api/casper.proto
@@ -192,6 +192,12 @@ message StreamEventsRequest {
   // Optional filters for deploy events; applies to anything opted into via the flags.
   DeployFilter deploy_filter = 9;
 
+  // Supports replaying events from a given ID.
+  // If the value is 0, it it will subscribe to future events;
+  // if it's non-zero, it will replay all past events from that ID, without subscribing to new.
+  // To catch up with events from the beginning, start from 1.
+  uint64 min_event_id = 10;
+
   // Filters to apply on deploy events; different fields combined with AND operator.
   message DeployFilter {
       // Filter to any of the accounts on the list.

--- a/storage/src/main/resources/db/migration/V20200317_1289__Add_event_log.sql
+++ b/storage/src/main/resources/db/migration/V20200317_1289__Add_event_log.sql
@@ -1,0 +1,7 @@
+-- Going to store the event stream and retrieve them from a certain rowid.
+CREATE TABLE events (
+    id INTEGER PRIMARY KEY,
+    -- Since Unix epoch
+    create_time_millis INTEGER NOT NULL,
+    value BLOB NOT NULL
+);

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -205,7 +205,7 @@ object SQLiteStorage {
       override def findAncestor(block: BlockHash, distance: Long) =
         dagStorage.findAncestor(block, distance)
 
-      override def storeEvents(values: Seq[Event.Value]): F[Seq[Event]] =
+      override def storeEvents(values: Seq[Event.Value]): F[List[Event]] =
         eventStorage.storeEvents(values)
 
       override def getEvents(minId: Long): fs2.Stream[F, Event] =

--- a/storage/src/main/scala/io/casperlabs/storage/event/EventStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/event/EventStorage.scala
@@ -1,0 +1,19 @@
+package io.casperlabs.storage.event
+
+import io.casperlabs.casper.consensus.info.Event
+
+/** Store all the events we return over the gRPC event stream.
+  * Give each of them an individual ID so they can be replayed
+  * later from the last value a client managed to get earlier,
+  * so that they can catch up with anything they missed.
+  *
+  * IDs are going to be different across nodes.
+  */
+trait EventStorage[F[_]] {
+
+  /** Store events and assign IDs. */
+  def storeEvents(values: Seq[Event.Value]): F[Seq[Event]]
+
+  /** Retrieve events from a given ID onwards to replay them to a client. */
+  def getEvents(minId: Long): fs2.Stream[F, Event]
+}

--- a/storage/src/main/scala/io/casperlabs/storage/event/EventStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/event/EventStorage.scala
@@ -1,6 +1,7 @@
 package io.casperlabs.storage.event
 
 import io.casperlabs.casper.consensus.info.Event
+import simulacrum.typeclass
 
 /** Store all the events we return over the gRPC event stream.
   * Give each of them an individual ID so they can be replayed
@@ -9,10 +10,11 @@ import io.casperlabs.casper.consensus.info.Event
   *
   * IDs are going to be different across nodes.
   */
+@typeclass
 trait EventStorage[F[_]] {
 
   /** Store events and assign IDs. */
-  def storeEvents(values: Seq[Event.Value]): F[Seq[Event]]
+  def storeEvents(values: Seq[Event.Value]): F[List[Event]]
 
   /** Retrieve events from a given ID onwards to replay them to a client. */
   def getEvents(minId: Long): fs2.Stream[F, Event]

--- a/storage/src/main/scala/io/casperlabs/storage/event/SQLiteEventStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/event/SQLiteEventStorage.scala
@@ -1,0 +1,44 @@
+package io.casperlabs.storage.event
+
+import cats._
+import cats.implicits._
+import cats.effect.Sync
+import doobie._
+import doobie.implicits._
+import io.casperlabs.casper.consensus.info.Event
+import io.casperlabs.storage.util.DoobieCodecs
+import io.casperlabs.shared.Time
+
+class SQLiteEventStorage[F[_]: Sync: Time](
+    readXa: Transactor[F],
+    writeXa: Transactor[F]
+) extends EventStorage[F]
+    with DoobieCodecs {
+  override def storeEvents(values: Seq[Event.Value]): F[Seq[Event]] = {
+    def insert(now: Long, value: Event.Value): ConnectionIO[Event] =
+      for {
+        _  <- sql"""INSERT INTO events(create_time_millis, value) VALUES ($now, $value)""".update.run
+        id <- sql"""SELECT last_insert_rowid()""".query[Long].unique
+      } yield Event().withEventId(id).withValue(value)
+
+    for {
+      now    <- Time[F].currentMillis
+      events <- values.toList.traverse(insert(now, _)).transact(writeXa)
+    } yield events
+  }
+
+  override def getEvents(minId: Long): fs2.Stream[F, Event] =
+    sql"""
+    SELECT id, value
+    FROM   events
+    WHERE  id >= $minId
+    ORDER BY id
+    """
+      .query[(Long, Event.Value)]
+      .map {
+        case (id, value) =>
+          Event().withEventId(id).withValue(value)
+      }
+      .stream
+      .transact(readXa)
+}

--- a/storage/src/main/scala/io/casperlabs/storage/event/SQLiteEventStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/event/SQLiteEventStorage.scala
@@ -42,3 +42,12 @@ class SQLiteEventStorage[F[_]: Sync: Time](
       .stream
       .transact(readXa)
 }
+
+object SQLiteEventStorage {
+  def create[F[_]: Sync: Time](
+      readXa: Transactor[F],
+      writeXa: Transactor[F]
+  ): F[EventStorage[F]] = Sync[F].delay {
+    new SQLiteEventStorage[F](readXa, writeXa)
+  }
+}

--- a/storage/src/main/scala/io/casperlabs/storage/event/SQLiteEventStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/event/SQLiteEventStorage.scala
@@ -14,7 +14,7 @@ class SQLiteEventStorage[F[_]: Sync: Time](
     writeXa: Transactor[F]
 ) extends EventStorage[F]
     with DoobieCodecs {
-  override def storeEvents(values: Seq[Event.Value]): F[Seq[Event]] = {
+  override def storeEvents(values: Seq[Event.Value]): F[List[Event]] = {
     def insert(now: Long, value: Event.Value): ConnectionIO[Event] =
       for {
         _  <- sql"""INSERT INTO events(create_time_millis, value) VALUES ($now, $value)""".update.run

--- a/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/util/DoobieCodecs.scala
@@ -5,7 +5,7 @@ import doobie._
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus.{BlockSummary, Deploy, Era}
 import io.casperlabs.crypto.Keys.{PublicKey, PublicKeyBS}
-import io.casperlabs.casper.consensus.info.BlockInfo
+import io.casperlabs.casper.consensus.info.{BlockInfo, Event}
 import io.casperlabs.casper.consensus.info.DeployInfo.ProcessingResult
 import io.casperlabs.storage.dag.FinalityStorage.FinalityStatus
 import io.casperlabs.ipc.TransformEntry
@@ -101,11 +101,16 @@ trait DoobieCodecs {
   }
 
   protected implicit val metaBlockSummary: Meta[BlockSummary] =
-    Meta[Array[Byte]].imap(BlockSummary.parseFrom)(_.toByteString.toByteArray)
+    Meta[Array[Byte]].imap(BlockSummary.parseFrom)(_.toByteArray)
 
   protected implicit val metaTransformEntry: Meta[TransformEntry] =
-    Meta[Array[Byte]].imap(TransformEntry.parseFrom)(_.toByteString.toByteArray)
+    Meta[Array[Byte]].imap(TransformEntry.parseFrom)(_.toByteArray)
 
   protected implicit val metaEra: Meta[Era] =
     Meta[Array[Byte]].imap(Era.parseFrom)(_.toByteString.toByteArray)
+
+  protected implicit val metaEventValue: Meta[Event.Value] =
+    // Event.Value is not directly parseable. We want SQLite to generate the ID,
+    // so store it as an Event without ID.
+    Meta[Array[Byte]].imap(Event.parseFrom(_).value)(v => Event(value = v).toByteArray)
 }

--- a/storage/src/test/scala/io/casperlabs/storage/event/EventStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/event/EventStorageTest.scala
@@ -1,0 +1,58 @@
+package io.casperlabs.storage.event
+
+import cats._
+import cats.implicits._
+import com.google.protobuf.ByteString
+import io.casperlabs.casper.consensus.info.Event
+import io.casperlabs.models.ArbitraryConsensus
+import io.casperlabs.storage.SQLiteFixture
+import io.casperlabs.storage.{SQLiteFixture, SQLiteStorage}
+import monix.eval.Task
+import org.scalatest._
+
+trait EventStorageTest extends FlatSpecLike with Matchers with ArbitraryConsensus {
+  def withStorage[R](f: EventStorage[Task] => Task[R]): R
+
+  behavior of "EventStorage"
+
+  // Content doesn't matter here.
+  val events = List(
+    Event().withBlockAdded(Event.BlockAdded()),
+    Event().withNewFinalizedBlock(Event.NewFinalizedBlock()),
+    Event().withDeployAdded(Event.DeployAdded()),
+    Event().withDeployProcessed(Event.DeployProcessed())
+  )
+
+  it should "assign IDs to events stored" in withStorage { db =>
+    for {
+      ev12 <- db.storeEvents(events.take(2).map(_.value))
+      ev34 <- db.storeEvents(events.drop(2).map(_.value))
+    } yield {
+      ev12(0).eventId shouldBe 1L
+      ev12(1).eventId shouldBe 2L
+      ev34(0).eventId shouldBe 3L
+      ev34(1).eventId shouldBe 4L
+    }
+  }
+
+  it should "retrieve events from a given ID onwards" in withStorage { db =>
+    val values = events.map(_.value)
+    for {
+      _   <- db.storeEvents(values)
+      evs <- db.getEvents(minId = 3).compile.toList
+    } yield {
+      evs.head.eventId shouldBe 3L
+      evs.last.eventId shouldBe 4L
+      evs.map(_.value) shouldBe values.drop(2)
+    }
+  }
+}
+
+class SQLiteEventStorageTest extends EventStorageTest with SQLiteFixture[EventStorage[Task]] {
+  override def withStorage[R](f: EventStorage[Task] => Task[R]): R = runSQLiteTest[R](f)
+
+  override def db: String = "/tmp/event_storage.db"
+
+  override def createTestResource: Task[EventStorage[Task]] =
+    SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
+}


### PR DESCRIPTION
### Overview
First jab at adding support to the API to replay events from a given event ID. 
Events are stored in SQLite which gives them an ID. The clients can use this to remember the last event they received and next time, or if the connection is lost, catch up from there.

There are some caveats:
* Different nodes see events in a different order, so the event IDs are going to be different.
* If the client uses filtering, they will see gaps in the event ID sequence.
* If the client uses filtering, they may not know about a newer event, in which case for example if they want to rely on polling from the same event until a new one is observed, they'd be retrieving the same records from the database over and over until finally something unfiltered arrives.

The only way I see around this is to return a List result instead of a stream, with some meta information about whether there are more events. Currently I just modified the existing streaming endpoint so that:
* It subscribes to future events if the event ID is 0.
* It replays past events if there's a minimum event passed. 

Currently the filtering is applied in the application layer even during replays. Created another ticket to move that to the DB (NODE-1302).

The way I see this working is for the clients to use the following sequence:

0. Retrieve the last event ID observed before.
1. Subscribe to future events and buffer them (`minEventId = 0`)
2. Replay past events (`minEventId = lastEventId + 1`) using a second stream.
3. When the second stream finishes, replay the buffered events from the first stream.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1289

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
