### PR TITLE
NO-TICKET: Add native `getMainChildren` method to the `DagStorage`.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -21,6 +21,7 @@ import io.casperlabs.storage.dag.{
 import io.casperlabs.storage.dag.DagRepresentation.Validator
 import io.casperlabs.casper.mocks.MockFinalityStorage
 import io.casperlabs.casper.util.ByteStringPrettifier
+import cats.data.IndexedStateT
 
 class FinalityDetectorUtilTest
     extends FlatSpec
@@ -199,6 +200,9 @@ object FinalityDetectorUtilTest {
 
       // We're not interested in these
       override def children(blockHash: BlockHash): StateT[F, Map[BlockHash, Int], Set[BlockHash]] =
+        ???
+
+      override def getMainChildren(blockHash: io.casperlabs.storage.BlockHash): StateT[F, Map[BlockHash, Int], Set[BlockHash]] =
         ???
 
       /** Return blocks that having a specify justification */

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -202,7 +202,9 @@ object FinalityDetectorUtilTest {
       override def children(blockHash: BlockHash): StateT[F, Map[BlockHash, Int], Set[BlockHash]] =
         ???
 
-      override def getMainChildren(blockHash: io.casperlabs.storage.BlockHash): StateT[F, Map[BlockHash, Int], Set[BlockHash]] =
+      override def getMainChildren(
+          blockHash: io.casperlabs.storage.BlockHash
+      ): StateT[F, Map[BlockHash, Int], Set[BlockHash]] =
         ???
 
       /** Return blocks that having a specify justification */

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockBlockDagStorage.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockBlockDagStorage.scala
@@ -43,12 +43,13 @@ class MockBlockDagStorage[F[_]: Monad](
     override def lookup(blockHash: BlockHash) =
       messagesRef.get.map(_.get(blockHash))
 
-    override def children(blockHash: BlockHash)                         = ???
-    override def justificationToBlocks(blockHash: BlockHash)            = ???
-    override def contains(blockHash: BlockHash)                         = ???
-    override def topoSort(startBlockNumber: Long, endBlockNumber: Long) = ???
-    override def topoSort(startBlockNumber: Long)                       = ???
-    override def topoSortTail(tailLength: Int)                          = ???
+    override def children(blockHash: BlockHash)                           = ???
+    override def getMainChildren(blockHash: BlockHash): F[Set[BlockHash]] = ???
+    override def justificationToBlocks(blockHash: BlockHash)              = ???
+    override def contains(blockHash: BlockHash)                           = ???
+    override def topoSort(startBlockNumber: Long, endBlockNumber: Long)   = ???
+    override def topoSort(startBlockNumber: Long)                         = ???
+    override def topoSortTail(tailLength: Int)                            = ???
     override def getBlockInfosByValidator(
         validator: Validator,
         limit: Int,

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -148,6 +148,9 @@ object SQLiteStorage {
       override def children(blockHash: BlockHash): F[Set[BlockHash]] =
         dagStorage.children(blockHash)
 
+      override def getMainChildren(blockHash: BlockHash): F[Set[BlockHash]] =
+        dagStorage.getMainChildren(blockHash)
+
       override def justificationToBlocks(blockHash: BlockHash): F[Set[BlockHash]] =
         dagStorage.justificationToBlocks(blockHash)
 

--- a/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/CachingDagStorage.scala
@@ -102,6 +102,9 @@ class CachingDagStorage[F[_]: Concurrent](
       underlying.children(blockHash)
     )
 
+  override def getMainChildren(blockHash: BlockHash): F[Set[BlockHash]] =
+    underlying.getMainChildren(blockHash)
+
   /** Return blocks that having a specify justification */
   override def justificationToBlocks(blockHash: BlockHash): F[Set[BlockHash]] =
     cacheOrUnderlying(

--- a/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/SQLiteDagStorage.scala
@@ -214,6 +214,14 @@ class SQLiteDagStorage[F[_]: Sync](
       .to[Set]
       .transact(readXa)
 
+  override def getMainChildren(blockHash: BlockHash): F[Set[BlockHash]] =
+    sql"""|SELECT child_block_hash
+          |FROM block_parents
+          |WHERE parent_block_hash=$blockHash AND is_main=true""".stripMargin
+      .query[BlockHash]
+      .to[Set]
+      .transact(readXa)
+
   override def justificationToBlocks(blockHash: BlockHash): F[Set[BlockHash]] =
     sql"""|SELECT block_hash
           |FROM block_justifications


### PR DESCRIPTION
### Overview
Instead of doing multiple SQL queries make one - we have `is_main` flag in the SQL table.


### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
