### PR TITLE
NODE-1305: Fix sync download mismatch

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -421,6 +421,11 @@ object GossipServiceCasperTestNodeFactory {
                                    casper.addMissingDependencies(partialBlock)
                                  }
 
+                               override def onScheduled(
+                                   summary: consensus.BlockSummary,
+                                   source: Node
+                               ) = ().pure[F]
+
                                override def onDownloaded(blockHash: ByteString) =
                                  // Calling `addBlock` during validation has already stored the block.
                                  Log[F].debug(

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/BlockDownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/BlockDownloadManager.scala
@@ -268,6 +268,8 @@ class BlockDownloadManagerImpl[F[_]: Concurrent: Log: Timer: Metrics](
               itemAndFeedback          <- mergeItem(items, summary, source, relay)
               (item, downloadFeedback) = itemAndFeedback
 
+              // Notify the rest of the system if this is the first time we schedule this item
+              // or if we're adding a new source to an item that already existed.
               existingItem = items.get(summary.blockHash)
               _ <- backend
                     .onScheduled(summary)

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImpl.scala
@@ -170,6 +170,7 @@ class InitialSynchronizationForwardImpl[F[_]: Parallel: Log: Timer](
             )
         _ <- Log[F].debug(s"Next round of syncing with nodes: ${nodes.map(_.show) -> "peers"}")
 
+        _ <- Log[F].info(s"Syncing with ${nodes.size -> "nodes"} from $rank")
         // Sync in parallel
         results <- nodes.parTraverse(n => syncDagSlice(n, rank).attempt.map(result => n -> result))
 
@@ -182,7 +183,7 @@ class InitialSynchronizationForwardImpl[F[_]: Parallel: Log: Timer](
         }
 
         _ <- if (fullSyncs >= minSuccessful) {
-              Log[F].debug(
+              Log[F].info(
                 s"Successfully synced with $fullSyncs nodes, required: $minSuccessful"
               )
             } else {
@@ -199,7 +200,7 @@ class InitialSynchronizationForwardImpl[F[_]: Parallel: Log: Timer](
                                      }
                                    }
                                  }
-                _ <- Log[F].debug(
+                _ <- Log[F].info(
                       s"Haven't reached required $minSuccessful amount of fully synced nodes, currently at $fullSyncs, continuing initial synchronization."
                     )
                 _ <- Timer[F].sleep(roundPeriod)

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
@@ -47,8 +47,11 @@ class StashingSynchronizer[F[_]: Concurrent: Parallel](
       res     <- attempt.rethrow
     } yield res
 
-  override def downloaded(blockHash: ByteString) =
-    underlying.downloaded(blockHash)
+  override def onDownloaded(blockHash: ByteString) =
+    underlying.onDownloaded(blockHash)
+
+  override def onScheduled(summary: BlockSummary, source: Node): F[Unit] =
+    underlying.onScheduled(summary, source)
 
   private def run: F[Unit] =
     for {

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/Synchronizer.scala
@@ -18,9 +18,16 @@ trait Synchronizer[F[_]] {
       targetBlockHashes: Set[ByteString]
   ): F[Either[SyncError, Vector[BlockSummary]]]
 
+  /** Called when the block is added to the download manager,
+    * so the synchronizer knows it doesn't have to keep traversing that path. */
+  def onScheduled(
+      summary: BlockSummary,
+      source: Node
+  ): F[Unit]
+
   /** Called when the block is finally downloaded to release any caches
     * the synchronizer keeps around. */
-  def downloaded(
+  def onDownloaded(
       blockHash: ByteString
   ): F[Unit]
 }

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/BlockDownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/BlockDownloadManagerSpec.scala
@@ -684,6 +684,8 @@ object BlockDownloadManagerSpec {
       }
     }
 
+    def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = Task.unit
+
     def onScheduled(summary: BlockSummary): Task[Unit] = Task.delay {
       synchronized { scheduled = scheduled :+ summary.blockHash }
     }
@@ -713,8 +715,9 @@ object BlockDownloadManagerSpec {
   /** Test implementation of the remote GossipService to download the blocks from. */
   object MockGossipService {
     private val emptySynchronizer = new Synchronizer[Task] {
-      def syncDag(source: Node, targetBlockHashes: Set[ByteString]) = ???
-      def downloaded(blockHash: ByteString): Task[Unit]             = ???
+      def syncDag(source: Node, targetBlockHashes: Set[ByteString])    = ???
+      def onDownloaded(blockHash: ByteString): Task[Unit]              = ???
+      def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = ???
     }
     private val emptyDownloadManager = new BlockDownloadManager[Task] {
       def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean) = ???

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -1173,7 +1173,8 @@ class GrpcGossipServiceSpec
                       // to `newBlocks` returns before all the syncing and downloading is finished.
                       Task.now(dag.asRight[SyncError]).delayResult(250.millis)
                     }
-                    def downloaded(blockHash: ByteString) = Task.unit
+                    def onDownloaded(blockHash: ByteString)              = Task.unit
+                    def onScheduled(summary: BlockSummary, source: Node) = Task.unit
                   }
 
                   val downloadManager = new BlockDownloadManager[Task] {
@@ -1412,8 +1413,9 @@ object GrpcGossipServiceSpec extends TestRuntime with ArbitraryConsensusAndComm 
 
   object TestEnvironment {
     private val emptySynchronizer = new Synchronizer[Task] {
-      def syncDag(source: Node, targetBlockHashes: Set[ByteString]) = ???
-      def downloaded(blockHash: ByteString): Task[Unit]             = ???
+      def syncDag(source: Node, targetBlockHashes: Set[ByteString])    = ???
+      def onDownloaded(blockHash: ByteString): Task[Unit]              = ???
+      def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = ???
     }
     private val emptyDownloadManager = new BlockDownloadManager[Task] {
       def scheduleDownload(summary: BlockSummary, source: Node, relay: Boolean) = ???

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationBackwardImplSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationBackwardImplSpec.scala
@@ -219,8 +219,9 @@ object InitialSynchronizationBackwardImplSpec extends ArbitraryConsensus {
   }
 
   object MockSynchronizer extends Synchronizer[Task] {
-    def syncDag(source: Node, targetBlockHashes: Set[ByteString]) = ???
-    def downloaded(blockHash: ByteString): Task[Unit]             = ???
+    def syncDag(source: Node, targetBlockHashes: Set[ByteString])    = ???
+    def onDownloaded(blockHash: ByteString): Task[Unit]              = ???
+    def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = ???
   }
 
   object MockBlockDownloadManager extends BlockDownloadManager[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
@@ -319,8 +319,13 @@ object InitialSynchronizationForwardImplSpec extends ArbitraryConsensus {
     ): Task[Either[Synchronizer.SyncError, Vector[BlockSummary]]] =
       f(targetBlockHashes).map(Right(_))
 
-    def downloaded(
+    def onDownloaded(
         blockHash: ByteString
+    ): Task[Unit] = Task.unit
+
+    def onScheduled(
+        summary: BlockSummary,
+        source: Node
     ): Task[Unit] = Task.unit
   }
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizerSpec.scala
@@ -160,7 +160,11 @@ object StashingSynchronizerSpec {
         }
       }
 
-    def downloaded(blockHash: ByteString): Task[Unit] = Task.unit
+    def onDownloaded(blockHash: ByteString): Task[Unit] = Task.unit
+    def onScheduled(
+        summary: BlockSummary,
+        source: Node
+    ): Task[Unit] = Task.unit
   }
 
   object TestFixture {

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -299,10 +299,13 @@ package object gossiping {
                             override def onScheduled(summary: BlockSummary): F[Unit] =
                               Consensus[F].onScheduled(summary)
 
+                            override def onScheduled(summary: BlockSummary, source: Node): F[Unit] =
+                              synchronizer.onScheduled(summary, source)
+
                             override def onDownloaded(blockHash: ByteString): F[Unit] =
                               // Calling `addBlock` during validation has already stored the block,
                               // so we have nothing more to do here with the consensus.
-                              synchronizer.downloaded(blockHash)
+                              synchronizer.onDownloaded(blockHash)
                           },
                           relaying = relaying,
                           retriesConf = BlockDownloadManagerImpl.RetriesConf(


### PR DESCRIPTION
### Overview
There was a possibility for a race condition to cause a mismatch between the `SynchronizerImpl` internal cache and the `BlockDownloadManager`'s scheduled items, which mean that the syncing always gave what looked like a partial DAG, with missing dependencies form the DM's perpective.

The PR changes the program so that the Synchronizer's internal cache is modified only when the item is scheduled for download, not before the results are returned.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1305

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
