### PR TITLE
EE-964: SystemContractCache adjustment

### DIFF
--- a/execution-engine/engine-core/src/engine_state/system_contract_cache.rs
+++ b/execution-engine/engine-core/src/engine_state/system_contract_cache.rs
@@ -24,10 +24,10 @@ impl SystemContractCache {
     /// If the cache did not have this key present, `None` is returned.
     ///
     /// If the cache did have this key present, the value is updated, and the old value is returned.
-    pub fn insert(&self, uref: URef, contract: Module) -> Option<Module> {
+    pub fn insert(&self, uref: URef, module: Module) -> Option<Module> {
         let mut guarded_map = self.0.write().unwrap();
         let uref = uref.remove_access_rights();
-        guarded_map.insert(uref, contract)
+        guarded_map.insert(uref, module)
     }
 
     /// Returns a clone of the contract corresponding to `uref`.
@@ -45,12 +45,11 @@ mod tests {
     use lazy_static::lazy_static;
     use parity_wasm::elements::{Module, ModuleNameSection, NameSection, Section};
 
-    use types::{AccessRights, URef};
-
     use crate::{
         engine_state::system_contract_cache::SystemContractCache,
         execution::{AddressGenerator, AddressGeneratorBuilder},
     };
+    use types::{AccessRights, URef};
 
     lazy_static! {
         static ref ADDRESS_GENERATOR: Mutex<AddressGenerator> = Mutex::new(

--- a/execution-engine/engine-shared/src/wasm.rs
+++ b/execution-engine/engine-shared/src/wasm.rs
@@ -1,3 +1,7 @@
+use parity_wasm::elements::Module;
+
+use engine_wasm_prep::{PreprocessingError, Preprocessor};
+
 static DO_NOTHING: &str = r#"
     (module
       (type (;0;) (func))
@@ -15,4 +19,9 @@ static DO_NOTHING: &str = r#"
 
 pub fn do_nothing_bytes() -> Vec<u8> {
     wabt::wat2wasm(DO_NOTHING).expect("failed to parse wat")
+}
+
+pub fn do_nothing_module(preprocessor: &Preprocessor) -> Result<Module, PreprocessingError> {
+    let do_nothing_bytes = do_nothing_bytes();
+    preprocessor.preprocess(&do_nothing_bytes)
 }

--- a/execution-engine/types/src/lib.rs
+++ b/execution-engine/types/src/lib.rs
@@ -35,7 +35,7 @@ mod phase;
 mod protocol_version;
 mod semver;
 pub mod system_contract_errors;
-mod system_contract_type;
+pub mod system_contract_type;
 mod transfer_result;
 mod uint;
 mod uref;

--- a/execution-engine/types/src/system_contract_type.rs
+++ b/execution-engine/types/src/system_contract_type.rs
@@ -1,3 +1,5 @@
+//! Home of system contract type enum.
+
 use core::{
     convert::TryFrom,
     fmt::{self, Display, Formatter},
@@ -18,6 +20,13 @@ pub enum SystemContractType {
     /// Standard Payment contract.
     StandardPayment,
 }
+
+/// Name of mint system contract
+pub const MINT: &str = "mint";
+/// Name of proof of stake system contract
+pub const PROOF_OF_STAKE: &str = "proof of stake";
+/// Name of standard payment system contract
+pub const STANDARD_PAYMENT: &str = "standard payment";
 
 impl From<SystemContractType> for u32 {
     fn from(system_contract_type: SystemContractType) -> u32 {
@@ -46,9 +55,9 @@ impl TryFrom<u32> for SystemContractType {
 impl Display for SystemContractType {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
-            SystemContractType::Mint => write!(f, "mint"),
-            SystemContractType::ProofOfStake => write!(f, "pos"),
-            SystemContractType::StandardPayment => write!(f, "standard payment"),
+            SystemContractType::Mint => write!(f, "{}", MINT),
+            SystemContractType::ProofOfStake => write!(f, "{}", PROOF_OF_STAKE),
+            SystemContractType::StandardPayment => write!(f, "{}", STANDARD_PAYMENT),
         }
     }
 }
@@ -63,14 +72,14 @@ mod tests {
     fn get_index_of_mint_contract() {
         let index: u32 = SystemContractType::Mint.into();
         assert_eq!(index, 0u32);
-        assert_eq!(SystemContractType::Mint.to_string(), "mint");
+        assert_eq!(SystemContractType::Mint.to_string(), MINT);
     }
 
     #[test]
     fn get_index_of_pos_contract() {
         let index: u32 = SystemContractType::ProofOfStake.into();
         assert_eq!(index, 1u32);
-        assert_eq!(SystemContractType::ProofOfStake.to_string(), "pos");
+        assert_eq!(SystemContractType::ProofOfStake.to_string(), PROOF_OF_STAKE);
     }
 
     #[test]
@@ -79,7 +88,7 @@ mod tests {
         assert_eq!(index, 2u32);
         assert_eq!(
             SystemContractType::StandardPayment.to_string(),
-            "standard payment"
+            STANDARD_PAYMENT
         );
     }
 


### PR DESCRIPTION
This PR modifies the `SystemContractCache` and deploy integration to not use system contract bytes for cached Module if use_system_contracts is false.

https://casperlabs.atlassian.net/browse/EE-964

- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] This PR is assigned.