### PR TITLE
NO-TICK: Fix the era creation log start instant.

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -215,7 +215,7 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: BlockRela
         val eraHash      = era.keyBlockHash.show
         val parentHash   = era.parentKeyBlockHash.show
         val startTick    = era.startTick
-        val startInstant = conf.toInstant(Ticks(era.endTick))
+        val startInstant = conf.toInstant(Ticks(era.startTick))
         val endTick      = era.endTick
         val endInstant   = conf.toInstant(Ticks(era.endTick))
         for {


### PR DESCRIPTION
### Overview
Noticed that the logs print the end instant twice when an era is created.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
