### PR TITLE
NO-TICKET: add metadata to new crate toml's

### DIFF
--- a/execution-engine/mint/Cargo.toml
+++ b/execution-engine/mint/Cargo.toml
@@ -3,6 +3,11 @@ name = "casperlabs-mint"
 version = "0.1.0"
 authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
+description = "Defines the mint api"
+documentation = "https://docs.rs/casperlabs-mint"
+homepage = "https://casperlabs.io"
+repository = "https://github.com/CasperLabs/CasperLabs/tree/master/execution-engine/mint"
+license-file = "../../LICENSE"
 
 [features]
 std = ["types/std"]

--- a/execution-engine/proof-of-stake/Cargo.toml
+++ b/execution-engine/proof-of-stake/Cargo.toml
@@ -3,6 +3,11 @@ name = "casperlabs-proof-of-stake"
 version = "0.1.0"
 authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
+description = "Defines the proof of stake api"
+documentation = "https://docs.rs/casperlabs-proof-of-stake"
+homepage = "https://casperlabs.io"
+repository = "https://github.com/CasperLabs/CasperLabs/tree/master/execution-engine/proof-of-stake"
+license-file = "../../LICENSE"
 
 [features]
 std = ["types/std"]

--- a/execution-engine/standard-payment/Cargo.toml
+++ b/execution-engine/standard-payment/Cargo.toml
@@ -3,6 +3,11 @@ name = "casperlabs-standard-payment"
 version = "0.1.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
+description = "Defines the standard payment api"
+documentation = "https://docs.rs/casperlabs-standard-payment"
+homepage = "https://casperlabs.io"
+repository = "https://github.com/CasperLabs/CasperLabs/tree/master/execution-engine/standard-payment"
+license-file = "../../LICENSE"
 
 [features]
 std = ["types/std"]


### PR DESCRIPTION
This PR adds missing metadata fields to three new rust crate toml files.

This work is un-ticketed.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR only adds metadata
- [X] This PR is assigned
