### PR TITLE
NODE-1355: Stop panorama calculation when jDag reaches the LFB height.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
@@ -106,10 +106,15 @@ object VotingMatrix {
         weights,
         validators
       )
+
       implicit0(votingMatrix: VotingMatrix[F]) <- of[F](state)
       // Apply the incremental update step to update voting matrix by taking M := V(i)latest
       _ <- latestMessagesToUpdated.values.toList.traverse { b =>
-            updateVotingMatrixOnNewBlock[F](dag, b, isHighway)
+            for {
+              panorama <- FinalityDetectorUtil
+                           .panoramaOfBlockByValidators[F](dag, b, lfb, validators.toSet)
+              _ <- updateVotingMatrixOnNewBlock[F](dag, b, panorama, isHighway)
+            } yield ()
           }
     } yield votingMatrix
 }

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -4,6 +4,9 @@ import cats.effect.Sync
 import cats.implicits._
 import com.github.ghik.silencer.silent
 import com.google.protobuf.ByteString
+import cats.Show
+import cats.syntax.show
+import io.casperlabs.shared.ByteStringPrettyPrinter._
 import io.casperlabs.casper.MultiParentCasperImpl.Broadcaster
 import io.casperlabs.casper.consensus.Block.{Justification, ProcessedDeploy}
 import io.casperlabs.casper.consensus._
@@ -1037,84 +1040,6 @@ abstract class HashSetCasperTest
               } yield result
             }
           }
-    } yield ()
-  }
-
-  it should "increment last finalized block as appropriate in round robin" in effectTest {
-    val stake      = 10L
-    val equalBonds = validators.map(_ -> stake).toMap
-    val BlockMsgWithTransform(Some(genesisWithEqualBonds), _) =
-      buildGenesis(Map.empty, equalBonds, 0L)
-
-    for {
-      nodes <- networkEff(
-                validatorKeys.take(3),
-                genesisWithEqualBonds,
-                faultToleranceThreshold = 0f // With equal bonds this should allow the final block to move as expected.
-              )
-      deployDatas <- (1L to 10L).toList.traverse(_ => ProtoUtil.basicDeploy[Task]())
-
-      _ <- nodes(0).deployAndPropose(deployDatas(0))
-      _ <- nodes(1).receive()
-      _ <- nodes(2).receive()
-
-      block2 <- nodes(1).deployAndPropose(deployDatas(1))
-      _      <- nodes(0).receive()
-      _      <- nodes(2).receive()
-
-      block3 <- nodes(2).deployAndPropose(deployDatas(2))
-      _      <- nodes(0).receive()
-      _      <- nodes(1).receive()
-
-      block4 <- nodes(0).deployAndPropose(deployDatas(3))
-      _      <- nodes(1).receive()
-      _      <- nodes(2).receive()
-
-      block5 <- nodes(1).deployAndPropose(deployDatas(4))
-      _      <- nodes(0).receive()
-      _      <- nodes(2).receive()
-
-      block6 <- nodes(2).deployAndPropose(deployDatas(5))
-      _      <- nodes(0).receive()
-      _      <- nodes(1).receive()
-
-      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block2
-      pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(1)
-
-      _ <- nodes(0).deployBuffer.addDeploy(deployDatas(6)) *> nodes(0).propose()
-      _ <- nodes(1).receive()
-      _ <- nodes(2).receive()
-
-      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block3
-      pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 4 and block 7
-
-      _ <- nodes(1).deployBuffer.addDeploy(deployDatas(7)) *> nodes(1).propose()
-      _ <- nodes(0).receive()
-      _ <- nodes(2).receive()
-
-      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block4
-      pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(1) // deploys contained in block 7
-
-      _ <- nodes(2).deployBuffer.addDeploy(deployDatas(8)) *> nodes(2).propose()
-      _ <- nodes(0).receive()
-      _ <- nodes(1).receive()
-
-      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block5
-      pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(1) // deploys contained in block 7
-
-      _ <- nodes(0).deployBuffer.addDeploy(deployDatas(9)) *> nodes(0).propose()
-      _ <- nodes(1).receive()
-      _ <- nodes(2).receive()
-
-      _                     <- nodes(0).casperEff.lastFinalizedBlock shouldBeF block6
-      pendingOrProcessedNum <- nodes(0).deployStorage.reader.sizePendingOrProcessed()
-      _                     = pendingOrProcessedNum should be(2) // deploys contained in block 7 and block 10
-
-      _ <- nodes.map(_.tearDown()).toList.sequence
     } yield ()
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -299,7 +299,7 @@ class FinalityDetectorByVotingMatrixTest
         _ = c4 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b1.blockHash))
         (b5, c5) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b4.blockHash),
-                     b1.blockHash,
+                     genesis.blockHash,
                      v2,
                      bonds,
                      HashMap(v1 -> b4.blockHash, v2 -> b2.blockHash, v3 -> b3.blockHash),
@@ -308,7 +308,7 @@ class FinalityDetectorByVotingMatrixTest
         _ = c5 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b2.blockHash))
         (b6, c6) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b5.blockHash),
-                     b2.blockHash,
+                     genesis.blockHash,
                      v3,
                      bonds,
                      HashMap(v1 -> b4.blockHash, v2 -> b5.blockHash, v3 -> b3.blockHash),
@@ -317,7 +317,7 @@ class FinalityDetectorByVotingMatrixTest
         _ = c6 shouldBe Seq(CommitteeWithConsensusValue(Set(v1, v2, v3), 30, b3.blockHash))
         (b7, c7) <- createBlockAndUpdateFinalityDetector[Task](
                      Seq(b6.blockHash),
-                     b3.blockHash,
+                     genesis.blockHash,
                      v1,
                      bonds,
                      HashMap(v1 -> b4.blockHash, v2 -> b5.blockHash, v3 -> b6.blockHash),


### PR DESCRIPTION
### Overview
Extracts calculation of the panorama out of the semaphore. Caps the calculation of the panorama to the current era messages and stops when reaches the jRank lower than the previous LFB.

Depends on #1850. Review the [last commit](https://github.com/CasperLabs/CasperLabs/pull/1857/commits/f4b10f62628f8ed989db353f3c81c71d29422ccf).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1355

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
