### PR TITLE
NODE-1285: Send empty payment_code instead of bundled standard_payment.wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,8 +311,7 @@ build-python-client: \
 build-client-contracts: \
 	client/src/main/resources/bonding.wasm \
 	client/src/main/resources/unbonding.wasm \
-	client/src/main/resources/transfer_to_account_u512.wasm \
-	client/src/main/resources/standard_payment.wasm
+	client/src/main/resources/transfer_to_account_u512.wasm
 
 build-node: \
 	.make/sbt-stage/node
@@ -327,7 +326,6 @@ build-explorer: \
 
 build-explorer-contracts: \
 	explorer/contracts/transfer_to_account_u512.wasm \
-	explorer/contracts/standard_payment.wasm \
 	explorer/contracts/faucet.wasm
 
 # Get the .proto files for REST annotations for Github. This is here for reference about what to get from where, the files are checked in.

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -680,7 +680,7 @@ object ProtoUtil {
         case Deploy.Code.Contract.Uref(uref) =>
           ipc.DeployPayload.Payload.StoredContractUref(ipc.StoredContractURef(uref, args))
         case Deploy.Code.Contract.Empty =>
-          ipc.DeployPayload.Payload.Empty
+          ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(ByteString.EMPTY, args))
       }
       ipc.DeployPayload(payload)
     }

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -79,10 +79,9 @@ object DeployBuffer {
           }
 
         for {
-          _ <- (deploy.getBody.session, deploy.getBody.payment) match {
-                case (None, _) | (_, None) | (Some(Deploy.Code(_, Deploy.Code.Contract.Empty)), _) |
-                    (_, Some(Deploy.Code(_, Deploy.Code.Contract.Empty))) =>
-                  illegal(s"Deploy was missing session and/or payment code.")
+          _ <- deploy.getBody.session match {
+                case None | Some(Deploy.Code(_, Deploy.Code.Contract.Empty)) =>
+                  illegal(s"Deploy was missing session code.")
                 case _ => ().pure[F]
               }
           _ <- check("Invalid deploy hash.")(Validation.deployHash[F](deploy))

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -79,9 +79,10 @@ object DeployBuffer {
           }
 
         for {
-          _ <- deploy.getBody.session match {
-                case None | Some(Deploy.Code(_, Deploy.Code.Contract.Empty)) =>
-                  illegal(s"Deploy was missing session code.")
+          _ <- (deploy.getBody.session, deploy.getBody.payment) match {
+                case (None, _) | (_, None) | (Some(Deploy.Code(_, Deploy.Code.Contract.Empty)), _) |
+                    (_, Some(Deploy.Code(_, Deploy.Code.Contract.Empty))) =>
+                  illegal(s"Deploy was missing session and/or payment code.")
                 case _ => ().pure[F]
               }
           _ <- check("Invalid deploy hash.")(Validation.deployHash[F](deploy))

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -402,7 +402,7 @@ object DeployRuntime {
       sessionArgs: Seq[Deploy.Arg]
   ): Deploy = {
     val session = deployConfig.session(sessionArgs)
-    // By default send empty WASM as payment to indicate that EE system payment contract should be used.
+    // By default send empty payment code to indicate that EE system payment contract should be used.
     val payment = deployConfig
       .payment(
         deployConfig.paymentAmount.map(bigIntArg("amount", _)).toList

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -36,7 +36,9 @@ object DeployRuntime {
   val BONDING_WASM_FILE   = "bonding.wasm"
   val UNBONDING_WASM_FILE = "unbonding.wasm"
   val TRANSFER_WASM_FILE  = "transfer_to_account_u512.wasm"
-  val PAYMENT_WASM_FILE   = "standard_payment.wasm"
+  // A virtual empty file used as payment. When EE receives empty WASM as payment
+  // it will use built-in system payment contract.
+  val EMPTY_WASM_FILE = ""
 
   def propose[F[_]: Sync: DeployService](
       exit: Boolean = true,
@@ -403,9 +405,9 @@ object DeployRuntime {
       sessionArgs: Seq[Deploy.Arg]
   ): Deploy = {
     val session = deployConfig.session(sessionArgs)
-    // It is advisable to provide payment via --payment-name or --payment-hash, if it's stored.
+    // By default send empty WASM as payment to indicate that EE system payment contract should be used.
     val payment = deployConfig
-      .withPaymentResource("")
+      .withPaymentResource(EMPTY_WASM_FILE)
       .payment(
         deployConfig.paymentAmount.map(bigIntArg("amount", _)).toList
       )

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -36,9 +36,6 @@ object DeployRuntime {
   val BONDING_WASM_FILE   = "bonding.wasm"
   val UNBONDING_WASM_FILE = "unbonding.wasm"
   val TRANSFER_WASM_FILE  = "transfer_to_account_u512.wasm"
-  // A virtual empty file used as payment. When EE receives empty WASM as payment
-  // it will use built-in system payment contract.
-  val EMPTY_WASM_FILE = ""
 
   def propose[F[_]: Sync: DeployService](
       exit: Boolean = true,
@@ -407,7 +404,6 @@ object DeployRuntime {
     val session = deployConfig.session(sessionArgs)
     // By default send empty WASM as payment to indicate that EE system payment contract should be used.
     val payment = deployConfig
-      .withPaymentResource(EMPTY_WASM_FILE)
       .payment(
         deployConfig.paymentAmount.map(bigIntArg("amount", _)).toList
       )

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -405,7 +405,7 @@ object DeployRuntime {
     val session = deployConfig.session(sessionArgs)
     // It is advisable to provide payment via --payment-name or --payment-hash, if it's stored.
     val payment = deployConfig
-      .withPaymentResource(PAYMENT_WASM_FILE)
+      .withPaymentResource("")
       .payment(
         deployConfig.paymentAmount.map(bigIntArg("amount", _)).toList
       )

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -109,12 +109,8 @@ object DeployConfig {
       }
     } orElse {
       opts.resource.map { x =>
-        // Check if this is the pseudo empty file that indicates EE should use system payment contract.
-        val wasm = if (x.isEmpty) {
-          ByteString.EMPTY
-        } else {
+        val wasm =
           ByteString.copyFrom(consumeInputStream(getClass.getClassLoader.getResourceAsStream(x)))
-        }
         Contract.Wasm(wasm)
       }
     } getOrElse {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -55,7 +55,6 @@ final case class DeployConfig(
     copy(sessionOptions = sessionOptions.copy(resource = Some(resource)))
   def withPaymentResource(resource: String) =
     copy(paymentOptions = paymentOptions.copy(resource = Some(resource)))
-  def withEmptyPaymentWasm = copy(paymentOptions = paymentOptions.copy(resource = Some("")))
 }
 
 object DeployConfig {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -55,6 +55,7 @@ final case class DeployConfig(
     copy(sessionOptions = sessionOptions.copy(resource = Some(resource)))
   def withPaymentResource(resource: String) =
     copy(paymentOptions = paymentOptions.copy(resource = Some(resource)))
+  def withEmptyPaymentWasm = copy(paymentOptions = paymentOptions.copy(resource = Some("")))
 }
 
 object DeployConfig {
@@ -109,8 +110,11 @@ object DeployConfig {
       }
     } orElse {
       opts.resource.map { x =>
-        val wasm =
+        val wasm = if (x.isEmpty) {
+          ByteString.EMPTY
+        } else {
           ByteString.copyFrom(consumeInputStream(getClass.getClassLoader.getResourceAsStream(x)))
+        }
         Contract.Wasm(wasm)
       }
     } getOrElse {

--- a/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
+++ b/client/src/main/scala/io/casperlabs/client/configuration/Configuration.scala
@@ -110,6 +110,7 @@ object DeployConfig {
       }
     } orElse {
       opts.resource.map { x =>
+        // Check if this is the pseudo empty file that indicates EE should use system payment contract.
         val wasm = if (x.isEmpty) {
           ByteString.EMPTY
         } else {

--- a/explorer/Dockerfile
+++ b/explorer/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:12.5.0-stretch-slim
 
 COPY contracts/transfer_to_account_u512.wasm /app/contracts/transfer.wasm
-COPY contracts/standard_payment.wasm /app/contracts/payment.wasm
 COPY contracts/faucet.wasm /app/contracts/faucet.wasm
 
 COPY server/node_modules /app/server/node_modules
@@ -18,6 +17,5 @@ ENV TRANSFER_AMOUNT=1000000000
 ENV GAS_PRICE=10
 # The link to graphql playground, used in Home page of UI.
 ENV UI_GRAPHQL_URL=http://devnet-graphql.casperlabs.io:40403/graphql
-ENV PAYMENT_CONTRACT_PATH=/app/contracts/payment.wasm
 ENV FAUCET_CONTRACT_PATH=/app/contracts/faucet.wasm
 ENTRYPOINT node server.js

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -158,16 +158,11 @@ def _deploy_kwargs(args, private_key_accepted=True):
         args.payment_args = ABI.args_to_json(
             ABI.args([ABI.big_int("amount", int(args.payment_amount))])
         )
-        # Unless one of payment* options supplied use bundled standard-payment
-        if not any(
-            (args.payment, args.payment_name, args.payment_hash, args.payment_uref)
-        ):
-            args.payment = bundled_contract("standard_payment.wasm")
 
     d = dict(
         from_addr=from_addr,
         gas_price=args.gas_price,
-        payment=args.payment or args.session,
+        payment=args.payment,
         session=args.session,
         public_key=args.public_key or None,
         session_args=args.session_args
@@ -435,7 +430,7 @@ def deploy_options(private_key_accepted=True):
         [('--dependencies',), dict(required=False, nargs="+", default=None, help="List of deploy hashes (base16 encoded) which must be executed before this deploy.")],
         [('--payment-amount',), dict(required=False, type=int, default=None, help="Standard payment amount. Use this with the default payment, or override with --payment-args if custom payment code is used. By default --payment-amount is set to 10000000")],
         [('--gas-price',), dict(required=False, type=int, default=10, help='The price of gas for this transaction in units dust/gas. Must be positive integer.')],
-        [('-p', '--payment'), dict(required=False, type=str, default=None, help='Path to the file with payment code, by default fallbacks to the --session code')],
+        [('-p', '--payment'), dict(required=False, type=str, default=None, help='Path to the file with payment code')],
         [('--payment-hash',), dict(required=False, type=str, default=None, help='Hash of the stored contract to be called in the payment; base16 encoded')],
         [('--payment-name',), dict(required=False, type=str, default=None, help='Name of the stored contract (associated with the executing account) to be called in the payment')],
         [('--payment-uref',), dict(required=False, type=str, default=None, help='URef of the stored contract to be called in the payment; base16 encoded')],

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
@@ -68,7 +68,8 @@ def _encode_contract(contract_options, contract_args):
         return Code(name=name, args=contract_args)
     if uref:
         return Code(uref=uref, args=contract_args)
-    return Code(args=contract_args)
+    # Send empty WASM to use system payment contract
+    return Code(wasm=b"", args=contract_args)
 
 
 def _serialize(o) -> bytes:

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
@@ -68,8 +68,7 @@ def _encode_contract(contract_options, contract_args):
         return Code(name=name, args=contract_args)
     if uref:
         return Code(uref=uref, args=contract_args)
-    # Send empty WASM to use system payment contract
-    return Code(wasm=b"", args=contract_args)
+    return Code(args=contract_args)
 
 
 def _serialize(o) -> bytes:

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
@@ -1,7 +1,6 @@
 import os
 import time
 import ssl
-import logging
 import pkg_resources
 import google.protobuf.text_format
 from . import abi
@@ -60,16 +59,16 @@ def key_variant(key_type):
 
 def _encode_contract(contract_options, contract_args):
     file_name, hash, name, uref = contract_options
-    C = consensus.Deploy.Code
+    Code = consensus.Deploy.Code
     if file_name:
-        return C(wasm=_read_binary(file_name), args=contract_args)
+        return Code(wasm=_read_binary(file_name), args=contract_args)
     if hash:
-        return C(hash=hash, args=contract_args)
+        return Code(hash=hash, args=contract_args)
     if name:
-        return C(name=name, args=contract_args)
+        return Code(name=name, args=contract_args)
     if uref:
-        return C(uref=uref, args=contract_args)
-    raise Exception("One of wasm, hash, name or uref is required")
+        return Code(uref=uref, args=contract_args)
+    return Code(args=contract_args)
 
 
 def _serialize(o) -> bytes:
@@ -108,26 +107,17 @@ def make_deploy(
     if payment_amount:
         payment_args = abi.ABI.args([abi.ABI.big_int("amount", int(payment_amount))])
 
-    # Unless one of payment* options supplied use bundled standard-payment
-    if not any((payment, payment_name, payment_hash, payment_uref)):
-        payment = bundled_contract("standard_payment.wasm")
-
     session_options = (session, session_hash, session_name, session_uref)
     payment_options = (payment, payment_hash, payment_name, payment_uref)
 
-    # Compatibility mode, should be removed when payment is obligatory
-    if len(list(filter(None, payment_options))) == 0:
-        logging.info("No payment contract provided, using session as payment")
-        payment_options = session_options
-
     if len(list(filter(None, session_options))) != 1:
         raise TypeError(
-            "deploy: only one of session, session_hash, session_name, session_uref must be provided"
+            "deploy: exactly one of session, session_hash, session_name or session_uref must be provided"
         )
 
-    if len(list(filter(None, payment_options))) != 1:
+    if len(list(filter(None, payment_options))) > 1:
         raise TypeError(
-            "deploy: only one of payment, payment_hash, payment_name, payment_uref must be provided"
+            "deploy: only one of payment, payment_hash, payment_name or payment_uref can be provided"
         )
 
     # session_args must go to payment as well for now cause otherwise we'll get GASLIMIT error,

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -178,12 +178,7 @@ def prepare_sdist():
     )
     bundled_contracts = [
         f"{contracts_dir}/{f}"
-        for f in [
-            "bonding.wasm",
-            "standard_payment.wasm",
-            "transfer_to_account_u512.wasm",
-            "unbonding.wasm",
-        ]
+        for f in ["bonding.wasm", "transfer_to_account_u512.wasm", "unbonding.wasm"]
     ]
     for file_name in bundled_contracts:
         if not os.path.exists(file_name):


### PR DESCRIPTION

### Overview

Use new standard payment system contract instead of sending `standard_payment.wasm` from Python and Scala clients.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1285

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
