### PR TITLE
NODE-1363: Separate DB thread pools

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -154,11 +154,14 @@ main-threads = 50
 # Size of the thread pool used to handle incoming requests.
 ingress-threads = 60
 
-# Size of the thread pool for database connections.
-db-threads = 70
+# Size of the thread pool waiting for the database writer connection.
+db-write-threads = 70
+
+# Size of the thread pool waiting for a database reader connection.
+db-read-threads = 75
 
 # Number of database connections in the reader pool.
-db-read-pool-size = 10
+db-read-connections = 10
 
 # Parallelism per CPU core.
 parallelism-cpu-multiplier = 1.0

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -157,6 +157,9 @@ ingress-threads = 60
 # Size of the thread pool for database connections.
 db-threads = 70
 
+# Number of database connections in the reader pool.
+db-read-pool-size = 10
+
 # Parallelism per CPU core.
 parallelism-cpu-multiplier = 1.0
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -135,7 +135,8 @@ class NodeRuntime private[node] (
       (writeTransactor, readTransactor) <- effects.doobieTransactors(
                                             connectEC = dbConnScheduler,
                                             transactEC = dbIOScheduler,
-                                            conf.server.dataDir
+                                            serverDataDir = conf.server.dataDir,
+                                            readPoolSize = conf.server.dbReadPoolSize.value
                                           )
       _ <- Resource.liftF(runRdmbsMigrations(conf.server.dataDir))
 

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -83,14 +83,14 @@ class NodeRuntime private[node] (
   private[this] val egressScheduler =
     Scheduler.cached("egress-io", 2, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
-  private[this] val dbConnScheduler = (name: String, connections: Int, threads: Int) =>
+  private[this] def dbConnScheduler(name: String, connections: Int, threads: Int) =
     Scheduler.cached(
       s"db-conn-$name",
       connections,
       math.max(connections, threads),
       reporter = uncaughtExceptionHandler
     )
-  private[this] val dbIOScheduler = (name: String, connections: Int) =>
+  private[this] def dbIOScheduler(name: String, connections: Int) =
     Scheduler.cached(s"db-io-$name", connections, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
   implicit val raiseIOError: RaiseIOError[Task] = IOError.raiseIOErrorThroughSync[Task]

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -83,15 +83,15 @@ class NodeRuntime private[node] (
   private[this] val egressScheduler =
     Scheduler.cached("egress-io", 2, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
-  private[this] val dbConnScheduler =
+  private[this] val dbConnScheduler = (name: String, poolSize: Int) =>
     Scheduler.cached(
-      "db-conn",
-      1,
-      conf.server.dbThreads.value,
+      s"db-conn-$name",
+      poolSize,
+      math.max(conf.server.dbThreads.value, poolSize),
       reporter = uncaughtExceptionHandler
     )
-  private[this] val dbIOScheduler =
-    Scheduler.cached("db-io", 1, Int.MaxValue, reporter = uncaughtExceptionHandler)
+  private[this] val dbIOScheduler = (name: String, poolSize: Int) =>
+    Scheduler.cached(s"db-io-$name", poolSize, Int.MaxValue, reporter = uncaughtExceptionHandler)
 
   implicit val raiseIOError: RaiseIOError[Task] = IOError.raiseIOErrorThroughSync[Task]
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -104,8 +104,9 @@ object Configuration extends ParserImplicits {
       blockUploadRateMaxThrottled: Int Refined NonNegative,
       mainThreads: Int Refined Positive,
       ingressThreads: Int Refined Positive,
-      dbThreads: Int Refined Positive,
-      dbReadPoolSize: Int Refined Positive,
+      dbWriteThreads: Int Refined Positive,
+      dbReadThreads: Int Refined Positive,
+      dbReadConnections: Int Refined Positive,
       parallelismCpuMultiplier: Double Refined Positive,
       minParallelism: Int Refined Positive
   ) extends SubConfig

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -105,6 +105,7 @@ object Configuration extends ParserImplicits {
       mainThreads: Int Refined Positive,
       ingressThreads: Int Refined Positive,
       dbThreads: Int Refined Positive,
+      dbReadPoolSize: Int Refined Positive,
       parallelismCpuMultiplier: Double Refined Positive,
       minParallelism: Int Refined Positive
   ) extends SubConfig

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -243,11 +243,15 @@ private[configuration] final case class Options private (
       gen[Int]("Size of the thread pool used to handle incoming requests.")
 
     @scallop
-    val serverDbThreads =
-      gen[Int]("Size of the thread pool for database connections.")
+    val serverDbWriteThreads =
+      gen[Int]("Size of the thread pool waiting for the database writer connection.")
 
     @scallop
-    val serverDbReadPoolSize =
+    val serverDbReadThreads =
+      gen[Int]("Size of the thread pool waiting for a database reader connection.")
+
+    @scallop
+    val serverDbReadConnections =
       gen[Int]("Number of database connections in the reader pool.")
 
     @scallop

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -247,6 +247,10 @@ private[configuration] final case class Options private (
       gen[Int]("Size of the thread pool for database connections.")
 
     @scallop
+    val serverDbReadPoolSize =
+      gen[Int]("Number of database connections in the reader pool.")
+
+    @scallop
     val serverParallelismCpuMultiplier =
       gen[Double]("Parallelism per CPU core.")
 

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -88,7 +88,8 @@ package object effects {
   def doobieTransactors(
       connectEC: ExecutionContext,
       transactEC: ExecutionContext,
-      serverDataDir: Path
+      serverDataDir: Path,
+      readPoolSize: Int
   ): Resource[Task, (Transactor[Task], Transactor[Task])] = {
     def mkConfig(poolSize: Int, foreignKeys: Boolean) = {
       val config = new HikariConfig()
@@ -120,7 +121,7 @@ package object effects {
     // Using a separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection
     // preventing acquiring a connection in other places if we use a connection pool with size of 1.
-    val readXaconfig = mkConfig(poolSize = 10, foreignKeys = false)
+    val readXaconfig = mkConfig(poolSize = readPoolSize, foreignKeys = false)
 
     // Hint: Use config.setLeakDetectionThreshold(10000) to detect connection leaking
     for {

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -9,6 +9,7 @@ import cats.mtl._
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
 import doobie.util.transactor.Transactor
+import io.casperlabs.node.configuration.Configuration
 import io.casperlabs.comm._
 import io.casperlabs.comm.discovery._
 import io.casperlabs.comm.rp.Connect._
@@ -79,9 +80,6 @@ package object effects {
       def ask: Task[List[Node]]          = state.get.map(_.bootstraps)
     }
 
-  // Make an execution context based on the name and size of the pool.
-  type DatabaseExecutionContextMaker = (String, Int) => ExecutionContext
-
   /**
     * @see https://tpolecat.github.io/doobie/docs/14-Managing-Connections.html#about-threading
     * @param connectEC for waiting on connections, should be bounded
@@ -89,11 +87,16 @@ package object effects {
     * @return Write and read Transactors
     */
   def doobieTransactors(
-      connectEC: DatabaseExecutionContextMaker,
-      transactEC: DatabaseExecutionContextMaker,
-      serverDataDir: Path,
-      readPoolSize: Int
+      conf: Configuration,
+      connectEC: (String, Int, Int) => ExecutionContext,
+      transactEC: (String, Int) => ExecutionContext
   ): Resource[Task, (Transactor[Task], Transactor[Task])] = {
+    val serverDataDir = conf.server.dataDir
+    val readThreads   = conf.server.dbReadThreads.value
+    val writeThreads  = conf.server.dbWriteThreads.value
+    val readPoolSize  = conf.server.dbReadConnections.value
+    val writePoolSize = 1
+
     def mkConfig(poolSize: Int, foreignKeys: Boolean) = {
       val config = new HikariConfig()
       config.setDriverClassName("org.sqlite.JDBC")
@@ -119,7 +122,6 @@ package object effects {
     // Using a connection pool with maximum size of 1 for writers because with the default settings we got SQLITE_BUSY errors.
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
-    val writePoolSize = 1
     val writeXaconfig = mkConfig(writePoolSize, foreignKeys = true)
 
     // Using a separate Transactor for read operations because
@@ -132,13 +134,13 @@ package object effects {
       writeXa <- HikariTransactor
                   .fromHikariConfig[Task](
                     writeXaconfig,
-                    connectEC("write", writePoolSize),
+                    connectEC("write", writePoolSize, writeThreads),
                     Blocker.liftExecutionContext(transactEC("write", writePoolSize))
                   )
       readXa <- HikariTransactor
                  .fromHikariConfig[Task](
                    readXaconfig,
-                   connectEC("read", readPoolSize),
+                   connectEC("read", readPoolSize, readThreads),
                    Blocker.liftExecutionContext(transactEC("read", readPoolSize))
                  )
     } yield (writeXa, readXa)

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -55,8 +55,9 @@ block-upload-rate-period = "0s"
 block-upload-rate-max-throttled = 0
 main-threads=1
 ingress-threads=1
-db-threads=1
-db-read-pool-size=1
+db-write-threads=1
+db-read-threads=1
+db-read-connections=1
 parallelism-cpu-multiplier = 1.0
 min-parallelism = 1
 

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -56,6 +56,7 @@ block-upload-rate-max-throttled = 0
 main-threads=1
 ingress-threads=1
 db-threads=1
+db-read-pool-size=1
 parallelism-cpu-multiplier = 1.0
 min-parallelism = 1
 

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -108,8 +108,9 @@ class ConfigurationSpec
       blockUploadRateMaxThrottled = 0,
       mainThreads = 1,
       ingressThreads = 1,
-      dbThreads = 1,
-      dbReadPoolSize = 1,
+      dbWriteThreads = 1,
+      dbReadThreads = 1,
+      dbReadConnections = 1,
       parallelismCpuMultiplier = 1.0,
       minParallelism = 1
     )

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -109,6 +109,7 @@ class ConfigurationSpec
       mainThreads = 1,
       ingressThreads = 1,
       dbThreads = 1,
+      dbReadPoolSize = 1,
       parallelismCpuMultiplier = 1.0,
       minParallelism = 1
     )


### PR DESCRIPTION
### Overview
We saw some cases where the thread pool dedicated for awaiting database connections got full. It's not clear whether it's the read or the write connection that gets contested so much. The PR separates the two so we have a better idea, and makes them individually configurable. Also makes the so-far hardcoded reader pool size configurable.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1359

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
