### PR TITLE
ECO-368: Make the url of Graphql playground configurable.

### DIFF
--- a/explorer/Dockerfile
+++ b/explorer/Dockerfile
@@ -16,6 +16,8 @@ ENV STATIC_ROOT=/app/ui
 ENV PAYMENT_AMOUNT=10000000
 ENV TRANSFER_AMOUNT=1000000000
 ENV GAS_PRICE=10
+# The link to graphql playground, used in Home page of UI.
+ENV UI_GRAPHQL_URL=http://devnet-graphql.casperlabs.io:40403/graphql
 ENV PAYMENT_CONTRACT_PATH=/app/contracts/payment.wasm
 ENV FAUCET_CONTRACT_PATH=/app/contracts/faucet.wasm
 ENTRYPOINT node server.js

--- a/explorer/server/.env
+++ b/explorer/server/.env
@@ -36,6 +36,9 @@ STATIC_ROOT=../../ui/build
 # In testing we can point to grpcwebproxy (started in `hack/docker`) which is configured to allow CORS.
 UI_GRPC_URL=http://localhost:8401
 
+# The link to graphql playground, used in Home page of UI.
+UI_GRAPHQL_URL=http://devnet-graphql.casperlabs.io:40403/graphql
+
 # Set this when in offline mode so the UI can be used with the mock account.
 # It's passed via config.js so I don't accidentally leave it on by commiting.
 AUTH_MOCK_ENABLED=false

--- a/explorer/server/.env
+++ b/explorer/server/.env
@@ -37,7 +37,7 @@ STATIC_ROOT=../../ui/build
 UI_GRPC_URL=http://localhost:8401
 
 # The link to graphql playground, used in Home page of UI.
-UI_GRAPHQL_URL=http://devnet-graphql.casperlabs.io:40403/graphql
+UI_GRAPHQL_URL=http://localhost:40403/graphql
 
 # Set this when in offline mode so the UI can be used with the mock account.
 # It's passed via config.js so I don't accidentally leave it on by commiting.

--- a/explorer/server/src/server.ts
+++ b/explorer/server/src/server.ts
@@ -78,6 +78,7 @@ const checkJwt: express.RequestHandler = isMock ?
 app.get("/config.js", (_, res) => {
   const conf = {
     auth0: config.auth0,
+    graphqlUrl: process.env.UI_GRAPHQL_URL,
     auth: {
       mock: {
         enabled: isMock

--- a/explorer/server/src/server.ts
+++ b/explorer/server/src/server.ts
@@ -78,7 +78,9 @@ const checkJwt: express.RequestHandler = isMock ?
 app.get("/config.js", (_, res) => {
   const conf = {
     auth0: config.auth0,
-    graphqlUrl: process.env.UI_GRAPHQL_URL,
+    graphql: {
+      url: process.env.UI_GRAPHQL_URL
+    },
     auth: {
       mock: {
         enabled: isMock

--- a/explorer/ui/src/@types/config.d.ts
+++ b/explorer/ui/src/@types/config.d.ts
@@ -6,13 +6,14 @@ interface Window {
 
 interface Config {
   auth0: Auth0Config;
+  graphqlUrl?: string;
   auth: {
     mock: {
       enabled: boolean;
     };
   };
   grpc: {
-    url: string | undefined;
+    url?: string;
   };
 }
 

--- a/explorer/ui/src/@types/config.d.ts
+++ b/explorer/ui/src/@types/config.d.ts
@@ -6,7 +6,9 @@ interface Window {
 
 interface Config {
   auth0: Auth0Config;
-  graphqlUrl?: string;
+  graphql:{
+    url?: string;
+  };
   auth: {
     mock: {
       enabled: boolean;

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -52,10 +52,14 @@ export class BlockDAG extends React.Component<Props, {}> {
   }
 
   private filteredBlocks() {
-    if (this.props.blocks && this.props.hideBallotsToggleStore?.isPressed) {
-      return this.props.blocks.filter(b => isBlock(b));
+    if (this.props.blocks === null) {
+      return null;
     } else {
-      return this.props.blocks!.map(b => b);
+      if (this.props.hideBallotsToggleStore?.isPressed) {
+        return this.props.blocks.filter(b => isBlock(b));
+      } else {
+        return this.props.blocks.map(b => b);
+      }
     }
   }
 

--- a/explorer/ui/src/components/Home.tsx
+++ b/explorer/ui/src/components/Home.tsx
@@ -159,7 +159,7 @@ const GraphQLCard = (_: {}) => {
     <Card
       background="info"
       icon="flask"
-      to={window.config.graphqlUrl || 'http://devnet-graphql.casperlabs.io:40403/graphql'}
+      to={window.config.graphql.url}
     >
       <CardMessage message="Try the GraphQL console!" />
     </Card>

--- a/explorer/ui/src/components/Home.tsx
+++ b/explorer/ui/src/components/Home.tsx
@@ -159,7 +159,7 @@ const GraphQLCard = (_: {}) => {
     <Card
       background="info"
       icon="flask"
-      to="http://devnet-graphql.casperlabs.io:40403/graphql"
+      to={window.config.graphqlUrl || 'http://devnet-graphql.casperlabs.io:40403/graphql'}
     >
       <CardMessage message="Try the GraphQL console!" />
     </Card>


### PR DESCRIPTION
### Overview
And also fix the bug of not rendering neighborhood DAG view. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-368

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
