### PR TITLE
NODE-1310: Move max-block-size-bytes to ChainSpec.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -30,7 +30,6 @@ final case class CasperConf(
     autoProposeBallotInterval: FiniteDuration,
     autoProposeAccInterval: FiniteDuration,
     autoProposeAccCount: Int,
-    maxBlockSizeBytes: Int,
     minTtl: FiniteDuration
 ) extends SubConfig
 

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -52,10 +52,28 @@ object DeploySelection {
       preconditionFailures: List[PreconditionFailure]
   )
 
+  final case class DeploySelectionParams[F[_]](
+      preStateHash: ByteString,
+      timestamp: Long,
+      protocolVersion: ProtocolVersion,
+      maxBlockSizeBytes: Int,
+      deploys: fs2.Stream[F, Deploy]
+  )
+
   trait DeploySelection[F[_]] extends Select[F] {
     // prestate hash, block time, protocol version, max block size, stream of deploys.
-    type A = (ByteString, Long, ProtocolVersion, Int, fs2.Stream[F, Deploy])
+    type A = DeploySelectionParams[F]
     type B = DeploySelectionResult
+
+    def select(
+        preStateHash: ByteString,
+        timestamp: Long,
+        protocolVersion: ProtocolVersion,
+        maxBlockSizeBytes: Int,
+        deploys: fs2.Stream[F, Deploy]
+    ): F[B] = select(
+      DeploySelectionParams(preStateHash, timestamp, protocolVersion, maxBlockSizeBytes, deploys)
+    )
   }
 
   def apply[F[_]](implicit ev: DeploySelection[F]): DeploySelection[F] = ev
@@ -105,7 +123,7 @@ object DeploySelection {
     val underlying = create[F]()
     new DeploySelection[F] {
       override def select(
-          in: (DeployHash, Long, ProtocolVersion, Int, fs2.Stream[F, Deploy])
+          in: DeploySelectionParams[F]
       ): F[DeploySelectionResult] =
         Metrics[F].timer("deploySelection")(underlying.select(in))
     }
@@ -128,13 +146,11 @@ object DeploySelection {
     new DeploySelection[F] {
 
       override def select(
-          in: (DeployHash, Long, ProtocolVersion, Int, fs2.Stream[F, Deploy])
+          in: DeploySelectionParams[F]
       ): F[DeploySelectionResult] = {
-        val (prestate, blocktime, protocolVersion, sizeLimitBytes, deploys) = in
-
         // If size of accumulated deploys is over 90% of the block limit, stop consuming more deploys.
         def isOversized(state: IntermediateState) =
-          state.size > 0.9 * sizeLimitBytes
+          state.size > 0.9 * in.maxBlockSizeBytes
 
         def go(
             state: IntermediateState,
@@ -146,10 +162,10 @@ object DeploySelection {
             case Some((chunk, deploys)) =>
               val batch = chunk.toList
               val newState = eeExecuteDeploys[F](
-                prestate,
-                blocktime,
+                in.preStateHash,
+                in.timestamp,
                 batch,
-                protocolVersion
+                in.protocolVersion
               )(ExecutionEngineService[F].exec _) map { results =>
                 // Using `Either` as fold for shortcutting semantics.
                 results
@@ -178,7 +194,7 @@ object DeploySelection {
           }
 
         val selectedDeploys =
-          go(IntermediateState(), deploys).stream.compile.last
+          go(IntermediateState(), in.deploys).stream.compile.last
 
         selectedDeploys.map {
           case None =>

--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -150,7 +150,7 @@ object DeploySelection {
       ): F[DeploySelectionResult] = {
         // If size of accumulated deploys is over 90% of the block limit, stop consuming more deploys.
         def isOversized(state: IntermediateState) =
-          state.size > 0.9 * in.maxBlockSizeBytes
+          state.size > 0.9 * in.maxBlockSizeBytes && in.maxBlockSizeBytes > 0
 
         def go(
             state: IntermediateState,

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -403,6 +403,7 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
                          timestamp,
                          props.protocolVersion,
                          props.mainRank,
+                         props.configuration.deployConfig.maxBlockSizeBytes,
                          upgrades
                        )
         result <- Sync[F]

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -153,6 +153,7 @@ object MessageProducer {
                            timestamp,
                            props.protocolVersion,
                            props.mainRank,
+                           props.configuration.deployConfig.maxBlockSizeBytes,
                            upgrades
                          )
 

--- a/casper/src/main/scala/io/casperlabs/casper/util/CasperLabsProtocol.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/CasperLabsProtocol.scala
@@ -35,9 +35,7 @@ object CasperLabsProtocol {
       versions: (Long, state.ProtocolVersion, Option[ipc.ChainSpec.DeployConfig])*
   ): CasperLabsProtocol[F] = {
     def toDeployConfig(ipcDeployConfig: Option[ipc.ChainSpec.DeployConfig]): DeployConfig =
-      ipcDeployConfig
-        .map(d => DeployConfig(d.maxTtlMillis, d.maxDependencies))
-        .getOrElse(DeployConfig())
+      ipcDeployConfig.getOrElse(DeployConfig())
 
     def toConfig(
         blockHeightMin: Long,

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -210,6 +210,7 @@ object ExecEngineUtil {
       blocktime: Long,
       protocolVersion: state.ProtocolVersion,
       mainRank: MainRank,
+      maxBlockSizeBytes: Int,
       upgrades: Seq[ChainSpec.UpgradePoint]
   ): F[DeploysCheckpoint] = Metrics[F].timer("computeDeploysCheckpoint") {
     for {
@@ -220,6 +221,7 @@ object ExecEngineUtil {
                                                                                   preStateHash,
                                                                                   blocktime,
                                                                                   protocolVersion,
+                                                                                  maxBlockSizeBytes,
                                                                                   deployStream
                                                                                 )
                                                                               )

--- a/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/execengine/ExecEngineUtil.scala
@@ -217,13 +217,11 @@ object ExecEngineUtil {
       preStateHash <- computePrestate[F](merged, mainRank, upgrades).timer("computePrestate")
       DeploySelectionResult(commuting, conflicting, preconditionFailures) <- DeploySelection[F]
                                                                               .select(
-                                                                                (
-                                                                                  preStateHash,
-                                                                                  blocktime,
-                                                                                  protocolVersion,
-                                                                                  maxBlockSizeBytes,
-                                                                                  deployStream
-                                                                                )
+                                                                                preStateHash,
+                                                                                blocktime,
+                                                                                protocolVersion,
+                                                                                maxBlockSizeBytes,
+                                                                                deployStream
                                                                               )
       _                             <- handleInvalidDeploys[F](preconditionFailures)
       (deploysForBlock, transforms) = ExecEngineUtil.unzipEffectsAndDeploys(commuting).unzip

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -106,11 +106,13 @@ class DeploySelectionTest
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
 
       val deploySelection: DeploySelection[Task] =
-        DeploySelection.create[Task](blockSizeBytes, chunkSize)
+        DeploySelection.create[Task](blockSizeBytes)
 
       val test = for {
         selected <- deploySelection
-                     .select((prestate, blocktime, protocolVersion, countedStream.stream))
+                     .select(
+                       (prestate, blocktime, protocolVersion, chunkSize, countedStream.stream)
+                     )
                      .map(_.commuting.map(_.deploy))
         _ <- Task.delay(assert(scaleWithChunkSize(countedStream.getCount()) == expectedPulls))
       } yield selected should contain theSameElementsAs expected
@@ -133,10 +135,10 @@ class DeploySelectionTest
       eeExecMock(everyOtherInvalidDeploy(counter) _)
 
     val deploySelection: DeploySelection[Task] =
-      DeploySelection.create[Task](smallBlockSizeBytes)
+      DeploySelection.create[Task]()
 
     val test = deploySelection
-      .select((prestate, blocktime, protocolVersion, stream))
+      .select((prestate, blocktime, protocolVersion, smallBlockSizeBytes, stream))
       .map(results => {
         assert(results.commuting.map(_.deploy) == cappedEffects)
       })
@@ -154,7 +156,7 @@ class DeploySelectionTest
     val counter                                   = AtomicInt(1)
     implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherCommutesExec(counter) _)
 
-    val deploySelection = DeploySelection.create[Task](sizeLimitBytes)
+    val deploySelection = DeploySelection.create[Task]()
 
     // The very first WRITE doesn't conflict
     val expectedCommuting = cappedEffects.head +: cappedEffects.zipWithIndex
@@ -164,7 +166,7 @@ class DeploySelectionTest
     val expectedConflicting = cappedEffects.zipWithIndex.filter(_._2 % 2 == 0).map(_._1).tail
 
     val test = deploySelection
-      .select((prestate, blocktime, protocolVersion, stream))
+      .select((prestate, blocktime, protocolVersion, sizeLimitBytes, stream))
       .map {
         case DeploySelectionResult(commutingRes, conflictingRes, _) =>
           conflictingRes should contain theSameElementsAs expectedConflicting
@@ -185,18 +187,18 @@ class DeploySelectionTest
             .tupleRight(size)
       )
   ) {
-    case (deploys, maxBlockSizeMb) =>
+    case (deploys, maxBlockSizeBytes) =>
       val cappedDeploys = deploys
 
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
 
       val deploySelection: DeploySelection[Task] =
-        DeploySelection.create[Task](maxBlockSizeMb)
+        DeploySelection.create[Task]()
 
       val stream = fs2.Stream.fromIterator(cappedDeploys.toIterator)
 
       val test = deploySelection
-        .select((prestate, blocktime, protocolVersion, stream))
+        .select((prestate, blocktime, protocolVersion, maxBlockSizeBytes, stream))
         .map(_.commuting.map(_.deploy))
         .map(_ should contain theSameElementsAs cappedDeploys)
 
@@ -218,11 +220,10 @@ class DeploySelectionTest
 
     val counter                                   = AtomicInt(0)
     implicit val ee: ExecutionEngineService[Task] = eeExecMock(everyOtherInvalidDeploy(counter) _)
-    val deploySelection: DeploySelection[Task] =
-      DeploySelection.create[Task](smallBlockSizeBytes)
+    val deploySelection: DeploySelection[Task]    = DeploySelection.create[Task]()
 
     val test = deploySelection
-      .select((prestate, blocktime, protocolVersion, stream))
+      .select((prestate, blocktime, protocolVersion, smallBlockSizeBytes, stream))
       .map {
         case DeploySelectionResult(chosenDeploys, _, invalidDeploys) => {
           // Assert that all invalid deploys are a subset of the input set of invalid deploys.

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -106,11 +106,17 @@ class DeploySelectionTest
       implicit val ee: ExecutionEngineService[Task] = eeExecMock(everythingCommutesExec _)
 
       val deploySelection: DeploySelection[Task] =
-        DeploySelection.create[Task](blockSizeBytes)
+        DeploySelection.create[Task](minChunkSize = chunkSize)
 
       val test = for {
         selected <- deploySelection
-                     .select(prestate, blocktime, protocolVersion, chunkSize, countedStream.stream)
+                     .select(
+                       prestate,
+                       blocktime,
+                       protocolVersion,
+                       blockSizeBytes,
+                       countedStream.stream
+                     )
                      .map(_.commuting.map(_.deploy))
         _ <- Task.delay(assert(scaleWithChunkSize(countedStream.getCount()) == expectedPulls))
       } yield selected should contain theSameElementsAs expected

--- a/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/DeploySelectionTest.scala
@@ -110,9 +110,7 @@ class DeploySelectionTest
 
       val test = for {
         selected <- deploySelection
-                     .select(
-                       (prestate, blocktime, protocolVersion, chunkSize, countedStream.stream)
-                     )
+                     .select(prestate, blocktime, protocolVersion, chunkSize, countedStream.stream)
                      .map(_.commuting.map(_.deploy))
         _ <- Task.delay(assert(scaleWithChunkSize(countedStream.getCount()) == expectedPulls))
       } yield selected should contain theSameElementsAs expected
@@ -138,7 +136,7 @@ class DeploySelectionTest
       DeploySelection.create[Task]()
 
     val test = deploySelection
-      .select((prestate, blocktime, protocolVersion, smallBlockSizeBytes, stream))
+      .select(prestate, blocktime, protocolVersion, smallBlockSizeBytes, stream)
       .map(results => {
         assert(results.commuting.map(_.deploy) == cappedEffects)
       })
@@ -166,7 +164,7 @@ class DeploySelectionTest
     val expectedConflicting = cappedEffects.zipWithIndex.filter(_._2 % 2 == 0).map(_._1).tail
 
     val test = deploySelection
-      .select((prestate, blocktime, protocolVersion, sizeLimitBytes, stream))
+      .select(prestate, blocktime, protocolVersion, sizeLimitBytes, stream)
       .map {
         case DeploySelectionResult(commutingRes, conflictingRes, _) =>
           conflictingRes should contain theSameElementsAs expectedConflicting
@@ -198,7 +196,7 @@ class DeploySelectionTest
       val stream = fs2.Stream.fromIterator(cappedDeploys.toIterator)
 
       val test = deploySelection
-        .select((prestate, blocktime, protocolVersion, maxBlockSizeBytes, stream))
+        .select(prestate, blocktime, protocolVersion, maxBlockSizeBytes, stream)
         .map(_.commuting.map(_.deploy))
         .map(_ should contain theSameElementsAs cappedDeploys)
 
@@ -223,7 +221,7 @@ class DeploySelectionTest
     val deploySelection: DeploySelection[Task]    = DeploySelection.create[Task]()
 
     val test = deploySelection
-      .select((prestate, blocktime, protocolVersion, smallBlockSizeBytes, stream))
+      .select(prestate, blocktime, protocolVersion, smallBlockSizeBytes, stream)
       .map {
         case DeploySelectionResult(chosenDeploys, _, invalidDeploys) => {
           // Assert that all invalid deploys are a subset of the input set of invalid deploys.

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -1352,9 +1352,7 @@ class ValidationTest
     implicit blockStorage => implicit dagStorage => implicit deployStorage => _ =>
       val deploys =
         Vector(ProtoUtil.deploy(System.currentTimeMillis, ByteString.EMPTY))
-      implicit val deploySelection: DeploySelection[Task] = DeploySelection.create[Task](
-        5 * 1024 * 1024
-      )
+      implicit val deploySelection: DeploySelection[Task] = DeploySelection.create[Task]()
 
       implicit val deployBuffer = DeployBuffer.create[Task]("casperlabs", Duration.Zero)
 
@@ -1366,6 +1364,7 @@ class ValidationTest
                               System.currentTimeMillis,
                               ProtocolVersion(1),
                               mainRank = 0,
+                              maxBlockSizeBytes = 5 * 1024 * 1024,
                               upgrades = Nil
                             )
         DeploysCheckpoint(

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -81,17 +81,16 @@ object BlockGenerator {
       parents <- ProtoUtil.unsafeGetParents[F](b)
       deploys = ProtoUtil.deploys(b).values.flatMap(_.toList).flatMap(_.deploy)
 
-      merged <- ExecutionEngineServiceStub.merge[F](parents, dag)
-      implicit0(deploySelection: DeploySelection[F]) = DeploySelection.create[F](
-        5 * 1024 * 1024
-      )
-      _ <- DeployStorageWriter[F].addAsPending(deploys.toList)
+      merged                                         <- ExecutionEngineServiceStub.merge[F](parents, dag)
+      implicit0(deploySelection: DeploySelection[F]) = DeploySelection.create[F]()
+      _                                              <- DeployStorageWriter[F].addAsPending(deploys.toList)
       result <- computeDeploysCheckpoint[F](
                  merged,
                  fs2.Stream.fromIterator(deploys.toIterator),
                  b.getHeader.timestamp,
                  ProtocolVersion(1),
                  mainRank = Message.asMainRank(0),
+                 maxBlockSizeBytes = 5 * 1024 * 1024,
                  upgrades = Nil
                )
     } yield result

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -78,7 +78,7 @@ class GossipServiceCasperTestNode[F[_]](
   implicit val raiseInvalidBlock      = casper.validation.raiseValidateErrorThroughApplicativeError[F]
   implicit val broadcaster: Broadcaster[F] =
     Broadcaster.fromGossipServices(Some(validatorId), relaying)
-  implicit val deploySelection = DeploySelection.create[F](5 * 1024 * 1024)
+  implicit val deploySelection = DeploySelection.create[F]()
   implicit val validationEff   = new NCBValidationImpl[F]
   implicit val eventEmitter    = NoOpsEventEmitter.create[F]
 

--- a/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/HashSetCasperTestNode.scala
@@ -336,10 +336,10 @@ object HashSetCasperTestNode {
       0L,
       consensus.state.ProtocolVersion(1),
       Some(
-        DeployConfig(
-          24 * 60 * 60 * 1000, // 1 day
-          10
-        )
+        DeployConfig()
+          .withMaxTtlMillis(24 * 60 * 60 * 1000) // 1 day
+          .withMaxDependencies(10)
+          .withMaxBlockSizeBytes(10 * 1024 * 1024)
       )
     )
   )

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -169,7 +169,7 @@ trait HighwayFixture
         bonds = genesisBlock.getHeader.getState.bonds
       )
 
-    implicit lazy val deploySelection = DeploySelection.create[Task](sizeLimitBytes = Int.MaxValue)
+    implicit lazy val deploySelection = DeploySelection.create[Task]()
 
     implicit val validationRaise = raiseValidateErrorThroughApplicativeError[Task]
     implicit val protocol = CasperLabsProtocol.unsafe[Task](

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
@@ -87,7 +87,7 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
     // Make a message producer that's supposed to make valid blocks.
     def makeMessageProducer(keys: AccountKeys): MessageProducer[Task] = {
       implicit val deployBuffer    = DeployBuffer.create[Task](chainName, minTtl = Duration.Zero)
-      implicit val deploySelection = DeploySelection.create[Task](sizeLimitBytes = Int.MaxValue)
+      implicit val deploySelection = DeploySelection.create[Task]()
 
       MessageProducer[Task](
         validatorIdentity = ValidatorIdentity(

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
@@ -127,7 +127,7 @@ class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with Hi
 
         override lazy val messageProducer: MessageProducer[Task] = {
           implicit val deployBuffer    = DeployBuffer.create[Task](chainName, minTtl = Duration.Zero)
-          implicit val deploySelection = DeploySelection.create[Task](sizeLimitBytes = Int.MaxValue)
+          implicit val deploySelection = DeploySelection.create[Task]()
 
           MessageProducer[Task](
             validatorIdentity =
@@ -218,7 +218,7 @@ class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with Hi
 
         override lazy val messageProducer: MessageProducer[Task] = {
           implicit val deployBuffer    = DeployBuffer.create[Task](chainName, minTtl = Duration.Zero)
-          implicit val deploySelection = DeploySelection.create[Task](sizeLimitBytes = Int.MaxValue)
+          implicit val deploySelection = DeploySelection.create[Task]()
 
           MessageProducer[Task](
             validatorIdentity =

--- a/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/etc_casperlabs/chainspec/genesis/manifest.toml
@@ -32,6 +32,7 @@ ftt = 0.1
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10
+max-block-size-bytes = 10485760
 
 [wasm-costs]
 regular = 1

--- a/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec-minor/genesis/manifest.toml
@@ -32,6 +32,7 @@ ftt = 0.1
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10
+max-block-size-bytes = 10485760
 
 [wasm-costs]
 regular = 1

--- a/integration-testing/resources/test-chainspec/genesis/manifest.toml
+++ b/integration-testing/resources/test-chainspec/genesis/manifest.toml
@@ -32,6 +32,7 @@ ftt = 0.1
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10
+max-block-size-bytes = 10485760
 
 [wasm-costs]
 regular = 1

--- a/node/src/main/resources/chainspec/genesis/manifest.toml
+++ b/node/src/main/resources/chainspec/genesis/manifest.toml
@@ -57,6 +57,9 @@ ftt = 0.1
 max-ttl-millis = 86400000
 max-dependencies = 10
 
+# Maximum block size in bytes
+max-block-size-bytes = 10485760
+
 [wasm-costs]
 # Default opcode cost
 regular = 1

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -246,9 +246,6 @@ auto-propose-acc-interval = "5seconds"
 # Number of deploys to accumulate before proposing.
 auto-propose-acc-count = 10
 
-# Maximum block size in bytes
-max-block-size-bytes = 10485760
-
 # Minimum TTL value of a deploy
 min-ttl = "1hour"
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -244,7 +244,7 @@ class NodeRuntime private[node] (
       implicit0(deploySelection: DeploySelection[Task]) <- Resource.liftF(
                                                             DeploySelection
                                                               .createMetered[Task](
-                                                                conf.casper.maxBlockSizeBytes
+                                                                chainSpec.getGenesis.getDeployConfig.maxBlockSizeBytes
                                                               )
                                                               .pure[Task]
                                                           )

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -243,9 +243,7 @@ class NodeRuntime private[node] (
 
       implicit0(deploySelection: DeploySelection[Task]) <- Resource.liftF(
                                                             DeploySelection
-                                                              .createMetered[Task](
-                                                                chainSpec.getGenesis.getDeployConfig.maxBlockSizeBytes
-                                                              )
+                                                              .createMetered[Task]
                                                               .pure[Task]
                                                           )
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
@@ -64,7 +64,8 @@ object ChainSpec extends ParserImplicits {
 
   final case class Deploy(
       maxTtlMillis: Int Refined NonNegative,
-      maxDependencies: Int Refined NonNegative
+      maxDependencies: Int Refined NonNegative,
+      maxBlockSizeBytes: Int Refined NonNegative
   ) extends SubConfig
 
   /** The first set of changes should define the Genesis section and the costs. */

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -300,10 +300,6 @@ private[configuration] final case class Options private (
       gen[Int]("Number of deploys to accumulate before proposing.")
 
     @scallop
-    val casperMaxBlockSizeBytes =
-      gen[Int]("Maximum block size [in bytes].")
-
-    @scallop
     val serverBootstrap =
       gen[List[NodeWithoutChainId]](
         "Bootstrap casperlabs node address for initial seed. Accepts multiple instances for redundancy.",

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -80,7 +80,6 @@ auto-propose-check-interval = "1second"
 auto-propose-ballot-interval = "1second"
 auto-propose-acc-interval = "1second"
 auto-propose-acc-count = 1
-max-block-size-bytes = 1
 min-ttl = "1hour"
 
 [highway]

--- a/node/src/test/resources/test-chainspec/genesis/manifest.toml
+++ b/node/src/test/resources/test-chainspec/genesis/manifest.toml
@@ -32,6 +32,7 @@ ftt = 0.1
 [deploys]
 max-ttl-millis = 86400000
 max-dependencies = 10
+max-block-size-bytes = 10485760
 
 [wasm-costs]
 regular = 1

--- a/node/src/test/resources/test-chainspec/upgrade-1/manifest.toml
+++ b/node/src/test/resources/test-chainspec/upgrade-1/manifest.toml
@@ -11,6 +11,7 @@ installer-code-path = "installer.wasm"
 # 10 days
 max-ttl-millis = 864000000
 max-dependencies = 10
+max-block-size-bytes = 10485760
 
 [wasm-costs]
 # Default opcode cost

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -126,7 +126,6 @@ class ConfigurationSpec
       autoProposeBallotInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeAccInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeAccCount = 1,
-      maxBlockSizeBytes = 1,
       minTtl = FiniteDuration(1, TimeUnit.HOURS)
     )
     val highway = Configuration.Highway(

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -263,6 +263,7 @@ message ChainSpec {
     message DeployConfig {
         uint32 max_ttl_millis = 2;
         uint32 max_dependencies = 3;
+        uint32 max_block_size_bytes = 4;
     }
 
     message HighwayConfig {


### PR DESCRIPTION
### Overview
Max block size should be uniform across the nodes. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1307

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
