### PR TITLE
NO-TICKET: Do not allow for empty `DeployConfig` in Genesis.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/DeploySelection.scala
@@ -150,7 +150,7 @@ object DeploySelection {
       ): F[DeploySelectionResult] = {
         // If size of accumulated deploys is over 90% of the block limit, stop consuming more deploys.
         def isOversized(state: IntermediateState) =
-          state.size > 0.9 * in.maxBlockSizeBytes && in.maxBlockSizeBytes > 0
+          state.size > 0.9 * in.maxBlockSizeBytes
 
         def go(
             state: IntermediateState,

--- a/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/ValidationTest.scala
@@ -73,7 +73,7 @@ class ValidationTest
   implicit val raiseValidateErr                       = validation.raiseValidateErrorThroughApplicativeError[Task]
   implicit val versions =
     CasperLabsProtocol.unsafe[Task](
-      (0L, state.ProtocolVersion(1), Some(DeployConfig(24 * 60 * 60 * 1000, 10)))
+      (0L, state.ProtocolVersion(1), Some(DeployConfig(24 * 60 * 60 * 1000, 10, 10 * 1024 * 1024)))
     )
 
   implicit val validationEff = new NCBValidationImpl[Task]()

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -29,11 +29,13 @@ import java.util.concurrent.TimeUnit
 import monix.catnap.SchedulerEffect
 import monix.eval.Task
 import monix.execution.schedulers.TestScheduler
+
 import scala.concurrent.duration._
 import org.scalatest.Suite
 import io.casperlabs.casper.util.execengine.ExecutionEngineServiceStub
 import io.casperlabs.casper.finality.MultiParentFinalizer
 import io.casperlabs.casper.util.ByteStringPrettifier
+import io.casperlabs.ipc.ChainSpec.DeployConfig
 import io.casperlabs.storage.dag.DagStorage
 
 trait HighwayFixture
@@ -173,7 +175,16 @@ trait HighwayFixture
 
     implicit val validationRaise = raiseValidateErrorThroughApplicativeError[Task]
     implicit val protocol = CasperLabsProtocol.unsafe[Task](
-      (0L, ProtocolVersion(0, 0, 0), none)
+      (
+        0L,
+        ProtocolVersion(0, 0, 0),
+        Some(
+          DeployConfig()
+            .withMaxTtlMillis(24 * 60 * 60 * 1000) // 1 day
+            .withMaxDependencies(10)
+            .withMaxBlockSizeBytes(10 * 1024 * 1024)
+        )
+      )
     )
     // While we're using the MockMessageProducer we can't fully validate blocks.
     implicit lazy val validation: Validation[Task] = new NoOpValidation[Task]

--- a/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/util/execengine/ExecEngineUtilTest.scala
@@ -322,7 +322,18 @@ class ExecEngineUtilTest
         .map(_.mapValues(_.toSet))
         .foldLeft(Map.empty[Int, Set[TransformEntry]])(_ |+| _)
 
-      implicit val cl = CasperLabsProtocol.unsafe[Task]((0, ProtocolVersion(1), None))
+      implicit val cl = CasperLabsProtocol.unsafe[Task](
+        (
+          0,
+          ProtocolVersion(1),
+          Some(
+            DeployConfig()
+              .withMaxTtlMillis(24 * 60 * 60 * 1000) // 1 day
+              .withMaxDependencies(10)
+              .withMaxBlockSizeBytes(10 * 1024 * 1024)
+          )
+        )
+      )
 
       val stageCounter = AtomicInt(0)
 

--- a/hack/docker/start_all.sh
+++ b/hack/docker/start_all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+#for i in {0..$CL_CASPER_NUM_VALIDATORS}; do
+for i in {0..5}; do
+	echo $i;
+done

--- a/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
@@ -410,7 +410,8 @@ object ChainSpecReader {
   private def toDeployConfig(deployConfig: Deploy): ipc.ChainSpec.DeployConfig =
     ipc.ChainSpec.DeployConfig(
       deployConfig.maxTtlMillis.value,
-      deployConfig.maxDependencies.value
+      deployConfig.maxDependencies.value,
+      deployConfig.maxBlockSizeBytes.value
     )
 
   private def toHighwayConfig(highwayConfig: Highway): ipc.ChainSpec.HighwayConfig =

--- a/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
@@ -65,7 +65,7 @@ object ChainSpec extends ParserImplicits {
   final case class Deploy(
       maxTtlMillis: Int Refined NonNegative,
       maxDependencies: Int Refined NonNegative,
-      maxBlockSizeBytes: Int Refined NonNegative
+      maxBlockSizeBytes: Int Refined Positive
   ) extends SubConfig
 
   /** The first set of changes should define the Genesis section and the costs. */


### PR DESCRIPTION
### Overview
Make sure there's a `DeployConfig` available in the merged chainspec configurations. Do not allow for 0 value.

### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
