### PR TITLE
NODE-1357: Add DeployStorage.countByBufferedState

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -35,6 +35,7 @@ import io.casperlabs.casper.dag.DagOperations
 import io.casperlabs.models.Message.{asMainRank, JRank, MainRank}
 import io.casperlabs.shared.Sorting._
 import scala.concurrent.duration._
+import io.casperlabs.casper.consensus.info.DeployInfo
 
 /** Produce a signed message, persisted message.
   * The producer should the thread safe, so that when it's
@@ -83,7 +84,7 @@ object MessageProducer {
         PublicKey(ByteString.copyFrom(validatorIdentity.publicKey))
 
       override def hasPendingDeploys: F[Boolean] =
-        DeployStorage[F].reader.readPendingHashes.map(_.nonEmpty)
+        DeployStorage[F].reader.countByBufferedState(DeployInfo.State.PENDING).map(_ > 0)
 
       override def ballot(
           keyBlockHash: BlockHash,

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -235,9 +235,9 @@ object DeployBuffer {
           block           <- ProtoUtil.unsafeGetBlock[F](blockHash)
           deploysToRemove = block.body.get.deploys.map(_.deploy.get).toList
           // NOTE: Do we really need this metric? It will make unncessary calls to the DB.
-          initialHistorySize <- DeployStorageReader[F].sizePendingOrProcessed
+          initialHistorySize <- DeployStorageReader[F].countPendingOrProcessed
           _                  <- DeployStorageWriter[F].markAsFinalized(deploysToRemove)
-          deploysRemoved <- DeployStorageReader[F].sizePendingOrProcessed
+          deploysRemoved <- DeployStorageReader[F].countPendingOrProcessed
                              .map(after => initialHistorySize - after)
         } yield deploysRemoved
 

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -235,10 +235,9 @@ object DeployBuffer {
           block           <- ProtoUtil.unsafeGetBlock[F](blockHash)
           deploysToRemove = block.body.get.deploys.map(_.deploy.get).toList
           // NOTE: Do we really need this metric? It will make unncessary calls to the DB.
-          initialHistorySize <- DeployStorageReader[F].sizePendingOrProcessed()
+          initialHistorySize <- DeployStorageReader[F].sizePendingOrProcessed
           _                  <- DeployStorageWriter[F].markAsFinalized(deploysToRemove)
-          deploysRemoved <- DeployStorageReader[F]
-                             .sizePendingOrProcessed()
+          deploysRemoved <- DeployStorageReader[F].sizePendingOrProcessed
                              .map(after => initialHistorySize - after)
         } yield deploysRemoved
 

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
@@ -92,7 +92,7 @@ import cats.mtl.ApplicativeAsk
 
   def getPendingOrProcessed(deployHash: DeployHash): F[Option[Deploy]]
 
-  def sizePendingOrProcessed(implicit A: Applicative[F]): F[Long] =
+  def countPendingOrProcessed(implicit A: Applicative[F]): F[Long] =
     countsByBufferedStates(DeployInfo.State.PENDING, DeployInfo.State.PROCESSED).map(_.values.sum)
 
   /** Count the deploys in the buffer per state. If `states` are passed, filter by them, otherwise return all. */

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/DeployStorage.scala
@@ -1,5 +1,7 @@
 package io.casperlabs.storage.deploy
 
+import cats._
+import cats.implicits._
 import com.google.protobuf.ByteString
 import io.casperlabs.casper.consensus.Block.ProcessedDeploy
 import io.casperlabs.casper.consensus.{Block, Deploy, DeploySummary}
@@ -12,9 +14,7 @@ import simulacrum.typeclass
 import scala.concurrent.duration._
 import cats.mtl.ApplicativeAsk
 
-@typeclass trait DeployStorageWriter[F[_]] {
-  private[storage] def addAsExecuted(block: Block): F[Unit]
-
+@typeclass trait DeployBufferWriter[F[_]] {
   /* Should not fail if the same deploy added twice */
   def addAsPending(deploys: List[Deploy]): F[Unit]
 
@@ -64,16 +64,18 @@ import cats.mtl.ApplicativeAsk
     * Otherwise all the data will be deleted.
     * @return Number of deleted deploys from buffer minus those who [[addAsExecuted]] */
   def cleanupDiscarded(expirationPeriod: FiniteDuration): F[Int]
+}
+
+@typeclass trait DeployStorageWriter[F[_]] extends DeployBufferWriter[F] {
+
+  private[storage] def addAsExecuted(block: Block): F[Unit]
 
   def clear(): F[Unit]
 
   def close(): F[Unit]
 }
-@typeclass trait DeployStorageReader[F[_]] {
-  def contains(deployHash: DeployHash): F[Boolean]
 
-  def getDeploySummary(deployHash: DeployHash): F[Option[DeploySummary]]
-
+@typeclass trait DeployBufferReader[F[_]] {
   def readProcessed: F[List[Deploy]]
 
   def readProcessedByAccount(account: ByteString): F[List[Deploy]]
@@ -90,7 +92,23 @@ import cats.mtl.ApplicativeAsk
 
   def getPendingOrProcessed(deployHash: DeployHash): F[Option[Deploy]]
 
-  def sizePendingOrProcessed(): F[Long]
+  def sizePendingOrProcessed(implicit A: Applicative[F]): F[Long] =
+    countsByBufferedStates(DeployInfo.State.PENDING, DeployInfo.State.PROCESSED).map(_.values.sum)
+
+  /** Count the deploys in the buffer per state. If `states` are passed, filter by them, otherwise return all. */
+  def countsByBufferedStates(states: DeployInfo.State*): F[Map[DeployInfo.State, Long]]
+
+  def countByBufferedState(state: DeployInfo.State)(implicit A: Applicative[F]): F[Long] =
+    countsByBufferedStates(state).map(_.getOrElse(state, 0))
+
+  /** Read the status of a deploy from the buffer, if it's still in it. */
+  def getBufferedStatus(deployHash: DeployHash): F[Option[DeployInfo.Status]]
+}
+
+@typeclass trait DeployStorageReader[F[_]] extends DeployBufferReader[F] {
+  def contains(deployHash: DeployHash): F[Boolean]
+
+  def getDeploySummary(deployHash: DeployHash): F[Option[DeploySummary]]
 
   def getByHash(deployHash: DeployHash): F[Option[Deploy]]
 
@@ -101,9 +119,6 @@ import cats.mtl.ApplicativeAsk
 
   /** Read all the processsed deploys in a block. */
   def getProcessedDeploys(blockHash: BlockHash): F[List[ProcessedDeploy]]
-
-  /** Read the status of a deploy from the buffer, if it's still in it. */
-  def getBufferedStatus(deployHash: DeployHash): F[Option[DeployInfo.Status]]
 
   def getDeployInfo(deployHash: DeployHash): F[Option[DeployInfo]]
 
@@ -200,8 +215,8 @@ object DeployStorageReader {
     abstract override def getPendingOrProcessed(deployHash: DeployHash) =
       incAndMeasure("getPendingOrProcessed", super.getPendingOrProcessed(deployHash))
 
-    abstract override def sizePendingOrProcessed() =
-      incAndMeasure("sizePendingOrProcessed", super.sizePendingOrProcessed())
+    abstract override def countsByBufferedStates(states: DeployInfo.State*) =
+      incAndMeasure("countsByBufferedStates", super.countsByBufferedStates(states: _*))
 
     abstract override def getByHash(deployHash: DeployHash) =
       incAndMeasure("getByHash", super.getByHash(deployHash))


### PR DESCRIPTION
### Overview
Adds a method to `DeployBuffer` that lets us count the number of deploys in each state, so that we don't have to retrieve the hashes and check the length.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1357

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
