### PR TITLE
NODE-1348: Display message role on Clarity.

### DIFF
--- a/explorer/ui/src/components/BlockDetails.tsx
+++ b/explorer/ui/src/components/BlockDetails.tsx
@@ -190,6 +190,7 @@ const blockAttrs: (block: BlockInfo) => Array<[string, any]> = (
     ['Round ID', header.getRoundId()],
     ['Timestamp', new Date(header.getTimestamp()).toISOString()],
     ['Type', <BlockType header={header} />],
+    ['Role', <BlockRole header={header} />],
     ['Validator', validatorId],
     ['Validator Block Number', header.getValidatorBlockSeqNum()],
     [
@@ -259,6 +260,16 @@ export const Balance = observer(
 export const BlockType = (props: { header: Block.Header }) => {
   let typ = props.header.getMessageType();
   let lbl = typ === Block.MessageType.BLOCK ? "Block" : typ === Block.MessageType.BALLOT ? "Ballot" : "n/a"
+  return <span>{lbl}</span>;
+}
+
+export const BlockRole = (props: { header: Block.Header }) => {
+  let role = props.header.getMessageRole()
+  let lbl =
+    role === Block.MessageRole.PROPOSAL ? "Proposal" :
+      role === Block.MessageRole.CONFIRMATION ? "Confirmation" :
+        role === Block.MessageRole.WITNESS ? "Witness" :
+          "n/a";
   return <span>{lbl}</span>;
 }
 

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -53,7 +53,7 @@ class _BlockList extends RefreshableComponent<Props, {}> {
         }
         refresh={() => this.refresh()}
         subscribeToggleStore={dag.subscribeToggleStore}
-        headers={['Block Hash', 'j-Rank', 'm-Rank', 'Timestamp', 'Validator', 'Type', 'Key Block Hash']}
+        headers={['Block Hash', 'j-Rank', 'm-Rank', 'Timestamp', 'Validator', 'Type', 'Role', 'Key Block Hash']}
         rows={dag.blocks}
         renderRow={(block: BlockInfo) => {
           const header = block.getSummary()!.getHeader()!;

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -16,7 +16,7 @@ import Pages from './Pages';
 import { encodeBase16 } from 'casperlabs-sdk';
 import { BondedValidatorsTable } from './BondedValidatorsTable';
 import { ToggleButton } from './ToggleButton';
-import { BlockType, FinalityIcon } from './BlockDetails';
+import { BlockType, BlockRole, FinalityIcon } from './BlockDetails';
 
 /** Show the tips of the DAG. */
 @observer
@@ -164,6 +164,7 @@ class BlockDetails extends React.Component<
         ['m-Rank', header.getMainRank()],
         ['Round ID', header.getRoundId()],
         ['Type', <BlockType header={header} />],
+        ['Role', <BlockRole header={header} />],
         ['Timestamp', new Date(header.getTimestamp()).toISOString()],
         ['Deploy Count', header.getDeployCount()],
         ['Validator', shortHash(validatorId)],


### PR DESCRIPTION
### Overview
Displays the new `message_role` field added in https://github.com/CasperLabs/CasperLabs/pull/1848 so that it's easier to tell what kind of ballot we are looking at.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1348

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
