### PR TITLE
NODE-1356: Remove schedule on error.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -10,8 +10,10 @@ import io.casperlabs.models.Message
 import io.casperlabs.storage.{BlockHash, SQLiteStorage}
 import monix.eval.Task
 import org.scalatest._
-
 import scala.concurrent.duration._
+import io.casperlabs.casper.highway.mocks.MockMessageProducer
+import io.casperlabs.crypto.Keys
+import io.casperlabs.shared.Log
 
 class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with HighwayFixture {
 
@@ -60,6 +62,37 @@ class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with High
             }
           }
       }
+  }
+
+  it should "not show active eras after errors" in testFixture { implicit timer => implicit db =>
+    new Fixture(
+      length = 1.hour,
+      initRoundExponent = 10, // ~20 minutes,
+      printLevel = Log.Level.Crit
+    ) {
+      // Create a message producer that will raise errors so the agenda will fail.
+      override lazy val messageProducer: MessageProducer[Task] =
+        new MockMessageProducer[Task](validator) {
+          override def block(
+              keyBlockHash: BlockHash,
+              roundId: Ticks,
+              mainParent: Message.Block,
+              justifications: Map[PublicKeyBS, Set[Message]],
+              isBookingBlock: Boolean
+          ) = Task.raiseError(new RuntimeException("Stop the agenda!"))
+        }
+
+      override def test =
+        makeSupervisor().use { supervisor =>
+          for {
+            active0 <- supervisor.activeEras
+            _       = active0 should not be empty
+            _       <- Task.sleep(30.minutes)
+            active1 <- supervisor.activeEras
+            _       = active1 shouldBe empty
+          } yield ()
+        }
+    }
   }
 
   it should "relay created messages to other nodes" in testFixtures(


### PR DESCRIPTION
### Overview
Makes sure that `scheduleRef` has no leftover keys which would cause multiple dead eras to show up as active.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1356

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
It might be worth separating the creation of the lambda message (which might fail) from the StartRound action (which schedules the next event), but then again if we can't execute the agenda it might be better to show it in /status that we have no active eras.
