### PR TITLE
ECO-312: Hide Base64 pub key and add `hide ballot` button to Block Details

### DIFF
--- a/explorer/ui/src/components/Accounts.tsx
+++ b/explorer/ui/src/components/Accounts.tsx
@@ -106,6 +106,12 @@ export default class Accounts extends RefreshableComponent<Props, {}> {
                 fieldState={importAccountForm.publicKeyBase64}
                 readonly={true}
               />
+              <TextField
+                id="id-public-key-base16"
+                label="Public Key (Base16)"
+                fieldState={base64to16(importAccountForm.publicKeyBase64.value)}
+                readonly={true}
+              />
             </Form>
           </Modal>
         );
@@ -118,7 +124,6 @@ export default class Accounts extends RefreshableComponent<Props, {}> {
           rows={this.props.auth.accounts}
           headers={[
             'Name',
-            'Public Key (Base64)',
             'Public Key (Base16)',
             'Balance',
             ''
@@ -130,7 +135,6 @@ export default class Accounts extends RefreshableComponent<Props, {}> {
             return (
               <tr key={account.name}>
                 <td>{account.name}</td>
-                <td>{account.publicKeyBase64}</td>
                 <td>{base64to16(account.publicKeyBase64)}</td>
                 <td>
                   <Balance balance={balance}/>

--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -70,6 +70,7 @@ class _BlockDetails extends RefreshableComponent<Props, {}> {
           title={`Neighborhood of block ${this.blockHashBase16}`}
           refresh={() => this.container.loadNeighborhood()}
           blocks={this.container.neighborhood}
+          hideBallotsToggleStore={this.container.hideBallotsToggleStore}
           width="100%"
           height="400px"
           selected={this.container.block!}

--- a/explorer/ui/src/components/DeployContracts.tsx
+++ b/explorer/ui/src/components/DeployContracts.tsx
@@ -54,7 +54,7 @@ export class DeployContractsForm extends React.Component<Props, {}> {
         <Form>
           <TextField
             id="id-private-key"
-            label="Private Key"
+            label="Private Key (Base64)"
             fieldState={deployContractsContainer.privateKey}
           />
         </Form>

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -23,10 +23,21 @@ import { BlockType, FinalityIcon } from './BlockDetails';
 class _Explorer extends RefreshableComponent<Props, {}> {
   constructor(props: Props) {
     super(props);
-    let maxRank = parseInt(props.maxRank || '') || 0;
-    let depth = parseInt(props.depth || '') || 10;
+    this.refreshWithDepthAndMaxRank(props.maxRank, props.depth);
+  }
+
+  refreshWithDepthAndMaxRank(maxRankStr: string | null, depthStr: string | null) {
+    let maxRank = parseInt(maxRankStr || '') || 0;
+    let depth = parseInt(depthStr || '') || 10;
     this.props.dag.updateMaxRankAndDepth(maxRank, depth);
     this.props.dag.refreshBlockDagAndSetupSubscriber();
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    if (this.props.depth === nextProps.depth && this.props.maxRank === nextProps.maxRank) {
+      return;
+    }
+    this.refreshWithDepthAndMaxRank(nextProps.maxRank, nextProps.depth);
   }
 
   async refresh() {

--- a/explorer/ui/src/containers/BlockContainer.ts
+++ b/explorer/ui/src/containers/BlockContainer.ts
@@ -5,6 +5,7 @@ import { CasperService, BalanceService, encodeBase16 } from 'casperlabs-sdk';
 import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
 import { Block } from 'casperlabs-grpc/io/casperlabs/casper/consensus/consensus_pb';
 import ObservableValueMap from '../lib/ObservableValueMap';
+import { ToggleStore } from '../components/ToggleButton';
 
 type AccountB16 = string;
 
@@ -14,6 +15,7 @@ export class BlockContainer {
   @observable neighborhood: BlockInfo[] | null = null;
   // How much of the DAG to load around the block.
   @observable depth = 10;
+  @observable hideBallotsToggleStore: ToggleStore = new ToggleStore(false);
   @observable deploys: Block.ProcessedDeploy[] | null = null;
   @observable balances: ObservableValueMap<
     AccountB16,

--- a/explorer/ui/src/contracts/Vesting/component/Vesting.tsx
+++ b/explorer/ui/src/contracts/Vesting/component/Vesting.tsx
@@ -72,7 +72,7 @@ const VestingHashesManageForm = observer(
       >
         <Form>
           <TextField
-            id="id-import-vesting-hash-base64"
+            id="id-import-vesting-hash-base16"
             label="Hash of vesting contract (Base16)"
             fieldState={vestingContainer.importVestingForm!.hashBase16}
           />


### PR DESCRIPTION
### Overview
In this PR,
1. Hide base64 pub key from the account list, but still show base64 pub key when creating or importing account, so that user can check with pub key file since the file is base64 encoded. 
2. Add `hide ballot` button to Block Details. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-312
https://casperlabs.atlassian.net/browse/ECO-370

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
