### PR TITLE
NO-TICK: Ignore Python modules generated by protoc.

### DIFF
--- a/integration-testing/client/CasperLabsClient/.gitignore
+++ b/integration-testing/client/CasperLabsClient/.gitignore
@@ -3,5 +3,6 @@
 build
 dist
 casperlabs_client/proto
+casperlabs_client/*_grpc.py
 report.json
 *.egg-info


### PR DESCRIPTION
### Overview
If I built the Python client for running integration tests I had all these untracked files prop up, generated for gRPC. @piokuc says they can be ignored.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

