### PR TITLE
NODE-1300: Pass justifications to the `messageJPast`.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/dag/EraObservedBehavior.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/dag/EraObservedBehavior.scala
@@ -145,10 +145,9 @@ object EraObservedBehavior {
     * It is the latest message (or multiple messages) per validator seen
     * in the j-past-cone of the message.
     *
-    * This particular method is capped by a "stop block". It won't consider
-    * blocks created before that stop block.
+    * We start with the `eraObservedBehavior` which is a local view of the DAG.
+    * It contains superset of what the `justificaions` may point at.
     *
-    * NOTE: In the future, this will be using Andreas' Merkle trie optimization.
     * @param dag
     * @param justifications
     * @param erasObservedBehavior

--- a/casper/src/test/scala/io/casperlabs/casper/dag/DagOperationsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/dag/DagOperationsTest.scala
@@ -644,7 +644,7 @@ class DagOperationsTest
           c3 <- createAndStoreBlockFull[Task](
                  v3,
                  Seq(c2),
-                 Seq(a2),
+                 Seq(a2, sb),
                  bondsThree,
                  keyBlockHash = c1.blockHash
                )
@@ -675,6 +675,7 @@ class DagOperationsTest
           latestGenesisMessageHashes = latestMessages
             .latestMessagesInEra(genesis.blockHash)
             .mapValues(_.map(_.messageHash))
+
           expectedGenesis = Map(
             v1 -> Set(a1.blockHash),
             v2 -> Set(sb.blockHash),
@@ -683,6 +684,7 @@ class DagOperationsTest
           latestChildMessageHashes = latestMessages
             .latestMessagesInEra(c1.blockHash)
             .mapValues(_.map(_.messageHash))
+
           expectedChild = Map(
             v1 -> Set(a2.blockHash),
             v3 -> Set(c2.blockHash)
@@ -849,7 +851,7 @@ class DagOperationsTest
             .mapValues(_.map(_.messageHash))
 
           expectedGenesis = Map(
-            v1 -> Set(a1.blockHash, a2.blockHash),
+            v1 -> Set(a1Prime.blockHash, a2.blockHash),
             v2 -> Set(b2.blockHash)
           )
 


### PR DESCRIPTION
### Overview
The bug was caused by the fact that we were already passing in direct justifications of the message but then, the method was looking up justifications of those again. That's why in `era-4` we ended up with justifications from `era-0` (because direct justifications from `era-1` were looked up and their justifications were fetched which returned `era-0` justifications).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1292

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
