### PR TITLE
NODE-1317: Notify the scheduler about download failures

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -435,6 +435,10 @@ object GossipServiceCasperTestNodeFactory {
                                    s"Download ready for ${PrettyPrinter.buildString(blockHash) -> "block" -> null}"
                                  )
 
+                               override def onFailed(blockHash: ByteString) =
+                                 Log[F].debug(
+                                   s"Download failed for ${PrettyPrinter.buildString(blockHash) -> "block" -> null}"
+                                 )
                              },
                              relaying = relaying,
                              retriesConf = BlockDownloadManagerImpl.RetriesConf.noRetries

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -83,7 +83,7 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
     def onDownloaded(identifier: Identifier): F[Unit]
 
     /** Notify about a downloadable having exhausted all its retries and ultimately failed.
-      * It won't be reattempted until its rescheduled.
+      * It won't be reattempted until it's rescheduled.
       */
     def onFailed(identifier: Identifier): F[Unit]
   }

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -81,6 +81,11 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
 
     /** Notify about a new downloadable we downloaded, verified and stored. */
     def onDownloaded(identifier: Identifier): F[Unit]
+
+    /** Notify about a downloadable having exhausted all its retries and ultimately failed.
+      * It won't be reattempted until its rescheduled.
+      */
+    def onFailed(identifier: Identifier): F[Unit]
   }
 
   /** Messages the Download Manager uses inside its scheduler "queue". */
@@ -249,16 +254,17 @@ trait DownloadManagerImpl[F[_]] extends DownloadManager[F] { self =>
               (item, downloadFeedback) = itemAndFeedback
 
               // Notify the rest of the system if this is the first time we schedule this item
-              // or if we're adding a new source to an item that already existed.
+              // or if we're adding a new source to an item that already existed,
+              // or if the item has been scheduled again after failure and will now be retried.
               existingItem = items.get(handle.id)
               _ <- backend
                     .onScheduled(handle)
                     .start
-                    .whenA(existingItem.isEmpty)
+                    .whenA(item.canStart || existingItem.isEmpty)
               _ <- backend
                     .onScheduled(handle, source)
                     .start
-                    .whenA(existingItem.forall(!_.sources(source)))
+                    .whenA(item.canStart || existingItem.forall(!_.sources(source)))
 
               _ <- itemsRef.update(_ + (handle.id -> item))
               _ <- if (item.canStart) startWorker(item) else Sync[F].unit
@@ -308,6 +314,7 @@ trait DownloadManagerImpl[F[_]] extends DownloadManager[F] { self =>
                      }
           // Tell whoever scheduled it before that it's over.
           _ <- watchers.traverse(_.complete(Left(ex)).attempt.void)
+          _ <- backend.onFailed(id).start
           _ <- setScheduledGauge()
         } yield ()
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
@@ -50,6 +50,9 @@ class StashingSynchronizer[F[_]: Concurrent: Parallel](
   override def onDownloaded(blockHash: ByteString) =
     underlying.onDownloaded(blockHash)
 
+  override def onFailed(blockHash: ByteString) =
+    underlying.onFailed(blockHash)
+
   override def onScheduled(summary: BlockSummary, source: Node): F[Unit] =
     underlying.onScheduled(summary, source)
 

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/Synchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/Synchronizer.scala
@@ -30,6 +30,12 @@ trait Synchronizer[F[_]] {
   def onDownloaded(
       blockHash: ByteString
   ): F[Unit]
+
+  /** Called when a block scheduled for download exhausted all its retry options and failed,
+    * so that the synchronizer can update its caches. */
+  def onFailed(
+      blockHash: ByteString
+  ): F[Unit]
 }
 
 object Synchronizer {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/BlockDownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/BlockDownloadManagerSpec.scala
@@ -718,6 +718,7 @@ object BlockDownloadManagerSpec {
     private val emptySynchronizer = new Synchronizer[Task] {
       def syncDag(source: Node, targetBlockHashes: Set[ByteString])    = ???
       def onDownloaded(blockHash: ByteString): Task[Unit]              = ???
+      def onFailed(blockHash: ByteString): Task[Unit]                  = ???
       def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = ???
     }
     private val emptyDownloadManager = new BlockDownloadManager[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/BlockDownloadManagerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/BlockDownloadManagerSpec.scala
@@ -694,6 +694,8 @@ object BlockDownloadManagerSpec {
     def onDownloaded(blockHash: ByteString): Task[Unit] = Task.delay {
       synchronized { downloaded = downloaded :+ blockHash }
     }
+
+    def onFailed(blockHash: ByteString): Task[Unit] = Task.unit
   }
   object MockBackend {
     def default                                               = apply()

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -1175,6 +1175,7 @@ class GrpcGossipServiceSpec
                       Task.now(dag.asRight[SyncError]).delayResult(250.millis)
                     }
                     def onDownloaded(blockHash: ByteString)              = Task.unit
+                    def onFailed(blockHash: ByteString)                  = Task.unit
                     def onScheduled(summary: BlockSummary, source: Node) = Task.unit
                   }
 
@@ -1416,6 +1417,7 @@ object GrpcGossipServiceSpec extends TestRuntime with ArbitraryConsensusAndComm 
     private val emptySynchronizer = new Synchronizer[Task] {
       def syncDag(source: Node, targetBlockHashes: Set[ByteString])    = ???
       def onDownloaded(blockHash: ByteString): Task[Unit]              = ???
+      def onFailed(blockHash: ByteString): Task[Unit]                  = ???
       def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = ???
     }
     private val emptyDownloadManager = new BlockDownloadManager[Task] {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationBackwardImplSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationBackwardImplSpec.scala
@@ -222,6 +222,7 @@ object InitialSynchronizationBackwardImplSpec extends ArbitraryConsensus {
   object MockSynchronizer extends Synchronizer[Task] {
     def syncDag(source: Node, targetBlockHashes: Set[ByteString])    = ???
     def onDownloaded(blockHash: ByteString): Task[Unit]              = ???
+    def onFailed(blockHash: ByteString): Task[Unit]                  = ???
     def onScheduled(summary: BlockSummary, source: Node): Task[Unit] = ???
   }
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImplSpec.scala
@@ -325,6 +325,10 @@ object InitialSynchronizationForwardImplSpec extends ArbitraryConsensus {
         blockHash: ByteString
     ): Task[Unit] = Task.unit
 
+    def onFailed(
+        blockHash: ByteString
+    ): Task[Unit] = Task.unit
+
     def onScheduled(
         summary: BlockSummary,
         source: Node

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizerSpec.scala
@@ -161,6 +161,7 @@ object StashingSynchronizerSpec {
       }
 
     def onDownloaded(blockHash: ByteString): Task[Unit] = Task.unit
+    def onFailed(blockHash: ByteString): Task[Unit]     = Task.unit
     def onScheduled(
         summary: BlockSummary,
         source: Node

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerSpec.scala
@@ -290,7 +290,7 @@ class SynchronizerSpec
 
     "syncs repeatedy" when {
       "using the same source" should {
-        "not traverse the DAG twice" in forAll(
+        "not traverse the DAG twice unless the download fails" in forAll(
           genPartialDagFromTips
         ) { dag =>
           // This was copied from the iterative test.
@@ -303,7 +303,8 @@ class SynchronizerSpec
             groups.grouped(ancestorsDepthRequest).toVector.map(_.flatten)
           }
           val finalParents = dag.takeRight(consensusConfig.dagWidth).map(_.blockHash).toSet
-          TestFixture((grouped ++ grouped): _*)(
+          // Initial request, second attempt with cache in place, third attempt after failure.
+          TestFixture((grouped ++ grouped.take(1) ++ grouped): _*)(
             maxDepthAncestorsRequest = ancestorsDepthRequest,
             notInDag = bs => Task.now(!finalParents(bs))
           ) { (synchronizer, variables) =>
@@ -311,15 +312,30 @@ class SynchronizerSpec
             for {
               r1 <- synchronizer.syncDag(source, Set(dag.head.blockHash))
               d1 = r1.fold(throw _, identity)
+
+              // Simulate the DownloadManager telling the Synchronizer about the items being scheduled.
               _ <- d1.traverse { d =>
                     synchronizer.onScheduled(d, source)
                   }
+
+              // Second time it should not go back as far as it did the first time.
               r2 <- synchronizer.syncDag(source, Set(dag.head.blockHash))
               d2 = r2.fold(throw _, identity)
-            } yield {
-              d2.length should be < d1.length
-              variables.requestsCounter.get should be < ((grouped.size.toDouble / ancestorsDepthRequest).ceil.toInt + 1) * 2
-            }
+              _  = d2.length shouldBe grouped(0).size
+              // Shouldn't ask everything twice.
+              _ = variables.requestsCounter.get should be < ((grouped.size.toDouble / ancestorsDepthRequest).ceil.toInt + 1) * 2
+
+              // Simulate the DownloadManager telling the Synchronizer about the first items having failed.
+              // Notifying about all of them just so that we can make sure that all of `d1` gets traversed again,
+              // not just a part that depends on for example d1.head
+              _ <- grouped(0).traverse(s => synchronizer.onFailed(s.blockHash))
+
+              // Third time it should go back right to the failed block again.
+              r3 <- synchronizer.syncDag(source, Set(dag.head.blockHash))
+              d3 = r3.fold(throw _, identity)
+              _  = d3.length shouldBe d1.length
+
+            } yield {}
           }
         }
       }

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -316,6 +316,9 @@ package object gossiping {
                               // Calling `addBlock` during validation has already stored the block,
                               // so we have nothing more to do here with the consensus.
                               synchronizer.onDownloaded(blockHash)
+
+                            override def onFailed(blockHash: ByteString): F[Unit] =
+                              synchronizer.onFailed(blockHash)
                           },
                           relaying = relaying,
                           retriesConf = BlockDownloadManagerImpl.RetriesConf(


### PR DESCRIPTION
### Overview
The `Synchronizer` used to traverse the ancestors again and again until they were downloaded, scheduling everything over and over. That had the effect that if the `DownloadManager` ultimately failed to download an item, if it came up again as a dependency of something new, it was scheduled again. Then a cache was added to the `Synchronizer` so that it knows about pending items, and doesn't traverse them again. Unfortunately that defeated this re-attempt mechanism as well, so now when the `DownloadManager` was configured with no download retries, or it ran out of retries, a block was never attempted again.

The PR adds an `onFailed` notification, which causes the `Synchronizer` to clear its cache of the block, therefore if it comes up again as a dependency of a new block, it will be visited and scheduled again, restarting the download sequence.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1317

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
