### PR TITLE
NO-TICKET: leave standard payment contract empty byte when making deploy.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,9 +329,6 @@ build-explorer-contracts: \
 	explorer/contracts/transfer_to_account_u512.wasm \
 	explorer/contracts/standard_payment.wasm \
 	explorer/contracts/faucet.wasm
-	# Change the extension since webpack has experiment support for WASM, but we just want to read as ArrayBuffer and use it
-	# in Clarity Deploy interface
-	cp explorer/contracts/standard_payment.wasm explorer/ui/src/standard_payment.wm
 
 # Get the .proto files for REST annotations for Github. This is here for reference about what to get from where, the files are checked in.
 # There were alternatives, like adding a reference to a Maven project called `googleapis-commons-protos` but it had version conflicts.

--- a/explorer/sdk/src/lib/Contracts.ts
+++ b/explorer/sdk/src/lib/Contracts.ts
@@ -22,9 +22,13 @@ export class Contract {
   private sessionWasm: ByteArray;
   private paymentWasm: ByteArray;
 
-  constructor(sessionPath: string, paymentPath: string) {
+  constructor(sessionPath: string, paymentPath?: string) {
     this.sessionWasm = fs.readFileSync(sessionPath);
-    this.paymentWasm = fs.readFileSync(paymentPath);
+    if(!paymentPath){
+      this.paymentWasm = Buffer.from("");
+    }else {
+      this.paymentWasm = fs.readFileSync(paymentPath);
+    }
   }
 
   public deploy(
@@ -32,9 +36,8 @@ export class Contract {
     paymentAmount: bigint,
     accountPublicKey: ByteArray,
     signingKeyPair: nacl.SignKeyPair,
-    gasPrice: number
   ): Deploy {
-    const deploy = makeDeploy(args, ContractType.WASM, this.sessionWasm, this.paymentWasm, paymentAmount, accountPublicKey, gasPrice);
+    const deploy = makeDeploy(args, ContractType.WASM, this.sessionWasm, this.paymentWasm, paymentAmount, accountPublicKey);
     return signDeploy(deploy, signingKeyPair);
   }
 }
@@ -46,13 +49,12 @@ export class BoundContract {
     private contractKeyPair: nacl.SignKeyPair
   ) {}
 
-  public deploy(args: Deploy.Arg[], paymentAmount: bigint, gasPrice: number): Deploy {
+  public deploy(args: Deploy.Arg[], paymentAmount: bigint): Deploy {
     return this.contract.deploy(
       args,
       paymentAmount,
       this.contractKeyPair.publicKey,
-      this.contractKeyPair,
-      gasPrice
+      this.contractKeyPair
     );
   }
 }

--- a/explorer/sdk/src/lib/DeployUtil.ts
+++ b/explorer/sdk/src/lib/DeployUtil.ts
@@ -9,14 +9,15 @@ export enum ContractType {
   Hash = 'Hash'
 }
 
+// If EE receives a deploy with no payment bytes,
+// then it will use host-side functionality equivalent to running the standard payment contract
 export const makeDeploy = (
   args: Deploy.Arg[],
   type: ContractType,
   session: ByteArray,
-  paymentWasm: ByteArray,
+  paymentWasm: ByteArray | null,
   paymentAmount: bigint,
-  accountPublicKey: ByteArray,
-  gasPrice: number
+  accountPublicKey: ByteArray
 ): Deploy => {
   const sessionCode = new Deploy.Code();
   if(type === ContractType.WASM){
@@ -25,6 +26,9 @@ export const makeDeploy = (
     sessionCode.setHash(session);
   }
   sessionCode.setArgsList(args);
+  if(paymentWasm === null) {
+    paymentWasm = Buffer.from("");
+  }
   const payment = new Deploy.Code();
   payment.setWasm(paymentWasm);
   payment.setArgsList(Args(['amount', BigIntValue(paymentAmount)]));
@@ -37,7 +41,8 @@ export const makeDeploy = (
   header.setAccountPublicKey(accountPublicKey);
   header.setTimestamp(new Date().getTime());
   header.setBodyHash(protoHash(body));
-  header.setGasPrice(gasPrice);
+  // we will remove gasPrice eventually
+  header.setGasPrice(1);
 
   const deploy = new Deploy();
   deploy.setBody(body);

--- a/explorer/server/src/server.ts
+++ b/explorer/server/src/server.ts
@@ -30,8 +30,7 @@ const contractKeys =
 // Faucet contract and deploy factory.
 const faucet = new Contracts.BoundContract(
   new Contracts.Contract(
-    process.env.FAUCET_CONTRACT_PATH!,
-    process.env.PAYMENT_CONTRACT_PATH!
+    process.env.FAUCET_CONTRACT_PATH!
   ),
   contractKeys);
 
@@ -39,9 +38,6 @@ const faucet = new Contracts.BoundContract(
 const paymentAmount = BigInt(process.env.PAYMENT_AMOUNT!);
 // How much to send to a user in a faucet request.
 const transferAmount = BigInt(process.env.TRANSFER_AMOUNT)!;
-
-// Constant gas price.
-const gasPrice = parseInt(process.env.GAS_PRICE!, 10);
 
 // gRPC client to the node.
 const deployService = new DeployService(process.env.CASPER_SERVICE_URL!);
@@ -120,7 +116,7 @@ app.post("/api/faucet", checkJwt, (req, res) => {
 
   // Prepare the signed deploy.
   const accountPublicKey = decodeBase64(accountPublicKeyBase64);
-  const deploy = faucet.deploy(Faucet.args(accountPublicKey, transferAmount), paymentAmount, gasPrice);
+  const deploy = faucet.deploy(Faucet.args(accountPublicKey, transferAmount), paymentAmount);
 
   // Send the deploy to the node and return the deploy hash to the browser.
   deployService

--- a/explorer/server/src/transfer.ts
+++ b/explorer/server/src/transfer.ts
@@ -7,13 +7,11 @@ import DeployService from "./services/DeployService";
 const optionDefinitions = [
   { name: "host-url", type: String },
   { name: "transfer-contract-path", type: String },
-  { name: "payment-contract-path", type: String },
   { name: "from-public-key-path", type: String },
   { name: "from-private-key-path", type: String },
   { name: "to-public-key-path", type: String },
   { name: "amount", type: BigInt },
-  { name: "payment-amount", type: BigInt },
-  { name: "gas-price", type: Number, defaultValue: 10},
+  { name: "payment-amount", type: BigInt }
 ];
 
 const options = commandLineArgs(optionDefinitions);
@@ -32,12 +30,12 @@ const contractKeys =
 
 const hex = (x: ByteArray) => Buffer.from(x).toString("hex");
 
-const accountPublicKey =  Keys.Ed25519.parsePublicKeyFile(options["to-public-key-path"]);
+const accountPublicKey = Keys.Ed25519.parsePublicKeyFile(options["to-public-key-path"]);
 const accountPublicKeyBase16 = hex(accountPublicKey);
 
 const transfer = new Contracts.Contract(
-  options["transfer-contract-path"],
-  options["payment-contract-path"]);
+  options["transfer-contract-path"]
+);
 
 const args = Contracts.Transfer.args(accountPublicKey, options.amount);
 
@@ -45,8 +43,8 @@ const deploy = transfer.deploy(
   args,
   options["payment-amount"],
   contractKeys.publicKey,
-  contractKeys,
-  options["gas-price"]);
+  contractKeys
+);
 
 const deployHashBase16 = hex(deploy.getDeployHash_asU8());
 

--- a/explorer/ui/.gitignore
+++ b/explorer/ui/.gitignore
@@ -20,5 +20,3 @@ build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-
-/src/standard_payment.wm

--- a/explorer/ui/src/containers/DeployContractsContainer.ts
+++ b/explorer/ui/src/containers/DeployContractsContainer.ts
@@ -9,7 +9,6 @@ import * as nacl from 'tweetnacl-ts';
 import $ from 'jquery';
 import { Deploy } from 'casperlabs-grpc/io/casperlabs/casper/consensus/consensus_pb';
 import { CLType, CLValueInstance, Key } from 'casperlabs-grpc/io/casperlabs/casper/consensus/state_pb';
-import paymentWASMUrl from '../standard_payment.wm';
 
 type SupportedType = CLType.SimpleMap[keyof CLType.SimpleMap] | 'Bytes';
 
@@ -272,13 +271,9 @@ export class DeployContractsContainer {
       let argsProto = args.map((arg: FormState<DeployArgument>) => {
         return this.buildArgument(arg);
       });
-      let wasmRequest = await fetch(paymentWASMUrl);
-      let paymentWASM: ArrayBuffer = await wasmRequest.arrayBuffer();
       const paymentAmount = config.paymentAmount.value;
 
-      // we will remove it completely
-      const gasPrice = 1;
-      return DeployUtil.makeDeploy(argsProto, type, session, new Uint8Array(paymentWASM), BigInt(paymentAmount), publicKey, gasPrice);
+      return DeployUtil.makeDeploy(argsProto, type, session, null, BigInt(paymentAmount), publicKey);
     }
   }
 


### PR DESCRIPTION
### Overview

As Fraser said:
> If EE receives a deploy with no payment bytes, then it will use host-side functionality equivalent to running the standard payment contract.  You still need to pass the same payment args in the deploy though of course.

So I still need to pass the same payment args but set the field `Wasm` to `Buffer.from('')`. I tested it with `faucet` and `transfer` contract and both work very well. 

2. Hardcode `gasPrice` to 1.

### Which JIRA ticket does this PR relate to?
No ticket. 

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
