### PR TITLE
NO-TICKET: Catch an error thrown during logging and print to the console.

### DIFF
--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -23,7 +23,7 @@ class UncaughtExceptionHandler(shutdownTimeout: FiniteDuration)(implicit logId: 
     ex match {
       case _: VirtualMachineError | _: LinkageError | _: FatalErrorShutdown =>
         // To flush logs
-        Thread.sleep(1000)
+        Thread.sleep(3000)
         exitOrHalt(1, shutdownTimeout)
       case _ =>
     }

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -23,7 +23,7 @@ class UncaughtExceptionHandler(shutdownTimeout: FiniteDuration)(implicit logId: 
         val timestamp = dateTimeFormatter.format(Instant.now())
         println(
           s"ERROR $timestamp (UncaughtExceptionHandler.scala) Exception thrown when logging. " +
-            s"Original stacktrace:\n"
+            s"Original stacktrace:\n${ex.getMessage}"
         )
         ex.printStackTrace()
     }

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -1,6 +1,9 @@
 package io.casperlabs.shared
 
-import java.util.Date
+import java.text.SimpleDateFormat
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
+import java.util.{Date, SimpleTimeZone, TimeZone}
 
 import cats.Id
 import monix.execution.UncaughtExceptionReporter
@@ -14,8 +17,12 @@ class UncaughtExceptionHandler(shutdownTimeout: FiniteDuration)(implicit logId: 
   override def reportFailure(ex: scala.Throwable): Unit = {
     Try(Log[Id].error(s"Uncaught Exception : $ex")).recover {
       case ex =>
+        // Logstage example formatting "2020-04-07T02:45:56.815 "
+        val dateTimeFormatter =
+          DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss.SSS").withZone(ZoneId.of("UTC"))
+        val timestamp = dateTimeFormatter.format(Instant.now())
         println(
-          s"ERROR ${new Date(System.currentTimeMillis())} (UncaughtExceptionHandler.scala) Exception thrown when logging. " +
+          s"ERROR $timestamp (UncaughtExceptionHandler.scala) Exception thrown when logging. " +
             s"Original stacktrace:\n"
         )
         ex.printStackTrace()


### PR DESCRIPTION
### Overview
We've seen nodes shut down without logging the cause. We suspect this might be happening in the `UncaughtExceptionHandler` that fails to log the real cause. Increasing the time for flushing the logs and printing to the console when an error is thrown in the log call.


### Which JIRA ticket does this PR relate to?
n/a

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
