### PR TITLE
NO-TICKET: testnet patch version bump

### DIFF
--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -105,7 +105,7 @@ lazy_static! {
         .join("src/integration_tests.rs");
     static ref ENGINE_TEST_SUPPORT: Dependency = Dependency::new(
         "casperlabs-engine-test-support",
-        "0.6.0",
+        "0.6.1",
         "engine-test-support"
     );
     static ref CARGO_TOML_ADDITIONAL_CONTENTS: String = format!(

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-test-support"
-version = "0.6.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.6.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the CasperLabs network."

--- a/execution-engine/engine-test-support/src/lib.rs
+++ b/execution-engine/engine-test-support/src/lib.rs
@@ -54,7 +54,7 @@
 //! assert_eq!(expected_value, returned_value);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/casperlabs-engine-test-support/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/casperlabs-engine-test-support/0.6.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR bumps the version patch for cargo-casperlabs and engine-test-support
