### PR TITLE
NODE-1346: Mark descendant tombstones as faulty and retry later

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -152,18 +152,18 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
       source: Node
   ): Set[Identifier] = {
     def loop(
-        visited: Set[Identifier],
+        acc: Set[Identifier],
         queue: Queue[Identifier]
     ): Set[Identifier] =
-      queue.dequeueOption.fold(visited) {
-        case (id, queue) if visited(id) =>
-          loop(visited, queue)
+      queue.dequeueOption.fold(acc) {
+        case (id, queue) if acc(id) =>
+          loop(acc, queue)
         case (id, queue) =>
           items.get(id) match {
             case Some(item) if item.isError || !item.sources(source) =>
-              loop(visited + id, queue ++ item.dependencies)
+              loop(acc + id, queue ++ item.dependencies)
             case _ =>
-              loop(visited, queue)
+              loop(acc, queue)
           }
       }
 
@@ -178,18 +178,18 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
       id: Identifier
   ): Set[Identifier] = {
     def loop(
-        visited: Set[Identifier],
+        acc: Set[Identifier],
         queue: Queue[Identifier]
     ): Set[Identifier] =
-      queue.dequeueOption.fold(visited) {
-        case (id, queue) if visited(id) =>
-          loop(visited, queue)
+      queue.dequeueOption.fold(acc) {
+        case (id, queue) if acc(id) =>
+          loop(acc, queue)
 
         case (id, queue) =>
           val dependants = items.collect {
             case (hash, dep) if dep.dependencies contains id => hash
           }
-          loop(visited + id, queue ++ dependants)
+          loop(acc + id, queue ++ dependants)
       }
 
     loop(Set.empty, Queue(id)) - id

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -158,12 +158,13 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
       queue.dequeueOption.fold(visited) {
         case (id, queue) if visited(id) =>
           loop(visited, queue)
-        case (id, queue) if !items.contains(id) =>
-          loop(visited, queue)
-        case (id, queue) if items(id).sources(source) =>
-          loop(visited, queue)
         case (id, queue) =>
-          loop(visited + id, queue ++ items(id).dependencies)
+          items.get(id) match {
+            case Some(item) if item.isError || !item.sources(source) =>
+              loop(visited + id, queue ++ item.dependencies)
+            case _ =>
+              loop(visited, queue)
+          }
       }
 
     loop(Set.empty, Queue(id)) - id


### PR DESCRIPTION
### Overview
The `addSource` optimisation had the unintended side effect of again defeating the retry mechanism of failed downloads. Fixing that now by marking all descendants in the download manager as faulty, so that next time `addSource` sees them it travels them even if the source isn't new.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1346

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
In theory we could remove the cache busting of the synchronizer, but it should be tested first for race conditions.
