### PR TITLE
NO-TICKET: rust current nightly step should not block CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -117,6 +117,7 @@ steps:
   - "make build CARGO_FLAGS=--all-targets"
   - "make build-contracts-rs"
   image: "casperlabs/buildenv:latest"
+  failure: "ignore"
   when:
     event:
     - pull_request


### PR DESCRIPTION
This PR prevents rust nightly build step failures from blocking CI (the critical path uses a pinned version of nightly).