### PR TITLE
NODE-1316: Rerun docker client on docker.errors.APIError: 409 Client Error

### DIFF
--- a/integration-testing/casperlabs_local_net/docker_client.py
+++ b/integration-testing/casperlabs_local_net/docker_client.py
@@ -121,7 +121,7 @@ class DockerClient(CasperLabsClientBase, LoggingMixin):
             stdout = decode_stdout and stdout_raw.decode("utf-8") or stdout_raw
             stderr = container.logs(stdout=False, stderr=True).decode("utf-8")
 
-            # TODO: I don't understand why bug if I just call `self.logger.debug` then
+            # TODO: I don't understand why but if I just call `self.logger.debug` then
             # it doesn't print anything, even though the level is clearly set.
             if self.log_level == "DEBUG" or status_code != 0:
                 self.logger.info(


### PR DESCRIPTION

### Overview
This PR changes `DockerClient.invoke_client` method so it retries on docker.errors.APIError: 409 Client Error in order to fix non-deterministic CI failures that started occurring since the integration tests run in CI was parallelized.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1316

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
