### PR TITLE
NODE-1365: StashingSynchronizer to free the stash and filter

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -22,7 +22,6 @@ import io.casperlabs.catscontrib.effect.implicits.fiberSyntax
 import io.casperlabs.comm.gossiping.relaying.Relaying
 import monix.tail.Iterant
 import monix.execution.Scheduler
-
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.control.NonFatal
 import scala.collection.immutable.Queue

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
@@ -59,7 +59,7 @@ class StashingSynchronizer[F[_]: Concurrent: Parallel](
   private def run: F[Unit] =
     for {
       _               <- semaphore.withPermit(transitionedRef.set(true))
-      stashedRequests <- stashedRequestsRef.get
+      stashedRequests <- stashedRequestsRef.modify(Map.empty -> _)
       _ <- stashedRequests.toList.parTraverse {
             case (source, (deferred, hashes)) =>
               underlying.syncDag(source, hashes).attempt >>= deferred.complete

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/StashingSynchronizer.scala
@@ -1,6 +1,5 @@
 package io.casperlabs.comm.gossiping.synchronization
 
-import cats.Parallel
 import cats.effect.concurrent.{Deferred, Ref, Semaphore}
 import cats.effect.implicits._
 import cats.effect.{Concurrent, Sync}
@@ -10,11 +9,12 @@ import io.casperlabs.casper.consensus.BlockSummary
 import io.casperlabs.comm.discovery.Node
 import io.casperlabs.comm.gossiping.synchronization.Synchronizer.SyncError
 
-class StashingSynchronizer[F[_]: Concurrent: Parallel](
+class StashingSynchronizer[F[_]: Concurrent](
     underlying: Synchronizer[F],
     stashedRequestsRef: Ref[F, StashingSynchronizer.Stash[F]],
     transitionedRef: Ref[F, Boolean],
-    semaphore: Semaphore[F]
+    semaphore: Semaphore[F],
+    isInDag: ByteString => F[Boolean]
 ) extends Synchronizer[F] {
   import StashingSynchronizer.SyncResult
 
@@ -64,7 +64,15 @@ class StashingSynchronizer[F[_]: Concurrent: Parallel](
       // from a lot of sources, so better take it easy.
       _ <- stashedRequests.toList.traverse {
             case (source, (deferred, hashes)) =>
-              underlying.syncDag(source, hashes).attempt >>= deferred.complete
+              // The initial synchronization could have acquired all the ones we stashed.
+              hashes.toList.filterA(isInDag(_).map(!_)).flatMap {
+                case Nil =>
+                  deferred.complete {
+                    Vector.empty[BlockSummary].asRight[SyncError].asRight[Throwable]
+                  }
+                case targetBlockHashes =>
+                  underlying.syncDag(source, targetBlockHashes.toSet).attempt >>= deferred.complete
+              }
           }
     } yield ()
 }
@@ -74,9 +82,10 @@ object StashingSynchronizer {
   type SyncResult  = Either[SyncError, Vector[BlockSummary]]
   type Stash[F[_]] = Map[Node, (Deferred[F, Either[Throwable, SyncResult]], Set[ByteString])]
 
-  def wrap[F[_]: Concurrent: Parallel](
+  def wrap[F[_]: Concurrent](
       underlying: Synchronizer[F],
-      await: F[Unit]
+      await: F[Unit],
+      isInDag: ByteString => F[Boolean]
   ): F[Synchronizer[F]] =
     for {
       stashedRequestsRef <- Ref.of[F, Stash[F]](Map.empty)
@@ -87,7 +96,8 @@ object StashingSynchronizer {
               underlying,
               stashedRequestsRef,
               transitionedRef,
-              semaphore
+              semaphore,
+              isInDag
             )
           )
       _ <- (await >> s.run).start

--- a/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/gossiping.scala
@@ -166,7 +166,8 @@ package object gossiping {
       stashingSynchronizer <- Resource.liftF {
                                StashingSynchronizer.wrap(
                                  synchronizer,
-                                 awaitApproval >> awaitSynchronization
+                                 awaitApproval >> awaitSynchronization,
+                                 isInDag[F](_)
                                )
                              }
 


### PR DESCRIPTION
### Overview
Noticed in VisualVM that the stash of the `StashingSynchronizer` is not freed after the requests are replayed. 

The PR also changes the way requests are replayed from parallel to sequential rather, since there can be quite a lot of them at the same time from all the validators, and new ones are also flowing in.

Also added a filtering mechanism so that if during the time of the initial synchronization a lot of targets were accumulated, they are not all sent to the sources, only the ones we still do not have.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1365

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
