### PR TITLE
NODE-1311: Build stests image automatically if missing.

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -81,7 +81,10 @@ node-%/metrics:
 
 
 # Start common components.
-up: .make/docker/network .casperlabs
+up: \
+		.make/docker/network \
+		.make/stests/build \
+		.casperlabs
 	$(REFRESH_TARGETS)
 	if [ "$(CL_VERSION)" != "latest" ]; then \
 		docker-compose pull; \
@@ -195,6 +198,13 @@ stests/build:
 		-f stests/Dockerfile -t casperlabs/stests:latest stests
 
 	rm -rf stests/.build
+
+# stests is part of the docker-compose that runs on `up`, but it has to be built, it's not published yet.
+.make/stests/build:
+	BUILT=$$(docker images | grep casperlabs/stests | wc -l); \
+	if [ "$${BUILT}" -eq "0" ]; then \
+		$(MAKE) stests/build; \
+	fi
 
 # After nodes have been started, and `redis` with `make up`,
 # and an stest image built with `make stests/build`,


### PR DESCRIPTION
### Overview
Make sure the `casperlabs/stests` image is available when someone runs `make up`. It was necessary to run it explicitly with `make stests/build`.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

