### PR TITLE
EE-771: Make sure Error::Interpreter does not get unnecessarily nested on call_contract

### DIFF
--- a/execution-engine/contracts/test/ee-771-regression/Cargo.toml
+++ b/execution-engine/contracts/test/ee-771-regression/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ee-771-regression"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@papierski.net>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["contract/std", "types/std"]
+
+[dependencies]
+contract = { path = "../../../contract", package = "casperlabs-contract" }
+types = { path = "../../../types", package = "casperlabs-types" }

--- a/execution-engine/contracts/test/ee-771-regression/src/lib.rs
+++ b/execution-engine/contracts/test/ee-771-regression/src/lib.rs
@@ -1,0 +1,54 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, string::ToString};
+
+use contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use types::{ApiError, ContractRef};
+
+const CONTRACT_EXT: &str = "contract_ext";
+const CONTRACT_KEY: &str = "contract";
+
+#[no_mangle]
+pub extern "C" fn contract_ext() {
+    match runtime::get_key(CONTRACT_KEY) {
+        Some(key) => {
+            // Calls a stored contract if exists.
+            runtime::call_contract(key.to_contract_ref().unwrap(), ())
+        }
+        None => {
+            // If given key doesn't exist it's the tail call, and an error is triggered.
+            storage::store_function_at_hash("functiondoesnotexist", Default::default());
+        }
+    }
+}
+
+fn install() -> Result<ContractRef, ApiError> {
+    let pointer = storage::store_function_at_hash(CONTRACT_EXT, BTreeMap::new());
+
+    let mut keys = BTreeMap::new();
+    keys.insert(CONTRACT_KEY.to_string(), pointer.into());
+    let pointer = storage::store_function_at_hash(CONTRACT_EXT, keys);
+
+    let mut keys_2 = BTreeMap::new();
+    keys_2.insert(CONTRACT_KEY.to_string(), pointer.into());
+    let pointer = storage::store_function_at_hash(CONTRACT_EXT, keys_2);
+
+    runtime::put_key(CONTRACT_KEY, pointer.clone().into());
+
+    Ok(pointer)
+}
+
+fn dispatch(contract: ContractRef) {
+    runtime::call_contract::<_, ()>(contract, ());
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let contract_key = install().unwrap_or_revert();
+    dispatch(contract_key)
+}

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -42,7 +42,7 @@ wasmi = "0.4.2"
 
 [dev-dependencies]
 lazy_static = "1"
-matches = "0.1.8"
+assert_matches = "1.3.0"
 proptest = "0.9.4"
 
 [features]

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
     WasmPreprocessing(engine_wasm_prep::PreprocessingError),
     #[fail(display = "Wasm serialization error: {:?}", _0)]
     WasmSerialization(parity_wasm::SerializationError),
-    #[fail(display = "Execution error: {}", _0)]
+    #[fail(display = "{}", _0)]
     Exec(execution::Error),
     #[fail(display = "Storage error: {}", _0)]
     Storage(engine_storage::error::Error),

--- a/execution-engine/engine-core/src/engine_state/execution_result.rs
+++ b/execution-engine/engine-core/src/engine_state/execution_result.rs
@@ -128,7 +128,7 @@ impl ExecutionResult {
         }
     }
 
-    pub fn error(&self) -> Option<&error::Error> {
+    pub fn as_error(&self) -> Option<&error::Error> {
         match self {
             ExecutionResult::Failure { error, .. } => Some(error),
             ExecutionResult::Success { .. } => None,

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -1,5 +1,4 @@
-use core::fmt;
-
+use failure::Fail;
 use parity_wasm::elements;
 
 use engine_shared::TypeMismatch;
@@ -10,49 +9,70 @@ use types::{
 
 use crate::resolvers::error::ResolverError;
 
-#[derive(Debug)]
+#[derive(Fail, Debug, Clone)]
 pub enum Error {
-    Interpreter(wasmi::Error),
+    #[fail(display = "Interpreter error: {}", _0)]
+    Interpreter(String),
+    #[fail(display = "Storage error: {}", _0)]
     Storage(engine_storage::error::Error),
+    #[fail(display = "Serialization error: {}", _0)]
     BytesRepr(bytesrepr::Error),
+    #[fail(display = "Key {} not found", _0)]
     KeyNotFound(Key),
+    #[fail(display = "Account {:?} not found", _0)]
     AccountNotFound(Key),
+    #[fail(display = "{}", _0)]
     TypeMismatch(TypeMismatch),
-    InvalidAccess {
-        required: AccessRights,
-    },
+    #[fail(display = "Invalid access rights: {}", required)]
+    InvalidAccess { required: AccessRights },
+    #[fail(display = "Forged reference: {}", _0)]
     ForgedReference(URef),
+    #[fail(display = "URef not found: {}", _0)]
     URefNotFound(String),
+    #[fail(display = "Function not found: {}", _0)]
     FunctionNotFound(String),
+    #[fail(display = "{}", _0)]
     ParityWasm(elements::Error),
+    #[fail(display = "Out of gas error")]
     GasLimit,
+    #[fail(display = "Return")]
     Ret(Vec<URef>),
-    Rng(rand::Error),
+    #[fail(display = "{}", _0)]
+    Rng(String),
+    #[fail(display = "Resolver error: {}", _0)]
     Resolver(ResolverError),
     /// Reverts execution with a provided status
+    #[fail(display = "{}", _0)]
     Revert(ApiError),
+    #[fail(display = "{}", _0)]
     AddKeyFailure(AddKeyFailure),
+    #[fail(display = "{}", _0)]
     RemoveKeyFailure(RemoveKeyFailure),
+    #[fail(display = "{}", _0)]
     UpdateKeyFailure(UpdateKeyFailure),
+    #[fail(display = "{}", _0)]
     SetThresholdFailure(SetThresholdFailure),
+    #[fail(display = "{}", _0)]
     SystemContract(system_contract_errors::Error),
+    #[fail(display = "Deployment authorization failure")]
     DeploymentAuthorizationFailure,
+    #[fail(display = "Expected return value")]
     ExpectedReturnValue,
+    #[fail(display = "Unexpected return value")]
     UnexpectedReturnValue,
+    #[fail(display = "Invalid context")]
     InvalidContext,
-    IncompatibleProtocolMajorVersion {
-        expected: u32,
-        actual: u32,
-    },
+    #[fail(
+        display = "Incompatible protocol major version. Current version {} but version {} is expected",
+        expected, actual
+    )]
+    IncompatibleProtocolMajorVersion { expected: u32, actual: u32 },
+    #[fail(display = "{}", _0)]
     CLValue(CLValueError),
+    #[fail(display = "Host buffer is empty")]
     HostBufferEmpty,
+    #[fail(display = "Unsupported WASM start")]
     UnsupportedWasmStart,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
-    }
 }
 
 impl wasmi::HostError for Error {}
@@ -64,8 +84,14 @@ impl From<!> for Error {
 }
 
 impl From<wasmi::Error> for Error {
-    fn from(e: wasmi::Error) -> Self {
-        Error::Interpreter(e)
+    fn from(error: wasmi::Error) -> Self {
+        match error
+            .as_host_error()
+            .and_then(|host_error| host_error.downcast_ref::<Error>())
+        {
+            Some(error) => error.clone(),
+            None => Error::Interpreter(error.into()),
+        }
     }
 }
 

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -63,7 +63,7 @@ pub enum Error {
     #[fail(display = "Invalid context")]
     InvalidContext,
     #[fail(
-        display = "Incompatible protocol major version. Current version {} but version {} is expected",
+        display = "Incompatible protocol major version. Expected version {} but actual version is {}",
         expected, actual
     )]
     IncompatibleProtocolMajorVersion { expected: u32, actual: u32 },

--- a/execution-engine/engine-core/src/resolvers/error.rs
+++ b/execution-engine/engine-core/src/resolvers/error.rs
@@ -1,7 +1,11 @@
+use failure::Fail;
+
 use types::ProtocolVersion;
 
-#[derive(Debug)]
+#[derive(Fail, Debug, Copy, Clone)]
 pub enum ResolverError {
+    #[fail(display = "Unknown protocol version: {}", _0)]
     UnknownProtocolVersion(ProtocolVersion),
+    #[fail(display = "No imported memory")]
     NoImportedMemory,
 }

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -227,7 +227,7 @@ where
                 let uref_bytes = self
                     .memory
                     .get(urefs_ptr, urefs_size as usize)
-                    .map_err(Error::Interpreter)?;
+                    .map_err(|e| Error::Interpreter(e.into()))?;
                 let urefs = bytesrepr::deserialize(uref_bytes).map_err(Error::BytesRepr)?;
                 let contract_hash = self.store_function(fn_bytes, urefs)?;
                 self.function_address(contract_hash, hash_ptr)?;
@@ -248,7 +248,7 @@ where
                 let uref_bytes = self
                     .memory
                     .get(urefs_ptr, urefs_size as usize)
-                    .map_err(Error::Interpreter)?;
+                    .map_err(|e| Error::Interpreter(e.into()))?;
                 let urefs = bytesrepr::deserialize(uref_bytes).map_err(Error::BytesRepr)?;
                 let contract_hash = self.store_function_at_hash(fn_bytes, urefs)?;
                 self.function_address(contract_hash, hash_ptr)?;
@@ -325,7 +325,7 @@ where
                 assert_eq!(dest_size, purse_bytes.len() as u32);
                 self.memory
                     .set(dest_ptr, &purse_bytes)
-                    .map_err(Error::Interpreter)?;
+                    .map_err(|e| Error::Interpreter(e.into()))?;
                 Ok(Some(RuntimeValue::I32(0)))
             }
 

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -2045,7 +2045,7 @@ where
                     self.context.access_rights_extend(ret_urefs_map);
                     // if ret has not set host_buffer consider it programmer error
                     return runtime.take_host_buffer().ok_or(Error::ExpectedReturnValue);
-                },
+                }
                 error => return Err(error.clone()),
             }
         }

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -1473,7 +1473,7 @@ where
         let arg_size_bytes = arg_size.to_le_bytes(); // Wasm is little-endian
 
         if let Err(e) = self.memory.set(size_ptr, &arg_size_bytes) {
-            return Err(Error::Interpreter(e).into());
+            return Err(Error::Interpreter(e.into()).into());
         }
 
         Ok(Ok(()))
@@ -1498,7 +1498,7 @@ where
             .memory
             .set(output_ptr, &arg.inner_bytes()[..output_size])
         {
-            return Err(Error::Interpreter(e).into());
+            return Err(Error::Interpreter(e.into()).into());
         }
 
         Ok(Ok(()))
@@ -1533,14 +1533,14 @@ where
 
         // Set serialized Key bytes into the output buffer
         if let Err(error) = self.memory.set(output_ptr, &key_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
 
         // For all practical purposes following cast is assumed to be safe
         let bytes_size = key_bytes.len() as u32;
         let size_bytes = bytes_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(bytes_written_ptr, &size_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
 
         Ok(Ok(()))
@@ -1579,7 +1579,7 @@ where
         let purse_bytes = purse.into_bytes().map_err(Error::BytesRepr)?;
         self.memory
             .set(dest_ptr, &purse_bytes)
-            .map_err(|e| Error::Interpreter(e).into())
+            .map_err(|e| Error::Interpreter(e.into()).into())
     }
 
     /// Writes caller (deploy) account public key to [dest_ptr] in the Wasm
@@ -1600,7 +1600,7 @@ where
         // Write output
         let output_size_bytes = value_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(output_size, &output_size_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
         Ok(Ok(()))
     }
@@ -1611,7 +1611,7 @@ where
         let bytes = phase.into_bytes().map_err(Error::BytesRepr)?;
         self.memory
             .set(dest_ptr, &bytes)
-            .map_err(|e| Error::Interpreter(e).into())
+            .map_err(|e| Error::Interpreter(e.into()).into())
     }
 
     /// Writes current blocktime to [dest_ptr] in Wasm memory.
@@ -1623,7 +1623,7 @@ where
             .map_err(Error::BytesRepr)?;
         self.memory
             .set(dest_ptr, &blocktime)
-            .map_err(|e| Error::Interpreter(e).into())
+            .map_err(|e| Error::Interpreter(e.into()).into())
     }
 
     /// Return some bytes from the memory and terminate the current `sub_call`. Note that the return
@@ -1633,7 +1633,7 @@ where
         let mem_get = self
             .memory
             .get(value_ptr, value_size)
-            .map_err(Error::Interpreter);
+            .map_err(|e| Error::Interpreter(e.into()));
         match mem_get {
             Ok(buf) => {
                 // Set the result field in the runtime and return the proper element of the `Error`
@@ -2045,21 +2045,12 @@ where
                     self.context.access_rights_extend(ret_urefs_map);
                     // if ret has not set host_buffer consider it programmer error
                     return runtime.take_host_buffer().ok_or(Error::ExpectedReturnValue);
-                }
-                Error::Revert(status) => {
-                    // Propagate revert as revert, instead of passing it as
-                    // InterpreterError.
-                    return Err(Error::Revert(*status));
-                }
-                Error::InvalidContext => {
-                    // TODO: https://casperlabs.atlassian.net/browse/EE-771
-                    return Err(Error::InvalidContext);
-                }
-                _ => {}
+                },
+                error => return Err(error.clone()),
             }
         }
 
-        Err(Error::Interpreter(error))
+        Err(Error::Interpreter(error.into()))
     }
 
     fn call_contract_host_buffer(
@@ -2085,7 +2076,7 @@ where
 
         let result_size_bytes = result_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(result_size_ptr, &result_size_bytes) {
-            return Err(Error::Interpreter(error));
+            return Err(Error::Interpreter(error.into()));
         }
 
         Ok(Ok(()))
@@ -2104,7 +2095,7 @@ where
         let total_keys = self.context.named_keys().len() as u32;
         let total_keys_bytes = total_keys.to_le_bytes();
         if let Err(error) = self.memory.set(total_keys_ptr, &total_keys_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
 
         if total_keys == 0 {
@@ -2122,7 +2113,7 @@ where
 
         let length_bytes = length.to_le_bytes();
         if let Err(error) = self.memory.set(result_size_ptr, &length_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
 
         Ok(Ok(()))
@@ -2160,7 +2151,7 @@ where
     fn function_address(&mut self, hash_bytes: [u8; 32], dest_ptr: u32) -> Result<(), Trap> {
         self.memory
             .set(dest_ptr, &hash_bytes)
-            .map_err(|e| Error::Interpreter(e).into())
+            .map_err(|e| Error::Interpreter(e.into()).into())
     }
 
     /// Generates new unforgable reference and adds it to the context's
@@ -2170,7 +2161,7 @@ where
         let uref = self.context.new_uref(StoredValue::CLValue(cl_value))?;
         self.memory
             .set(uref_ptr, &uref.into_bytes().map_err(Error::BytesRepr)?)
-            .map_err(|e| Error::Interpreter(e).into())
+            .map_err(|e| Error::Interpreter(e.into()).into())
     }
 
     /// Writes `value` under `key` in GlobalState.
@@ -2264,7 +2255,7 @@ where
 
         let value_bytes = value_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(output_size_ptr, &value_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
 
         Ok(Ok(()))
@@ -2297,7 +2288,7 @@ where
 
         let value_bytes = value_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(output_size_ptr, &value_bytes) {
-            return Err(Error::Interpreter(error).into());
+            return Err(Error::Interpreter(error.into()).into());
         }
 
         Ok(Ok(()))
@@ -2687,7 +2678,7 @@ where
 
         let balance_size_bytes = balance_size.to_le_bytes(); // Wasm is little-endian
         if let Err(error) = self.memory.set(output_size_ptr, &balance_size_bytes) {
-            return Err(Error::Interpreter(error));
+            return Err(Error::Interpreter(error.into()));
         }
 
         Ok(Ok(()))
@@ -2738,7 +2729,7 @@ where
         let attenuated_uref_bytes = attenuated_uref.into_bytes().map_err(Error::BytesRepr)?;
         match self.memory.set(dest_ptr, &attenuated_uref_bytes) {
             Ok(_) => Ok(Ok(())),
-            Err(error) => Err(Error::Interpreter(error).into()),
+            Err(error) => Err(Error::Interpreter(error.into()).into()),
         }
     }
 
@@ -2785,14 +2776,14 @@ where
         // as whole.
         let sliced_buf = &serialized_value[..cmp::min(dest_size, serialized_value.len())];
         if let Err(error) = self.memory.set(dest_ptr, sliced_buf) {
-            return Err(Error::Interpreter(error));
+            return Err(Error::Interpreter(error.into()));
         }
 
         let bytes_written = sliced_buf.len() as u32;
         let bytes_written_data = bytes_written.to_le_bytes();
 
         if let Err(error) = self.memory.set(bytes_written_ptr, &bytes_written_data) {
-            return Err(Error::Interpreter(error));
+            return Err(Error::Interpreter(error.into()));
         }
 
         Ok(Ok(()))

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -1,6 +1,6 @@
 use std::{cell::Cell, collections::BTreeMap, iter, rc::Rc};
 
-use matches::assert_matches;
+use assert_matches::assert_matches;
 use proptest::{collection::vec, prelude::*};
 
 use engine_shared::{

--- a/execution-engine/engine-shared/src/type_mismatch.rs
+++ b/execution-engine/engine-shared/src/type_mismatch.rs
@@ -1,7 +1,19 @@
+use std::fmt;
+
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub struct TypeMismatch {
     pub expected: String,
     pub found: String,
+}
+
+impl fmt::Display for TypeMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "Type mismatch. Expected {} but found {}.",
+            self.expected, self.found
+        )
+    }
 }
 
 impl TypeMismatch {

--- a/execution-engine/engine-test-support/src/internal/utils.rs
+++ b/execution-engine/engine-test-support/src/internal/utils.rs
@@ -9,6 +9,7 @@ use lazy_static::lazy_static;
 use engine_core::engine_state::{
     execution_result::ExecutionResult,
     genesis::{GenesisAccount, GenesisConfig},
+    Error,
 };
 use engine_shared::{
     account::Account, additive_map::AdditiveMap, gas::Gas, stored_value::StoredValue,
@@ -134,13 +135,13 @@ pub fn get_success_result(response: &[Rc<ExecutionResult>]) -> &ExecutionResult 
     &*response.get(0).expect("should have a result")
 }
 
-pub fn get_precondition_failure(response: &[Rc<ExecutionResult>]) -> String {
+pub fn get_precondition_failure(response: &[Rc<ExecutionResult>]) -> &Error {
     let result = response.get(0).expect("should have a result");
     assert!(
         result.has_precondition_failure(),
         "should be a precondition failure"
     );
-    format!("{}", result.error().expect("should have an error"))
+    result.as_error().expect("should have an error")
 }
 
 pub fn get_error_message<T: AsRef<ExecutionResult>, I: IntoIterator<Item = T>>(

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -574,6 +574,10 @@ where
         &self.engine_state
     }
 
+    pub fn get_exec_responses(&self) -> &Vec<Vec<Rc<ExecutionResult>>> {
+        &self.exec_responses
+    }
+
     pub fn get_exec_response(&self, index: usize) -> Option<&Vec<Rc<ExecutionResult>>> {
         self.exec_responses.get(index)
     }

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -27,6 +27,7 @@ num-traits = "0.2.10"
 serde_json = "1"
 tempfile = "3"
 wabt = "0.9.2"
+assert_matches = "1.3.0"
 
 [features]
 enable-bonding = ["engine-test-support/enable-bonding"]

--- a/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
@@ -66,7 +66,7 @@ fn should_raise_auth_failure_with_invalid_key() {
         "{:?}",
         deploy_result
     );
-    let message = format!("{}", deploy_result.error().unwrap());
+    let message = format!("{}", deploy_result.as_error().unwrap());
 
     assert_eq!(message, format!("{}", engine_state::Error::Authorization))
 }
@@ -109,7 +109,7 @@ fn should_raise_auth_failure_with_invalid_keys() {
         .expect("should have at least one deploy result");
 
     assert!(deploy_result.has_precondition_failure());
-    let message = format!("{}", deploy_result.error().unwrap());
+    let message = format!("{}", deploy_result.as_error().unwrap());
 
     assert_eq!(message, format!("{}", engine_state::Error::Authorization))
 }
@@ -197,7 +197,7 @@ fn should_raise_deploy_authorization_failure() {
             .expect("should have at least one deploy result");
 
         assert!(deploy_result.has_precondition_failure());
-        let message = format!("{}", deploy_result.error().unwrap());
+        let message = format!("{}", deploy_result.as_error().unwrap());
         assert!(message.contains(&format!(
             "{}",
             execution::Error::DeploymentAuthorizationFailure
@@ -244,7 +244,7 @@ fn should_raise_deploy_authorization_failure() {
             .expect("should have at least one deploy result");
 
         assert!(deploy_result.has_precondition_failure());
-        let message = format!("{}", deploy_result.error().unwrap());
+        let message = format!("{}", deploy_result.as_error().unwrap());
         assert!(message.contains(&format!(
             "{}",
             execution::Error::DeploymentAuthorizationFailure
@@ -387,7 +387,7 @@ fn should_not_authorize_deploy_with_duplicated_keys() {
         "{:?}",
         deploy_result
     );
-    let message = format!("{}", deploy_result.error().unwrap());
+    let message = format!("{}", deploy_result.as_error().unwrap());
     assert!(message.contains(&format!(
         "{}",
         execution::Error::DeploymentAuthorizationFailure

--- a/execution-engine/engine-tests/src/test/deploy/preconditions.rs
+++ b/execution-engine/engine-tests/src/test/deploy/preconditions.rs
@@ -1,3 +1,6 @@
+use assert_matches::assert_matches;
+
+use engine_core::engine_state::Error;
 use engine_test_support::{
     internal::{
         utils, DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder,
@@ -44,11 +47,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
         .expect("there should be a response");
 
     let precondition_failure = utils::get_precondition_failure(response);
-
-    assert_eq!(
-        precondition_failure, "Authorization failure: not authorized.",
-        "expected authorization failure"
-    );
+    assert_matches!(precondition_failure, Error::Authorization);
 }
 
 #[ignore]
@@ -79,11 +78,7 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
         .expect("there should be a response");
 
     let precondition_failure = utils::get_precondition_failure(response);
-
-    assert_eq!(
-        precondition_failure, "Authorization failure: not authorized.",
-        "expected authorization failure"
-    );
+    assert_matches!(precondition_failure, Error::Authorization);
 }
 
 #[ignore]
@@ -121,9 +116,5 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
         .expect("there should be a response");
 
     let precondition_failure = utils::get_precondition_failure(response);
-
-    assert_eq!(
-        precondition_failure, "Authorization failure: not authorized.",
-        "expected authorization failure"
-    );
+    assert_matches!(precondition_failure, Error::Authorization);
 }

--- a/execution-engine/engine-tests/src/test/regression/ee_532.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_532.rs
@@ -34,7 +34,7 @@ fn should_run_ee_532_get_uref_regression_test() {
         "expected precondition failure"
     );
 
-    let message = deploy_result.error().map(|err| format!("{}", err));
+    let message = deploy_result.as_error().map(|err| format!("{}", err));
     assert_eq!(
         message,
         Some(format!("{}", Error::Authorization)),

--- a/execution-engine/engine-tests/src/test/regression/ee_771.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_771.rs
@@ -24,7 +24,7 @@ fn should_run_ee_771_regression() {
         .expect("should have a response")
         .to_owned();
 
-    let error = response[0].error().expect("should have error");
+    let error = response[0].as_error().expect("should have error");
     assert_eq!(
         format!("{}", error),
         "Function not found: functiondoesnotexist"

--- a/execution-engine/engine-tests/src/test/regression/ee_771.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_771.rs
@@ -1,0 +1,33 @@
+use engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG},
+    DEFAULT_ACCOUNT_ADDR,
+};
+
+const CONTRACT_EE_771_REGRESSION: &str = "ee_771_regression.wasm";
+
+#[ignore]
+#[test]
+fn should_run_ee_771_regression() {
+    let exec_request =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_EE_771_REGRESSION, ())
+            .build();
+
+    let result = InMemoryWasmTestBuilder::default()
+        .run_genesis(&DEFAULT_GENESIS_CONFIG)
+        .exec(exec_request)
+        .commit()
+        .finish();
+
+    let response = result
+        .builder()
+        .get_exec_response(0)
+        .expect("should have a response")
+        .to_owned();
+
+    // let error_message = utils::get_error_message(response);
+    let error = response[0].error().expect("should have error");
+    assert_eq!(
+        format!("{}", error),
+        "Function not found: functiondoesnotexist."
+    );
+}

--- a/execution-engine/engine-tests/src/test/regression/ee_771.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_771.rs
@@ -24,10 +24,9 @@ fn should_run_ee_771_regression() {
         .expect("should have a response")
         .to_owned();
 
-    // let error_message = utils::get_error_message(response);
     let error = response[0].error().expect("should have error");
     assert_eq!(
         format!("{}", error),
-        "Function not found: functiondoesnotexist."
+        "Function not found: functiondoesnotexist"
     );
 }

--- a/execution-engine/engine-tests/src/test/regression/mod.rs
+++ b/execution-engine/engine-tests/src/test/regression/mod.rs
@@ -15,5 +15,6 @@ mod ee_597;
 mod ee_598;
 mod ee_599;
 mod ee_601;
+mod ee_771;
 mod ee_803;
 mod ee_890;

--- a/execution-engine/types/src/account.rs
+++ b/execution-engine/types/src/account.rs
@@ -54,7 +54,7 @@ impl TryFrom<u32> for ActionType {
 /// Errors that can occur while changing action thresholds (i.e. the total [`Weight`]s of signing
 /// [`PublicKey`]s required to perform various actions) on an account.
 #[repr(i32)]
-#[derive(Debug, Fail, PartialEq, Eq)]
+#[derive(Debug, Fail, PartialEq, Eq, Copy, Clone)]
 pub enum SetThresholdFailure {
     /// Setting the key-management threshold to a value lower than the deployment threshold is
     /// disallowed.
@@ -281,7 +281,7 @@ impl FromBytes for PublicKey {
 }
 
 /// Errors that can occur while adding a new [`PublicKey`] to an account's associated keys map.
-#[derive(PartialEq, Eq, Fail, Debug)]
+#[derive(PartialEq, Eq, Fail, Debug, Copy, Clone)]
 #[repr(i32)]
 pub enum AddKeyFailure {
     /// There are already [`MAX_ASSOCIATED_KEYS`] [`PublicKey`]s associated with the given account.
@@ -312,7 +312,7 @@ impl TryFrom<i32> for AddKeyFailure {
 }
 
 /// Errors that can occur while removing a [`PublicKey`] from an account's associated keys map.
-#[derive(Fail, Debug, Eq, PartialEq)]
+#[derive(Fail, Debug, Eq, PartialEq, Copy, Clone)]
 #[repr(i32)]
 pub enum RemoveKeyFailure {
     /// The given [`PublicKey`] is not associated with the given account.
@@ -349,7 +349,7 @@ impl TryFrom<i32> for RemoveKeyFailure {
 
 /// Errors that can occur while updating the [`Weight`] of a [`PublicKey`] in an account's
 /// associated keys map.
-#[derive(PartialEq, Eq, Fail, Debug)]
+#[derive(PartialEq, Eq, Fail, Debug, Copy, Clone)]
 #[repr(i32)]
 pub enum UpdateKeyFailure {
     /// The given [`PublicKey`] is not associated with the given account.

--- a/execution-engine/types/src/cl_value.rs
+++ b/execution-engine/types/src/cl_value.rs
@@ -1,4 +1,7 @@
 use alloc::vec::Vec;
+use core::fmt;
+
+use failure::Fail;
 
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes, U32_SERIALIZED_LENGTH},
@@ -15,12 +18,24 @@ pub struct CLTypeMismatch {
     pub found: CLType,
 }
 
+impl fmt::Display for CLTypeMismatch {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "Expected {:?} but found {:?}.",
+            self.expected, self.found
+        )
+    }
+}
+
 /// Error relating to [`CLValue`] operations.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(Fail, PartialEq, Eq, Clone, Debug)]
 pub enum CLValueError {
     /// An error while serializing or deserializing the underlying data.
+    #[fail(display = "CLValue error: {}", _0)]
     Serialization(bytesrepr::Error),
     /// A type mismatch while trying to convert a [`CLValue`] into a given type.
+    #[fail(display = "Type mismatch: {}", _0)]
     Type(CLTypeMismatch),
 }
 

--- a/execution-engine/types/src/system_contract_errors/mod.rs
+++ b/execution-engine/types/src/system_contract_errors/mod.rs
@@ -1,14 +1,17 @@
 //! Home of error types returned by system contracts.
+use failure::Fail;
 
 pub mod mint;
 pub mod pos;
 
 /// An aggregate enum error with variants for each system contract's error.
-#[derive(Debug)]
+#[derive(Fail, Debug, Copy, Clone)]
 pub enum Error {
     /// Contains a [`mint::Error`].
+    #[fail(display = "Mint error: {}", _0)]
     Mint(mint::Error),
     /// Contains a [`pos::Error`].
+    #[fail(display = "Proof of Stake error: {}", _0)]
     Pos(pos::Error),
 }
 

--- a/execution-engine/types/src/system_contract_errors/pos.rs
+++ b/execution-engine/types/src/system_contract_errors/pos.rs
@@ -1,4 +1,5 @@
 //! Home of the Proof of Stake contract's [`Error`] type.
+use failure::Fail;
 
 use alloc::vec::Vec;
 use core::result;
@@ -10,72 +11,99 @@ use crate::{
 
 /// Errors which can occur while executing the Proof of Stake contract.
 // TODO: Split this up into user errors vs. system errors.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Fail, Debug, Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Error {
     // ===== User errors =====
     /// The given validator is not bonded.
+    #[fail(display = "Not bonded")]
     NotBonded = 0,
     /// There are too many bonding or unbonding attempts already enqueued to allow more.
+    #[fail(display = "Too many events in queue")]
     TooManyEventsInQueue,
     /// At least one validator must remain bonded.
+    #[fail(display = "Cannot unbond last validator")]
     CannotUnbondLastValidator,
     /// Failed to bond or unbond as this would have resulted in exceeding the maximum allowed
     /// difference between the largest and smallest stakes.
+    #[fail(display = "Spread is too high")]
     SpreadTooHigh,
     /// The given validator already has a bond or unbond attempt enqueued.
+    #[fail(display = "Multiple requests")]
     MultipleRequests,
     /// Attempted to bond with a stake which was too small.
+    #[fail(display = "Bond is too small")]
     BondTooSmall,
     /// Attempted to bond with a stake which was too large.
+    #[fail(display = "Bond is too large")]
     BondTooLarge,
     /// Attempted to unbond an amount which was too large.
+    #[fail(display = "Unbond is too large")]
     UnbondTooLarge,
     /// While bonding, the transfer from source purse to the Proof of Stake internal purse failed.
+    #[fail(display = "Bond transfer failed")]
     BondTransferFailed,
     /// While unbonding, the transfer from the Proof of Stake internal purse to the destination
     /// purse failed.
+    #[fail(display = "Unbond transfer failed")]
     UnbondTransferFailed,
     // ===== System errors =====
     /// Internal error: a [`BlockTime`](crate::BlockTime) was unexpectedly out of sequence.
+    #[fail(display = "Time went backwards")]
     TimeWentBackwards,
     /// Internal error: stakes were unexpectedly empty.
+    #[fail(display = "Stakes not found")]
     StakesNotFound,
     /// Internal error: the PoS contract's payment purse wasn't found.
+    #[fail(display = "Payment purse not found")]
     PaymentPurseNotFound,
     /// Internal error: the PoS contract's payment purse key was the wrong type.
+    #[fail(display = "Payment purse has unexpected type")]
     PaymentPurseKeyUnexpectedType,
     /// Internal error: couldn't retrieve the balance for the PoS contract's payment purse.
+    #[fail(display = "Payment purse balance not found")]
     PaymentPurseBalanceNotFound,
     /// Internal error: the PoS contract's bonding purse wasn't found.
+    #[fail(display = "Bonding purse not found")]
     BondingPurseNotFound,
     /// Internal error: the PoS contract's bonding purse key was the wrong type.
+    #[fail(display = "Bonding purse key has unexpected type")]
     BondingPurseKeyUnexpectedType,
     /// Internal error: the PoS contract's refund purse key was the wrong type.
+    #[fail(display = "Refund purse key has unexpected type")]
     RefundPurseKeyUnexpectedType,
     /// Internal error: the PoS contract's rewards purse wasn't found.
+    #[fail(display = "Rewards purse not found")]
     RewardsPurseNotFound,
     /// Internal error: the PoS contract's rewards purse key was the wrong type.
+    #[fail(display = "Rewards purse has unexpected type")]
     RewardsPurseKeyUnexpectedType,
     // TODO: Put these in their own enum, and wrap them separately in `BondingError` and
     //       `UnbondingError`.
     /// Internal error: failed to deserialize the stake's key.
+    #[fail(display = "Failed to deserialize stake's key")]
     StakesKeyDeserializationFailed,
     /// Internal error: failed to deserialize the stake's balance.
+    #[fail(display = "Failed to deserialize stake's balance")]
     StakesDeserializationFailed,
     /// The invoked PoS function can only be called by system contracts, but was called by a user
     /// contract.
+    #[fail(display = "System function was called by user account")]
     SystemFunctionCalledByUserAccount,
     /// Internal error: while finalizing payment, the amount spent exceeded the amount available.
+    #[fail(display = "Insufficient payment for amount spent")]
     InsufficientPaymentForAmountSpent,
     /// Internal error: while finalizing payment, failed to pay the validators (the transfer from
     /// the PoS contract's payment purse to rewards purse failed).
+    #[fail(display = "Transfer to rewards purse has failed")]
     FailedTransferToRewardsPurse,
     /// Internal error: while finalizing payment, failed to refund the caller's purse (the transfer
     /// from the PoS contract's payment purse to refund purse or account's main purse failed).
+    #[fail(display = "Transfer to account's purse failed")]
     FailedTransferToAccountPurse,
     /// PoS contract's "set_refund_purse" method can only be called by the payment code of a
     /// deploy, but was called by the session code.
+    #[fail(display = "Set refund purse was called outside payment")]
     SetRefundPurseCalledOutsidePayment,
 }
 


### PR DESCRIPTION
### Overview
Errors happening inside contract execution were nested inside `Error::Interpreter`. The more nested contract calls are, more objects were nested. This made error reporting ugly:

```
      Interpreter(Trap(Trap {
        kind: Host(Interpreter(Trap(Trap {
          kind: Host(Interpreter(Trap(Trap {
            kind: Host(Interpreter(Trap(Trap {
              kind: Host(FunctionNotFound(\"functiondoesnotexist\")) }))) }))) }))) }))
```

With this PR `Function not found: functiondoesnotexist` is reported regardless of how much nested calls are made. It also makes testing easier as you can match directly on error i.e. `assert_matches!(error, Error::Exec(execution::Error::Foo))`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-771

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
