### PR TITLE
NODE-1325: Retry node start on "Failed to bind"

### DIFF
--- a/integration-testing/casperlabs_local_net/wait.py
+++ b/integration-testing/casperlabs_local_net/wait.py
@@ -41,10 +41,19 @@ class LogsContainOneOf:
 
     def __str__(self) -> str:
         args = ", ".join(repr(a) for a in (self.node.name, str(self.messages)))
-        return "<{}({})>".format(self.__class__.__name__, args)
+        return "<{}>".format(self.__class__.__name__)
 
     def is_satisfied(self) -> bool:
         return any(m in self.node.logs() for m in self.messages)
+
+
+LISTENING_FOR_TRAFFIC = "Listening for traffic on peer=casperlabs://"
+FAILED_TO_BIND = "java.io.IOException: Failed to bind"
+
+
+class NodeStartedOrFailedToBind(LogsContainOneOf):
+    def __init__(self, node: DockerNode):
+        super().__init__(node, [LISTENING_FOR_TRAFFIC, FAILED_TO_BIND])
 
 
 class NodeStarted(LogsContainMessage):
@@ -411,16 +420,6 @@ def wait_for_new_fork_choice_tip_block(
     wait_on_using_wall_clock_time(predicate, timeout_seconds)
 
 
-def wait_for_finished_adding_block(node: DockerNode, block: str, timeout_seconds: int):
-    predicate = FinishedAddingBlock(node, block)
-    wait_on_using_wall_clock_time(predicate, timeout_seconds)
-
-
-def wait_for_added_block(node: DockerNode, block: str, timeout_seconds: int):
-    predicate = AddedBlock(node, block)
-    wait_on_using_wall_clock_time(predicate, timeout_seconds)
-
-
 def wait_for_genesis_block(node: DockerNode, timeout_seconds: int = 60):
     predicate = BlocksCountAtLeast(node, 1, 1)
     wait_using_wall_clock_time_or_fail(predicate, timeout_seconds)
@@ -445,6 +444,11 @@ def wait_for_block_hashes_propagated_to_all_nodes(
 def wait_for_node_started(node: DockerNode, startup_timeout: int, times: int = 1):
     predicate = NodeStarted(node, times)
     wait_on_using_wall_clock_time(predicate, startup_timeout)
+
+
+def node_started_and_not_failed_to_bind(node: DockerNode, startup_timeout: int = 60):
+    wait_on_using_wall_clock_time(NodeStartedOrFailedToBind(node), startup_timeout)
+    return FAILED_TO_BIND not in node.logs()
 
 
 def wait_for_approved_block_received_handler_state(

--- a/integration-testing/test/test_network_topology_R2.py
+++ b/integration-testing/test/test_network_topology_R2.py
@@ -14,23 +14,6 @@ def test_metrics_api_socket(two_node_network):
         assert exit_code == 0, "Could not get the metrics for node {node.name}"
 
 
-def check_blocks(node, expected_string, network, context, block_hash):
-    logging.info("Check all peer logs for blocks containing {}".format(expected_string))
-
-    other_nodes = [n for n in network.nodes if n.container.name != node.container.name]
-
-    for node in other_nodes:
-        wait_for_block_contains(
-            node, block_hash, expected_string, context.receive_timeout
-        )
-
-
-def mk_expected_string(node, random_token):
-    return "<{name}:{random_token}>".format(
-        name=node.container.name, random_token=random_token
-    )
-
-
 def test_star_network(star_network):
     # Deploy on one of the star edge nodes.
     node1 = star_network.docker_nodes[1]
@@ -38,5 +21,4 @@ def test_star_network(star_network):
         GENESIS_ACCOUNT, Contract.HELLO_NAME_DEFINE
     )
     # Validate all nodes get block.
-    for node in star_network.docker_nodes:
-        wait_for_block_hash_propagated_to_all_nodes([node], block_hash)
+    wait_for_block_hash_propagated_to_all_nodes(star_network.docker_nodes, block_hash)


### PR DESCRIPTION
### Overview
This PR attempts to fix non-deterministic failure in CI that happened a few times after integration tests in CI were parallelized.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1325

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
