### PR TITLE
NODE-1317: Clear the whole cache in the synchronizer upon failure

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
@@ -53,12 +53,7 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     // Tried recursively clearing out the synced summaries moving forward, but it didn't seem to work,
     // somehow the failed summary didn't have any dependants, yet they kept piling up, preventing
     // further downloads. For now just clear the whole cache.
-    for {
-      removed <- removeSyncedDescendants(blockHash)
-      _ <- Log[F].info(
-            s"Cleared ${removed} blocks from the cache after the failure of ${hex(blockHash) -> "block"}"
-          )
-    } yield ()
+    syncedSummariesRef.set(Map.empty)
 
   override def syncDag(
       source: Node,
@@ -214,53 +209,6 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
           }
       }
     remove(Queue(blockHash)) >> recordSyncedSummaries
-  }
-
-  /** Recursively clear out summaries and their descendants from the cache.
-    * This caters for the case when the download manager ultimately fails to
-    * fetch a block, despite all the retries it does. If that happens, it's
-    * up to the synchronizer to schedule the block again, if it comes up
-    * as a dependency of something newer. But that can only be done if it's
-    * visited during traversal, which will not happen as long as it's in the
-    * cache. So we clear out anything that depends on the failed item, so
-    * that next time we sync we again visit this one, if we have to,
-    * causing another download cycle to be scheduled.
-    */
-  private def removeSyncedDescendants(blockHash: ByteString): F[Int] = {
-    def remove(
-        removed: Int,
-        queue: Queue[ByteString],
-        dependants: Map[ByteString, Set[ByteString]]
-    ): F[Int] =
-      queue.dequeueOption.fold(removed.pure[F]) {
-        case (blockHash, queue) =>
-          syncedSummariesRef.modify { ss =>
-            (ss - blockHash) -> ss.get(blockHash)
-          } flatMap {
-            case None =>
-              remove(removed, queue, dependants)
-            case Some(s) =>
-              remove(removed + 1, queue.enqueue(dependants(s.summary.blockHash)), dependants)
-          }
-      }
-
-    def parentToChildrenMap(syncedSummaries: Map[ByteString, SyncedSummary]) =
-      syncedSummaries.foldLeft(
-        Map.empty[ByteString, Set[ByteString]].withDefaultValue(Set.empty)
-      ) {
-        case (dependants, (childBlockHash, s)) =>
-          s.dependencies.toSeq.foldLeft(dependants) {
-            case (dependants, parentBlockHash) =>
-              dependants.updated(parentBlockHash, dependants(parentBlockHash) + childBlockHash)
-          }
-      }
-
-    for {
-      syncedSummaries <- syncedSummariesRef.get
-      dependants      = parentToChildrenMap(syncedSummaries)
-      removed         <- remove(0, Queue(blockHash), dependants)
-      _               <- recordSyncedSummaries
-    } yield removed
   }
 
   private def recordSyncedSummaries =

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
@@ -12,6 +12,7 @@ import io.casperlabs.shared.SemaphoreMap
 import io.casperlabs.comm.discovery.Node
 import io.casperlabs.comm.discovery.NodeUtils.showNode
 import io.casperlabs.comm.gossiping._
+import io.casperlabs.comm.gossiping.Utils.hex
 import io.casperlabs.comm.gossiping.synchronization.Synchronizer.SyncError
 import io.casperlabs.comm.gossiping.synchronization.Synchronizer.SyncError._
 import io.casperlabs.metrics.Metrics
@@ -49,7 +50,15 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
   // This will be called if the download failed, so we invalidate everythig in the cache that
   // depended on this item, which should next time cause it to be traversed again, if it comes up.
   override def onFailed(blockHash: ByteString) =
-    removeSyncedDescendants(blockHash)
+    // Tried recursively clearing out the synced summaries moving forward, but it didn't seem to work,
+    // somehow the failed summary didn't have any dependants, yet they kept piling up, preventing
+    // further downloads. For now just clear the whole cache.
+    for {
+      removed <- removeSyncedDescendants(blockHash)
+      _ <- Log[F].info(
+            s"Cleared ${removed} blocks from the cache after the failure of ${hex(blockHash) -> "block"}"
+          )
+    } yield ()
 
   override def syncDag(
       source: Node,
@@ -217,17 +226,21 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
     * that next time we sync we again visit this one, if we have to,
     * causing another download cycle to be scheduled.
     */
-  private def removeSyncedDescendants(blockHash: ByteString): F[Unit] = {
-    def remove(queue: Queue[ByteString], dependants: Map[ByteString, Set[ByteString]]): F[Unit] =
-      queue.dequeueOption.fold(().pure[F]) {
+  private def removeSyncedDescendants(blockHash: ByteString): F[Int] = {
+    def remove(
+        removed: Int,
+        queue: Queue[ByteString],
+        dependants: Map[ByteString, Set[ByteString]]
+    ): F[Int] =
+      queue.dequeueOption.fold(removed.pure[F]) {
         case (blockHash, queue) =>
           syncedSummariesRef.modify { ss =>
             (ss - blockHash) -> ss.get(blockHash)
           } flatMap {
             case None =>
-              remove(queue, dependants)
+              remove(removed, queue, dependants)
             case Some(s) =>
-              remove(queue.enqueue(dependants(s.summary.blockHash)), dependants)
+              remove(removed + 1, queue.enqueue(dependants(s.summary.blockHash)), dependants)
           }
       }
 
@@ -235,19 +248,19 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
       syncedSummaries.foldLeft(
         Map.empty[ByteString, Set[ByteString]].withDefaultValue(Set.empty)
       ) {
-        case (dependants, (blockHash, s)) =>
+        case (dependants, (childBlockHash, s)) =>
           s.dependencies.toSeq.foldLeft(dependants) {
-            case (dependants, dep) =>
-              dependants.updated(blockHash, dependants(blockHash) + dep)
+            case (dependants, parentBlockHash) =>
+              dependants.updated(parentBlockHash, dependants(parentBlockHash) + childBlockHash)
           }
       }
 
     for {
       syncedSummaries <- syncedSummariesRef.get
       dependants      = parentToChildrenMap(syncedSummaries)
-      _               <- remove(Queue(blockHash), dependants)
+      removed         <- remove(0, Queue(blockHash), dependants)
       _               <- recordSyncedSummaries
-    } yield ()
+    } yield removed
   }
 
   private def recordSyncedSummaries =

--- a/hack/docker/README.md
+++ b/hack/docker/README.md
@@ -347,7 +347,7 @@ When stests is up and running then the testing workflow becomes something like:
 
 ```bash
 # Launch a generator
-stests-wg-100 poc1 --user-accounts 5 --run 1
+stests-wg-100 poc1 --user-accounts 5
 # Check it is running
 stests-ls-runs poc1
 # Check what stage it is at

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -31,7 +31,7 @@ dynamic-host-address = false
 no-upnp = false
 
 # Default timeout for roundtrip connections.
-default-timeout = "5second"
+default-timeout = "15second"
 
 # Timeout for shutting down gRPC services.
 shutdown-timeout = "1minute"


### PR DESCRIPTION
### Overview
It looks like the previous fix of clearing the cache of recursive descendants didn't work, the failing item doesn't seem to have dependants, but yet the items keep piling up. PR changes it so the whole cache is cleared, causing re-sync.

Also raises the default timeout from 5s to 15s which seems more realistic in AWS.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1317

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
This time I tried many times by raising random/persistent errors. This was the only way it didn't pile up, and kept trying.
