### PR TITLE
EE-953: Counter can be incremented from other accounts

### DIFF
--- a/execution-engine/contracts/examples/counter-define/README.md
+++ b/execution-engine/contracts/examples/counter-define/README.md
@@ -12,7 +12,7 @@ The `counter` smart contract exposes two methods:
 
 Build the `wasm` file using `make` in the `execution-engine` directory.
 ```
-$ make build-contract/counter-define
+$ make build-contract-rs/counter-define
 ```
 
 ## Deploy
@@ -42,4 +42,87 @@ $ casperlabs-client --host $HOST query-state \
     --type address \
     --key $PUBLIC_KEY \
     --path "counter/count"
+```
+
+## Use the counter from another account
+
+First we need to know the locations of the contracts. We look up the account
+they were deployed from and find the `"counter"` and `"counter_inc"` named keys.
+
+```
+$ casperlabs-client --host $HOST query-state \
+    --block-hash $BLOCK_HASH \
+    --key $PUBLIC_KEY \
+    --type address \
+    --path ""
+
+account {
+  ...
+  named_keys {
+    name: "counter"
+    key {
+      hash {
+        hash: "<COUNTER>"
+      }
+    }
+  }
+  named_keys {
+    name: "counter_inc"
+    key {
+      hash {
+        hash: "<COUNTER_INC>"
+      }
+    }
+  }
+  ...
+}
+```
+
+Then we call the `"counter_inc"` key, passing the `"counter"` key as an argument:
+
+```
+$ casperlabs-client --host $HOST deploy \
+    --private-key $DIFFERENT_PRIVATE_KEY_PATH \
+    --payment-amount 10000000 \
+    --session-hash <COUNTER_INC>
+    --session-args '[{"name" : "counter_key", "value" : {"cl_type" : { "simple_type" : "KEY" }, "value" : {"key": {"hash": {"hash": "<COUNTER>"}}}}}]'
+```
+
+Or with the [Python client](https://pypi.org/project/casperlabs-client/):
+
+```python
+import casperlabs_client
+from casperlabs_client.abi import ABI
+
+# Variables depending on your setup
+host = "<host-for-your-setup>"
+block_hash = "<block-counter-define-included-in>"
+counter_account = "<base16-public-key-of-account-deploying-counter-define>"
+different_account_id = "<base16-public-key-of-other-account>"
+different_account_pk = "<path-to-other-account-public-key>"
+different_account_sk = "<path-to-other-account-private-key>"
+
+# Create client instance
+client = casperlabs_client.CasperLabsClient(host=host)
+
+# Look up named keys for account which deployed `counter_define`
+named_keys = client.queryState(
+    key=counter_account,
+    keyType="address",
+    path="",
+    blockHash=block_hash
+).account.named_keys
+# Get addresses of `counter` and `counter_inc` contracts
+counter_address = next(filter(lambda x: x.name == "counter", named_keys)).key.hash.hash
+counter_inc_address = next(filter(lambda x: x.name == "counter_inc", named_keys)).key.hash.hash
+
+# Send deploy from other account to increment the counter
+deploy_hash = client.deploy(
+    from_addr=different_account_id,
+    session_hash=counter_inc_address,
+    session_args=[ABI.key_hash("counter_key", counter_address)],
+    payment_amount=10000000,
+    private_key=different_account_sk,
+    public_key=different_account_pk
+)
 ```

--- a/execution-engine/contracts/examples/counter-define/src/lib.rs
+++ b/execution-engine/contracts/examples/counter-define/src/lib.rs
@@ -61,7 +61,10 @@ pub extern "C" fn counter_increment() {
     // This function will call the stored counter contract (defined above) and increment it.
     // It is stored in `call` below so that it can be called directly by the client
     // (without needing to send any further wasm).
-    let counter_key = runtime::get_key(COUNTER_KEY).unwrap_or_revert_with(ApiError::GetKey);
+    let counter_key = runtime::get_arg(0)
+        .map(|arg| arg.unwrap_or_revert_with(ApiError::InvalidArgument))
+        .unwrap_or_else(|| runtime::get_key(COUNTER_KEY).unwrap_or_revert_with(ApiError::GetKey));
+
     let contract_ref = counter_key
         .to_contract_ref()
         .unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);


### PR DESCRIPTION
### Overview
Allows counter created by `counter_define` to be easily incremented from other accounts.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-953

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
