### PR TITLE
NODE-1312: Change ballots' finality status in the storage.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -175,16 +175,35 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
         result <- MultiParentFinalizer[F].onNewMessageAdded(message)
         _ <- result.traverse {
               case fb @ FinalizedBlocks(newLFB, _, finalized, orphaned) => {
-                val lfbStr       = PrettyPrinter.buildString(newLFB)
-                val finalizedStr = finalized.map(PrettyPrinter.buildString).mkString("{", ", ", "}")
+                val lfbStr = PrettyPrinter.buildString(newLFB)
+                val finalizedStr = finalized
+                  .filter(_.isBlock)
+                  .map(_.messageHash)
+                  .map(PrettyPrinter.buildString)
+                  .mkString("{", ", ", "}")
                 for {
                   _ <- Log[F].info(
                         s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}."
                       )
-                  _ <- lfbRef.set(newLFB)
-                  _ <- FinalityStorage[F].markAsFinalized(newLFB, finalized, orphaned)
-                  _ <- DeployBuffer[F].removeFinalizedDeploys(finalized + newLFB).forkAndLog
-                  _ <- BlockEventEmitter[F].newLastFinalizedBlock(newLFB, finalized, orphaned)
+                  _               <- lfbRef.set(newLFB)
+                  finalizedHashes = finalized.map(_.messageHash)
+                  orphanedHashes  = orphaned.map(_.messageHash)
+                  _ <- FinalityStorage[F].markAsFinalized(
+                        newLFB,
+                        finalizedHashes,
+                        orphanedHashes
+                      )
+                  _ <- DeployBuffer[F].removeFinalizedDeploys(finalizedHashes + newLFB).forkAndLog
+                  // Ballots cannot be really finalized but we mark them as such in the DAG
+                  // to improve the performance of the finalizer (that has to follow all justifications).
+                  // Send out notification about blocks ONLY.
+                  orphanedBlockHashes  = orphaned.filter(_.isBlock).map(_.messageHash)
+                  finalizedBlockHashes = finalized.filter(_.isBlock).map(_.messageHash)
+                  _ <- BlockEventEmitter[F].newLastFinalizedBlock(
+                        newLFB,
+                        finalizedBlockHashes,
+                        orphanedBlockHashes
+                      )
                 } yield ()
               }
             }

--- a/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetectorUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetectorUtil.scala
@@ -243,7 +243,14 @@ object FinalityDetectorUtil {
                     dag,
                     lfbHash,
                     isHighway,
-                    m => m.parents ++ m.justifications.map(_.latestBlockHash)
+                    m => {
+                      val msgDeps = m.parents ++ m.justifications.map(_.latestBlockHash)
+                      // We don't want to follow the dependencies that we know are finalized.
+                      // This is really only necessary in the very first step but there's no way around it with current interfaces.
+                      // And it should be cheap anyway.
+                      val sansFinalized = msgDeps.toSet -- finalizedIndirectly - lfbHash
+                      sansFinalized.toSeq
+                    }
                   )
-    } yield undecided.toSet -- finalizedIndirectly - lfbHash
+    } yield undecided.toSet
 }

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -48,11 +48,9 @@ object MultiParentFinalizer {
       // New finalized block in the main chain.
       newLFB: BlockHash,
       quorum: BigInt,
-      indirectlyFinalized: Set[BlockHash],
-      indirectlyOrphaned: Set[BlockHash]
-  ) {
-    def finalizedBlocks: Set[BlockHash] = indirectlyFinalized + newLFB
-  }
+      indirectlyFinalized: Set[Message],
+      indirectlyOrphaned: Set[Message]
+  )
 
   def create[F[_]: Concurrent: FinalityStorage: Metrics](
       dag: DagRepresentation[F],
@@ -87,7 +85,7 @@ object MultiParentFinalizer {
                                              .orphanedIndirectly(
                                                dag,
                                                newLFB,
-                                               justFinalized,
+                                               justFinalized.map(_.messageHash),
                                                isHighway
                                              )
                                              .timer("orphanedIndirectly")

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -8,6 +8,7 @@ import cats.effect.concurrent.{Ref, Semaphore}
 import io.casperlabs.casper.Estimator.BlockHash
 import io.casperlabs.casper.finality.MultiParentFinalizer.FinalizedBlocks
 import io.casperlabs.casper.CasperMetricsSource
+import io.casperlabs.metrics.implicits._
 import io.casperlabs.metrics.Metrics
 import io.casperlabs.models.Message
 import io.casperlabs.storage.dag.DagRepresentation
@@ -25,12 +26,12 @@ import io.casperlabs.storage.dag.FinalityStorage
 }
 
 object MultiParentFinalizer {
+  private implicit val metricsSource = CasperMetricsSource / "MultiParentFinalizer"
+
   class MeteredMultiParentFinalizer[F[_]] private (
       finalizer: MultiParentFinalizer[F],
       metrics: Metrics[F]
   ) extends MultiParentFinalizer[F] {
-
-    private implicit val metricsSource = CasperMetricsSource / "MultiParentFinalizer"
 
     override def onNewMessageAdded(message: Message): F[Option[FinalizedBlocks]] =
       metrics.timer("onNewMessageAdded")(finalizer.onNewMessageAdded(message))
@@ -53,7 +54,7 @@ object MultiParentFinalizer {
     def finalizedBlocks: Set[BlockHash] = indirectlyFinalized + newLFB
   }
 
-  def create[F[_]: Concurrent: FinalityStorage](
+  def create[F[_]: Concurrent: FinalityStorage: Metrics](
       dag: DagRepresentation[F],
       latestLFB: BlockHash, // Last LFB from the main chain
       finalityDetector: FinalityDetector[F],
@@ -70,21 +71,26 @@ object MultiParentFinalizer {
           previousLFB <- lfbCache.get
           finalizedBlock <- finalityDetector
                              .onNewMessageAddedToTheBlockDag(dag, message, previousLFB)
+                             .timer("onNewMessageAddedToTheBlockDag")
           finalized <- finalizedBlock.fold(Applicative[F].pure(None: Option[FinalizedBlocks])) {
                         case CommitteeWithConsensusValue(_, quorum, newLFB) =>
                           for {
                             _ <- lfbCache.set(newLFB)
-                            justFinalized <- FinalityDetectorUtil.finalizedIndirectly[F](
-                                              dag,
-                                              newLFB,
-                                              isHighway
-                                            )
-                            justOrphaned <- FinalityDetectorUtil.orphanedIndirectly(
-                                             dag,
-                                             newLFB,
-                                             justFinalized,
-                                             isHighway
-                                           )
+                            justFinalized <- FinalityDetectorUtil
+                                              .finalizedIndirectly[F](
+                                                dag,
+                                                newLFB,
+                                                isHighway
+                                              )
+                                              .timer("finalizedIndirectly")
+                            justOrphaned <- FinalityDetectorUtil
+                                             .orphanedIndirectly(
+                                               dag,
+                                               newLFB,
+                                               justFinalized,
+                                               isHighway
+                                             )
+                                             .timer("orphanedIndirectly")
                           } yield Some(
                             FinalizedBlocks(newLFB, quorum, justFinalized, justOrphaned)
                           )

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -108,7 +108,7 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
               val finalizedStr = finalized.map(_.show).mkString("{", ", ", "}")
               for {
                 _ <- Log[F].info(
-                      s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}."
+                      s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}. Orphaned ${orphaned.size} messages."
                     )
                 _  <- FinalityStorage[F].markAsFinalized(newLFB, finalized, orphaned)
                 w1 <- DeployBuffer[F].removeFinalizedDeploys(finalized + newLFB).forkAndLog

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -99,8 +99,9 @@ class FinalityDetectorUtilTest
 
         // First finalizing C.
         expectedNodesVisitedA = Map(
-          c.blockHash -> 1,
-          a.blockHash -> 1
+          c.blockHash       -> 1,
+          a.blockHash       -> 1,
+          genesis.blockHash -> 2
         )
         implicit0(finalityStorage: FinalityStorage[G]) <- MockFinalityStorage[G](
                                                            Seq(genesis.blockHash): _*
@@ -123,7 +124,9 @@ class FinalityDetectorUtilTest
           f -> 1,
           d -> 1,
           e -> 1,
-          b -> 1
+          b -> 1,
+          c -> 1,
+          a -> 2
         ).map(p => (p._1.blockHash, p._2))
 
         _ <- finalityStorage
@@ -160,7 +163,7 @@ class FinalityDetectorUtilTest
           b   <- createAndStoreBlockFull[Task](v2, Seq(g), Seq.empty, bonds)
           c   <- createAndStoreBlockFull[Task](v2, Seq(b), Seq(b), bonds)
           d   <- createAndStoreBlockFull[Task](v2, Seq(a), Seq(c), bonds)
-          e   <- createAndStoreBlockFull[Task](v1, Seq(a, d), Seq(c), bonds)
+          e   <- createAndStoreBlockFull[Task](v1, Seq(a, d), Seq(), bonds)
           _   <- createAndStoreBlockFull[Task](v2, Seq(e), Seq(), bonds)
           dag <- ds.getRepresentation
           implicit0(finalityStorage: FinalityStorage[Task]) <- MockFinalityStorage[Task](


### PR DESCRIPTION
### Overview
Ballot messages did not get their finality state updated in the storage (either _finalized_ or _orphaned_) which lead to traversing over them again and again within an era. This PR marks them appropriately in the DB but publishes to the event stream only blocks (since ballots cannot be finalized/orphaned).

After the change, running the finalizer looks more stable (10 nodes, 16 seconds rounds, 20 minutes eras):
![image](https://user-images.githubusercontent.com/5120801/77490215-94b0e180-6e3a-11ea-93e8-d8526e9e2f3c.png)


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1312

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
