### PR TITLE
NODE-1353: Remove isHighway from MultiParentFinalizer.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -559,8 +559,7 @@ object MultiParentCasperImpl {
       implicit0(multiParentFinalizer: MultiParentFinalizer[F]) <- MultiParentFinalizer.create[F](
                                                                    dag,
                                                                    lfb,
-                                                                   finalityDetector,
-                                                                   isHighway = false
+                                                                   finalityDetector
                                                                  )
     } yield new MultiParentCasperImpl[F](
       semaphoreMap,

--- a/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/MultiParentFinalizer.scala
@@ -54,8 +54,7 @@ object MultiParentFinalizer {
   def create[F[_]: Concurrent: FinalityStorage: Metrics](
       dag: DagRepresentation[F],
       latestLFB: BlockHash, // Last LFB from the main chain
-      finalityDetector: FinalityDetector[F],
-      isHighway: Boolean
+      finalityDetector: FinalityDetector[F]
   ): F[MultiParentFinalizer[F]] =
     for {
       lfbCache  <- Ref[F].of[BlockHash](latestLFB)
@@ -76,16 +75,14 @@ object MultiParentFinalizer {
                             justFinalized <- FinalityDetectorUtil
                                               .finalizedIndirectly[F](
                                                 dag,
-                                                newLFB,
-                                                isHighway
+                                                newLFB
                                               )
                                               .timer("finalizedIndirectly")
                             justOrphaned <- FinalityDetectorUtil
                                              .orphanedIndirectly(
                                                dag,
                                                newLFB,
-                                               justFinalized.map(_.messageHash),
-                                               isHighway
+                                               justFinalized.map(_.messageHash)
                                              )
                                              .timer("orphanedIndirectly")
                             _ <- FinalityStorage[F].markAsFinalized(

--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -58,8 +58,7 @@ class FinalityDetectorUtilTest
                                                             )
         finalizedIndirectly <- FinalityDetectorUtil.finalizedIndirectly[Task](
                                 dag,
-                                b.blockHash,
-                                isHighway = false
+                                b.blockHash
                               )(Sync[Task], finalityStorage)
         finalizedIndirectlyHash = finalizedIndirectly.map(_.messageHash)
       } yield assert(finalizedIndirectlyHash == Set(a1.blockHash))
@@ -110,8 +109,7 @@ class FinalityDetectorUtilTest
         (nodesVisited, finalizedIndirectly) <- FinalityDetectorUtil
                                                 .finalizedIndirectly[G](
                                                   stateTDag,
-                                                  c.blockHash,
-                                                  isHighway = false
+                                                  c.blockHash
                                                 )(Sync[G], finalityStorage)
                                                 .run(Map.empty)
         _ = nodesVisited shouldBe expectedNodesVisitedA
@@ -137,8 +135,7 @@ class FinalityDetectorUtilTest
         (nodeVisitedB, finalizedIndirectlyB) <- FinalityDetectorUtil
                                                  .finalizedIndirectly[G](
                                                    stateTDag,
-                                                   f.blockHash,
-                                                   isHighway = false
+                                                   f.blockHash
                                                  )
                                                  .run(Map.empty)
         _ = nodeVisitedB shouldBe expectedNodesVisitedB
@@ -173,8 +170,7 @@ class FinalityDetectorUtilTest
         orphanedIndirectly <- FinalityDetectorUtil.orphanedIndirectly[Task](
                                dag,
                                e.blockHash,
-                               finalizedIndirectly = Set(d.blockHash),
-                               isHighway = false
+                               finalizedIndirectly = Set(d.blockHash)
                              )(Sync[Task], finalityStorage)
         orphanedHashes = orphanedIndirectly.map(_.messageHash)
       } yield {

--- a/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/MultiParentFinalizerTest.scala
@@ -46,8 +46,7 @@ class MultiParentFinalizerTest
         multiParentFinalizer <- MultiParentFinalizer.create[Task](
                                  dag,
                                  genesis.blockHash,
-                                 MultiParentFinalizerTest.immediateFinalityStub,
-                                 isHighway = false
+                                 MultiParentFinalizerTest.immediateFinalityStub
                                )(Concurrent[Task], fs, metrics)
         a0                         <- createAndStoreBlockFull[Task](v1, Seq(genesis), Seq.empty, bonds)
         a1                         <- createAndStoreBlockFull[Task](v1, Seq(a0), Seq.empty, bonds)
@@ -105,8 +104,7 @@ class MultiParentFinalizerTest
                                                                         .create[Task](
                                                                           dag,
                                                                           genesis.blockHash,
-                                                                          finalizer,
-                                                                          isHighway = false
+                                                                          finalizer
                                                                         )(
                                                                           Concurrent[Task],
                                                                           fs,

--- a/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/GossipServiceCasperTestNode.scala
@@ -183,8 +183,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
           multiParentFinalizer <- MultiParentFinalizer.create(
                                    dag,
                                    genesis.blockHash,
-                                   finalityDetector,
-                                   isHighway = false
+                                   finalityDetector
                                  )
           node = new GossipServiceCasperTestNode[F](
             identity,
@@ -291,8 +290,7 @@ trait GossipServiceCasperTestNodeFactory extends HashSetCasperTestNodeFactory {
                 multiParentFinalizer <- MultiParentFinalizer.create(
                                          dag,
                                          genesis.blockHash,
-                                         finalityDetector,
-                                         isHighway = false
+                                         finalityDetector
                                        )
                 chainName    = "casperlabs"
                 minTTL       = 1.minute

--- a/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
@@ -249,8 +249,7 @@ object Highway {
             finalizer <- MultiParentFinalizer.create[F](
                           dag,
                           lfb,
-                          finalityDetector,
-                          isHighway = true
+                          finalityDetector
                         )
             meteredFinalized = MeteredMultiParentFinalizer.of[F](finalizer)
           } yield meteredFinalized


### PR DESCRIPTION
### Overview
Because a block finalized in the child era didn't visit blocks in the parent era, it left some orphans unmarked. I think the condition not to follow across eras can be removed, since first the LFB will move to the switch block, so the child era messages will not come into play until they are relevant.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1353

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
