### PR TITLE
NODE-1311: Bump faucet initial balance.

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -132,7 +132,7 @@ slow:
 	@# Create a `faucet-account` to hold some initial tokens to distribute.
 	mkdir -p keys/faucet-account
 	../key-management/docker-gen-account-keys.sh keys/faucet-account
-	(cat keys/faucet-account/account-id; echo ",10000000000,0") > .casperlabs/chainspec/genesis/accounts.csv
+	(cat keys/faucet-account/account-id; echo ",1000000000000000000,0") > .casperlabs/chainspec/genesis/accounts.csv
 
 	@# Create bonded validators with 0 balance.
 	bash -c 'i=0 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \


### PR DESCRIPTION
### Overview
Give 10^18 to the faucet, like on LRT. The 10^10 it had so far is not enough as that's all used up by the stests. With this change the wg-100 workflow completes.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1311

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
