### PR TITLE
NODE-1304: Not following orphans/finalized into different eras 

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -545,7 +545,8 @@ object MultiParentCasperImpl {
       implicit0(multiParentFinalizer: MultiParentFinalizer[F]) <- MultiParentFinalizer.create[F](
                                                                    dag,
                                                                    lfb,
-                                                                   finalityDetector
+                                                                   finalityDetector,
+                                                                   isHighway = false
                                                                  )
     } yield new MultiParentCasperImpl[F](
       semaphoreMap,

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -52,7 +52,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
                                                               )
           finalizedIndirectly <- FinalityDetectorUtil.finalizedIndirectly[Task](
                                   dag,
-                                  b.blockHash
+                                  b.blockHash,
+                                  isHighway = false
                                 )
         } yield assert(finalizedIndirectly == Set(a1.blockHash))
   }
@@ -97,7 +98,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
         _ <- FinalityDetectorUtil
               .finalizedIndirectly[G](
                 stateTDag,
-                c.blockHash
+                c.blockHash,
+                isHighway = false
               )
               .run(Map.empty) shouldBeF ((expectedNodesVisitedA, Set(a.blockHash)))
         d <- createAndStoreBlockFull[Task](v1, Seq(a), Seq.empty, bonds)
@@ -116,7 +118,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
         _ <- FinalityDetectorUtil
               .finalizedIndirectly[G](
                 stateTDag,
-                f.blockHash
+                f.blockHash,
+                isHighway = false
               )
               .run(Map.empty) shouldBeF (
               (
@@ -151,7 +154,8 @@ class FinalityDetectorUtilTest extends FlatSpec with BlockGenerator with Storage
           orphanedIndirectly <- FinalityDetectorUtil.orphanedIndirectly[Task](
                                  dag,
                                  e.blockHash,
-                                 finalizedIndirectly = Set(d.blockHash)
+                                 finalizedIndirectly = Set(d.blockHash),
+                                 isHighway = false
                                )
         } yield {
           assert(orphanedIndirectly == Set(b.blockHash, c.blockHash))

--- a/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
@@ -41,7 +41,8 @@ class MultiParentFinalizerTest extends FlatSpec with BlockGenerator with Storage
         multiParentFinalizer <- MultiParentFinalizer.create[Task](
                                  dag,
                                  genesis.blockHash,
-                                 MultiParentFinalizerTest.immediateFinalityStub
+                                 MultiParentFinalizerTest.immediateFinalityStub,
+                                 isHighway = false
                                )
         a0                    <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
         a1                    <- createAndStoreBlockFull[Task](v1, Seq(a0), Seq.empty, bonds)
@@ -92,7 +93,8 @@ class MultiParentFinalizerTest extends FlatSpec with BlockGenerator with Storage
                                                                         .create[Task](
                                                                           dag,
                                                                           genesis.blockHash,
-                                                                          finalizer
+                                                                          finalizer,
+                                                                          isHighway = false
                                                                         )
         a        <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
         nelBonds = NonEmptyList.fromListUnsafe(bonds.toList)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -175,7 +175,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
           multiParentFinalizer <- MultiParentFinalizer.create(
                                    dag,
                                    genesis.blockHash,
-                                   finalityDetector
+                                   finalityDetector,
+                                   isHighway = false
                                  )
           node = new GossipServiceCasperTestNode[F](
             identity,
@@ -278,7 +279,8 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                 multiParentFinalizer <- MultiParentFinalizer.create(
                                          dag,
                                          genesis.blockHash,
-                                         finalityDetector
+                                         finalityDetector,
+                                         isHighway = false
                                        )
                 chainName    = "casperlabs"
                 minTTL       = 1.minute

--- a/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
@@ -266,7 +266,8 @@ object Highway {
             finalizer <- MultiParentFinalizer.create[F](
                           dag,
                           lfb,
-                          finalityDetector
+                          finalityDetector,
+                          isHighway = true
                         )
             meteredFinalized = MeteredMultiParentFinalizer.of[F](finalizer)
           } yield meteredFinalized


### PR DESCRIPTION
### Overview
The parent era voting ballots are in the justifications of the child era messages. For this reason they got traversed when we were looking for orphaned blocks. They are also not marked as final/orphan, so this happened again and again. They all lead back to the switch block, which is final, but it's a lot of work. We also know that it should be the parent era validators who finalize the switch block, not the ones in the child era (virtually different), so there's no reason to traverse the messages of the parent era. The only thing we could be orphaning by a child era LFB are parents in the parent era that weren't picked as secondaries; but we are not using secondary parents at the moment.

The original idea was to mark ballots as final/oprhaned, however during the voting period they'll just keep growing, and there's no LFB after the switch block in the parent era that would trigger implicit finalization for them, and the child era blocks should not affect their finality (because ballots have no finality). So I abandoned this idea in favor of just not following them at all, maybe it's enough.

Ballots in the child era are going to be traversed, possibly repeatedly, but that's a shorter route, hopefully. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1304

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
This change ~potentially leaves the switch block unfinalized~ until we fix https://casperlabs.atlassian.net/browse/CON-653
