### PR TITLE
NODE-1359: Moving some loops into explicit tail position.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -558,7 +558,7 @@ trait DownloadManagerImpl[F[_]] extends DownloadManager[F] { self =>
                         Metrics[F].incrementCounter("downloads_failed") *>
                           Log[F].warn(
                             s"Retrying download of ${kind} ${id.show -> "id"} from other sources, failed source: ${source.show -> "peer"}, prev $attempt: $ex"
-                          ) *>
+                          ) >>
                           loop(counterPerSource.updated(source, nextAttempt), ex.some)
                     }
                 case _: Duration.Infinite => sys.error("Unreachable")

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationBackwardImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationBackwardImpl.scala
@@ -71,7 +71,7 @@ class InitialSynchronizationBackwardImpl[F[_]: Concurrent: Log: Timer](
               val newFailed              = failed ++ failedE.map(_._1)
 
               if (successful.size >= minSuccessful) {
-                Log[F].debug(
+                Log[F].info(
                   s"Successfully synced with ${successful.size} nodes, required: $minSuccessful"
                 )
               } else {
@@ -88,11 +88,11 @@ class InitialSynchronizationBackwardImpl[F[_]: Concurrent: Log: Timer](
                       }
                     }
                   }
-                Log[F].debug(
+                Log[F].info(
                   s"Haven't reached required $minSuccessful amount of nodes, retrying in $roundPeriod"
                 ) >>
-                  Timer[F].sleep(roundPeriod) >> nextRoundNodes >>= { ns =>
-                  loop(ns, newFailed)
+                  Timer[F].sleep(roundPeriod) >> nextRoundNodes >>= {
+                  loop(_, newFailed)
                 }
               }
             }

--- a/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
@@ -94,6 +94,7 @@ object StatusInfo {
     }
     case class GenesisDetails(
         genesisBlockHash: String,
+        chainName: String,
         genesisLikeBlocks: List[BlockDetails]
     )
 
@@ -374,7 +375,8 @@ object StatusInfo {
           case _   => "There are multiple genesis blocks!"
         },
         details = GenesisDetails(
-          genesis.blockHash.show,
+          genesisBlockHash = genesis.blockHash.show,
+          chainName = genesis.getHeader.chainName,
           genesisLike.map { s =>
             BlockDetails(Message.fromBlockSummary(s).get)
           }

--- a/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
@@ -30,7 +30,7 @@ object StatusInfo {
 
   case class Check[T](
       ok: Boolean,
-      message: Option[String] = None,
+      message: String,
       details: Option[T] = None
   )
   object Check {
@@ -47,7 +47,7 @@ object StatusInfo {
       */
     def apply[F[_]: Sync, T](f: F[Check[T]]): StateT[F, Boolean, Check[T]] = StateT { acc =>
       f.attempt.map {
-        case Left(ex) => (false, Check[T](ok = false, message = ex.getMessage.some, details = None))
+        case Left(ex) => (false, Check[T](ok = false, message = ex.getMessage, details = None))
         case Right(x) => (acc && x.ok, x)
       }
     }
@@ -159,7 +159,7 @@ object StatusInfo {
       import doobie._
       import doobie.implicits._
       sql"""select 1""".query[Int].unique.transact(readXa).map { _ =>
-        Check[Unit](ok = true)
+        Check[Unit](ok = true, message = "Database is readable.")
       }
     }
 
@@ -167,10 +167,9 @@ object StatusInfo {
       NodeDiscovery[F].recentlyAlivePeersAscendingDistance.map { nodes =>
         Check(
           ok = conf.casper.standalone || nodes.nonEmpty,
-          message = Some {
+          message =
             if (conf.casper.standalone) s"Standalone mode, connected to ${nodes.length} peer(s)."
-            else s"Connected to ${nodes.length} recently alive peer(s)."
-          },
+            else s"Connected to ${nodes.length} recently alive peer(s).",
           details = PeerDetails(count = nodes.size).some
         )
       }
@@ -182,12 +181,11 @@ object StatusInfo {
         val connected = bootstrapNodes.filter(nodes)
         Check(
           ok = bootstrapNodes.isEmpty || connected.nonEmpty,
-          message = Some {
+          message =
             if (bootstrapNodes.nonEmpty)
               s"Connected to ${connected.size} of the bootstrap node(s) out of the ${bootstrapNodes.size} configured."
             else
-              "No bootstraps configured."
-          },
+              "No bootstraps configured.",
           details = PeerDetails(count = connected.size).some
         )
       }
@@ -198,10 +196,9 @@ object StatusInfo {
         getIsSynced.map { synced =>
           Check[Unit](
             ok = synced,
-            message = Option(
+            message =
               if (synced) "Initial synchronization complete."
               else "Initial synchronization running."
-            )
           )
         }
       }.withoutAccumulation
@@ -235,11 +232,10 @@ object StatusInfo {
           isTooOld <- isTooOld(chainSpec, lfb.some)
         } yield Check(
           ok = !isTooOld,
-          message = Some {
+          message =
             if (isTooOld) "Last block was finalized too long ago."
             else if (lfbHash == genesis.blockHash) "The last finalized block is the Genesis."
-            else "The last finalized block was moved not too long ago."
-          },
+            else "The last finalized block was moved not too long ago.",
           details = BlockDetails(lfb).some
         )
       }
@@ -263,12 +259,11 @@ object StatusInfo {
 
       } yield Check[Unit](
         ok = !isTooOld,
-        message = Some {
+        message =
           if (isTooOld) "Last block was received too long ago."
           else if (latest.nonEmpty) "Received a block not too long ago."
           else if (conf.casper.standalone) "Running in standalone mode."
           else "Haven't received a block yet."
-        }
       )
     }
 
@@ -289,26 +284,25 @@ object StatusInfo {
         isTooOld <- isTooOld(chainSpec, latest)
       } yield Check[Unit](
         ok = !isTooOld,
-        message = Some {
+        message =
           if (isTooOld) "The last created block was too long ago."
           else if (maybeValidatorId.isEmpty) "Running in read-only mode."
           else if (latest.isEmpty) "Haven't created any blocks yet."
           else "Created a block not too long ago."
-        }
       )
     }
 
     def activeEras[F[_]: Sync: Time: Consensus](conf: Configuration) = Check {
       if (!conf.highway.enabled)
-        Check[ErasDetails](ok = true, message = "Not in highway mode.".some).pure[F]
+        Check[ErasDetails](ok = true, message = "Not in highway mode.").pure[F]
       else
         for {
           active       <- Consensus[F].activeEras
           now          <- Time[F].currentMillis
           (past, curr) = active.partition(era => era.startTick < now)
-          maybeError = if (active.isEmpty) "There are no active eras.".some
-          else if (curr.size > 1) "There are more than 1 current eras.".some
-          else none
+          maybeError = if (active.isEmpty) "There are no active eras."
+          else if (curr.size > 1) "There are more than 1 current eras."
+          else ""
         } yield {
           Check(
             ok = maybeError.isEmpty,
@@ -320,7 +314,7 @@ object StatusInfo {
 
     def genesisEra[F[_]: Sync: Time: EraStorage](conf: Configuration, genesis: Block) = Check {
       if (!conf.highway.enabled)
-        Check[ErasDetails](ok = true, message = "Not in highway mode.".some).pure[F]
+        Check[ErasDetails](ok = true, message = "Not in highway mode.").pure[F]
       else
         for {
           now        <- Time[F].currentMillis
@@ -328,8 +322,7 @@ object StatusInfo {
         } yield {
           Check(
             ok = true,
-            message =
-              if (genesisEra.startTick > now) "Genesis era hasn't started yet.".some else none,
+            message = if (genesisEra.startTick > now) "Genesis era hasn't started yet." else "",
             details = ErasDetails(Set(genesisEra)).some
           )
         }
@@ -341,10 +334,10 @@ object StatusInfo {
     ) = Check {
       maybeValidatorId match {
         case _ if !conf.highway.enabled =>
-          Check[ErasDetails](ok = true, message = "Not in highway mode.".some)
+          Check[ErasDetails](ok = true, message = "Not in highway mode.")
             .pure[F]
         case None =>
-          Check[ErasDetails](ok = true, message = "Running in read-only mode".some)
+          Check[ErasDetails](ok = true, message = "Running in read-only mode")
             .pure[F]
         case Some(id) =>
           for {
@@ -353,10 +346,9 @@ object StatusInfo {
           } yield {
             Check(
               ok = bonded.nonEmpty,
-              message = Some {
+              message =
                 if (bonded.isEmpty) "Not bonded in any active era."
-                else s"Bonded in ${bonded.size} active era(s)."
-              },
+                else s"Bonded in ${bonded.size} active era(s).",
               details = ErasDetails(bonded).some
             )
           }
@@ -374,14 +366,12 @@ object StatusInfo {
                         .map(_.flatten.map(_.getSummary))
       } yield Check(
         ok = genesisLike.size == 1 && genesisLike.head.blockHash == genesis.blockHash,
-        message = Some {
-          genesisLike match {
-            case List(g) if g.blockHash == genesis.blockHash => ""
-            case List(_) =>
-              "There's a genesis block but it's not the expected one!"
-            case Nil => "There's no genesis block!"
-            case _   => "There are multiple genesis blocks!"
-          }
+        message = genesisLike match {
+          case List(g) if g.blockHash == genesis.blockHash => ""
+          case List(_) =>
+            "There's a genesis block but it's not the expected one!"
+          case Nil => "There's no genesis block!"
+          case _   => "There are multiple genesis blocks!"
         },
         details = GenesisDetails(
           genesis.blockHash.show,


### PR DESCRIPTION
### Overview
I was trying to replicate the situation we observed with some validators not having cleared their state before joining the new chain, causing the others to repeatedly try and fail to sync with their multiple genesis blocks. The steps to reproduce are in the ticket, however the stack overflow did not happen. Still this PR moves some lines that could explain it, had we not used the `better-monadic-for` plugin.

The PR also adds `genesisBlocks` entry to the `/status` checklist which signals an error if there are multiple ones.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1359

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
