### PR TITLE
NO-TICKET: bump ee versions (changes only)

### DIFF
--- a/execution-engine/cargo-casperlabs/Cargo.toml
+++ b/execution-engine/cargo-casperlabs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casperlabs"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Command line tool for creating a Wasm smart contract and tests for use on the CasperLabs network."

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -105,7 +105,7 @@ lazy_static! {
         .join("src/integration_tests.rs");
     static ref ENGINE_TEST_SUPPORT: Dependency = Dependency::new(
         "casperlabs-engine-test-support",
-        "0.5.0",
+        "0.6.0",
         "engine-test-support"
     );
     static ref CARGO_TOML_ADDITIONAL_CONTENTS: String = format!(

--- a/execution-engine/contract-as/.npmrc
+++ b/execution-engine/contract-as/.npmrc
@@ -1,0 +1,1 @@
+unsafe-perm = true

--- a/execution-engine/contract-as/package.json
+++ b/execution-engine/contract-as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casperlabs/contract",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Library for developing CasperLabs smart contracts.",
   "main": "index.js",
   "ascMain": "assembly/index.ts",

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-core"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Main component of the CasperLabs Wasm execution engine."
@@ -20,7 +20,7 @@ base16 = "0.2.1"
 blake2 = "0.8.1"
 contract = { version = "0.4.0", path = "../contract",  package = "casperlabs-contract", features = ["std"] }
 engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-storage = { version = "0.4.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
+engine-storage = { version = "0.5.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
 engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 failure = "0.1.6"
 hex_fmt = "0.3.0"

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-grpc-server"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Wasm execution engine for CasperLabs smart contracts."
@@ -22,9 +22,9 @@ include = [
 clap = "2"
 ctrlc = "3"
 dirs = "2"
-engine-core = { version = "0.4.0", path = "../engine-core", package = "casperlabs-engine-core" }
+engine-core = { version = "0.5.0", path = "../engine-core", package = "casperlabs-engine-core" }
 engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-storage = { version = "0.4.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
+engine-storage = { version = "0.5.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
 engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 grpc = "0.6.1"
 lmdb = "0.8"

--- a/execution-engine/engine-storage/Cargo.toml
+++ b/execution-engine/engine-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-storage"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 description = "Storage component of the CasperLabs Wasm execution engine."

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-test-support"
-version = "0.5.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.6.0" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the CasperLabs network."
@@ -12,10 +12,10 @@ license-file = "../../LICENSE"
 
 [dependencies]
 contract = { version = "0.4.0", path = "../contract", package = "casperlabs-contract" }
-engine-core = { version = "0.4.0", path = "../engine-core", package = "casperlabs-engine-core" }
-engine-grpc-server = { version = "0.16.0", path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
+engine-core = { version = "0.5.0", path = "../engine-core", package = "casperlabs-engine-core" }
+engine-grpc-server = { version = "0.17.0", path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
 engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-storage = { version = "0.4.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
+engine-storage = { version = "0.5.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
 engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 grpc = "0.6.1"
 lazy_static = "1"

--- a/execution-engine/engine-test-support/src/lib.rs
+++ b/execution-engine/engine-test-support/src/lib.rs
@@ -54,7 +54,7 @@
 //! assert_eq!(expected_value, returned_value);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/casperlabs-engine-test-support/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/casperlabs-engine-test-support/0.6.0")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR bumps updated EE crate versions and AssemblyScript npm package version.

This PR is not ticketed.

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR adds no features.
- [X] This PR is assigned.