### PR TITLE
EE-937: add 'use-system-contracts' option to cargo-casperlabs

### DIFF
--- a/execution-engine/cargo-casperlabs/Cargo.toml
+++ b/execution-engine/cargo-casperlabs/Cargo.toml
@@ -20,8 +20,10 @@ include = [
 
 [dependencies]
 clap = "2"
-colour = "0.4"
+colour = "0.5"
 lazy_static = "1"
 
 [dev-dependencies]
+assert_cmd = "0.12"
+tempdir = "0.3.7"
 toml = "0.5.5"

--- a/execution-engine/cargo-casperlabs/src/common.rs
+++ b/execution-engine/cargo-casperlabs/src/common.rs
@@ -6,7 +6,7 @@ use std::{
     str,
 };
 
-use colour::red;
+use colour::e_red;
 use lazy_static::lazy_static;
 
 use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
@@ -18,7 +18,7 @@ lazy_static! {
 }
 
 pub fn print_error_and_exit(msg: &str) -> ! {
-    red!("error");
+    e_red!("error");
     eprintln!("{}", msg);
     process::exit(FAILURE_EXIT_CODE)
 }

--- a/execution-engine/cargo-casperlabs/src/contract_package.rs
+++ b/execution-engine/cargo-casperlabs/src/contract_package.rs
@@ -21,13 +21,13 @@ use casperlabs_contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use casperlabs_types::{ApiError, Key};
+use casperlabs_types::{ApiError, Key, URef};
 
 const KEY: &str = "special_value";
 
 fn store(value: String) {
     // Store `value` under a new unforgeable reference.
-    let value_ref = storage::new_uref(value);
+    let value_ref: URef = storage::new_uref(value);
 
     // Wrap the unforgeable reference in a value of type `Key`.
     let value_key: Key = value_ref.into();

--- a/execution-engine/cargo-casperlabs/src/main.rs
+++ b/execution-engine/cargo-casperlabs/src/main.rs
@@ -25,6 +25,12 @@ const ROOT_PATH_ARG_NAME: &str = "path";
 const ROOT_PATH_ARG_VALUE_NAME: &str = "path";
 const ROOT_PATH_ARG_HELP: &str = "Path to new folder for contract and tests";
 
+const USE_SYSTEM_CONTRACTS_ARG_NAME: &str = "use-system-contracts";
+const USE_SYSTEM_CONTRACTS_ARG_LONG: &str = "use-system-contracts";
+const USE_SYSTEM_CONTRACTS_ARG_SHORT: &str = "z";
+const USE_SYSTEM_CONTRACTS_ARG_HELP: &str =
+    "Use system contracts instead of host-side logic for Mint, Proof of Stake and Standard Payment";
+
 const WORKSPACE_PATH_ARG_NAME: &str = "workspace-path";
 const WORKSPACE_PATH_ARG_LONG: &str = "workspace-path";
 
@@ -32,7 +38,7 @@ const FAILURE_EXIT_CODE: i32 = 101;
 
 lazy_static! {
     static ref USAGE: String = format!(
-        r#"cargo casperlabs <path>
+        r#"cargo casperlabs [FLAGS] <path>
     rustup install {0}
     rustup target add --toolchain {0} wasm32-unknown-unknown
     cd <path>/tests
@@ -45,6 +51,7 @@ lazy_static! {
 #[derive(Debug)]
 struct Args {
     root_path: PathBuf,
+    use_system_contracts: bool,
     workspace_path: Option<PathBuf>,
 }
 
@@ -72,6 +79,11 @@ impl Args {
             .value_name(ROOT_PATH_ARG_VALUE_NAME)
             .help(ROOT_PATH_ARG_HELP);
 
+        let use_system_contracts_arg = Arg::with_name(USE_SYSTEM_CONTRACTS_ARG_NAME)
+            .long(USE_SYSTEM_CONTRACTS_ARG_LONG)
+            .short(USE_SYSTEM_CONTRACTS_ARG_SHORT)
+            .help(USE_SYSTEM_CONTRACTS_ARG_HELP);
+
         let workspace_path_arg = Arg::with_name(WORKSPACE_PATH_ARG_NAME)
             .long(WORKSPACE_PATH_ARG_LONG)
             .takes_value(true)
@@ -82,6 +94,7 @@ impl Args {
             .about(ABOUT)
             .usage(USAGE.as_str())
             .arg(root_path_arg)
+            .arg(use_system_contracts_arg)
             .arg(workspace_path_arg)
             .get_matches_from(filtered_args_iter);
 
@@ -90,18 +103,25 @@ impl Args {
             .expect("expected path")
             .into();
 
+        let use_system_contracts = arg_matches.is_present(USE_SYSTEM_CONTRACTS_ARG_NAME);
+
         let workspace_path = arg_matches
             .value_of(WORKSPACE_PATH_ARG_NAME)
             .map(PathBuf::from);
 
         Args {
             root_path,
+            use_system_contracts,
             workspace_path,
         }
     }
 
     pub fn root_path(&self) -> &Path {
         &self.root_path
+    }
+
+    pub fn use_system_contracts(&self) -> bool {
+        self.use_system_contracts
     }
 
     pub fn workspace_path(&self) -> Option<&Path> {
@@ -126,11 +146,13 @@ fn main() {
     contract_package::add_config();
 
     tests_package::run_cargo_new();
-    tests_package::update_cargo_toml();
+    tests_package::update_cargo_toml(ARGS.use_system_contracts());
     tests_package::add_rust_toolchain();
     tests_package::add_build_rs();
     tests_package::replace_main_rs();
-    tests_package::copy_wasm_files();
+    if ARGS.use_system_contracts() {
+        tests_package::copy_wasm_files();
+    }
 }
 
 #[cfg(test)]

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -19,9 +19,9 @@ const STANDARD_PAYMENT: &str = "standard_payment.wasm";
 const INTEGRATION_TESTS_RS_CONTENTS: &str = r#"#[cfg(test)]
 mod tests {
     use casperlabs_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
-    use casperlabs_types::U512;
+    use casperlabs_types::{account::PublicKey, U512};
 
-    const MY_ACCOUNT: [u8; 32] = [7u8; 32];
+    const MY_ACCOUNT: PublicKey = PublicKey::ed25519_from([7u8; 32]);
     // define KEY constant to match that in the contract
     const KEY: &str = "special_value";
     const VALUE: &str = "hello world";
@@ -119,8 +119,7 @@ name = "integration-tests"
 path = "src/integration_tests.rs"
 
 [features]
-default = ["casperlabs-contract/std", "casperlabs-types/std"]
-"#,
+default = ["casperlabs-contract/std", "casperlabs-types/std""#,
         *CL_CONTRACT, *CL_TYPES, *ENGINE_TEST_SUPPORT,
     );
     static ref WASM_SRC_DIR: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("wasm");
@@ -131,8 +130,17 @@ pub fn run_cargo_new() {
     common::run_cargo_new(PACKAGE_NAME);
 }
 
-pub fn update_cargo_toml() {
-    common::append_to_file(&*CARGO_TOML, &*CARGO_TOML_ADDITIONAL_CONTENTS);
+pub fn update_cargo_toml(use_system_contracts: bool) {
+    let cargo_toml_additional_contents = format!(
+        "{}{}\n",
+        &*CARGO_TOML_ADDITIONAL_CONTENTS,
+        if use_system_contracts {
+            ", \"casperlabs-engine-test-support/use-system-contracts\"]"
+        } else {
+            "]"
+        }
+    );
+    common::append_to_file(&*CARGO_TOML, cargo_toml_additional_contents);
 }
 
 pub fn add_rust_toolchain() {

--- a/execution-engine/cargo-casperlabs/tests/integration_tests.rs
+++ b/execution-engine/cargo-casperlabs/tests/integration_tests.rs
@@ -1,0 +1,81 @@
+use std::process::Output;
+
+use assert_cmd::Command;
+use lazy_static::lazy_static;
+use tempdir::TempDir;
+
+const FAILURE_EXIT_CODE: i32 = 101;
+const SUCCESS_EXIT_CODE: i32 = 0;
+const USE_SYSTEM_CONTRACTS: &str = "--use-system-contracts";
+const TURBO: &str = "turbo";
+
+lazy_static! {
+    static ref WORKSPACE_PATH_ARG: String =
+        format!("--workspace-path={}/..", env!("CARGO_MANIFEST_DIR"));
+    static ref TEST_DIR: TempDir = TempDir::new("cargo-casperlabs").unwrap();
+}
+
+#[test]
+fn should_fail_when_target_path_already_exists() {
+    let output_error = Command::cargo_bin(env!("CARGO_PKG_NAME"))
+        .unwrap()
+        .arg(TEST_DIR.path())
+        .unwrap_err();
+
+    let exit_code = output_error.as_output().unwrap().status.code().unwrap();
+    assert_eq!(FAILURE_EXIT_CODE, exit_code);
+
+    let stderr: String = String::from_utf8_lossy(&output_error.as_output().unwrap().stderr).into();
+    let expected_msg_fragment = format!(
+        ": destination '{}' already exists",
+        TEST_DIR.path().display()
+    );
+    assert!(stderr.contains(&expected_msg_fragment));
+    assert!(stderr.contains("error"));
+}
+
+/// Runs `cmd` and returns the `Output` if successful, or panics on failure.
+fn output_from_command(mut command: Command) -> Output {
+    match command.ok() {
+        Ok(output) => output,
+        Err(error) => {
+            panic!(
+                "\nFailed to execute {:?}\n===== stderr begin =====\n{}\n===== stderr end =====\n",
+                command,
+                String::from_utf8_lossy(&error.as_output().unwrap().stderr)
+            );
+        }
+    }
+}
+
+fn run_tool_and_resulting_tests(turbo: bool) {
+    // Run 'cargo-casperlabs <test dir>/<subdir> --workspace-path=<path to EE root>'
+    let subdir = if turbo { TURBO } else { USE_SYSTEM_CONTRACTS };
+    let test_dir = TEST_DIR.path().join(subdir);
+    let mut tool_cmd = Command::cargo_bin(env!("CARGO_PKG_NAME")).unwrap();
+    tool_cmd.arg(&test_dir);
+    tool_cmd.arg(&*WORKSPACE_PATH_ARG);
+    // Also pass '--use-system-contracts' for non-turbo mode
+    if !turbo {
+        tool_cmd.arg(&*USE_SYSTEM_CONTRACTS);
+    }
+    let tool_output = output_from_command(tool_cmd);
+    assert_eq!(SUCCESS_EXIT_CODE, tool_output.status.code().unwrap());
+
+    // Run 'cargo test' in the 'tests' folder of the generated project.  This builds the Wasm
+    // contract as well as the tests.
+    let mut test_cmd = Command::new(env!("CARGO"));
+    test_cmd.arg("test").current_dir(test_dir.join("tests"));
+    let test_output = output_from_command(test_cmd);
+    assert_eq!(SUCCESS_EXIT_CODE, test_output.status.code().unwrap());
+}
+
+#[test]
+fn should_succeed_without_using_system_contracts() {
+    run_tool_and_resulting_tests(true);
+}
+
+#[test]
+fn should_succeed_using_system_contracts() {
+    run_tool_and_resulting_tests(false);
+}

--- a/execution-engine/cargo-casperlabs/tests/integration_tests.rs
+++ b/execution-engine/cargo-casperlabs/tests/integration_tests.rs
@@ -59,6 +59,9 @@ fn run_tool_and_resulting_tests(turbo: bool) {
     if !turbo {
         tool_cmd.arg(&*USE_SYSTEM_CONTRACTS);
     }
+    // The CI environment doesn't have a Git user configured, so we can set the env var `USER` for
+    // use by 'cargo new' which is called as a subprocess of 'cargo-casperlabs'.
+    tool_cmd.env("USER", "tester");
     let tool_output = output_from_command(tool_cmd);
     assert_eq!(SUCCESS_EXIT_CODE, tool_output.status.code().unwrap());
 

--- a/execution-engine/engine-test-support/src/lib.rs
+++ b/execution-engine/engine-test-support/src/lib.rs
@@ -25,15 +25,15 @@
 //! The test could be written as follows:
 //! ```no_run
 //! # use types as casperlabs_types;
-//! use casperlabs_engine_test_support::{TestContextBuilder, SessionBuilder, Value, Error, Code};
-//! use casperlabs_types::account::PublicKey;
+//! use casperlabs_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
+//! use casperlabs_types::{account::PublicKey, U512};
 //!
 //! const MY_ACCOUNT: PublicKey = PublicKey::ed25519_from([7u8; 32]);
 //! const KEY: &str = "special_value";
 //! const VALUE: &str = "hello world";
 //!
 //! let mut context = TestContextBuilder::new()
-//!     .with_account(MY_ACCOUNT, 128_000_000.into())
+//!     .with_account(MY_ACCOUNT, U512::from(128_000_000))
 //!     .build();
 //!
 //! // The test framework checks for compiled Wasm files in '<current working dir>/wasm'.  Paths
@@ -46,9 +46,7 @@
 //!     .with_authorization_keys(&[MY_ACCOUNT])
 //!     .build();
 //!
-//! let result_of_query: Result<Value, Error> = context
-//!     .run(session)
-//!     .query(MY_ACCOUNT, &[KEY]);
+//! let result_of_query: Result<Value, Error> = context.run(session).query(MY_ACCOUNT, &[KEY]);
 //!
 //! let returned_value = result_of_query.expect("should be a value");
 //!

--- a/execution-engine/engine-test-support/src/session.rs
+++ b/execution-engine/engine-test-support/src/session.rs
@@ -5,9 +5,7 @@ use engine_core::engine_state::execute_request::ExecuteRequest;
 use types::ProtocolVersion;
 
 use crate::{
-    internal::{
-        DeployItemBuilder, ExecuteRequestBuilder, DEFAULT_PAYMENT, STANDARD_PAYMENT_CONTRACT,
-    },
+    internal::{DeployItemBuilder, ExecuteRequestBuilder, DEFAULT_PAYMENT},
     Code, PublicKey,
 };
 
@@ -24,11 +22,10 @@ pub struct SessionBuilder {
 
 impl SessionBuilder {
     /// Constructs a new `SessionBuilder` containing a deploy with the provided session code and
-    /// session args, and with default values for the account address, payment code, payment code
-    /// args, gas price, authorization keys and protocol version.
+    /// session args, and with default values for the account address, payment code args, gas price,
+    /// authorization keys and protocol version.
     pub fn new(session_code: Code, session_args: impl ArgsParser) -> Self {
-        let di_builder = DeployItemBuilder::new()
-            .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,));
+        let di_builder = DeployItemBuilder::new().with_empty_payment_bytes((*DEFAULT_PAYMENT,));
         let di_builder = match session_code {
             Code::Path(path) => di_builder.with_session_code(path, session_args),
             Code::NamedKey(name) => di_builder.with_stored_session_named_key(&name, session_args),


### PR DESCRIPTION
### Overview
This updates the `cargo-casperlabs` tool to accept a command line arg which enables using system contracts in the resulting generated project.

It also adds integration tests for the tool.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-937

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The integration tests add a minute or two to the overall test time, since they invoke the tool and then build and run the resulting generated tests.