### PR TITLE
NO-TICKET: bump contract-as lockfile version

### DIFF
--- a/execution-engine/contract-as/package-lock.json
+++ b/execution-engine/contract-as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@casperlabs/contract",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR fixes a lock file version discrepancy.

- [X] This PR contains 1 line of generated code
