### PR TITLE
NO-TICK: 'make up-all' in hack/docker

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -92,6 +92,12 @@ up: .make/docker/network .casperlabs
 down:
 	docker-compose -p casperlabs down
 
+# Start all nodes and supporting services, for convenience.
+up-all: up
+	bash -c 'i=0 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \
+		$(MAKE) node-$$i/up ; \
+		((i = i + 1)) ; \
+	done'
 
 # Slow down traffic between nodes to simulate network effects and large blocks.
 # If we slow it down too much then the client won't be able to connect though.


### PR DESCRIPTION
### Overview
Adds a `make up-all` target in `hack/docker` that brings up all the `CL_CASPER_NUM_VALIDATORS` number of nodes and all the supporting services as well. Should be easier than typing `make node-0/up node-1/up ... node-9/up` or having an external script to do the looping.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
