### PR TITLE
NO-TICKET: bump EE versions

### DIFF
--- a/execution-engine/cargo-casperlabs/Cargo.toml
+++ b/execution-engine/cargo-casperlabs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-casperlabs"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Command line tool for creating a Wasm smart contract and tests for use on the CasperLabs network."

--- a/execution-engine/cargo-casperlabs/src/common.rs
+++ b/execution-engine/cargo-casperlabs/src/common.rs
@@ -13,8 +13,8 @@ use crate::{dependency::Dependency, ARGS, FAILURE_EXIT_CODE};
 
 lazy_static! {
     pub static ref CL_CONTRACT: Dependency =
-        Dependency::new("casperlabs-contract", "0.4.0", "contract");
-    pub static ref CL_TYPES: Dependency = Dependency::new("casperlabs-types", "0.4.0", "types");
+        Dependency::new("casperlabs-contract", "0.4.1", "contract");
+    pub static ref CL_TYPES: Dependency = Dependency::new("casperlabs-types", "0.4.1", "types");
 }
 
 pub fn print_error_and_exit(msg: &str) -> ! {

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -105,7 +105,7 @@ lazy_static! {
         .join("src/integration_tests.rs");
     static ref ENGINE_TEST_SUPPORT: Dependency = Dependency::new(
         "casperlabs-engine-test-support",
-        "0.6.1",
+        "0.6.2",
         "engine-test-support"
     );
     static ref CARGO_TOML_ADDITIONAL_CONTENTS: String = format!(

--- a/execution-engine/contract-as/package-lock.json
+++ b/execution-engine/contract-as/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@casperlabs/contract",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/execution-engine/contract-as/package.json
+++ b/execution-engine/contract-as/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@casperlabs/contract",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Library for developing CasperLabs smart contracts.",
   "main": "index.js",
   "ascMain": "assembly/index.ts",

--- a/execution-engine/contract/Cargo.toml
+++ b/execution-engine/contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-contract"
-version = "0.4.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.4.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Library for developing CasperLabs smart contracts."
@@ -16,7 +16,7 @@ std = ["casperlabs-types/std"]
 test-support = []
 
 [dependencies]
-casperlabs-types = { version = "0.4.0", path = "../types" }
+casperlabs-types = { version = "0.4.1", path = "../types" }
 failure = { version = "0.1.6", default-features = false, features = ["failure_derive"] }
 hex_fmt = "0.3.0"
 wee_alloc = "0.4.5"

--- a/execution-engine/contract/src/lib.rs
+++ b/execution-engine/contract/src/lib.rs
@@ -62,7 +62,7 @@
     core_intrinsics,
     lang_items
 )]
-#![doc(html_root_url = "https://docs.rs/casperlabs-contract/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/casperlabs-contract/0.4.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-core"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Main component of the CasperLabs Wasm execution engine."
@@ -18,26 +18,26 @@ include = [
 [dependencies]
 base16 = "0.2.1"
 blake2 = "0.8.1"
-contract = { version = "0.4.0", path = "../contract",  package = "casperlabs-contract", features = ["std"] }
-engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-storage = { version = "0.5.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
-engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
+contract = { version = "0.4.1", path = "../contract",  package = "casperlabs-contract", features = ["std"] }
+engine-shared = { version = "0.5.1", path = "../engine-shared", package = "casperlabs-engine-shared" }
+engine-storage = { version = "0.5.1", path = "../engine-storage", package = "casperlabs-engine-storage" }
+engine-wasm-prep = { version = "0.4.1", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 failure = "0.1.6"
 hex_fmt = "0.3.0"
 itertools = "0.8.2"
 lazy_static = "1.4.0"
 linked-hash-map = "0.5.2"
 log = "0.4.8"
-mint = { version = "0.2.0", path = "../mint", package = "casperlabs-mint" }
-proof-of-stake = { version = "0.2.0", path = "../proof-of-stake", package = "casperlabs-proof-of-stake" }
+mint = { version = "0.2.1", path = "../mint", package = "casperlabs-mint" }
+proof-of-stake = { version = "0.2.1", path = "../proof-of-stake", package = "casperlabs-proof-of-stake" }
 num-derive = "0.3.0"
 num-traits = "0.2.10"
 parity-wasm = "0.31.3"
 pwasm-utils = "0.6.2"
 rand = "0.7.2"
 rand_chacha = "0.2.1"
-standard-payment = { version = "0.2.0", path = "../standard-payment", package = "casperlabs-standard-payment" }
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
+standard-payment = { version = "0.2.1", path = "../standard-payment", package = "casperlabs-standard-payment" }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 wasmi = "0.4.2"
 
 [dev-dependencies]

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-grpc-server"
-version = "0.17.2"
+version = "0.18.0"
 authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Wasm execution engine for CasperLabs smart contracts."

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-grpc-server"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Wasm execution engine for CasperLabs smart contracts."
@@ -22,16 +22,16 @@ include = [
 clap = "2"
 ctrlc = "3"
 dirs = "2"
-engine-core = { version = "0.5.0", path = "../engine-core", package = "casperlabs-engine-core" }
-engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-storage = { version = "0.5.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
-engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
+engine-core = { version = "0.5.1", path = "../engine-core", package = "casperlabs-engine-core" }
+engine-shared = { version = "0.5.1", path = "../engine-shared", package = "casperlabs-engine-shared" }
+engine-storage = { version = "0.5.1", path = "../engine-storage", package = "casperlabs-engine-storage" }
+engine-wasm-prep = { version = "0.4.1", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 grpc = "0.6.1"
 lmdb = "0.8"
 log = "0.4.8"
 proptest = "0.9.4"
 protobuf = "=2.8"
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 
 [build-dependencies]
 protoc-rust-grpc = "0.6.1"

--- a/execution-engine/engine-shared/Cargo.toml
+++ b/execution-engine/engine-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-shared"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Henry Till <henrytill@gmail.com>", "Ed Hastings <ed@casperlabs.io>"]
 edition = "2018"
 description = "Library of shared types for use by the various CasperLabs execution engine crates."
@@ -14,7 +14,7 @@ license-file = "../../LICENSE"
 base16 = "0.2.1"
 blake2 = "0.8.1"
 chrono = "0.4.10"
-engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
+engine-wasm-prep = { version = "0.4.1", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 hostname = "0.3.0"
 lazy_static = "1.4.0"
 libc = "0.2.66"
@@ -24,7 +24,7 @@ parity-wasm = "0.31.3"
 proptest = "0.9.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wabt = "0.9.2"
 

--- a/execution-engine/engine-storage/Cargo.toml
+++ b/execution-engine/engine-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-storage"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Michael Birch <birchmd@casperlabs.io>"]
 edition = "2018"
 description = "Storage component of the CasperLabs Wasm execution engine."
@@ -11,12 +11,12 @@ repository = "https://github.com/CasperLabs/CasperLabs/tree/master/execution-eng
 license-file = "../../LICENSE"
 
 [dependencies]
-engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
+engine-shared = { version = "0.5.1", path = "../engine-shared", package = "casperlabs-engine-shared" }
+engine-wasm-prep = { version = "0.4.1", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 failure = "0.1.6"
 lmdb = "0.8.0"
 parking_lot = "0.10.0"
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
 wasmi = "0.4.2"
 
 [dev-dependencies]

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -13,7 +13,7 @@ license-file = "../../LICENSE"
 [dependencies]
 contract = { version = "0.4.1", path = "../contract", package = "casperlabs-contract" }
 engine-core = { version = "0.5.1", path = "../engine-core", package = "casperlabs-engine-core" }
-engine-grpc-server = { version = "0.17.2", path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
+engine-grpc-server = { version = "0.18.0", path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
 engine-shared = { version = "0.5.1", path = "../engine-shared", package = "casperlabs-engine-shared" }
 engine-storage = { version = "0.5.1", path = "../engine-storage", package = "casperlabs-engine-storage" }
 engine-wasm-prep = { version = "0.4.1", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-test-support"
-version = "0.6.1" # when updating, also update 'html_root_url' in lib.rs
+version = "0.6.2" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Library to support testing of Wasm smart contracts for use on the CasperLabs network."
@@ -11,12 +11,12 @@ repository = "https://github.com/CasperLabs/CasperLabs/tree/master/execution-eng
 license-file = "../../LICENSE"
 
 [dependencies]
-contract = { version = "0.4.0", path = "../contract", package = "casperlabs-contract" }
-engine-core = { version = "0.5.0", path = "../engine-core", package = "casperlabs-engine-core" }
-engine-grpc-server = { version = "0.17.1", path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
-engine-shared = { version = "0.5.0", path = "../engine-shared", package = "casperlabs-engine-shared" }
-engine-storage = { version = "0.5.0", path = "../engine-storage", package = "casperlabs-engine-storage" }
-engine-wasm-prep = { version = "0.4.0", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
+contract = { version = "0.4.1", path = "../contract", package = "casperlabs-contract" }
+engine-core = { version = "0.5.1", path = "../engine-core", package = "casperlabs-engine-core" }
+engine-grpc-server = { version = "0.17.2", path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
+engine-shared = { version = "0.5.1", path = "../engine-shared", package = "casperlabs-engine-shared" }
+engine-storage = { version = "0.5.1", path = "../engine-storage", package = "casperlabs-engine-storage" }
+engine-wasm-prep = { version = "0.4.1", path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 grpc = "0.6.1"
 lazy_static = "1"
 lmdb = "0.8.0"
@@ -24,7 +24,7 @@ log = "0.4.8"
 num-traits = "0.2.10"
 rand = "0.7.2"
 protobuf = "=2.8"
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types", features = ["std"] }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std"] }
 
 [dev-dependencies]
 version-sync = "0.8"

--- a/execution-engine/engine-test-support/src/lib.rs
+++ b/execution-engine/engine-test-support/src/lib.rs
@@ -54,7 +54,7 @@
 //! assert_eq!(expected_value, returned_value);
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/casperlabs-engine-test-support/0.6.1")]
+#![doc(html_root_url = "https://docs.rs/casperlabs-engine-test-support/0.6.2")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Symbol_RGB.png",

--- a/execution-engine/engine-wasm-prep/Cargo.toml
+++ b/execution-engine/engine-wasm-prep/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-engine-wasm-prep"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Michael Birch <birchmd@casperlabs.io>", "Mateusz Górski <gorski.mateusz@protonmail.ch>"]
 edition = "2018"
 description = "Preprocessor of Wasm modules for use as smart contracts on the CasperLabs network."
@@ -14,4 +14,4 @@ license-file = "../../LICENSE"
 parity-wasm = "0.31.3"
 proptest = "0.9.4"
 pwasm-utils = "0.6.2"
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types", features = ["std"] }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std"] }

--- a/execution-engine/mint/Cargo.toml
+++ b/execution-engine/mint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-mint"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 description = "Defines the mint api"
@@ -13,4 +13,4 @@ license-file = "../../LICENSE"
 std = ["types/std"]
 
 [dependencies]
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types" }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types" }

--- a/execution-engine/proof-of-stake/Cargo.toml
+++ b/execution-engine/proof-of-stake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-proof-of-stake"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Henry Till <henrytill@gmail.com>"]
 edition = "2018"
 description = "Defines the proof of stake api"
@@ -14,4 +14,4 @@ std = ["types/std"]
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types" }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types" }

--- a/execution-engine/standard-payment/Cargo.toml
+++ b/execution-engine/standard-payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-standard-payment"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Defines the standard payment api"
@@ -13,4 +13,4 @@ license-file = "../../LICENSE"
 std = ["types/std"]
 
 [dependencies]
-types = { version = "0.4.0", path = "../types", package = "casperlabs-types" }
+types = { version = "0.4.1", path = "../types", package = "casperlabs-types" }

--- a/execution-engine/types/Cargo.toml
+++ b/execution-engine/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casperlabs-types"
-version = "0.4.0" # when updating, also update 'html_root_url' in lib.rs
+version = "0.4.1" # when updating, also update 'html_root_url' in lib.rs
 authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
 edition = "2018"
 description = "Types used to allow creation of Wasm contracts and tests for use on the CasperLabs network."

--- a/execution-engine/types/src/lib.rs
+++ b/execution-engine/types/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![feature(specialization, try_reserve)]
-#![doc(html_root_url = "https://docs.rs/casperlabs-types/0.4.0")]
+#![doc(html_root_url = "https://docs.rs/casperlabs-types/0.4.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Favicon_RGB_50px.png",
     html_logo_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Symbol_RGB.png",


### PR DESCRIPTION
This PR bumps EE crate and npm package versions.