### PR TITLE
CON-653: Fix bug in the finalizer where validators would finalize blocks in ancestor eras.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
@@ -14,6 +14,7 @@ import io.casperlabs.casper.util.ProtoUtil
 import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.models.Message
 import io.casperlabs.shared.Log
+import io.casperlabs.catscontrib.MonadStateOps._
 import io.casperlabs.storage.dag.DagRepresentation
 import io.casperlabs.casper.validation.Validation
 
@@ -55,34 +56,55 @@ class FinalityDetectorVotingMatrix[F[_]: Concurrent: Log] private (rFTT: Double,
               for {
                 votedBranch <- ProtoUtil.votedBranch(dag, latestFinalizedBlock, message.messageHash)
                 result <- votedBranch match {
-                           case Some(branch) =>
+                           case Some(lfbChildHash) =>
                              for {
-                               _ <- updateVoterPerspective[F](
-                                     dag,
-                                     message,
-                                     branch,
-                                     isHighway
-                                   )
-                               result <- checkForCommittee[F](dag, rFTT, isHighway).flatMap {
-                                          case Some(newLFB) =>
-                                            val isBlock: F[Boolean] =
-                                              dag.lookupUnsafe(newLFB.consensusValue).map(_.isBlock)
+                               lfbChild                  <- dag.lookupUnsafe(lfbChildHash)
+                               // Check if the vote (message) is in different era than LFB's child it votes for.
+                               // We disallow validators from different era to advance the LFB chain.
+                               votedBranchIsDifferentEra = isHighway && lfbChild.eraId != message.eraId
+                               result <- if (votedBranchIsDifferentEra)
+                                          none[CommitteeWithConsensusValue].pure[F]
+                                        else {
+                                          for {
+                                            _ <- updateVoterPerspective[F](
+                                                  dag,
+                                                  message,
+                                                  lfbChildHash,
+                                                  isHighway
+                                                )
+                                            result <- checkForCommittee[F](dag, rFTT, isHighway)
+                                                       .flatMap {
+                                                         case Some(newLFB) =>
+                                                           val isBlock: F[Boolean] =
+                                                             dag
+                                                               .lookupUnsafe(newLFB.consensusValue)
+                                                               .map(_.isBlock)
 
-                                            // On new LFB (but only if it's a block) we rebuild VotingMatrix and start the new game.
-                                            Monad[F].ifM(isBlock)(
-                                              VotingMatrix
-                                                .create[F](dag, newLFB.consensusValue, isHighway)
-                                                .flatMap(_.get.flatMap(matrix.set))
-                                                .as(Option(newLFB)),
-                                              Log[F].info(
-                                                s"New LFB is a ballot: ${PrettyPrinter
-                                                  .buildString(newLFB.consensusValue) -> "message"}"
-                                              ) *> Applicative[F]
-                                                .pure(none[CommitteeWithConsensusValue])
-                                            )
+                                                           // On new LFB (but only if it's a block) we rebuild VotingMatrix and start the new game.
+                                                           Monad[F].ifM(isBlock)(
+                                                             VotingMatrix
+                                                               .create[F](
+                                                                 dag,
+                                                                 newLFB.consensusValue,
+                                                                 isHighway
+                                                               )
+                                                               .flatMap(_.get.flatMap(matrix.set))
+                                                               .as(Option(newLFB)),
+                                                             Log[F].info(
+                                                               s"New LFB is a ballot: ${PrettyPrinter
+                                                                 .buildString(newLFB.consensusValue) -> "message"}"
+                                                             ) *> Applicative[F]
+                                                               .pure(
+                                                                 none[CommitteeWithConsensusValue]
+                                                               )
+                                                           )
 
-                                          case None =>
-                                            Applicative[F].pure(none[CommitteeWithConsensusValue])
+                                                         case None =>
+                                                           Applicative[F].pure(
+                                                             none[CommitteeWithConsensusValue]
+                                                           )
+                                                       }
+                                          } yield result
                                         }
                              } yield result
 

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
@@ -39,13 +39,13 @@ object VotingMatrix {
     */
   private[votingmatrix] def create[F[_]: Concurrent](
       dag: DagRepresentation[F],
-      newFinalizedBlock: BlockHash,
+      lfbHash: BlockHash,
       isHighway: Boolean
   ): F[VotingMatrix[F]] =
     for {
       // Start a new round, get weightMap and validatorSet from the post-global-state of new finalized block's
-      message <- dag.lookup(newFinalizedBlock)
-      block <- message.get match {
+      lfb <- dag.lookupUnsafe(lfbHash)
+      block <- lfb match {
                 case b: Message.Block => b.pure[F]
                 case ballot: Message.Ballot =>
                   MonadThrowable[F].raiseError[Message.Block](
@@ -68,7 +68,7 @@ object VotingMatrix {
                              ProtoUtil
                                .votedBranch[F](
                                  dag,
-                                 newFinalizedBlock,
+                                 lfbHash,
                                  b.messageHash
                                )
                                .map {

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -16,7 +16,7 @@ import io.casperlabs.casper.util.BondingUtil.Bond
 import io.casperlabs.casper.{validation, CasperState, InvalidBlock}
 import io.casperlabs.models.Message
 import io.casperlabs.shared.LogStub
-import io.casperlabs.shared.{Cell, Log, Time}
+import io.casperlabs.shared.{Log, Time}
 import io.casperlabs.storage.block.BlockStorage
 import io.casperlabs.storage.dag.IndexedDagStorage
 import monix.eval.Task
@@ -71,9 +71,6 @@ class FinalityDetectorByVotingMatrixTest
         val bonds  = Seq(v1Bond, v2Bond)
 
         for {
-          implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                              CasperState()
-                                                            )
           genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
           dag                                                     <- dagStorage.getRepresentation
           implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -130,9 +127,6 @@ class FinalityDetectorByVotingMatrixTest
         val bonds  = Seq(v1Bond, v2Bond)
 
         for {
-          implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                              CasperState()
-                                                            )
           genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
           dag                                                     <- dagStorage.getRepresentation
           implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -190,9 +184,6 @@ class FinalityDetectorByVotingMatrixTest
         val v1Bond = Bond(v1, 10)
         val bonds  = Seq(v1Bond)
         for {
-          implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                              CasperState()
-                                                            )
           genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
           dag                                                     <- dagStorage.getRepresentation
           implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -261,9 +252,6 @@ class FinalityDetectorByVotingMatrixTest
         val v3Bond = Bond(v3, 10)
         val bonds  = Seq(v1Bond, v2Bond, v3Bond)
         for {
-          implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                              CasperState()
-                                                            )
           genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
           dag                                                     <- dagStorage.getRepresentation
           implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -337,9 +325,6 @@ class FinalityDetectorByVotingMatrixTest
       val bonds  = Seq(v1Bond, v2Bond, v3Bond)
 
       for {
-        implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                            CasperState()
-                                                          )
         genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
         dag                                                     <- blockDagStorage.getRepresentation
         implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -402,9 +387,6 @@ class FinalityDetectorByVotingMatrixTest
       val bonds  = Seq(v1Bond, v2Bond, v3Bond)
 
       for {
-        implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                            CasperState()
-                                                          )
         genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
         dag                                                     <- blockDagStorage.getRepresentation
         implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -466,9 +448,6 @@ class FinalityDetectorByVotingMatrixTest
       val v3Bond = Bond(v3, 10)
       val bonds  = Seq(v1Bond, v2Bond, v3Bond)
       for {
-        implicit0(casperState: Cell[Task, CasperState]) <- Cell.mvarCell[Task, CasperState](
-                                                            CasperState()
-                                                          )
         genesis                                                 <- createAndStoreMessage[Task](Seq(), ByteString.EMPTY, bonds)
         dag                                                     <- blockDagStorage.getRepresentation
         implicit0(detector: FinalityDetectorVotingMatrix[Task]) <- mkVotingMatrix(dag, genesis)
@@ -547,8 +526,6 @@ class FinalityDetectorByVotingMatrixTest
       justifications: collection.Map[Validator, BlockHash] = HashMap.empty[Validator, BlockHash],
       postStateHash: ByteString = ByteString.copyFromUtf8(scala.util.Random.nextString(64)),
       messageType: Block.MessageType = Block.MessageType.BLOCK
-  )(
-      implicit casperState: Cell[F, CasperState]
   ): F[(Block, Option[CommitteeWithConsensusValue])] =
     for {
       block <- createMessage[F](


### PR DESCRIPTION
### Overview
The LFB chain is advanced one block at a time. When a new message is being added to the local DAG we check on which child of the latest LFB it votes for and update the Voting Matrix state when it does vote (is a descendant along the main-parent path).

The bug was about not updating the LFB chain when a validator from a child era builds on the LFB from the parent era.
This is accomplished by not counting as votes messages that vote on a child of LFB from an era different from the vote. This means that an LFB can be voted on only by validators from the same era.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/CON-653

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I tried using `OptionT` to "flatten" the for comprehension and get rid of all `(flat)map + Some/None` dance but then I could not log the message.