### PR TITLE
NO-TICKET: Refactor `alloc_bytes` to be stable.

### DIFF
--- a/execution-engine/contract/src/contract_api/account.rs
+++ b/execution-engine/contract/src/contract_api/account.rs
@@ -18,8 +18,12 @@ use crate::{contract_api, ext_ffi, unwrap_or_revert::UnwrapOrRevert};
 pub fn get_main_purse() -> URef {
     let dest_ptr = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
     let bytes = unsafe {
-        ext_ffi::get_main_purse(dest_ptr);
-        Vec::from_raw_parts(dest_ptr, UREF_SERIALIZED_LENGTH, UREF_SERIALIZED_LENGTH)
+        ext_ffi::get_main_purse(dest_ptr.as_ptr());
+        Vec::from_raw_parts(
+            dest_ptr.as_ptr(),
+            UREF_SERIALIZED_LENGTH,
+            UREF_SERIALIZED_LENGTH,
+        )
     };
     bytesrepr::deserialize(bytes).unwrap_or_revert()
 }

--- a/execution-engine/contract/src/contract_api/account.rs
+++ b/execution-engine/contract/src/contract_api/account.rs
@@ -16,11 +16,11 @@ use crate::{contract_api, ext_ffi, unwrap_or_revert::UnwrapOrRevert};
 
 /// Retrieves the ID of the account's main purse.
 pub fn get_main_purse() -> URef {
-    let dest_ptr = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
+    let dest_non_null_ptr = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
     let bytes = unsafe {
-        ext_ffi::get_main_purse(dest_ptr.as_ptr());
+        ext_ffi::get_main_purse(dest_non_null_ptr.as_ptr());
         Vec::from_raw_parts(
-            dest_ptr.as_ptr(),
+            dest_non_null_ptr.as_ptr(),
             UREF_SERIALIZED_LENGTH,
             UREF_SERIALIZED_LENGTH,
         )

--- a/execution-engine/contract/src/contract_api/mod.rs
+++ b/execution-engine/contract/src/contract_api/mod.rs
@@ -6,30 +6,31 @@ pub mod storage;
 pub mod system;
 
 use alloc::{
-    alloc::{AllocRef, Global, Layout},
+    alloc::{alloc, Layout},
     vec::Vec,
 };
+use core::{mem, ptr::NonNull};
 
 use casperlabs_types::{bytesrepr::ToBytes, ApiError};
 
 use crate::unwrap_or_revert::UnwrapOrRevert;
 
-#[allow(clippy::zero_ptr)]
-fn alloc_bytes(n: usize) -> *mut u8 {
-    if n == 0 {
-        // cannot allocate with size 0
-        0 as *mut u8
-    } else {
-        let layout = Layout::array::<u8>(n)
-            .map_err(|_| ApiError::AllocLayout)
-            .unwrap_or_revert();
-        Global
-            .alloc(layout)
-            .map(|(non_null_ptr, _size)| non_null_ptr)
-            .map_err(|_| ApiError::OutOfMemory)
-            .unwrap_or_revert()
-            .as_ptr()
-    }
+/// Calculates size and alignment for an array of T.
+const fn size_align_for_array<T>(n: usize) -> (usize, usize) {
+    (n * mem::size_of::<T>(), mem::align_of::<T>())
+}
+
+fn alloc_bytes(n: usize) -> NonNull<u8> {
+    let (size, align) = size_align_for_array::<u8>(n);
+    // We treat allocated memory as raw bytes, that will be later passed to deserializer which also
+    // operates on raw bytes.
+    let layout = Layout::from_size_align(size, align)
+        .map_err(|_| ApiError::AllocLayout)
+        .unwrap_or_revert();
+    let raw_ptr = unsafe { alloc(layout) };
+    NonNull::new(raw_ptr)
+        .ok_or(ApiError::OutOfMemory)
+        .unwrap_or_revert()
 }
 
 fn to_ptr<T: ToBytes>(t: T) -> (*const u8, usize, Vec<u8>) {

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -74,7 +74,7 @@ pub fn call_contract<A: ArgsParser, T: CLTyped + FromBytes>(c_ptr: ContractRef, 
         // here causes several contracts to fail with a Wasmi `Unreachable` error.
         let bytes_ptr = contract_api::alloc_bytes(bytes_written);
         let mut dest: Vec<u8> =
-            unsafe { Vec::from_raw_parts(bytes_ptr, bytes_written, bytes_written) };
+            unsafe { Vec::from_raw_parts(bytes_ptr.as_ptr(), bytes_written, bytes_written) };
         read_host_buffer_into(&mut dest).unwrap_or_revert();
         dest
     };
@@ -116,16 +116,18 @@ fn get_arg_size(i: u32) -> Option<usize> {
 /// is not invoked with any arguments.
 pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
     let arg_size = get_arg_size(i)?;
-
-    let arg_bytes = {
+    let arg_bytes = if arg_size > 0 {
         let res = {
             let data_ptr = contract_api::alloc_bytes(arg_size);
-            let ret = unsafe { ext_ffi::get_arg(i as usize, data_ptr, arg_size) };
-            let data = unsafe { Vec::from_raw_parts(data_ptr, arg_size, arg_size) };
+            let ret = unsafe { ext_ffi::get_arg(i as usize, data_ptr.as_ptr(), arg_size) };
+            let data = unsafe { Vec::from_raw_parts(data_ptr.as_ptr(), arg_size, arg_size) };
             api_error::result_from(ret).map(|_| data)
         };
         // Assumed to be safe as `get_arg_size` checks the argument already
         res.unwrap_or_revert()
+    } else {
+        // Avoids allocation with 0 bytes and a call to get_arg
+        Vec::new()
     };
     Some(bytesrepr::deserialize(arg_bytes))
 }
@@ -147,9 +149,9 @@ pub fn get_caller() -> PublicKey {
 pub fn get_blocktime() -> BlockTime {
     let dest_ptr = contract_api::alloc_bytes(BLOCKTIME_SERIALIZED_LENGTH);
     let bytes = unsafe {
-        ext_ffi::get_blocktime(dest_ptr);
+        ext_ffi::get_blocktime(dest_ptr.as_ptr());
         Vec::from_raw_parts(
-            dest_ptr,
+            dest_ptr.as_ptr(),
             BLOCKTIME_SERIALIZED_LENGTH,
             BLOCKTIME_SERIALIZED_LENGTH,
         )
@@ -160,9 +162,14 @@ pub fn get_blocktime() -> BlockTime {
 /// Returns the current [`Phase`].
 pub fn get_phase() -> Phase {
     let dest_ptr = contract_api::alloc_bytes(PHASE_SERIALIZED_LENGTH);
-    unsafe { ext_ffi::get_phase(dest_ptr) };
-    let bytes =
-        unsafe { Vec::from_raw_parts(dest_ptr, PHASE_SERIALIZED_LENGTH, PHASE_SERIALIZED_LENGTH) };
+    unsafe { ext_ffi::get_phase(dest_ptr.as_ptr()) };
+    let bytes = unsafe {
+        Vec::from_raw_parts(
+            dest_ptr.as_ptr(),
+            PHASE_SERIALIZED_LENGTH,
+            PHASE_SERIALIZED_LENGTH,
+        )
+    };
     bytesrepr::deserialize(bytes).unwrap_or_revert()
 }
 
@@ -264,8 +271,12 @@ fn read_host_buffer_into(dest: &mut [u8]) -> Result<usize, ApiError> {
 }
 
 pub(crate) fn read_host_buffer(size: usize) -> Result<Vec<u8>, ApiError> {
-    let bytes_ptr = contract_api::alloc_bytes(size);
-    let mut dest: Vec<u8> = unsafe { Vec::from_raw_parts(bytes_ptr, size, size) };
+    let mut dest: Vec<u8> = if size == 0 {
+        Vec::new()
+    } else {
+        let bytes_ptr = contract_api::alloc_bytes(size);
+        unsafe { Vec::from_raw_parts(bytes_ptr.as_ptr(), size, size) }
+    };
     read_host_buffer_into(&mut dest)?;
     Ok(dest)
 }

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -72,9 +72,9 @@ pub fn call_contract<A: ArgsParser, T: CLTyped + FromBytes>(c_ptr: ContractRef, 
     } else {
         // NOTE: this is a copy of the contents of `read_host_buffer()`.  Calling that directly from
         // here causes several contracts to fail with a Wasmi `Unreachable` error.
-        let bytes_ptr = contract_api::alloc_bytes(bytes_written);
+        let bytes_non_null_ptr = contract_api::alloc_bytes(bytes_written);
         let mut dest: Vec<u8> =
-            unsafe { Vec::from_raw_parts(bytes_ptr.as_ptr(), bytes_written, bytes_written) };
+            unsafe { Vec::from_raw_parts(bytes_non_null_ptr.as_ptr(), bytes_written, bytes_written) };
         read_host_buffer_into(&mut dest).unwrap_or_revert();
         dest
     };
@@ -118,9 +118,9 @@ pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
     let arg_size = get_arg_size(i)?;
     let arg_bytes = if arg_size > 0 {
         let res = {
-            let data_ptr = contract_api::alloc_bytes(arg_size);
-            let ret = unsafe { ext_ffi::get_arg(i as usize, data_ptr.as_ptr(), arg_size) };
-            let data = unsafe { Vec::from_raw_parts(data_ptr.as_ptr(), arg_size, arg_size) };
+            let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
+            let ret = unsafe { ext_ffi::get_arg(i as usize, data_non_null_ptr.as_ptr(), arg_size) };
+            let data = unsafe { Vec::from_raw_parts(data_non_null_ptr.as_ptr(), arg_size, arg_size) };
             api_error::result_from(ret).map(|_| data)
         };
         // Assumed to be safe as `get_arg_size` checks the argument already
@@ -147,11 +147,11 @@ pub fn get_caller() -> PublicKey {
 
 /// Returns the current [`BlockTime`].
 pub fn get_blocktime() -> BlockTime {
-    let dest_ptr = contract_api::alloc_bytes(BLOCKTIME_SERIALIZED_LENGTH);
+    let dest_non_null_ptr = contract_api::alloc_bytes(BLOCKTIME_SERIALIZED_LENGTH);
     let bytes = unsafe {
-        ext_ffi::get_blocktime(dest_ptr.as_ptr());
+        ext_ffi::get_blocktime(dest_non_null_ptr.as_ptr());
         Vec::from_raw_parts(
-            dest_ptr.as_ptr(),
+            dest_non_null_ptr.as_ptr(),
             BLOCKTIME_SERIALIZED_LENGTH,
             BLOCKTIME_SERIALIZED_LENGTH,
         )
@@ -161,11 +161,11 @@ pub fn get_blocktime() -> BlockTime {
 
 /// Returns the current [`Phase`].
 pub fn get_phase() -> Phase {
-    let dest_ptr = contract_api::alloc_bytes(PHASE_SERIALIZED_LENGTH);
-    unsafe { ext_ffi::get_phase(dest_ptr.as_ptr()) };
+    let dest_non_null_ptr = contract_api::alloc_bytes(PHASE_SERIALIZED_LENGTH);
+    unsafe { ext_ffi::get_phase(dest_non_null_ptr.as_ptr()) };
     let bytes = unsafe {
         Vec::from_raw_parts(
-            dest_ptr.as_ptr(),
+            dest_non_null_ptr.as_ptr(),
             PHASE_SERIALIZED_LENGTH,
             PHASE_SERIALIZED_LENGTH,
         )
@@ -274,8 +274,8 @@ pub(crate) fn read_host_buffer(size: usize) -> Result<Vec<u8>, ApiError> {
     let mut dest: Vec<u8> = if size == 0 {
         Vec::new()
     } else {
-        let bytes_ptr = contract_api::alloc_bytes(size);
-        unsafe { Vec::from_raw_parts(bytes_ptr.as_ptr(), size, size) }
+        let bytes_non_null_ptr = contract_api::alloc_bytes(size);
+        unsafe { Vec::from_raw_parts(bytes_non_null_ptr.as_ptr(), size, size) }
     };
     read_host_buffer_into(&mut dest)?;
     Ok(dest)

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -73,8 +73,9 @@ pub fn call_contract<A: ArgsParser, T: CLTyped + FromBytes>(c_ptr: ContractRef, 
         // NOTE: this is a copy of the contents of `read_host_buffer()`.  Calling that directly from
         // here causes several contracts to fail with a Wasmi `Unreachable` error.
         let bytes_non_null_ptr = contract_api::alloc_bytes(bytes_written);
-        let mut dest: Vec<u8> =
-            unsafe { Vec::from_raw_parts(bytes_non_null_ptr.as_ptr(), bytes_written, bytes_written) };
+        let mut dest: Vec<u8> = unsafe {
+            Vec::from_raw_parts(bytes_non_null_ptr.as_ptr(), bytes_written, bytes_written)
+        };
         read_host_buffer_into(&mut dest).unwrap_or_revert();
         dest
     };
@@ -120,7 +121,8 @@ pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
         let res = {
             let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
             let ret = unsafe { ext_ffi::get_arg(i as usize, data_non_null_ptr.as_ptr(), arg_size) };
-            let data = unsafe { Vec::from_raw_parts(data_non_null_ptr.as_ptr(), arg_size, arg_size) };
+            let data =
+                unsafe { Vec::from_raw_parts(data_non_null_ptr.as_ptr(), arg_size, arg_size) };
             api_error::result_from(ret).map(|_| data)
         };
         // Assumed to be safe as `get_arg_size` checks the argument already

--- a/execution-engine/contract/src/contract_api/storage.rs
+++ b/execution-engine/contract/src/contract_api/storage.rs
@@ -140,13 +140,13 @@ pub fn store_function_at_hash(name: &str, named_keys: BTreeMap<String, Key>) -> 
 
 /// Returns a new unforgeable pointer, where the value is initialized to `init`.
 pub fn new_uref<T: CLTyped + ToBytes>(init: T) -> URef {
-    let key_ptr = contract_api::alloc_bytes(Key::max_serialized_length());
+    let key_non_null_ptr = contract_api::alloc_bytes(Key::max_serialized_length());
     let cl_value = CLValue::from_t(init).unwrap_or_revert();
     let (cl_value_ptr, cl_value_size, _cl_value_bytes) = contract_api::to_ptr(cl_value);
     let bytes = unsafe {
-        ext_ffi::new_uref(key_ptr.as_ptr(), cl_value_ptr, cl_value_size); // URef has `READ_ADD_WRITE`
+        ext_ffi::new_uref(key_non_null_ptr.as_ptr(), cl_value_ptr, cl_value_size); // URef has `READ_ADD_WRITE`
         Vec::from_raw_parts(
-            key_ptr.as_ptr(),
+            key_non_null_ptr.as_ptr(),
             KEY_UREF_SERIALIZED_LENGTH,
             KEY_UREF_SERIALIZED_LENGTH,
         )

--- a/execution-engine/contract/src/contract_api/storage.rs
+++ b/execution-engine/contract/src/contract_api/storage.rs
@@ -144,9 +144,9 @@ pub fn new_uref<T: CLTyped + ToBytes>(init: T) -> URef {
     let cl_value = CLValue::from_t(init).unwrap_or_revert();
     let (cl_value_ptr, cl_value_size, _cl_value_bytes) = contract_api::to_ptr(cl_value);
     let bytes = unsafe {
-        ext_ffi::new_uref(key_ptr, cl_value_ptr, cl_value_size); // URef has `READ_ADD_WRITE`
+        ext_ffi::new_uref(key_ptr.as_ptr(), cl_value_ptr, cl_value_size); // URef has `READ_ADD_WRITE`
         Vec::from_raw_parts(
-            key_ptr,
+            key_ptr.as_ptr(),
             KEY_UREF_SERIALIZED_LENGTH,
             KEY_UREF_SERIALIZED_LENGTH,
         )

--- a/execution-engine/contract/src/contract_api/system.rs
+++ b/execution-engine/contract/src/contract_api/system.rs
@@ -67,12 +67,12 @@ pub fn get_standard_payment() -> ContractRef {
 
 /// Creates a new empty purse and returns its [`URef`].
 pub fn create_purse() -> URef {
-    let purse = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
+    let purse_non_null_ptr = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
     unsafe {
-        let ret = ext_ffi::create_purse(purse.as_ptr(), UREF_SERIALIZED_LENGTH);
+        let ret = ext_ffi::create_purse(purse_non_null_ptr.as_ptr(), UREF_SERIALIZED_LENGTH);
         if ret == 0 {
             let bytes = Vec::from_raw_parts(
-                purse.as_ptr(),
+                purse_non_null_ptr.as_ptr(),
                 UREF_SERIALIZED_LENGTH,
                 UREF_SERIALIZED_LENGTH,
             );

--- a/execution-engine/contract/src/contract_api/system.rs
+++ b/execution-engine/contract/src/contract_api/system.rs
@@ -69,9 +69,13 @@ pub fn get_standard_payment() -> ContractRef {
 pub fn create_purse() -> URef {
     let purse = contract_api::alloc_bytes(UREF_SERIALIZED_LENGTH);
     unsafe {
-        let ret = ext_ffi::create_purse(purse, UREF_SERIALIZED_LENGTH);
+        let ret = ext_ffi::create_purse(purse.as_ptr(), UREF_SERIALIZED_LENGTH);
         if ret == 0 {
-            let bytes = Vec::from_raw_parts(purse, UREF_SERIALIZED_LENGTH, UREF_SERIALIZED_LENGTH);
+            let bytes = Vec::from_raw_parts(
+                purse.as_ptr(),
+                UREF_SERIALIZED_LENGTH,
+                UREF_SERIALIZED_LENGTH,
+            );
             bytesrepr::deserialize(bytes).unwrap_or_revert()
         } else {
             runtime::revert(ApiError::PurseNotCreated)


### PR DESCRIPTION
### Overview

Previously we've used Global trait directly, which proven to be
unstable, and changing often without us noticing. In this PR I've used
`alloc` function which might be deprecated in future in favor of Global
trait if ever it will become stable. This way we can have stable
function until deprecation notice and further refactor, although it
shouldn't be affected to internal API changes of unstable features.

This also doesn't pass null pointer through FFI, or doesn't try to
allocate zero sized arrays - which according to the docs is UB, but
tries to handle the zero sized allocation at call site by creating empty
vector.

Co-authored-by: Fraser Hutchison <fraser@casperlabs.io>


### Which JIRA ticket does this PR relate to?

NO-TICKET

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
