### PR TITLE
NODE-1319: Configurable fixed thread pool sizes.

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -145,6 +145,15 @@ block-upload-rate-period = "0s"
 # if 0 then unlimited, if reached max size then peer will receive RESOURCE_EXHAUSTED response.
 block-upload-rate-max-throttled = 0
 
+# Size of the main thread pool.
+main-threads = 64
+
+# Size of the thread pool used to handle incoming requests.
+ingress-threads = 32
+
+# Size of the thread pool for database connections.
+db-threads = 48
+
 # io.casperlabs.node.configuration.Configuration.BlockStorage
 [blockstorage]
 

--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -41,7 +41,7 @@ object Main {
               // We could move this to config, but NodeRuntime creates even more.
               // Let's see if it helps with the issue we see in long term tests where
               // block processing just stops at some point.
-              maxThreads = 64,
+              maxThreads = conf.server.mainThreads.value,
               name = "node-runner",
               reporter = uncaughtExceptionHandler
             )

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -73,13 +73,23 @@ class NodeRuntime private[node] (
 
   // Bounded thread pool for incoming traffic. Limited thread pool size so loads of request cannot exhaust all resources.
   private[this] val ingressScheduler =
-    Scheduler.cached("ingress-io", 2, 64, reporter = uncaughtExceptionHandler)
+    Scheduler.cached(
+      "ingress-io",
+      2,
+      conf.server.ingressThreads.value,
+      reporter = uncaughtExceptionHandler
+    )
   // Unbounded thread pool for outgoing, blocking IO. It is recommended to have unlimited thread pools for waiting on IO.
   private[this] val egressScheduler =
     Scheduler.cached("egress-io", 2, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
   private[this] val dbConnScheduler =
-    Scheduler.cached("db-conn", 1, 64, reporter = uncaughtExceptionHandler)
+    Scheduler.cached(
+      "db-conn",
+      1,
+      conf.server.dbThreads.value,
+      reporter = uncaughtExceptionHandler
+    )
   private[this] val dbIOScheduler =
     Scheduler.cached("db-io", 1, Int.MaxValue, reporter = uncaughtExceptionHandler)
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -100,7 +100,10 @@ object Configuration extends ParserImplicits {
       cleanBlockStorage: Boolean,
       blockUploadRateMaxRequests: Int Refined NonNegative,
       blockUploadRatePeriod: FiniteDuration,
-      blockUploadRateMaxThrottled: Int Refined NonNegative
+      blockUploadRateMaxThrottled: Int Refined NonNegative,
+      mainThreads: Int Refined Positive,
+      ingressThreads: Int Refined Positive,
+      dbThreads: Int Refined Positive
   ) extends SubConfig
 
   case class BlockStorage(

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -235,6 +235,18 @@ private[configuration] final case class Options private (
       )
 
     @scallop
+    val serverMainThreads =
+      gen[Int]("Size of the main thread pool.")
+
+    @scallop
+    val serverIngressThreads =
+      gen[Int]("Size of the thread pool used to handle incoming requests.")
+
+    @scallop
+    val serverDbThreads =
+      gen[Int]("Size of the thread pool for database connections.")
+
+    @scallop
     val tlsCertificate =
       gen[Path](
         "Path to node's X.509 certificate file, that is being used for identification.",

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -52,6 +52,9 @@ clean-block-storage = false
 block-upload-rate-max-requests = 0
 block-upload-rate-period = "0s"
 block-upload-rate-max-throttled = 0
+main-threads=1
+ingress-threads=1
+db-threads=1
 
 [grpc]
 socket = "/tmp/test"

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -104,7 +104,10 @@ class ConfigurationSpec
       cleanBlockStorage = false,
       blockUploadRateMaxRequests = 0,
       blockUploadRatePeriod = Duration.Zero,
-      blockUploadRateMaxThrottled = 0
+      blockUploadRateMaxThrottled = 0,
+      mainThreads = 1,
+      ingressThreads = 1,
+      dbThreads = 1
     )
     val grpcServer = Configuration.Grpc(
       socket = Paths.get("/tmp/test"),


### PR DESCRIPTION
### Overview
There is potentially some mismatch between how the thread pools with maximum sized are used vs the intention. Unfortuantely when they reject tasks it's difficult to say which one was the culprit. The values were also hardcoded. 

The PR makes the fixed sizes configurable for the main, the ingress and the DB thread pool. Different values as well so we should be able to tell which one to raise.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1319

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
