### PR TITLE
EE-920: Debug messages from inside the smart contract

### DIFF
--- a/execution-engine/cargo-casperlabs/src/contract_package.rs
+++ b/execution-engine/cargo-casperlabs/src/contract_package.rs
@@ -72,7 +72,7 @@ doctest = false
 test = false
 
 [features]
-default = ["casperlabs-contract/std", "casperlabs-types/std", "casperlabs-contract/print-function"]
+default = ["casperlabs-contract/std", "casperlabs-types/std", "casperlabs-contract/test-support"]
 "#,
         *CL_CONTRACT, *CL_TYPES,
     );

--- a/execution-engine/cargo-casperlabs/src/contract_package.rs
+++ b/execution-engine/cargo-casperlabs/src/contract_package.rs
@@ -72,7 +72,7 @@ doctest = false
 test = false
 
 [features]
-default = ["casperlabs-contract/std", "casperlabs-types/std"]
+default = ["casperlabs-contract/std", "casperlabs-types/std", "casperlabs-contract/print-function"]
 "#,
         *CL_CONTRACT, *CL_TYPES,
     );

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -120,7 +120,7 @@ name = "integration-tests"
 path = "src/integration_tests.rs"
 
 [features]
-default = ["casperlabs-contract/std", "casperlabs-types/std""#,
+default = ["casperlabs-contract/std", "casperlabs-types/std", "casperlabs-engine-test-support/print-function", "casperlabs-contract/print-function""#,
         *CL_CONTRACT, *CL_TYPES, *ENGINE_TEST_SUPPORT,
     );
     static ref WASM_SRC_DIR: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("wasm");

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -120,7 +120,7 @@ name = "integration-tests"
 path = "src/integration_tests.rs"
 
 [features]
-default = ["casperlabs-contract/std", "casperlabs-types/std", "casperlabs-engine-test-support/print-function", "casperlabs-contract/print-function""#,
+default = ["casperlabs-contract/std", "casperlabs-types/std", "casperlabs-engine-test-support/test-support", "casperlabs-contract/test-support""#,
         *CL_CONTRACT, *CL_TYPES, *ENGINE_TEST_SUPPORT,
     );
     static ref WASM_SRC_DIR: PathBuf = Path::new(env!("CARGO_MANIFEST_DIR")).join("wasm");

--- a/execution-engine/contract/Cargo.toml
+++ b/execution-engine/contract/Cargo.toml
@@ -13,7 +13,7 @@ license-file = "../../LICENSE"
 [features]
 default = []
 std = ["casperlabs-types/std"]
-print-function = []
+test-support = []
 
 [dependencies]
 casperlabs-types = { version = "0.4.0", path = "../types" }

--- a/execution-engine/contract/Cargo.toml
+++ b/execution-engine/contract/Cargo.toml
@@ -13,6 +13,7 @@ license-file = "../../LICENSE"
 [features]
 default = []
 std = ["casperlabs-types/std"]
+print-function = []
 
 [dependencies]
 casperlabs-types = { version = "0.4.0", path = "../types" }

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -269,3 +269,10 @@ pub(crate) fn read_host_buffer(size: usize) -> Result<Vec<u8>, ApiError> {
     read_host_buffer_into(&mut dest)?;
     Ok(dest)
 }
+
+#[cfg(feature = "print-function")]
+/// Prints a debug message
+pub fn print(text: &str) {
+    let (text_ptr, text_size, _bytes) = contract_api::to_ptr(text);
+    unsafe { ext_ffi::print(text_ptr, text_size) }
+}

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -270,7 +270,7 @@ pub(crate) fn read_host_buffer(size: usize) -> Result<Vec<u8>, ApiError> {
     Ok(dest)
 }
 
-#[cfg(feature = "print-function")]
+#[cfg(feature = "test-support")]
 /// Prints a debug message
 pub fn print(text: &str) {
     let (text_ptr, text_size, _bytes) = contract_api::to_ptr(text);

--- a/execution-engine/contract/src/ext_ffi.rs
+++ b/execution-engine/contract/src/ext_ffi.rs
@@ -104,6 +104,6 @@ extern "C" {
     ) -> i32;
     pub fn get_main_purse(dest_ptr: *mut u8);
     pub fn read_host_buffer(dest_ptr: *mut u8, dest_size: usize, bytes_written: *mut usize) -> i32;
-    #[cfg(feature = "print-function")]
+    #[cfg(feature = "test-support")]
     pub fn print(text_ptr: *const u8, text_size: usize);
 }

--- a/execution-engine/contract/src/ext_ffi.rs
+++ b/execution-engine/contract/src/ext_ffi.rs
@@ -104,4 +104,6 @@ extern "C" {
     ) -> i32;
     pub fn get_main_purse(dest_ptr: *mut u8);
     pub fn read_host_buffer(dest_ptr: *mut u8, dest_size: usize, bytes_written: *mut usize) -> i32;
+    #[cfg(feature = "print-function")]
+    pub fn print(text_ptr: *const u8, text_size: usize);
 }

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -46,4 +46,4 @@ matches = "0.1.8"
 proptest = "0.9.4"
 
 [features]
-print-function = []
+test-support = []

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -44,3 +44,6 @@ wasmi = "0.4.2"
 lazy_static = "1"
 matches = "0.1.8"
 proptest = "0.9.4"
+
+[features]
+print-function = []

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -43,7 +43,7 @@ pub enum FunctionIndex {
     GetMainPurseIndex,
     GetArgSizeFuncIndex,
     ReadHostBufferIndex,
-    #[cfg(feature = "print-function")]
+    #[cfg(feature = "test-support")]
     PrintIndex,
 }
 

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -43,6 +43,8 @@ pub enum FunctionIndex {
     GetMainPurseIndex,
     GetArgSizeFuncIndex,
     ReadHostBufferIndex,
+    #[cfg(feature = "print-function")]
+    PrintIndex,
 }
 
 impl Into<usize> for FunctionIndex {

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -188,7 +188,7 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::ReadHostBufferIndex.into(),
             ),
-            #[cfg(feature = "print-function")]
+            #[cfg(feature = "test-support")]
             "print" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32; 2][..], None),
                 FunctionIndex::PrintIndex.into(),

--- a/execution-engine/engine-core/src/resolvers/v1_resolver.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_resolver.rs
@@ -188,6 +188,11 @@ impl ModuleImportResolver for RuntimeModuleImportResolver {
                 Signature::new(&[ValueType::I32; 3][..], Some(ValueType::I32)),
                 FunctionIndex::ReadHostBufferIndex.into(),
             ),
+            #[cfg(feature = "print-function")]
+            "print" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32; 2][..], None),
+                FunctionIndex::PrintIndex.into(),
+            ),
             _ => {
                 return Err(InterpreterError::Function(format!(
                     "host module doesn't export function with name {}",

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -448,6 +448,13 @@ where
                 let ret = self.read_host_buffer(dest_ptr, dest_size as usize, bytes_written_ptr)?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
+
+            #[cfg(feature = "print-function")]
+            FunctionIndex::PrintIndex => {
+                let (text_ptr, text_size) = Args::parse(args)?;
+                self.print(text_ptr, text_size)?;
+                Ok(None)
+            }
         }
     }
 }

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -449,7 +449,7 @@ where
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
 
-            #[cfg(feature = "print-function")]
+            #[cfg(feature = "test-support")]
             FunctionIndex::PrintIndex => {
                 let (text_ptr, text_size) = Args::parse(args)?;
                 self.print(text_ptr, text_size)?;

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -2798,7 +2798,7 @@ where
         Ok(Ok(()))
     }
 
-    #[cfg(feature = "print-function")]
+    #[cfg(feature = "test-support")]
     fn print(&mut self, text_ptr: u32, text_size: u32) -> Result<(), Trap> {
         let text = self.string_from_mem(text_ptr, text_size)?;
         println!("{}", text);

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -2797,6 +2797,13 @@ where
 
         Ok(Ok(()))
     }
+
+    #[cfg(feature = "print-function")]
+    fn print(&mut self, text_ptr: u32, text_size: u32) -> Result<(), Trap> {
+        let text = self.string_from_mem(text_ptr, text_size)?;
+        println!("{}", text);
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -40,6 +40,9 @@ protoc-rust-grpc = "0.6.1"
 parity-wasm = "0.31.3"
 rand = "0.7.2"
 
+[features]
+print-function = ["engine-core/print-function"]
+
 [[bin]]
 name = "casperlabs-engine-grpc-server"
 path = "src/main.rs"

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -41,7 +41,7 @@ parity-wasm = "0.31.3"
 rand = "0.7.2"
 
 [features]
-print-function = ["engine-core/print-function"]
+test-support = ["engine-core/test-support"]
 
 [[bin]]
 name = "casperlabs-engine-grpc-server"

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -33,3 +33,4 @@ version-sync = "0.8"
 highway = []
 use-as-wasm = []
 use-system-contracts = []
+print-function = ["engine-core/print-function", "engine-grpc-server/print-function", "contract/print-function"]

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -33,4 +33,4 @@ version-sync = "0.8"
 highway = []
 use-as-wasm = []
 use-system-contracts = []
-print-function = ["engine-core/print-function", "engine-grpc-server/print-function", "contract/print-function"]
+test-support = ["engine-core/test-support", "engine-grpc-server/test-support", "contract/test-support"]


### PR DESCRIPTION
### Overview
This PR adds a way to print messages from within contracts only available when the `test-support` compile-time flag is enabled. The test projects generated by `cargo-casperlabs` will have this flag enabled by default.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-920

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Crate versions on `crates.io` will have to be bumped before this works out-of-the-box.
