### PR TITLE
NODE-1315: Check for the finality after rebuilding the VotingMatrix.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -187,14 +187,7 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
                           s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}."
                         )
                     _                    <- lfbRef.set(newLFB)
-                    finalizedHashes      = finalized.map(_.messageHash)
-                    orphanedHashes       = orphaned.map(_.messageHash)
                     finalizedBlockHashes = finalized.filter(_.isBlock).map(_.messageHash)
-                    _ <- FinalityStorage[F].markAsFinalized(
-                          newLFB,
-                          finalizedHashes,
-                          orphanedHashes
-                        )
                     _ <- DeployBuffer[F]
                           .removeFinalizedDeploys(finalizedBlockHashes + newLFB)
                     // Ballots cannot be really finalized but we mark them as such in the DAG

--- a/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetector.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/FinalityDetector.scala
@@ -11,5 +11,5 @@ trait FinalityDetector[F[_]] {
       dag: DagRepresentation[F],
       message: Message,
       latestFinalizedBlock: BlockHash
-  ): F[Option[CommitteeWithConsensusValue]]
+  ): F[Seq[CommitteeWithConsensusValue]]
 }

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -51,7 +51,7 @@ object MultiParentFinalizer {
       indirectlyOrphaned: Set[Message]
   )
 
-  def create[F[_]: Monad: Concurrent: FinalityStorage: Metrics](
+  def create[F[_]: Concurrent: FinalityStorage: Metrics](
       dag: DagRepresentation[F],
       latestLFB: BlockHash, // Last LFB from the main chain
       finalityDetector: FinalityDetector[F],

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -88,6 +88,11 @@ object MultiParentFinalizer {
                                                isHighway
                                              )
                                              .timer("orphanedIndirectly")
+                            _ <- FinalityStorage[F].markAsFinalized(
+                                  newLFB,
+                                  justFinalized.map(_.messageHash),
+                                  justOrphaned.map(_.messageHash)
+                                )
                           } yield FinalizedBlocks(newLFB, quorum, justFinalized, justOrphaned)
                       }
         } yield finalized)

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
@@ -24,13 +24,13 @@ package object votingmatrix {
     * Updates voting matrix when a new block added to dag
     * @param dag
     * @param msg the new message
-    * @param currentVoteValue which branch the new block vote for
+    * @param lfbChild which branch the new block vote for
     * @return
     */
   def updateVoterPerspective[F[_]: Monad](
       dag: DagRepresentation[F],
       msg: Message,
-      currentVoteValue: BlockHash,
+      lfbChild: BlockHash,
       isHighway: Boolean
   )(implicit matrix: VotingMatrix[F]): F[Unit] =
     for {
@@ -43,7 +43,7 @@ package object votingmatrix {
           } else {
             for {
               _ <- updateVotingMatrixOnNewBlock[F](dag, msg, isHighway)
-              _ <- updateFirstZeroLevelVote[F](voter, currentVoteValue, msg.mainRank)
+              _ <- updateFirstZeroLevelVote[F](voter, lfbChild, msg.mainRank)
             } yield ()
           }
     } yield ()
@@ -61,40 +61,42 @@ package object votingmatrix {
       implicit matrix: VotingMatrix[F]
   ): F[Option[CommitteeWithConsensusValue]] =
     for {
-      weightMap                 <- (matrix >> 'weightMap).get
-      totalWeight               = weightMap.values.sum
-      quorum                    = totalWeight * (rFTT + 0.5)
-      committeeApproximationOpt <- findCommitteeApproximation[F](dag, quorum, isHighway)
-      result <- committeeApproximationOpt match {
-                 case Some(
-                     CommitteeWithConsensusValue(committeeApproximation, _, consensusValue)
-                     ) =>
-                   for {
-                     votingMatrix        <- (matrix >> 'votingMatrix).get
-                     firstLevelZeroVotes <- (matrix >> 'firstLevelZeroVotes).get
-                     validatorToIndex    <- (matrix >> 'validatorToIdx).get
-                     mask = FinalityDetectorUtil
-                       .fromMapToArray(validatorToIndex, committeeApproximation.contains)
-                     weight = FinalityDetectorUtil
-                       .fromMapToArray(validatorToIndex, weightMap.getOrElse(_, Zero))
-                     committeeOpt = pruneLoop(
-                       votingMatrix,
-                       firstLevelZeroVotes,
-                       consensusValue,
-                       mask,
-                       quorum,
-                       weight
-                     )
-                     committee = committeeOpt.map {
-                       case (mask, totalWeight) =>
-                         val committee = validatorToIndex.filter { case (_, i) => mask(i) }.keySet
-                         CommitteeWithConsensusValue(committee, totalWeight, consensusValue)
-                     }
-                   } yield committee
-                 case None =>
-                   none[CommitteeWithConsensusValue].pure[F]
-               }
-    } yield result
+      weightMap   <- (matrix >> 'weightMap).get
+      totalWeight = weightMap.values.sum
+      quorum      = totalWeight * (rFTT + 0.5)
+      committee <- findCommitteeApproximation[F](dag, quorum, isHighway)
+                    .flatMap {
+                      case Some(
+                          CommitteeWithConsensusValue(committeeApproximation, _, consensusValue)
+                          ) =>
+                        for {
+                          votingMatrix        <- (matrix >> 'votingMatrix).get
+                          firstLevelZeroVotes <- (matrix >> 'firstLevelZeroVotes).get
+                          validatorToIndex    <- (matrix >> 'validatorToIdx).get
+                          // A sequence of bits where 1 represents an i-th validator present
+                          // in the committee approximation.
+                          validatorsMask = FinalityDetectorUtil
+                            .fromMapToArray(validatorToIndex, committeeApproximation.contains)
+                          // A sequence of validators' weights.
+                          weight = FinalityDetectorUtil
+                            .fromMapToArray(validatorToIndex, weightMap.getOrElse(_, Zero))
+                          committee = pruneLoop(
+                            votingMatrix,
+                            firstLevelZeroVotes,
+                            consensusValue,
+                            validatorsMask,
+                            quorum,
+                            weight
+                          ) map {
+                            case (mask, totalWeight) =>
+                              val committee = validatorToIndex.filter { case (_, i) => mask(i) }.keySet
+                              CommitteeWithConsensusValue(committee, totalWeight, consensusValue)
+                          }
+                        } yield committee
+                      case None =>
+                        none[CommitteeWithConsensusValue].pure[F]
+                    }
+    } yield committee
 
   private[votingmatrix] def updateVotingMatrixOnNewBlock[F[_]: Monad](
       dag: DagRepresentation[F],
@@ -152,40 +154,57 @@ package object votingmatrix {
       validators          <- (matrix >> 'validators).get
       firstLevelZeroVotes <- (matrix >> 'firstLevelZeroVotes).get
       // Get Map[VoteBranch, List[Validator]] directly from firstLevelZeroVotes
-      consensusValueToHonestValidators <- firstLevelZeroVotes.zipWithIndex
-                                           .collect {
-                                             case (Some((blockHash, _)), idx) =>
-                                               (blockHash, validators(idx))
-                                           }
-                                           .toList
-                                           .filterA {
-                                             case (voteHash, validator) =>
-                                               val highwayCheck = for {
-                                                 voteMsg <- dag.lookupUnsafe(voteHash)
-                                                 eraEquivocators <- dag.getEquivocatorsInEra(
-                                                                     voteMsg.eraId
-                                                                   )
-                                               } yield !eraEquivocators.contains(validator)
+      committee <- if (firstLevelZeroVotes.isEmpty) {
+                    // No one voted on anything in the current b-game
+                    none[CommitteeWithConsensusValue].pure[F]
+                  } else
+                    firstLevelZeroVotes.zipWithIndex
+                      .collect {
+                        case (Some((blockHash, _)), idx) =>
+                          (blockHash, validators(idx))
+                      }
+                      .toList
+                      .filterA {
+                        case (voteHash, validator) =>
+                          // Get rid of validators' votes.
+                          // Need to cater for both NCB and Highway modes.
+                          val highwayCheck = for {
+                            voteMsg <- dag.lookupUnsafe(voteHash)
+                            eraEquivocators <- dag.getEquivocatorsInEra(
+                                                voteMsg.eraId
+                                              )
+                          } yield !eraEquivocators.contains(validator)
 
-                                               val ncbCheck =
-                                                 dag.getEquivocators.map(!_.contains(validator))
+                          val ncbCheck =
+                            dag.getEquivocators.map(!_.contains(validator))
 
-                                               if (isHighway) highwayCheck else ncbCheck
-                                           }
-                                           .map(_.groupBy(_._1).mapValues(_.map(_._2)))
-      // Get most support voteBranch and its support weight
-      mostSupport = consensusValueToHonestValidators
-        .mapValues(_.map(weightMap.getOrElse(_, Zero)).sum)
-        .maxBy(_._2)
-      (voteValue, supportingWeight) = mostSupport
-      // Get the voteBranch's supporters
-      supporters = consensusValueToHonestValidators(voteValue)
-    } yield
-      if (supportingWeight > quorum) {
-        Some(CommitteeWithConsensusValue(supporters.toSet, supportingWeight, voteValue))
-      } else {
-        None
-      }
+                          if (isHighway) highwayCheck else ncbCheck
+                      }
+                      .map(_.groupBy(_._1).mapValues(_.map(_._2)))
+                      .map { consensusValueToHonestValidators =>
+                        if (consensusValueToHonestValidators.isEmpty)
+                          // After filtering out equivocators we don't have any honest votes.
+                          none[CommitteeWithConsensusValue]
+                        else {
+                          // Get most support voteBranch and its support weight
+                          val mostSupport = consensusValueToHonestValidators
+                            .mapValues(_.map(weightMap.getOrElse(_, Zero)).sum)
+                            .maxBy(_._2)
+                          val (voteValue, supportingWeight) = mostSupport
+                          // Get the voteBranch's supporters
+                          val supporters = consensusValueToHonestValidators(voteValue)
+                          if (supportingWeight > quorum) {
+                            Some(
+                              CommitteeWithConsensusValue(
+                                supporters.toSet,
+                                supportingWeight,
+                                voteValue
+                              )
+                            )
+                          } else None
+                        }
+                      }
+    } yield committee
 
   @tailrec
   private[votingmatrix] def pruneLoop(

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -114,13 +114,6 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
                   _ <- Log[F].info(
                         s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}. Orphaned ${orphaned.size} messages."
                       )
-                  finalizedHashes = finalized.map(_.messageHash)
-                  orphanedHashes  = orphaned.map(_.messageHash)
-                  _ <- FinalityStorage[F].markAsFinalized(
-                        newLFB,
-                        finalizedHashes,
-                        orphanedHashes
-                      )
                   finalizedBlockHashes = finalized.filter(_.isBlock).map(_.messageHash)
                   _ <- DeployBuffer[F]
                         .removeFinalizedDeploys(finalizedBlockHashes + newLFB)

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -100,47 +100,47 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
 
   private def updateLastFinalizedBlock(message: Message): F[F[Unit]] =
     for {
-      result <- MultiParentFinalizer[F]
-                 .onNewMessageAdded(message)
-      w <- result.traverse {
-            case MultiParentFinalizer.FinalizedBlocks(newLFB, _, finalized, orphaned) => {
-              val lfbStr = newLFB.show
-              val finalizedStr = finalized
-                .filter(_.isBlock)
-                .map(_.messageHash)
-                .map(PrettyPrinter.buildString)
-                .mkString("{", ", ", "}")
-              for {
-                _ <- Log[F].info(
-                      s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}. Orphaned ${orphaned.size} messages."
-                    )
-                finalizedHashes = finalized.map(_.messageHash)
-                orphanedHashes  = orphaned.map(_.messageHash)
-                _ <- FinalityStorage[F].markAsFinalized(
-                      newLFB,
-                      finalizedHashes,
-                      orphanedHashes
-                    )
-                finalizedBlockHashes = finalized.filter(_.isBlock).map(_.messageHash)
-                w1 <- DeployBuffer[F]
-                       .removeFinalizedDeploys(finalizedBlockHashes + newLFB)
-                       .forkAndLog
-                // Ballots cannot be really finalized but we mark them as such in the DAG
-                // to improve the performance of the finalizer (that has to follow all justifications).
-                // Send out notification about blocks ONLY.
-                orphanedBlockHashes = orphaned.filter(_.isBlock).map(_.messageHash)
-                w2 <- BlockEventEmitter[F]
-                       .newLastFinalizedBlock(
-                         newLFB,
-                         finalizedBlockHashes,
-                         orphanedBlockHashes
-                       )
-                       .timer("emitNewLFB")
-                       .forkAndLog
-              } yield w1 *> w2
+      results <- MultiParentFinalizer[F].onNewMessageAdded(message)
+      w <- results.toList
+            .traverse {
+              case MultiParentFinalizer.FinalizedBlocks(newLFB, _, finalized, orphaned) => {
+                val lfbStr = newLFB.show
+                val finalizedStr = finalized
+                  .filter(_.isBlock)
+                  .map(_.messageHash)
+                  .map(PrettyPrinter.buildString)
+                  .mkString("{", ", ", "}")
+                for {
+                  _ <- Log[F].info(
+                        s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}. Orphaned ${orphaned.size} messages."
+                      )
+                  finalizedHashes = finalized.map(_.messageHash)
+                  orphanedHashes  = orphaned.map(_.messageHash)
+                  _ <- FinalityStorage[F].markAsFinalized(
+                        newLFB,
+                        finalizedHashes,
+                        orphanedHashes
+                      )
+                  finalizedBlockHashes = finalized.filter(_.isBlock).map(_.messageHash)
+                  _ <- DeployBuffer[F]
+                        .removeFinalizedDeploys(finalizedBlockHashes + newLFB)
+                  // Ballots cannot be really finalized but we mark them as such in the DAG
+                  // to improve the performance of the finalizer (that has to follow all justifications).
+                  // Send out notification about blocks ONLY.
+                  orphanedBlockHashes = orphaned.filter(_.isBlock).map(_.messageHash)
+                  _ <- BlockEventEmitter[F]
+                        .newLastFinalizedBlock(
+                          newLFB,
+                          finalizedBlockHashes,
+                          orphanedBlockHashes
+                        )
+                        .timer("emitNewLFB")
+                } yield ()
+              }
             }
-          }
-    } yield w getOrElse ().pure[F]
+            .void
+            .forkAndLog
+    } yield w
 
   private def markDeploysAsProcessed(message: Message): F[Unit] =
     for {

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -13,7 +13,7 @@ import io.casperlabs.casper.helper.BlockGenerator._
 import io.casperlabs.casper.helper.BlockUtil.generateValidator
 import io.casperlabs.casper.helper.{BlockGenerator, StorageFixture}
 import io.casperlabs.casper.util.BondingUtil.Bond
-import io.casperlabs.casper.{validation, CasperState, InvalidBlock}
+import io.casperlabs.casper.{validation, CasperState, InvalidBlock, PrettyPrinter}
 import io.casperlabs.models.Message
 import io.casperlabs.shared.LogStub
 import io.casperlabs.shared.{Log, Time}
@@ -83,7 +83,7 @@ class FinalityDetectorByVotingMatrixTest
                        messageType = Block.MessageType.BLOCK,
                        lfb = genesis
                      )
-          _ = c1 shouldBe None
+          _ = c1 shouldBe empty
           (b1, c2) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(a1.blockHash),
                        genesis.blockHash,
@@ -93,7 +93,7 @@ class FinalityDetectorByVotingMatrixTest
                        messageType = Block.MessageType.BLOCK,
                        lfb = genesis
                      )
-          _ = c2 shouldBe None
+          _ = c2 shouldBe empty
           (ballot, c3) <- createBlockAndUpdateFinalityDetector[Task](
                            Seq(b1.blockHash),
                            genesis.blockHash,
@@ -103,7 +103,7 @@ class FinalityDetectorByVotingMatrixTest
                            messageType = Block.MessageType.BALLOT,
                            lfb = genesis
                          )
-          _ = c3 shouldBe Some(CommitteeWithConsensusValue(Set(v1, v2), 20, a1.blockHash))
+          _ = c3 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2), 20, a1.blockHash))
         } yield ()
   }
 
@@ -141,7 +141,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> genesis.blockHash),
                        lfb = genesis
                      )
-          _ = c1 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 20, b1.blockHash))
+          _ = c1 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 20, b1.blockHash))
           (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b1.blockHash),
                        b1.blockHash,
@@ -150,7 +150,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b1.blockHash),
                        lfb = b1
                      )
-          _ = c2 shouldBe None
+          _ = c2 shouldBe empty
           (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b1.blockHash),
                        b1.blockHash,
@@ -159,7 +159,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b1.blockHash),
                        lfb = b1
                      )
-          _ = c3 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 20, b3.blockHash))
+          _ = c3 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 20, b3.blockHash))
           (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b3.blockHash),
                        b3.blockHash,
@@ -168,7 +168,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b3.blockHash, v2 -> b2.blockHash),
                        lfb = b3
                      )
-          result = c4 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 20, b4.blockHash))
+          result = c4 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 20, b4.blockHash))
         } yield result
   }
 
@@ -202,7 +202,7 @@ class FinalityDetectorByVotingMatrixTest
                        lfb = genesis
                      )
 
-          _ = c1 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 10, b1.blockHash))
+          _ = c1 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 10, b1.blockHash))
           (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b1.blockHash),
                        b1.blockHash,
@@ -211,7 +211,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b1.blockHash),
                        lfb = b1
                      )
-          _ = c2 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 10, b2.blockHash))
+          _ = c2 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 10, b2.blockHash))
           (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b2.blockHash),
                        b2.blockHash,
@@ -220,7 +220,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b2.blockHash),
                        lfb = b2
                      )
-          _ = c3 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 10, b3.blockHash))
+          _ = c3 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 10, b3.blockHash))
           (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b3.blockHash),
                        b3.blockHash,
@@ -229,7 +229,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b3.blockHash),
                        lfb = b3
                      )
-          result = c4 shouldBe Some(CommitteeWithConsensusValue(Set(v1), 10, b4.blockHash))
+          result = c4 shouldBe Seq(CommitteeWithConsensusValue(Set(v1), 10, b4.blockHash))
         } yield result
   }
 
@@ -273,7 +273,7 @@ class FinalityDetectorByVotingMatrixTest
                        bonds,
                        lfb = genesis
                      )
-          _ = c1 shouldBe None
+          _ = c1 shouldBe empty
           (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b1.blockHash),
                        genesis.blockHash,
@@ -282,7 +282,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b1.blockHash),
                        lfb = genesis
                      )
-          _ = c2 shouldBe None
+          _ = c2 shouldBe empty
           (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b2.blockHash),
                        genesis.blockHash,
@@ -291,7 +291,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b1.blockHash, v2 -> b2.blockHash),
                        lfb = genesis
                      )
-          _ = c3 shouldBe None
+          _ = c3 shouldBe empty
           (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b3.blockHash),
                        genesis.blockHash,
@@ -300,7 +300,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b1.blockHash, v2 -> b2.blockHash, v3 -> b3.blockHash),
                        lfb = genesis
                      )
-          _ = c4 shouldBe Some(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b1.blockHash))
+          _ = c4 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b1.blockHash))
           (b5, c5) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b4.blockHash),
                        b1.blockHash,
@@ -309,7 +309,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b4.blockHash, v2 -> b2.blockHash, v3 -> b3.blockHash),
                        lfb = b1
                      )
-          _ = c5 shouldBe Some(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b2.blockHash))
+          _ = c5 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b2.blockHash))
           (b6, c6) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b5.blockHash),
                        b2.blockHash,
@@ -318,7 +318,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b4.blockHash, v2 -> b5.blockHash, v3 -> b3.blockHash),
                        lfb = b2
                      )
-          _ = c6 shouldBe Some(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b3.blockHash))
+          _ = c6 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b3.blockHash))
           (b7, c7) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b6.blockHash),
                        b3.blockHash,
@@ -327,7 +327,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> b4.blockHash, v2 -> b5.blockHash, v3 -> b6.blockHash),
                        lfb = b3
                      )
-          result = c7 shouldBe Some(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b4.blockHash))
+          result = c7 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b4.blockHash))
         } yield result
   }
 
@@ -353,7 +353,7 @@ class FinalityDetectorByVotingMatrixTest
                      bonds,
                      lfb = genesis
                    )
-        _ = c1 shouldBe None
+        _ = c1 shouldBe empty
         (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b1.blockHash),
                      genesis.blockHash,
@@ -362,7 +362,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v1 -> b1.blockHash),
                      lfb = genesis
                    )
-        _ = c2 shouldBe None
+        _ = c2 shouldBe empty
         // b4 and b2 are both created by v2 but don't cite each other
         (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b1.blockHash, genesis.blockHash),
@@ -373,7 +373,7 @@ class FinalityDetectorByVotingMatrixTest
                      ByteString.copyFromUtf8(scala.util.Random.nextString(64)),
                      lfb = genesis
                    )
-        _ = c4 shouldBe None
+        _ = c4 shouldBe empty
         // so v2 can be detected equivocating
         _ <- dag.getEquivocators.map(_ shouldBe Set(v2))
         (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
@@ -384,7 +384,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v2 -> b2.blockHash),
                      lfb = genesis
                    )
-        _ = c3 shouldBe None
+        _ = c3 shouldBe empty
         (b5, c5) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b3.blockHash),
                      genesis.blockHash,
@@ -394,7 +394,7 @@ class FinalityDetectorByVotingMatrixTest
                      lfb = genesis
                    )
         // Though v2 also votes for b1, it has been detected equivocating, so the committee doesn't include v2 or count its weight
-        result = c5 shouldBe Some(CommitteeWithConsensusValue(Set(v1, v3), 20, b1.blockHash))
+        result = c5 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v3), 20, b1.blockHash))
       } yield result
   }
 
@@ -420,7 +420,7 @@ class FinalityDetectorByVotingMatrixTest
                      bonds,
                      lfb = genesis
                    )
-        _ = c1 shouldBe None
+        _ = c1 shouldBe empty
         (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b1.blockHash),
                      genesis.blockHash,
@@ -429,7 +429,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v1 -> b1.blockHash),
                      lfb = genesis
                    )
-        _ = c2 shouldBe None
+        _ = c2 shouldBe empty
         // b1 and b3 are both created by v1 but don't cite each other
         (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(genesis.blockHash),
@@ -438,7 +438,7 @@ class FinalityDetectorByVotingMatrixTest
                      bonds,
                      lfb = genesis
                    )
-        _ = c3 shouldBe None
+        _ = c3 shouldBe empty
         // so v1 can be detected equivocating
         _ <- dag.getEquivocators.map(_ shouldBe Set(v1))
         (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](
@@ -449,7 +449,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v2 -> b2.blockHash),
                      lfb = genesis
                    )
-        _ = c4 shouldBe None
+        _ = c4 shouldBe empty
         (b5, c5) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b4.blockHash),
                      genesis.blockHash,
@@ -461,7 +461,10 @@ class FinalityDetectorByVotingMatrixTest
         // After creating b5, v2 knows v3 and himself vote for b1, and v3 knows v2 and
         // himself vote for b1, so v2 and v3 construct a committee.
         // So even b1 was created by v1 who equivocated, it gets finalized as having enough honest supporters
-        result = c5 shouldBe Some(CommitteeWithConsensusValue(Set(v2, v3), 20, b1.blockHash))
+        result = c5 shouldBe Seq(
+          CommitteeWithConsensusValue(Set(v2, v3), 20, b1.blockHash),
+          CommitteeWithConsensusValue(Set(v2, v3), 20, b2.blockHash)
+        )
       } yield result
   }
 
@@ -486,7 +489,7 @@ class FinalityDetectorByVotingMatrixTest
                      bonds,
                      lfb = genesis
                    )
-        _ = c1 shouldBe None
+        _ = c1 shouldBe empty
         (b2, c2) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b1.blockHash),
                      genesis.blockHash,
@@ -495,7 +498,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v1 -> b1.blockHash),
                      lfb = genesis
                    )
-        _ = c2 shouldBe None
+        _ = c2 shouldBe empty
         // b1 and b3 are both created by v1 but don't cite each other
         (b3, c3) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(genesis.blockHash),
@@ -504,7 +507,7 @@ class FinalityDetectorByVotingMatrixTest
                      bonds,
                      lfb = genesis
                    )
-        _ = c3 shouldBe None
+        _ = c3 shouldBe empty
         // so v1 can be detected equivocating
         _ <- dag.getEquivocators.map(_ shouldBe Set(v1))
         (b4, c4) <- createBlockAndUpdateFinalityDetector[Task](
@@ -515,7 +518,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v3 -> genesis.blockHash),
                      lfb = genesis
                    )
-        _ = c4 shouldBe None
+        _ = c4 shouldBe empty
         // b4 and b5 are both created by v3 but don't cite each other
         (b5, c5) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b2.blockHash),
@@ -525,7 +528,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v2 -> b2.blockHash),
                      lfb = genesis
                    )
-        _ = c5 shouldBe None
+        _ = c5 shouldBe empty
         // so v3 can be detected equivocating
         _ <- dag.getEquivocators.map(_ shouldBe Set(v1, v3))
         (b6, c6) <- createBlockAndUpdateFinalityDetector[Task](
@@ -536,7 +539,7 @@ class FinalityDetectorByVotingMatrixTest
                      HashMap(v3 -> b5.blockHash),
                      lfb = genesis
                    )
-        _ = c6 shouldBe None
+        _ = c6 shouldBe empty
         (b7, c7) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b5.blockHash),
                      genesis.blockHash,
@@ -546,7 +549,7 @@ class FinalityDetectorByVotingMatrixTest
                      lfb = genesis
                    )
         // After creating b7, all validators know they all vote for v1, but b1 still can not get finalized, because v1 and v3 equivocated
-        result = c7 shouldBe None
+        result = c7 shouldBe empty
       } yield result
   }
 
@@ -588,7 +591,7 @@ class FinalityDetectorByVotingMatrixTest
                        bonds,
                        lfb = genesis
                      )
-          _ = c1 shouldBe None
+          _ = c1 shouldBe empty
           (b1, c2) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(a0.blockHash),
                        a0.blockHash,
@@ -597,7 +600,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> a0.blockHash),
                        lfb = genesis
                      )
-          _ = c2 shouldBe None
+          _ = c2 shouldBe empty
           (c1, c3) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(b1.blockHash),
                        a0.blockHash,
@@ -606,7 +609,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> a0.blockHash, v2 -> b1.blockHash),
                        lfb = genesis
                      )
-          _ = c3 shouldBe None
+          _ = c3 shouldBe empty
           (a1, c4) <- createBlockAndUpdateFinalityDetector[Task](
                        Seq(c1.blockHash),
                        a0.blockHash,
@@ -615,7 +618,7 @@ class FinalityDetectorByVotingMatrixTest
                        HashMap(v1 -> a0.blockHash, v2 -> b1.blockHash, v3 -> c1.blockHash),
                        lfb = genesis
                      )
-          _ = c4 shouldBe none
+          _ = c4 shouldBe empty
         } yield ()
   }
 
@@ -631,7 +634,7 @@ class FinalityDetectorByVotingMatrixTest
       postStateHash: ByteString = ByteString.copyFromUtf8(scala.util.Random.nextString(64)),
       messageType: Block.MessageType = Block.MessageType.BLOCK,
       lfb: Block
-  ): F[(Block, Option[CommitteeWithConsensusValue])] =
+  ): F[(Block, Seq[CommitteeWithConsensusValue])] =
     for {
       block <- createMessage[F](
                 parentsHashList,

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -159,7 +159,7 @@ trait HighwayFixture
     implicit lazy val finalizer = new MultiParentFinalizer[Task] {
       override def onNewMessageAdded(
           message: Message
-      ): Task[Option[MultiParentFinalizer.FinalizedBlocks]] = none.pure[Task]
+      ): Task[Seq[MultiParentFinalizer.FinalizedBlocks]] = Seq.empty.pure[Task]
     }
 
     implicit lazy val deployBuffer = DeployBuffer.create[Task](chainName, minTtl = Duration.Zero)

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
@@ -367,11 +367,11 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
       override lazy val finalizer = new MultiParentFinalizer[Task] {
         override def onNewMessageAdded(
             message: Message
-        ) =
+        ): Task[Seq[MultiParentFinalizer.FinalizedBlocks]] =
           messageAddedRef
             .set(Some(message))
             .as(
-              Some(
+              Seq(
                 MultiParentFinalizer
                   .FinalizedBlocks(message.messageHash, BigInt(0), Set.empty, Set.empty)
               )

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageExecutorSpec.scala
@@ -368,14 +368,13 @@ class MessageExecutorSpec extends FlatSpec with Matchers with Inspectors with Hi
         override def onNewMessageAdded(
             message: Message
         ): Task[Seq[MultiParentFinalizer.FinalizedBlocks]] =
-          messageAddedRef
-            .set(Some(message))
-            .as(
-              Seq(
-                MultiParentFinalizer
-                  .FinalizedBlocks(message.messageHash, BigInt(0), Set.empty, Set.empty)
-              )
-            )
+          for {
+            _ <- messageAddedRef.set(Some(message))
+            _ <- FinalityStorage[Task].markAsFinalized(message.messageHash, Set.empty, Set.empty)
+          } yield Seq(
+            MultiParentFinalizer
+              .FinalizedBlocks(message.messageHash, BigInt(0), Set.empty, Set.empty)
+          )
       }
 
       override def test =


### PR DESCRIPTION
### Overview
This has an additional side-effect of producing more finalized blocks per message added to the DAG. If that message finalizes more than one block of course.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1315

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
