### PR TITLE
NO-TICKET: execution-engine: invert "highway" flag

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -108,8 +108,8 @@ build-contracts-rs: \
 	$(SYSTEM_CONTRACTS) \
 	$(TEST_CONTRACTS)
 
-build-contracts-highway-rs: FEATURES := highway
-build-contracts-highway-rs: \
+build-contracts-enable-bonding-rs: FEATURES := enable-bonding
+build-contracts-enable-bonding-rs: \
 	$(BENCH_CONTRACTS) \
 	$(CLIENT_CONTRACTS) \
 	$(EXAMPLE_CONTRACTS) \
@@ -157,10 +157,10 @@ test-contracts-rs: build-contracts-rs
 	$(CARGO) test $(CARGO_FLAGS) -p casperlabs-engine-tests -- --ignored --nocapture
 	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "use-system-contracts" -- --ignored --nocapture
 
-.PHONY: test-contracts-highway-rs
-test-contracts-highway-rs: build-contracts-highway-rs
-	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "highway" -- --ignored --nocapture
-	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "highway,use-system-contracts" -- --ignored --nocapture
+.PHONY: test-contracts-enable-bonding-rs
+test-contracts-enable-bonding-rs: build-contracts-enable-bonding-rs
+	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "enable-bonding" -- --ignored --nocapture
+	$(CARGO) test $(CARGO_FLAGS) --manifest-path "engine-tests/Cargo.toml" --features "enable-bonding,use-system-contracts" -- --ignored --nocapture
 
 .PHONY: test-contracts-as
 test-contracts-as: build-contracts-rs build-contracts-as
@@ -195,7 +195,7 @@ check-rs: \
 	audit \
 	test-rs \
 	test-contracts-rs \
-	test-contracts-highway-rs
+	test-contracts-enable-bonding-rs
 
 .PHONY: check
 check: \

--- a/execution-engine/contracts/system/pos-install/Cargo.toml
+++ b/execution-engine/contracts/system/pos-install/Cargo.toml
@@ -12,7 +12,7 @@ test = false
 
 [features]
 std = ["contract/std", "types/std"]
-highway = ["pos/highway"]
+enable-bonding = ["pos/enable-bonding"]
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }

--- a/execution-engine/contracts/system/pos/Cargo.toml
+++ b/execution-engine/contracts/system/pos/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [features]
 std = ["contract/std", "types/std"]
 lib = []
-highway = []
+enable-bonding = []
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -167,7 +167,7 @@ pub fn delegate() {
     match method_name.as_str() {
         // Type of this method: `fn bond(amount: U512, purse: URef)`
         METHOD_BOND => {
-            if cfg!(feature = "highway") {
+            if !cfg!(feature = "enable-bonding") {
                 runtime::revert(ApiError::Unhandled)
             }
 
@@ -184,7 +184,7 @@ pub fn delegate() {
         }
         // Type of this method: `fn unbond(amount: Option<U512>)`
         METHOD_UNBOND => {
-            if cfg!(feature = "highway") {
+            if !cfg!(feature = "enable-bonding") {
                 runtime::revert(ApiError::Unhandled)
             }
 

--- a/execution-engine/engine-core/src/engine_state/engine_config.rs
+++ b/execution-engine/engine-core/src/engine_state/engine_config.rs
@@ -3,7 +3,7 @@
 pub struct EngineConfig {
     // feature flags go here
     use_system_contracts: bool,
-    highway: bool,
+    enable_bonding: bool,
 }
 
 impl EngineConfig {
@@ -21,12 +21,12 @@ impl EngineConfig {
         self
     }
 
-    pub fn highway(self) -> bool {
-        self.highway
+    pub fn enable_bonding(self) -> bool {
+        self.enable_bonding
     }
 
-    pub fn with_highway(mut self, highway: bool) -> EngineConfig {
-        self.highway = highway;
+    pub fn with_enable_bonding(mut self, enable_bonding: bool) -> EngineConfig {
+        self.enable_bonding = enable_bonding;
         self
     }
 }

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -1838,7 +1838,7 @@ where
 
         let ret: CLValue = match method_name.as_str() {
             METHOD_BOND => {
-                if self.config.highway() {
+                if !self.config.enable_bonding() {
                     let err = Error::Revert(ApiError::Unhandled.into());
                     return Err(err);
                 }
@@ -1852,7 +1852,7 @@ where
                 CLValue::from_t(()).map_err(Self::reverter)?
             }
             METHOD_UNBOND => {
-                if self.config.highway() {
+                if !self.config.enable_bonding() {
                     let err = Error::Revert(ApiError::Unhandled.into());
                     return Err(err);
                 }

--- a/execution-engine/engine-grpc-server/src/engine_server/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mod.rs
@@ -450,11 +450,7 @@ where
         _request_options: RequestOptions,
         _bid_state_request: BidStateRequest,
     ) -> SingleResponse<BidStateResponse> {
-        if !self.config().highway() {
-            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
-        }
-        let response = BidStateResponse::new();
-        SingleResponse::completed(response)
+        SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()))
     }
 
     fn distribute_rewards(
@@ -462,11 +458,7 @@ where
         _request_options: RequestOptions,
         _distribute_rewards_request: DistributeRewardsRequest,
     ) -> SingleResponse<DistributeRewardsResponse> {
-        if !self.config().highway() {
-            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
-        }
-        let response = DistributeRewardsResponse::new();
-        SingleResponse::completed(response)
+        SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()))
     }
 
     fn slash(
@@ -474,11 +466,7 @@ where
         _request_options: RequestOptions,
         _slash_request: SlashRequest,
     ) -> SingleResponse<SlashResponse> {
-        if !self.config().highway() {
-            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
-        }
-        let response = SlashResponse::new();
-        SingleResponse::completed(response)
+        SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()))
     }
 
     fn unbond_payout(
@@ -486,11 +474,7 @@ where
         _request_options: RequestOptions,
         _unbond_payout_request: UnbondPayoutRequest,
     ) -> SingleResponse<UnbondPayoutResponse> {
-        if !self.config().highway() {
-            return SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()));
-        }
-        let response = UnbondPayoutResponse::new();
-        SingleResponse::completed(response)
+        SingleResponse::err(GrpcError::Panic(UNIMPLEMENTED.to_string()))
     }
 }
 

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -103,9 +103,9 @@ const ARG_USE_SYSTEM_CONTRACTS_HELP: &str =
     "Use system contracts instead of host-side logic for Mint, Proof of Stake and Standard Payment";
 
 // Highway
-const ARG_HIGHWAY: &str = "highway";
-const ARG_HIGHWAY_SHORT: &str = "w";
-const ARG_HIGHWAY_HELP: &str = "Highway consensus mode";
+const ARG_ENABLE_BONDING: &str = "enable-bonding";
+const ARG_ENABLE_BONDING_SHORT: &str = "b";
+const ARG_ENABLE_BONDING_HELP: &str = "Enable bonding";
 
 // runnable
 const SIGINT_HANDLE_EXPECT: &str = "Error setting Ctrl-C handler";
@@ -233,9 +233,9 @@ fn get_args() -> ArgMatches<'static> {
                 .help(ARG_USE_SYSTEM_CONTRACTS_HELP),
         )
         .arg(
-            Arg::with_name(ARG_HIGHWAY)
-                .short(ARG_HIGHWAY_SHORT)
-                .help(ARG_HIGHWAY_HELP),
+            Arg::with_name(ARG_ENABLE_BONDING)
+                .short(ARG_ENABLE_BONDING_SHORT)
+                .help(ARG_ENABLE_BONDING_HELP),
         )
         .arg(
             Arg::with_name(ARG_SOCKET)
@@ -301,10 +301,10 @@ fn get_thread_count(arg_matches: &ArgMatches) -> usize {
 fn get_engine_config(arg_matches: &ArgMatches) -> EngineConfig {
     // feature flags go here
     let use_system_contracts = arg_matches.is_present(ARG_USE_SYSTEM_CONTRACTS);
-    let highway = arg_matches.is_present(ARG_HIGHWAY);
+    let enable_bonding = arg_matches.is_present(ARG_ENABLE_BONDING);
     EngineConfig::new()
         .with_use_system_contracts(use_system_contracts)
-        .with_highway(highway)
+        .with_enable_bonding(enable_bonding)
 }
 
 /// Builds and returns a gRPC server.

--- a/execution-engine/engine-grpc-server/src/main.rs
+++ b/execution-engine/engine-grpc-server/src/main.rs
@@ -230,11 +230,13 @@ fn get_args() -> ArgMatches<'static> {
         .arg(
             Arg::with_name(ARG_USE_SYSTEM_CONTRACTS)
                 .short(ARG_USE_SYSTEM_CONTRACTS_SHORT)
+                .long(ARG_USE_SYSTEM_CONTRACTS)
                 .help(ARG_USE_SYSTEM_CONTRACTS_HELP),
         )
         .arg(
             Arg::with_name(ARG_ENABLE_BONDING)
                 .short(ARG_ENABLE_BONDING_SHORT)
+                .long(ARG_ENABLE_BONDING)
                 .help(ARG_ENABLE_BONDING_HELP),
         )
         .arg(

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -30,6 +30,6 @@ types = { version = "0.4.0", path = "../types", package = "casperlabs-types", fe
 version-sync = "0.8"
 
 [features]
-highway = []
+enable-bonding = []
 use-as-wasm = []
 use-system-contracts = []

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -102,7 +102,7 @@ impl Default for InMemoryWasmTestBuilder {
         Self::initialize_logging();
         let engine_config = EngineConfig::new()
             .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
-            .with_highway(cfg!(feature = "highway"));
+            .with_enable_bonding(cfg!(feature = "enable-bonding"));
 
         let global_state = InMemoryGlobalState::empty().expect("should create global state");
         let engine_state = EngineState::new(global_state, engine_config);

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -29,7 +29,7 @@ tempfile = "3"
 wabt = "0.9.2"
 
 [features]
-highway = ["engine-test-support/highway"]
+enable-bonding = ["engine-test-support/enable-bonding"]
 use-as-wasm = ["engine-test-support/use-as-wasm"]
 use-system-contracts = ["engine-test-support/use-system-contracts"]
 

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -49,7 +49,7 @@ fn bootstrap(data_dir: &Path, accounts: &[PublicKey], amount: U512) -> LmdbWasmT
 
     let engine_config = EngineConfig::new()
         .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
-        .with_highway(cfg!(feature = "highway"));
+        .with_enable_bonding(cfg!(feature = "enable-bonding"));
 
     let mut builder = LmdbWasmTestBuilder::new_with_config(data_dir, engine_config);
 

--- a/execution-engine/engine-tests/src/profiling/simple_transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple_transfer.rs
@@ -114,7 +114,7 @@ fn main() {
 
     let engine_config = EngineConfig::new()
         .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
-        .with_highway(cfg!(feature = "highway"));
+        .with_enable_bonding(cfg!(feature = "enable-bonding"));
 
     let mut test_builder = LmdbWasmTestBuilder::open(&args.data_dir, engine_config, root_hash);
 

--- a/execution-engine/engine-tests/src/test/regression/ee_597.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_597.rs
@@ -27,7 +27,7 @@ fn should_fail_when_bonding_amount_is_zero_ee_597_regression() {
 
     let error_message = utils::get_error_message(response);
 
-    if cfg!(feature = "highway") {
+    if !cfg!(feature = "enable-bonding") {
         assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::Unhandled))));
     } else {
         // Error::BondTooSmall => 5,

--- a/execution-engine/engine-tests/src/test/regression/ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_598.rs
@@ -74,7 +74,7 @@ fn should_fail_unboding_more_than_it_was_staked_ee_598_regression() {
         .to_owned();
     let error_message = utils::get_error_message(response);
 
-    if cfg!(feature = "highway") {
+    if !cfg!(feature = "enable-bonding") {
         assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::Unhandled))));
     } else {
         // Error::UnbondTooLarge => 7,

--- a/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/mint_install.rs
@@ -14,7 +14,7 @@ fn should_run_mint_install_contract() {
     let mut builder = WasmTestBuilder::default();
     let engine_config = EngineConfig::new()
         .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
-        .with_highway(cfg!(feature = "highway"));
+        .with_enable_bonding(cfg!(feature = "enable-bonding"));
 
     builder.run_genesis(&DEFAULT_GENESIS_CONFIG);
 

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -29,7 +29,7 @@ fn should_run_pos_install_contract() {
     let mut builder = WasmTestBuilder::default();
     let engine_config = EngineConfig::new()
         .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
-        .with_highway(cfg!(feature = "highway"));
+        .with_enable_bonding(cfg!(feature = "enable-bonding"));
 
     let exec_request = ExecuteRequestBuilder::standard(
         DEFAULT_ACCOUNT_ADDR,

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
@@ -79,7 +79,7 @@ fn should_run_successful_bond_and_unbond() {
     let mut builder = InMemoryWasmTestBuilder::from_result(result);
 
     let result = builder.exec(exec_request_1);
-    if cfg!(feature = "highway") && result.is_error() {
+    if !cfg!(feature = "enable-bonding") && result.is_error() {
         return;
     }
 
@@ -470,7 +470,7 @@ fn should_fail_bonding_with_insufficient_funds() {
 
     let error_message = utils::get_error_message(response);
 
-    if cfg!(feature = "highway") {
+    if !cfg!(feature = "enable-bonding") {
         assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::Unhandled))));
     } else {
         // pos::Error::BondTransferFailed => 8
@@ -517,7 +517,7 @@ fn should_fail_unbonding_validator_without_bonding_first() {
 
     let error_message = utils::get_error_message(response);
 
-    if cfg!(feature = "highway") {
+    if !cfg!(feature = "enable-bonding") {
         assert!(error_message.contains(&format!("Revert({})", u32::from(ApiError::Unhandled))));
     } else {
         // pos::Error::NotBonded => 0

--- a/integration-testing/casperlabs_local_net/docker_execution_engine.py
+++ b/integration-testing/casperlabs_local_net/docker_execution_engine.py
@@ -8,7 +8,7 @@ class DockerExecutionEngine(LoggingDockerBase):
 
     @property
     def command(self) -> str:
-        return f".casperlabs/sockets/.casper-node.sock"
+        return f"--enable-bonding .casperlabs/sockets/.casper-node.sock"
 
     @property
     def volumes(self) -> dict:


### PR DESCRIPTION
### Overview
This PR disables bonding & unbonding by default, allowing it to be enabled through an `--enable-bonding` flag, replacing the inverse "--highway" flag that existed before.

### Which JIRA ticket does this PR relate to?
This is unticketed work.

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
N/A
