### PR TITLE
NODE-1366: Fix the cause of stackoverflow error during syncing.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -26,6 +26,7 @@ import monix.execution.Scheduler
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.control.NonFatal
 import scala.collection.immutable.Queue
+import scala.annotation.tailrec
 
 trait DownloadManagerTypes {
 
@@ -151,14 +152,17 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
       id: Identifier,
       source: Node
   ): Set[Identifier] = {
+
+    @tailrec
     def loop(
         acc: Set[Identifier],
         queue: Queue[Identifier]
     ): Set[Identifier] =
-      queue.dequeueOption.fold(acc) {
-        case (id, queue) if acc(id) =>
+      queue.dequeueOption match {
+        case None => acc
+        case Some((id, queue)) if acc(id) =>
           loop(acc, queue)
-        case (id, queue) =>
+        case Some((id, queue)) =>
           items.get(id) match {
             case Some(item) if item.isError || !item.sources(source) =>
               loop(acc + id, queue ++ item.dependencies)
@@ -177,15 +181,18 @@ trait DownloadManagerCompanion extends DownloadManagerTypes {
       items: Map[Identifier, Item[F]],
       id: Identifier
   ): Set[Identifier] = {
+
+    @tailrec
     def loop(
         acc: Set[Identifier],
         queue: Queue[Identifier]
     ): Set[Identifier] =
-      queue.dequeueOption.fold(acc) {
-        case (id, queue) if acc(id) =>
+      queue.dequeueOption match {
+        case None => acc
+        case Some((id, queue)) if acc(id) =>
           loop(acc, queue)
 
-        case (id, queue) =>
+        case Some((id, queue)) =>
           val dependants = items.collect {
             case (hash, dep) if dep.dependencies contains id => hash
           }

--- a/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
+++ b/shared/src/main/scala/io/casperlabs/shared/UncaughtExceptionHandler.scala
@@ -1,32 +1,15 @@
 package io.casperlabs.shared
 
-import java.text.SimpleDateFormat
-import java.time.format.DateTimeFormatter
-import java.time.{Instant, ZoneId}
-import java.util.{Date, SimpleTimeZone, TimeZone}
-
 import cats.Id
 import monix.execution.UncaughtExceptionReporter
 
 import scala.concurrent.duration.FiniteDuration
-import scala.util.Try
 
 class UncaughtExceptionHandler(shutdownTimeout: FiniteDuration)(implicit logId: Log[Id])
     extends UncaughtExceptionReporter
     with RuntimeOps {
   override def reportFailure(ex: scala.Throwable): Unit = {
-    Try(Log[Id].error(s"Uncaught Exception : $ex")).recover {
-      case ex =>
-        // Logstage example formatting "2020-04-07T02:45:56.815 "
-        val dateTimeFormatter =
-          DateTimeFormatter.ofPattern("YYYY-MM-dd'T'HH:mm:ss.SSS").withZone(ZoneId.of("UTC"))
-        val timestamp = dateTimeFormatter.format(Instant.now())
-        println(
-          s"ERROR $timestamp (UncaughtExceptionHandler.scala) Exception thrown when logging. " +
-            s"Original stacktrace:\n${ex.getMessage}"
-        )
-        ex.printStackTrace()
-    }
+    Log[Id].error(s"Uncaught Exception : $ex")
     ex match {
       case _: VirtualMachineError | _: LinkageError | _: FatalErrorShutdown =>
         // To flush logs


### PR DESCRIPTION
### Overview
`Option.fold`is not tail recursive and was used in such context. Rewrite to use tail call elimination.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1366

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
