### PR TITLE
NODE-1321: EraRuntime.initAgenda to handle future start time.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraRuntime.scala
@@ -522,14 +522,17 @@ class EraRuntime[F[_]: Sync: Clock: Metrics: Log: EraStorage: FinalityStorageRea
   def initAgenda: F[Agenda] =
     maybeMessageProducer.fold(Agenda.empty.pure[F]) { _ =>
       currentTick flatMap { tick =>
-        isEraOverAt(tick).ifM(
-          Agenda.empty.pure[F],
-          roundBoundariesAt(tick) flatMap {
-            case (from, to) =>
-              val roundId = if (from >= tick) from else to
-              Agenda(roundId -> StartRound(roundId)).pure[F]
-          }
-        )
+        if (tick < startTick)
+          Agenda(startTick -> StartRound(startTick)).pure[F]
+        else
+          isEraOverAt(tick).ifM(
+            Agenda.empty.pure[F],
+            roundBoundariesAt(tick) flatMap {
+              case (from, to) =>
+                val roundId = if (from >= tick) from else to
+                Agenda(roundId -> StartRound(roundId)).pure[F]
+            }
+          )
       }
     }
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -583,6 +583,17 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
         genesisEraRuntime(validator = "Alice".some).initAgenda shouldBe empty
       }
     }
+
+    "the era hasn't started yet" should {
+      "schedule the first round for the beginning" in {
+        implicit val clock = TestClock.frozen[Id](conf.genesisEraStart minus 8.hours)
+        val runtime        = genesisEraRuntime(validator = "Alice".some)
+        val agenda         = runtime.initAgenda
+        agenda should have size 1
+        agenda.head.tick shouldBe runtime.startTick
+        agenda.head.action shouldBe Agenda.StartRound(runtime.startTick)
+      }
+    }
   }
 
   "handleMessage" when {


### PR DESCRIPTION
### Overview
Handles the case when the genesis era start time is in the future. This allows all validators to start their machines before the block processing would commence, and they should all start producing blocks as soon as the genesis era starts.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1321

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
