### PR TITLE
NODE-1311: Add stests to hack/docker

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -216,7 +216,12 @@ class EraRuntime[F[_]: Sync: Clock: Metrics: Log: EraStorage: FinalityStorageRea
     */
   private def ifCanBuildOn[T](choice: ForkChoice.Result)(build: => F[T]): F[Option[T]] =
     // Doesn't apply on Genesis.
-    if (!choice.block.parentBlock.isEmpty && choice.block.roundId < startTick) none.pure[F]
+    if (!choice.block.parentBlock.isEmpty && choice.block.roundId < startTick)
+      Log[F]
+        .warn(
+          s"Skipping the build: fork choice ${choice.block.messageHash.show -> "message"} is before the era start."
+        )
+        .as(none)
     else build.map(_.some)
 
   private def createLambdaResponse(

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -52,11 +52,12 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
     * it will be gossiped if it's successfully validated. Only need to broadcast responses. */
   def validateAndAddBlock(block: Block): F[Unit] =
     for {
-      _      <- ensureNotShutdown
-      header = block.getHeader
-      hash   = block.blockHash.show
+      _       <- ensureNotShutdown
+      header  = block.getHeader
+      hash    = block.blockHash.show
+      instant = conf.toInstant(Ticks(header.roundId))
       _ <- Log[F].info(
-            s"Handling incoming ${hash -> "message"} from ${header.validatorPublicKey.show -> "validator"} in ${header.roundId -> "round"} ${header.keyBlockHash.show -> "era"}"
+            s"Handling incoming ${hash -> "message"} from ${header.validatorPublicKey.show -> "validator"} in ${header.roundId -> "round"} $instant ${header.keyBlockHash.show -> "era"}"
           )
       entry <- load(header.keyBlockHash)
 
@@ -118,6 +119,7 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
       era     <- EraStorage[F].getEraUnsafe(keyBlockHash)
       runtime <- makeRuntime(era)
       agenda  <- runtime.initAgenda
+      _       <- Log[F].info(s"${era.keyBlockHash.show -> "era"} has ${agenda.size} initial actions.")
       entry   <- start(runtime, agenda)
     } yield entry
 
@@ -138,12 +140,14 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
   private def schedule(runtime: EraRuntime[F], agenda: Agenda): F[Unit] =
     agenda.traverse {
       case delayed @ Agenda.DelayedAction(tick, action) =>
-        val key = (runtime.era.keyBlockHash, delayed)
+        val key     = (runtime.era.keyBlockHash, delayed)
+        val instant = conf.toInstant(tick)
         for {
+          _ <- Log[F].info(s"Scheduling $action to $instant")
           fiber <- scheduleAt(tick) {
                     val era = runtime.era.keyBlockHash.show
                     val exec = for {
-                      _ <- Log[F].debug(s"Executing $action in $era")
+                      _ <- Log[F].info(s"Executing $action scheduled to $instant in $era")
                       (events, agenda) <- runtime
                                            .handleAgenda(action)
                                            .run
@@ -208,13 +212,15 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: Relaying:
 
     events.traverse {
       case HighwayEvent.CreatedEra(era) =>
-        val eraHash    = era.keyBlockHash.show
-        val parentHash = era.parentKeyBlockHash.show
-        val tick       = era.startTick
-        val start      = conf.toInstant(Ticks(tick))
+        val eraHash      = era.keyBlockHash.show
+        val parentHash   = era.parentKeyBlockHash.show
+        val startTick    = era.startTick
+        val startInstant = conf.toInstant(Ticks(era.endTick))
+        val endTick      = era.endTick
+        val endInstant   = conf.toInstant(Ticks(era.endTick))
         for {
           _ <- Log[F].info(
-                s"Created ${eraHash -> "era"} starting at ${tick -> "tick"} ${start -> "instant"} child of ${parentHash -> "parent"}"
+                s"Created ${eraHash -> "era"} from ${startInstant} (${startTick}) to ${endInstant} ($endTick) child of ${parentHash -> "parent"}"
               )
           // Schedule the child era.
           child <- load(era.keyBlockHash)

--- a/hack/docker/.gitignore
+++ b/hack/docker/.gitignore
@@ -3,3 +3,4 @@ node-*
 .casperlabs
 monitoring/prometheus/targets.yml
 keys
+stests/.build

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -195,10 +195,11 @@ stests/build:
 # this command can run stests in interactive mode.
 stests/console: .casperlabs
 	@# Collect existing nodes, so we can register them automatically.
-	@# stests workers will try to connect to them as soon as they are registered so
-	@# they should be running as well; but maybe it can handle nodes that will go
-	@# on and offline, so this is now based on just the fact that these nodes are declared.
-	@# Otherwise we could just list the running docker containers.
+	@# I think stests workers will try to connect to them as soon as they are registered,
+	@# (if not then they will after a `docker restart stests`),
+	@# so these nodes are expected to be running as well.
+	@# To not assume nodes will be online/offline, the registration is based on declared directories,
+	@# but if that doesn't work we could just list the running docker containers.
 	$(eval NODES = $(shell find . -maxdepth 1 -type d -name "node-*" | sort | sed 's/.\///'))
 
 	docker run -it --rm \

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -202,6 +202,10 @@ stests/console: .casperlabs
 	@# after this console has registered all the required containers.
 	$(eval NODES = $(shell find . -maxdepth 1 -type d -name "node-*" | sort | sed 's/.\///'))
 
+	@# Make sure stests workers pick up newly registered nodes.
+	@# This will be happening automatically at some point in stests.
+	sh -c 'sleep 30s && docker restart stests' > /dev/null 2>&1 &
+
 	docker run -it --rm \
 	  --network casperlabs \
 		--name stests-console \

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -182,6 +182,7 @@ stests/console: .casperlabs
 	  --network casperlabs \
 		--name stests \
 		-v ${PWD}/keys:/root/casperlabs/keys \
+		-e KEYS=/root/casperlabs/keys \
 		-e STESTS_BROKER_REDIS_HOST=redis \
 		-e STESTS_CACHE_REDIS_HOST=redis \
 		-e STESTS_MWARE_REDIS_HOST=redis \

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -195,11 +195,11 @@ stests/build:
 # this command can run stests in interactive mode.
 stests/console: .casperlabs
 	@# Collect existing nodes, so we can register them automatically.
-	@# I think stests workers will try to connect to them as soon as they are registered,
-	@# (if not then they will after a `docker restart stests`),
-	@# so these nodes are expected to be running as well.
 	@# To not assume nodes will be online/offline, the registration is based on declared directories,
 	@# but if that doesn't work we could just list the running docker containers.
+	@# Unfortunately the stests workers will only subscribe to events in the beginning,
+	@# but not when nodes are registered later, so we have to do a `docker restart stests`
+	@# after this console has registered all the required containers.
 	$(eval NODES = $(shell find . -maxdepth 1 -type d -name "node-*" | sort | sed 's/.\///'))
 
 	docker run -it --rm \

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -169,10 +169,26 @@ maybe-reset-highway-env:
 
 # https://github.com/CasperLabs/stests
 stests/build:
-	cd stests && \
+	# Build contracts stests will want to use.
+	cd ../../execution-engine && \
+	  make build-contract-rs/transfer-to-account-u512-stored
+	# Copy them over under the python client; it's where stests will look for them at the moment.
+	cp ../../execution-engine/target/wasm32-unknown-unknown/release/transfer_to_account_u512_stored.wasm \
+	   ../../integration-testing/client/CasperLabsClient/casperlabs_client/
+
+	# Package a the latest Python client; the one on pypi might be older than the latest and greatest; plus lacks some of the wasms.
+	cd ../.. &&	make build-python-client
+
+	# Make the client available to the docker deamon here (smaller context.).
+	rm -rf stests/.build
+	mkdir -p stests/.build
+	cp ../../integration-testing/client/CasperLabsClient/dist/casperlabs_client*.tar.gz stests/.build/
+
 	docker build \
-		--build-arg CACHEBUST=$$(date +%s) \
-		-f Dockerfile -t casperlabs/stests:latest .
+	  --build-arg CACHEBUST=$$(date +%s) \
+		-f stests/Dockerfile -t casperlabs/stests:latest stests
+
+	rm -rf stests/.build
 
 # After nodes have been started, and `redis` with `make up`,
 # and an stest image built with `make stests/build`,

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -196,7 +196,7 @@ stests/build:
 stests/console: .casperlabs
 	docker run -it --rm \
 	  --network casperlabs \
-		--name stests \
+		--name stests-console \
 		-v ${PWD}/keys:/root/casperlabs/keys \
 		-e KEYS=/root/casperlabs/keys \
 		-e STESTS_BROKER_REDIS_HOST=redis \

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -165,3 +165,22 @@ maybe-reset-highway-env:
 	if [ "$${RUNNING}" -eq "0" ] || [ "$${DEFINED}" -eq "1" ]; then \
 		$(RESET_HIGHWAY_ENV); \
 	fi
+
+
+# https://github.com/CasperLabs/stests
+stests/build:
+	cd stests && \
+	docker build \
+		--build-arg CACHEBUST=$$(date +%s) \
+		-f Dockerfile -t casperlabs/stests:latest .
+
+# After nodes have been started, and `redis` with `make up`,
+# and an stest image built with `make stests/build`,
+# this command can run stests in interactive mode.
+stests/console:
+	docker run -it --rm \
+	  --network casperlabs \
+		-e STESTS_BROKER_REDIS_HOST=redis \
+		-e STESTS_CACHE_REDIS_HOST=redis \
+		-e STESTS_MWARE_REDIS_HOST=redis \
+		casperlabs/stests:latest bash

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -198,8 +198,10 @@ stests/console: .casperlabs
 	  --network casperlabs \
 		--name stests-console \
 		-v ${PWD}/keys:/root/casperlabs/keys \
+		-v ${PWD}/stests/start-console.sh:/root/casperlabs/start-console.sh \
 		-e KEYS=/root/casperlabs/keys \
 		-e STESTS_BROKER_REDIS_HOST=redis \
 		-e STESTS_CACHE_REDIS_HOST=redis \
 		-e STESTS_MWARE_REDIS_HOST=redis \
-		casperlabs/stests:latest bash
+		-e NETWORK=poc1 \
+		casperlabs/stests:latest bash -c 'chmod +x start-console.sh && ./start-console.sh'

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -129,7 +129,7 @@ slow:
 	mkdir -p .casperlabs/nodes
 	mkdir -p .casperlabs/chainspec/genesis
 
-	@# Create a `facet-account` to hold some initial tokens to distribute.
+	@# Create a `faucet-account` to hold some initial tokens to distribute.
 	mkdir -p keys/faucet-account
 	../key-management/docker-gen-account-keys.sh keys/faucet-account
 	(cat keys/faucet-account/account-id; echo ",10000000000,0") > .casperlabs/chainspec/genesis/accounts.csv
@@ -194,6 +194,13 @@ stests/build:
 # and an stest image built with `make stests/build`,
 # this command can run stests in interactive mode.
 stests/console: .casperlabs
+	@# Collect existing nodes, so we can register them automatically.
+	@# stests workers will try to connect to them as soon as they are registered so
+	@# they should be running as well; but maybe it can handle nodes that will go
+	@# on and offline, so this is now based on just the fact that these nodes are declared.
+	@# Otherwise we could just list the running docker containers.
+	$(eval NODES = $(shell find . -maxdepth 1 -type d -name "node-*" | sort | sed 's/.\///'))
+
 	docker run -it --rm \
 	  --network casperlabs \
 		--name stests-console \
@@ -204,4 +211,5 @@ stests/console: .casperlabs
 		-e STESTS_CACHE_REDIS_HOST=redis \
 		-e STESTS_MWARE_REDIS_HOST=redis \
 		-e NETWORK=poc1 \
+		-e NODES='$(NODES)' \
 		casperlabs/stests:latest bash -c 'chmod +x start-console.sh && ./start-console.sh'

--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -177,9 +177,11 @@ stests/build:
 # After nodes have been started, and `redis` with `make up`,
 # and an stest image built with `make stests/build`,
 # this command can run stests in interactive mode.
-stests/console:
+stests/console: .casperlabs
 	docker run -it --rm \
 	  --network casperlabs \
+		--name stests \
+		-v ${PWD}/keys:/root/casperlabs/keys \
 		-e STESTS_BROKER_REDIS_HOST=redis \
 		-e STESTS_CACHE_REDIS_HOST=redis \
 		-e STESTS_MWARE_REDIS_HOST=redis \

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -380,6 +380,7 @@ $ docker logs -f stests
 2020-03-23 11:20:19.391230 [INFO] [00036] STESTS :: PYCLX :: do_transfer :: executing ...
 2020-03-23 11:20:19.395011 [INFO] [00036] STESTS :: PYCLX :: connecting to node :: POC-01:N-0002 :: node-1:40401
 2020-03-23 11:20:19.625877 [INFO] [00036] STESTS :: PYCLX :: transfer :: 77c60f7769a742927d434fc98162eb1efec046258c214eab09acbff1058a34a8 :: 10000000000 CLX :: 5609d011 -> 044e0bc6
-
 ...
 ```
+
+Unlike other containers, `stests` logs go to `stderr`, so if we want to look for something we have to do it like this: `docker logs stests 2>&1 | grep <blockhash>`.

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -316,5 +316,23 @@ root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 $KEYS/faucet-
 
 root@6566753ba2f7:~/casperlabs# stests-set-node poc1:1 node-0:40401 full
 2020-03-20 17:50:39.831992 [INFO] [00048] STESTS :: Node poc1:1 was successfully registered
-
 ```
+
+When you get stests up and running then the testing workflow becomes something like:
+
+```bash
+# Launch a generator
+stests-wg-100 poc1 --user-accounts 5 --run 1
+# Check it is running
+stests-ls-runs poc1
+# Check what stage it is at
+stests-ls-run poc1 wg-100 1
+# Check what deploys it has dispatched
+stests-ls-run-deploys poc1 wg-100 1
+# Launch generator on a loop
+stests-wg-110 poc1 --user-accounts 5 --run 1 --loop-count 9
+# Check the status of of the runs
+stests-ls-runs poc1
+```
+
+To see what the workers are doing, run `docker logs -f stests`.

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -305,20 +305,45 @@ make stests/console
 ```
 
 Inside the console, we can register a test network. Note that we have to use full path to files.
+The existing nodes will be registered automatically under the network name `poc1`.
 
 ```console
-root@6566753ba2f7:~/casperlabs# stests-set-network poc1
-2020-03-20 16:06:48.433057 [INFO] [00017] STESTS :: Network poc1 was successfully registered
-root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
-
-root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
-2020-03-20 17:43:49.038532 [INFO] [00036] STESTS :: Network poc1 faucet key was successfully registered
-
-root@6566753ba2f7:~/casperlabs# stests-set-node poc1:1 node-0:40401 full
-2020-03-20 17:50:39.831992 [INFO] [00048] STESTS :: Node poc1:1 was successfully registered
+1. Register network + faucet key:
+2020-03-23 11:06:26.476677 [INFO] [00016] STESTS :: Network poc1 was successfully registered
+2020-03-23 11:06:28.224201 [INFO] [00027] STESTS :: Network poc1 faucet key was successfully registered
+2. Register nodes + node bonding keys:
+Registering node-0...
+2020-03-23 11:06:29.890818 [INFO] [00041] STESTS :: Node poc1:1 was successfully registered
+2020-03-23 11:06:31.631960 [INFO] [00052] STESTS :: Node poc1:1 bonding key was successfully registered
+Registering node-1...
+2020-03-23 11:06:33.320199 [INFO] [00066] STESTS :: Node poc1:2 was successfully registered
+2020-03-23 11:06:35.032807 [INFO] [00077] STESTS :: Node poc1:2 bonding key was successfully registered
+Registering node-2...
+2020-03-23 11:06:36.744621 [INFO] [00091] STESTS :: Node poc1:3 was successfully registered
+2020-03-23 11:06:38.458501 [INFO] [00102] STESTS :: Node poc1:3 bonding key was successfully registered
+3. Switching to interactive mode:
+root@2ccf027c80ff:~/casperlabs# stests-ls-nodes poc1
+---------------------------------
+ ID  Host:Port     Type   Status
+---------------------------------
+ 1   node-0:40401  FULL  HEALTHY
+ 2   node-1:40411  FULL  HEALTHY
+ 3   node-2:40421  FULL  HEALTHY
+---------------------------------
+POC-01 node count = 3
 ```
 
-When you get stests up and running then the testing workflow becomes something like:
+Alternatively you can manually register networks and nodes like so:
+
+```bash
+stests-set-network poc1
+stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
+
+stests-set-node poc1:1 node-0:40401 full
+stests-set-node-bonding-key poc1:1 $KEYS/account-0/account-private.pem
+```
+
+When stests is up and running then the testing workflow becomes something like:
 
 ```bash
 # Launch a generator
@@ -335,4 +360,26 @@ stests-wg-110 poc1 --user-accounts 5 --run 1 --loop-count 9
 stests-ls-runs poc1
 ```
 
-To see what the workers are doing, run `docker logs -f stests`.
+To see what the workers are doing, check the docker logs:
+
+```
+$ docker logs -f stests
+[2020-03-23 11:14:17,164] [PID 17] [MainThread] [dramatiq.MainProcess] [INFO] Dramatiq '1.8.1' is booting up.
+2020-03-23 11:14:16.458145 [INFO] [00027] STESTS :: CORE :: established connection to REDIS MQ broker
+[2020-03-23 11:14:17,169] [PID 72] [MainThread] [dramatiq.ForkProcess(0)] [INFO] Fork process 'dramatiq.middleware.prometheus:_run_exposition_server' is ready for action.
+2020-03-23 11:14:17.230114 [INFO] [00028] STESTS :: PYCLX :: stream_events :: executing ...
+[2020-03-23 11:14:17,236] [PID 28] [MainThread] [dramatiq.WorkerProcess(1)] [INFO] Worker process is ready for action.
+2020-03-23 11:14:17.237550 [INFO] [00036] STESTS :: PYCLX :: stream_events :: executing ...
+2020-03-23 11:14:17.238025 [INFO] [00028] STESTS :: PYCLX :: connecting to node :: POC-01:N-0003 :: node-2:40401
+2020-03-23 11:20:19.178203 [INFO] [00029] STESTS :: WFLOW :: WG-100 :: R-001 -> starts
+2020-03-23 11:20:19.189840 [INFO] [00029] STESTS :: WFLOW :: WG-100 :: R-001 :: P-01 -> starts
+2020-03-23 11:20:19.209768 [INFO] [00029] STESTS :: WFLOW :: WG-100 :: R-001 :: P-01 :: S-01 :: create-accounts -> starts
+2020-03-23 11:20:19.362629 [INFO] [00028] STESTS :: WFLOW :: WG-100 :: R-001 :: P-01 :: S-01 :: create-accounts -> end
+2020-03-23 11:20:19.380875 [INFO] [00028] STESTS :: WFLOW :: WG-100 :: R-001 :: P-01 :: S-02 :: fund-faucet -> starts
+2020-03-23 11:20:19.382372 [INFO] [00028] STESTS :: WFLOW :: WG-100 :: R-001 :: P-01 :: S-02 :: fund-faucet -> listening for chain events
+2020-03-23 11:20:19.391230 [INFO] [00036] STESTS :: PYCLX :: do_transfer :: executing ...
+2020-03-23 11:20:19.395011 [INFO] [00036] STESTS :: PYCLX :: connecting to node :: POC-01:N-0002 :: node-1:40401
+2020-03-23 11:20:19.625877 [INFO] [00036] STESTS :: PYCLX :: transfer :: 77c60f7769a742927d434fc98162eb1efec046258c214eab09acbff1058a34a8 :: 10000000000 CLX :: 5609d011 -> 044e0bc6
+
+...
+```

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -304,12 +304,17 @@ make up
 make stests/console
 ```
 
-Inside the console, we can register a test network:
+Inside the console, we can register a test network. Note that we have to use full path to files.
 
 ```console
 root@6566753ba2f7:~/casperlabs# stests-set-network poc1
 2020-03-20 16:06:48.433057 [INFO] [00017] STESTS :: Network poc1 was successfully registered
 root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
-# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
+
+root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
 2020-03-20 17:43:49.038532 [INFO] [00036] STESTS :: Network poc1 faucet key was successfully registered
+
+root@6566753ba2f7:~/casperlabs# stests-set-node poc1:1 node-0:40401 full
+2020-03-20 17:50:39.831992 [INFO] [00048] STESTS :: Node poc1:1 was successfully registered
+
 ```

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -283,3 +283,31 @@ make clean
 You can run the similar setup as we use at SRE team to test how nodes perform over time.
 
 [The script to run LRT](/hack/docker/scripts/lrt.sh).
+
+
+## stests
+
+We can run [stests](https://github.com/CasperLabs/stests) workflow generators agains locally started nodes. This is possible over the ports they expose, in case we already have `stests` installed with
+all of its dependencies as per the project README, however we can also start it in docker.
+
+First build an image that we can use locally:
+
+```console
+make stests/build
+```
+
+Then start the nodes and the singleton services, which includes `redis`, the database and message
+broker used by `stests`. Following that we can launch an interactive console where the `stests` command aliases are already registered:
+
+```console
+make up
+make stests/console
+```
+
+Inside the console, we can register a test network:
+```console
+root@a8e09c5af719:/# stests-set-network poc1
+~/casperlabs/stests /
+2020-03-20 15:48:10.116893 [INFO] [00014] STESTS :: Network poc1 was successfully registered
+/
+```

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -305,9 +305,11 @@ make stests/console
 ```
 
 Inside the console, we can register a test network:
+
 ```console
-root@a8e09c5af719:/# stests-set-network poc1
-~/casperlabs/stests /
-2020-03-20 15:48:10.116893 [INFO] [00014] STESTS :: Network poc1 was successfully registered
-/
+root@6566753ba2f7:~/casperlabs# stests-set-network poc1
+~/casperlabs/stests ~/casperlabs
+2020-03-20 16:06:48.433057 [INFO] [00017] STESTS :: Network poc1 was successfully registered
+~/casperlabs
+root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 keys/faucet-account/account-private.pem
 ```

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -287,7 +287,7 @@ You can run the similar setup as we use at SRE team to test how nodes perform ov
 
 ## stests
 
-We can run [stests](https://github.com/CasperLabs/stests) workflow generators agains locally started nodes. This is possible over the ports they expose, in case we already have `stests` installed with
+We can run [stests](https://github.com/CasperLabs/stests) workflow generators against locally started nodes. This is possible over the ports they expose, in case we already have `stests` installed with
 all of its dependencies as per the project README, however we can also start it in docker.
 
 First build an image that we can use locally:
@@ -308,8 +308,8 @@ Inside the console, we can register a test network:
 
 ```console
 root@6566753ba2f7:~/casperlabs# stests-set-network poc1
-~/casperlabs/stests ~/casperlabs
 2020-03-20 16:06:48.433057 [INFO] [00017] STESTS :: Network poc1 was successfully registered
-~/casperlabs
-root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 keys/faucet-account/account-private.pem
+root@6566753ba2f7:~/casperlabs# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
+# stests-set-network-faucet-key poc1 $KEYS/faucet-account/account-private.pem
+2020-03-20 17:43:49.038532 [INFO] [00036] STESTS :: Network poc1 faucet key was successfully registered
 ```

--- a/hack/docker/docker-compose.yml
+++ b/hack/docker/docker-compose.yml
@@ -112,6 +112,27 @@ services:
     networks:
       - casperlabs
 
+  # stests workers
+  stests:
+    image: casperlabs/stests:latest
+    container_name: stests
+    environment:
+      STESTS_HOME: /root/casperlabs/stests
+      STESTS_PATH_ROOT: /root/.casperlabs-stests
+      STESTS_BROKER_REDIS_HOST: redis
+      STESTS_CACHE_REDIS_HOST: redis
+      STESTS_MWARE_REDIS_HOST: redis
+    volumes:
+      - $PWD/stests/start-worker.sh:/root/casperlabs/start-worker.sh
+    entrypoint:
+      - sh
+      - -c
+      - chmod +x ./start-worker.sh && ./start-worker.sh
+    networks:
+      - casperlabs
+    depends_on:
+      - redis
+
   # Redis database required for stests.
   redis:
     image: redis:5.0

--- a/hack/docker/docker-compose.yml
+++ b/hack/docker/docker-compose.yml
@@ -111,3 +111,10 @@ services:
       - ${PWD}/grpcwebproxy/key.pem:/etc/nginx/tls/key.pem
     networks:
       - casperlabs
+
+  # Redis database required for stests.
+  redis:
+    image: redis:5.0
+    container_name: redis
+    networks:
+      - casperlabs

--- a/hack/docker/stests/Dockerfile
+++ b/hack/docker/stests/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.7-slim
+
+RUN apt update && apt install -y git curl pipenv
+
+# Use bash so up/down arrow work in the interactive console.
+ENV SHELL /bin/bash
+
+# Add some randomness so cache is busted every time we build.
+# ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache
+ARG CACHEBUST=0
+
+RUN curl https://raw.githubusercontent.com/CasperLabs/stests/master/installer | bash
+
+# Make the variables configurable via env vars by turning
+# `export STESTS_BROKER_REDIS_HOST=localhost` into
+# `export STESTS_BROKER_REDIS_HOST=${STESTS_BROKER_REDIS_HOST:-localhost}`
+RUN sed -i -E 's/([A-Z_]+)=(.+)/\1=${\1:-\2}/' ~/.casperlabs-stests/vars

--- a/hack/docker/stests/Dockerfile
+++ b/hack/docker/stests/Dockerfile
@@ -18,6 +18,7 @@ RUN curl https://raw.githubusercontent.com/CasperLabs/stests/master/installer | 
 RUN sed -i -E 's/([A-Z_]+)=(.+)/\1=${\1:-\2}/' ~/.casperlabs-stests/vars
 
 # Replace the old client with a new one we prepared with some extra wasms in it.
-COPY .build/casperlabs_client-*.tar.gz .
-RUN pip uninstall casperlabs-client && \
-  pip install casperlabs_client-*.tar.gz
+COPY .build/casperlabs_client-*.tar.gz stests/
+RUN cd stests && \
+  pipenv uninstall casperlabs-client && \
+  pipenv install casperlabs_client-*.tar.gz

--- a/hack/docker/stests/Dockerfile
+++ b/hack/docker/stests/Dockerfile
@@ -16,3 +16,8 @@ RUN curl https://raw.githubusercontent.com/CasperLabs/stests/master/installer | 
 # `export STESTS_BROKER_REDIS_HOST=localhost` into
 # `export STESTS_BROKER_REDIS_HOST=${STESTS_BROKER_REDIS_HOST:-localhost}`
 RUN sed -i -E 's/([A-Z_]+)=(.+)/\1=${\1:-\2}/' ~/.casperlabs-stests/vars
+
+# Replace the old client with a new one we prepared with some extra wasms in it.
+COPY .build/casperlabs_client-*.tar.gz .
+RUN pip uninstall casperlabs-client && \
+  pip install casperlabs_client-*.tar.gz

--- a/hack/docker/stests/Dockerfile
+++ b/hack/docker/stests/Dockerfile
@@ -4,6 +4,7 @@ RUN apt update && apt install -y git curl pipenv
 
 # Use bash so up/down arrow work in the interactive console.
 ENV SHELL /bin/bash
+WORKDIR /root/casperlabs
 
 # Add some randomness so cache is busted every time we build.
 # ADD "https://www.random.org/cgi-bin/randbyte?nbytes=10&format=h" skipcache

--- a/hack/docker/stests/start-console.sh
+++ b/hack/docker/stests/start-console.sh
@@ -19,6 +19,16 @@ echo 1.  Register network + faucet key:
 stests-set-network $NETWORK
 stests-set-network-faucet-key $NETWORK $KEYS/faucet-account/account-private.pem
 
+echo 2.  Register nodes + node bonding keys:
 
-# Switch to interactive mode.
+for NODE in $NODES; do
+  echo Registering $NODE...
+  n=$(echo $NODE | sed -r 's/node-([0-9])/\1/')
+  i=$(( n + 1 ))
+  stests-set-node $NETWORK:${i} ${NODE}:40401 full
+  stests-set-node-bonding-key $NETWORK:${i} $KEYS/account-${n}/account-private.pem
+done
+
+echo 3.  Switching to interactive mode:
+
 exec bash

--- a/hack/docker/stests/start-console.sh
+++ b/hack/docker/stests/start-console.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e
+
+# stests will register aliases that normally cannot be used in scripts.
+shopt -s expand_aliases
+
+# Activate the stests commands.
+source $HOME/.bashrc
+
+# Get rid of the pushd/popd decorations.
+source $STESTS_PATH_SH/utils.sh
+# Make sure we get rid of them in the interactive session too.
+cat >> $HOME/.bashrc <<- EOM
+	source $STESTS_PATH_SH/utils.sh
+EOM
+
+echo 1.  Register network + faucet key:
+stests-set-network $NETWORK
+stests-set-network-faucet-key $NETWORK $KEYS/faucet-account/account-private.pem
+
+
+# Switch to interactive mode.
+exec bash

--- a/hack/docker/stests/start-worker.sh
+++ b/hack/docker/stests/start-worker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source $STESTS_HOME/sh/utils/set_paths.sh
+source $STESTS_PATH_ROOT/vars
+
+exec $STESTS_PATH_SH/workers/interactive.sh

--- a/hack/docker/stests/start-worker.sh
+++ b/hack/docker/stests/start-worker.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-source $STESTS_HOME/sh/utils/set_paths.sh
-source $STESTS_PATH_ROOT/vars
+set -e
+
+shopt -s expand_aliases
+
+source $HOME/.bashrc
 
 exec $STESTS_PATH_SH/workers/interactive.sh


### PR DESCRIPTION
### Overview
Want to be able to run `stests` in `hack/docker` without installing it or any of its dependencies.

- [x] Build stests image
- [x] Start stests console
- [x] Inject modified client
- [x] Generate script to register nodes
- [x] Add an `stest` service to `docker-compose` that runs in interactive mode
- [x] Run the wg-100 generator

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1311

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Looks like when `stests` is started in interactive mode it subscribes to the events from a certain number of nodes. But if the nodes haven't been registered yet, then it looks like the events are not going to be consumed. It does handle workflows, but I'm wondering if it will detect events correctly.

Would be good if the registration of a new node triggered the event subscription. Currently it looks like I need to do a `docker restart stests` to make it look for the nodes.