### PR TITLE
NODE-1261: Add shutdown timeout for closing gRPC servers.

### DIFF
--- a/hack/docker/template/docker-compose.yml
+++ b/hack/docker/template/docker-compose.yml
@@ -60,6 +60,7 @@ services:
       CL_GRPC_USE_TLS: "false"
       CL_METRICS_PROMETHEUS: "true"
       CL_SERVER_ALIVE_PEERS_CACHE_EXPIRATION_PERIOD: 15second
+      CL_SERVER_SHUTDOWN_TIMEOUT: 5second
       CL_LOG_JSON_PATH: /var/logs/casperlabs
     env_file:
       - .env

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -33,6 +33,9 @@ no-upnp = false
 # Default timeout for roundtrip connections.
 default-timeout = "5second"
 
+# Timeout for shutting down gRPC services.
+shutdown-timeout = "10second"
+
 # Bootstrap casperlabs node addresses for initial seeds. Empty defaut provided for standalone mode.
 # bootstrap = "casperlabs://<keccak-hash-of-tls-public-key>:<chain id>@<host>?protocol=<intra-node-port>&discovery=<kademila-port>"
 bootstrap = ""

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -34,7 +34,7 @@ no-upnp = false
 default-timeout = "5second"
 
 # Timeout for shutting down gRPC services.
-shutdown-timeout = "10second"
+shutdown-timeout = "1minute"
 
 # Bootstrap casperlabs node addresses for initial seeds. Empty defaut provided for standalone mode.
 # bootstrap = "casperlabs://<keccak-hash-of-tls-public-key>:<chain id>@<host>?protocol=<intra-node-port>&discovery=<kademila-port>"

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -310,6 +310,7 @@ class NodeRuntime private[node] (
             .internalServersR(
               conf.grpc.portInternal,
               conf.server.maxMessageSize,
+              conf.server.shutdownTimeout,
               ingressScheduler,
               blockApiLock,
               maybeApiSslContext
@@ -318,6 +319,7 @@ class NodeRuntime private[node] (
       _ <- api.Servers.externalServersR[Task](
             conf.grpc.portExternal,
             conf.server.maxMessageSize,
+            conf.server.shutdownTimeout,
             ingressScheduler,
             maybeApiSslContext,
             maybeValidatorId.isEmpty

--- a/node/src/main/scala/io/casperlabs/node/api/Servers.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/Servers.scala
@@ -31,7 +31,7 @@ import monix.execution.Scheduler
 import org.http4s.implicits._
 import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
-
+import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.ExecutionContext
 
 object Servers {
@@ -45,6 +45,7 @@ object Servers {
   def internalServersR(
       port: Int,
       maxMessageSize: Int,
+      shutdownTimeout: FiniteDuration,
       ingressScheduler: Scheduler,
       blockApiLock: Semaphore[Task],
       maybeSslContext: Option[SslContext]
@@ -72,7 +73,8 @@ object Servers {
         new MetricsInterceptor(),
         ErrorInterceptor.default
       ),
-      sslContext = maybeSslContext
+      sslContext = maybeSslContext,
+      shutdownTimeout = shutdownTimeout
     ) *> Resource.liftF(
       logStarted[Task]("Internal", port, maybeSslContext.isDefined)
     )
@@ -82,6 +84,7 @@ object Servers {
   def externalServersR[F[_]: Concurrent: TaskLike: Log: FinalityStorage: Metrics: BlockStorage: ExecutionEngineService: DeployStorage: Fs2Compiler: DeployBuffer: DagStorage: EventStream: NodeDiscovery](
       port: Int,
       maxMessageSize: Int,
+      shutdownTimeout: FiniteDuration,
       ingressScheduler: Scheduler,
       maybeSslContext: Option[SslContext],
       isReadOnlyNode: Boolean
@@ -104,7 +107,8 @@ object Servers {
         new MetricsInterceptor(),
         ErrorInterceptor.default
       ),
-      sslContext = maybeSslContext
+      sslContext = maybeSslContext,
+      shutdownTimeout = shutdownTimeout
     ) *>
       Resource.liftF(
         logStarted[F]("External", port, maybeSslContext.isDefined)

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -65,6 +65,7 @@ object Configuration extends ParserImplicits {
       dynamicHostAddress: Boolean,
       noUpnp: Boolean,
       defaultTimeout: FiniteDuration,
+      shutdownTimeout: FiniteDuration,
       bootstrap: List[NodeWithoutChainId],
       dataDir: Path,
       maxNumOfConnections: Int,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -229,6 +229,12 @@ private[configuration] final case class Options private (
       )
 
     @scallop
+    val serverShutdownTimeout =
+      gen[FiniteDuration](
+        "Timeout for shutting down gRPC services."
+      )
+
+    @scallop
     val tlsCertificate =
       gen[Path](
         "Path to node's X.509 certificate file, that is being used for identification.",

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -14,6 +14,7 @@ kademlia-port = 1
 dynamic-host-address = false
 no-upnp = false
 default-timeout = "1second"
+shutdown-timeout = "1second"
 standalone = false
 map-size = 1
 bootstrap = "casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@52.119.8.109?protocol=1&discovery=1 casperlabs://de6eed5d00cf080fc587eeb412cb31a75fd10358@127.0.0.1?protocol=1&discovery=1"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -50,6 +50,7 @@ class ConfigurationSpec
       dynamicHostAddress = false,
       noUpnp = false,
       defaultTimeout = FiniteDuration(1, TimeUnit.SECONDS),
+      shutdownTimeout = FiniteDuration(1, TimeUnit.SECONDS),
       bootstrap = List(
         NodeWithoutChainId(
           Node(


### PR DESCRIPTION
### Overview
Make shutdown faster (and if it blocked on open streams, close it anyway) by using a timeout for closing gRPC services.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1261

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
