### PR TITLE
NODE-1303: Add support for min_event_id to stream_events API and CLI

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/casperlabs_client.py
@@ -661,6 +661,7 @@ class CasperLabsClient:
         deploy_orphaned: bool = False,
         account_public_keys=None,
         deploy_hashes=None,
+        min_event_id: int = 0,
     ):
         """
         See StreamEventsRequest in
@@ -696,6 +697,7 @@ class CasperLabsClient:
                     ],
                     deploy_hashes=[bytes.fromhex(h) for h in deploy_hashes or []],
                 ),
+                min_event_id=min_event_id,
             )
         )
 

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -378,9 +378,11 @@ def stream_events_command(casperlabs_client, args):
     )
     if not any(subscribed_events.values()):
         raise argparse.ArgumentTypeError("No events chosen")
+
     stream = casperlabs_client.stream_events(
         account_public_keys=args.account_public_key,
         deploy_hashes=args.deploy_hash,
+        min_event_id=args.min_event_id,
         **subscribed_events,
     )
     for event in stream:
@@ -630,6 +632,7 @@ def cli(*arguments) -> int:
         [('--deploy-orphaned',), dict(action='store_true', help='Deploy orphaned')],
         [('-k', '--account-public-key'), dict(action='append', help='Filter by (possibly multiple) account public key(s)')],
         [('-d', '--deploy-hash'), dict(action='append', help='Filter by (possibly multiple) deploy hash(es)')],
+        [('--min-event-id',), dict(required=False, default=0, type=int, help="Supports replaying events from a given ID. If the value is 0, it it will subscribe to future events; if it's non-zero, it will replay all past events from that ID, without subscribing to new. To catch up with events from the beginning, start from 1.")],
     ])
     # fmt:on
     return parser.run([str(a) for a in arguments])


### PR DESCRIPTION
### Overview
Add support for min_event_id to `stream_events` Python API and CLI.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1303

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
