### PR TITLE
EE-638: add instrumentation for all FFI host functions

### DIFF
--- a/execution-engine/contracts/profiling/host-function-metrics/Cargo.toml
+++ b/execution-engine/contracts/profiling/host-function-metrics/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "host-function-metrics"
+version = "0.1.0"
+authors = ["Fraser Hutchison <fraser@casperlabs.io>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+bench = false
+doctest = false
+test = false
+
+[features]
+default = ["contract/test-support", "rand/small_rng"]
+std = ["contract/std", "types/std"]
+
+[dependencies]
+contract = { path = "../../../contract", package = "casperlabs-contract" }
+types = { path = "../../../types", package = "casperlabs-types" }
+rand = { version = "0.7", default-features = false }

--- a/execution-engine/contracts/profiling/host-function-metrics/src/lib.rs
+++ b/execution-engine/contracts/profiling/host-function-metrics/src/lib.rs
@@ -1,0 +1,221 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+
+use rand::{distributions::Alphanumeric, rngs::SmallRng, Rng, SeedableRng};
+
+use contract::{
+    contract_api::{account, runtime, storage, system},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use types::{
+    account::{ActionType, PublicKey, Weight},
+    ApiError, BlockTime, CLValue, Key, Phase, U512,
+};
+
+const LARGE_FUNCTION: &str = "large_function";
+const SMALL_FUNCTION: &str = "small_function";
+
+const NAMED_KEY_COUNT: usize = 10;
+const MIN_NAMED_KEY_NAME_LENGTH: usize = 10;
+// TODO - consider increasing to e.g. 1_000 once https://casperlabs.atlassian.net/browse/EE-966 is
+//        resolved.
+const MAX_NAMED_KEY_NAME_LENGTH: usize = 100;
+const VALUE_FOR_ADDITION_1: u64 = 1;
+const VALUE_FOR_ADDITION_2: u64 = 2;
+const TRANSFER_AMOUNT: u64 = 1_000_000;
+
+enum Arg {
+    Seed = 0,
+    Others = 1,
+}
+
+#[repr(u16)]
+enum Error {
+    GetCaller = 0,
+    GetBlockTime = 1,
+    GetPhase = 2,
+    HasKey = 3,
+    GetKey = 4,
+    NamedKeys = 5,
+    ReadOrRevert = 6,
+    ReadLocal = 7,
+    IsValidURef = 8,
+    Transfer = 9,
+    Revert = 10,
+}
+
+impl From<Error> for ApiError {
+    fn from(error: Error) -> ApiError {
+        ApiError::User(error as u16)
+    }
+}
+
+fn create_random_names(seed: u64) -> impl Iterator<Item = String> {
+    let mut names = Vec::new();
+    let mut rng = SmallRng::seed_from_u64(seed);
+    for _ in 0..NAMED_KEY_COUNT {
+        let key_length: usize = rng.gen_range(MIN_NAMED_KEY_NAME_LENGTH, MAX_NAMED_KEY_NAME_LENGTH);
+        let key_name = (&mut rng)
+            .sample_iter(&Alphanumeric)
+            .take(key_length)
+            .collect::<String>();
+        names.push(key_name);
+    }
+    names.into_iter()
+}
+
+// Executes the named key functions from the `runtime` module and most of the functions from the
+// `storage` module.
+#[no_mangle]
+pub extern "C" fn large_function() {
+    let seed: u64 = runtime::get_arg(Arg::Seed as u32)
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
+    let random_bytes: Vec<u8> = runtime::get_arg(Arg::Others as u32)
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
+
+    let uref = storage::new_uref(random_bytes.clone());
+
+    let mut key_name = String::new();
+    for random_name in create_random_names(seed) {
+        key_name = random_name;
+        runtime::put_key(&key_name, Key::from(uref));
+    }
+
+    if !runtime::has_key(&key_name) {
+        runtime::revert(Error::HasKey);
+    }
+
+    if runtime::get_key(&key_name) != Some(Key::from(uref)) {
+        runtime::revert(Error::GetKey);
+    }
+
+    runtime::remove_key(&key_name);
+
+    let named_keys = runtime::list_named_keys();
+    if named_keys.len() != NAMED_KEY_COUNT - 1 {
+        runtime::revert(Error::NamedKeys)
+    }
+
+    storage::write(uref, random_bytes.clone());
+    let retrieved_value: Vec<u8> = storage::read_or_revert(uref);
+    if retrieved_value != random_bytes {
+        runtime::revert(Error::ReadOrRevert);
+    }
+
+    storage::write(uref, VALUE_FOR_ADDITION_1);
+    storage::add(uref, VALUE_FOR_ADDITION_2);
+
+    storage::write_local(key_name.clone(), random_bytes.clone());
+    let retrieved_value = storage::read_local(&key_name);
+    if retrieved_value != Ok(Some(random_bytes)) {
+        runtime::revert(Error::ReadLocal);
+    }
+
+    storage::write_local(key_name.clone(), VALUE_FOR_ADDITION_1);
+    storage::add_local(key_name, VALUE_FOR_ADDITION_2);
+
+    runtime::ret(CLValue::from_t(named_keys).unwrap_or_revert());
+}
+
+#[no_mangle]
+pub extern "C" fn small_function() {
+    if runtime::get_phase() != Phase::Session {
+        runtime::revert(Error::GetPhase);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let seed: u64 = runtime::get_arg(Arg::Seed as u32)
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
+    let (random_bytes, source_account, destination_account): (Vec<u8>, PublicKey, PublicKey) =
+        runtime::get_arg(Arg::Others as u32)
+            .unwrap_or_revert_with(ApiError::MissingArgument)
+            .unwrap_or_revert_with(ApiError::InvalidArgument);
+
+    // ========== storage, execution and upgrading of contracts ====================================
+
+    // Store large function with no named keys under a URef, then execute it to get named keys
+    // returned.
+    let mut contract_ref = storage::store_function(LARGE_FUNCTION, BTreeMap::new());
+
+    let named_keys: BTreeMap<String, Key> =
+        runtime::call_contract(contract_ref.clone(), (seed, random_bytes.clone()));
+
+    runtime::upgrade_contract_at_uref(LARGE_FUNCTION, contract_ref.into_uref().unwrap_or_revert());
+
+    // Store large function with 10 named keys under a URef, then execute it.
+    contract_ref = storage::store_function(LARGE_FUNCTION, named_keys.clone());
+    let _ = runtime::call_contract::<_, BTreeMap<String, Key>>(
+        contract_ref.clone(),
+        (seed, random_bytes.clone()),
+    );
+    runtime::upgrade_contract_at_uref(SMALL_FUNCTION, contract_ref.into_uref().unwrap_or_revert());
+
+    // Store small function with no named keys under a URef, then execute it.
+    contract_ref = storage::store_function(SMALL_FUNCTION, BTreeMap::new());
+    runtime::call_contract::<_, ()>(contract_ref.clone(), ());
+    runtime::upgrade_contract_at_uref(LARGE_FUNCTION, contract_ref.into_uref().unwrap_or_revert());
+
+    // Store small function with 10 named keys under a URef, then execute it.
+    contract_ref = storage::store_function(SMALL_FUNCTION, named_keys.clone());
+    runtime::call_contract::<_, ()>(contract_ref.clone(), ());
+    runtime::upgrade_contract_at_uref(SMALL_FUNCTION, contract_ref.into_uref().unwrap_or_revert());
+
+    // Store same functions and keys combinations under a hash, but no need to execute any.
+    let _ = storage::store_function_at_hash(LARGE_FUNCTION, BTreeMap::new());
+    let _ = storage::store_function_at_hash(LARGE_FUNCTION, named_keys.clone());
+    let _ = storage::store_function_at_hash(SMALL_FUNCTION, BTreeMap::new());
+    let _ = storage::store_function_at_hash(SMALL_FUNCTION, named_keys);
+
+    // ========== functions from `account` module ==================================================
+
+    let main_purse = account::get_main_purse();
+    account::set_action_threshold(ActionType::Deployment, Weight::new(1)).unwrap_or_revert();
+    account::add_associated_key(destination_account, Weight::new(1)).unwrap_or_revert();
+    account::update_associated_key(destination_account, Weight::new(1)).unwrap_or_revert();
+    account::remove_associated_key(destination_account).unwrap_or_revert();
+
+    // ========== functions from `system` module ===================================================
+
+    let _ = system::get_mint();
+
+    let new_purse = system::create_purse();
+
+    let transfer_amount = U512::from(TRANSFER_AMOUNT);
+    system::transfer_from_purse_to_purse(main_purse, new_purse, transfer_amount).unwrap_or_revert();
+
+    let balance = system::get_balance(new_purse).unwrap_or_revert();
+    if balance != transfer_amount {
+        runtime::revert(Error::Transfer);
+    }
+
+    system::transfer_from_purse_to_account(new_purse, destination_account, transfer_amount)
+        .unwrap_or_revert();
+
+    system::transfer_to_account(destination_account, transfer_amount).unwrap_or_revert();
+
+    // ========== remaining functions from `runtime` module ========================================
+
+    if !runtime::is_valid_uref(main_purse) {
+        runtime::revert(Error::IsValidURef);
+    }
+
+    if runtime::get_blocktime() != BlockTime::new(0) {
+        runtime::revert(Error::GetBlockTime);
+    }
+
+    if runtime::get_caller() != source_account {
+        runtime::revert(Error::GetCaller);
+    }
+
+    runtime::print(&String::from_utf8_lossy(&random_bytes));
+
+    runtime::revert(Error::Revert);
+}

--- a/execution-engine/engine-core/src/resolvers/v1_function_index.rs
+++ b/execution-engine/engine-core/src/resolvers/v1_function_index.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use num_derive::{FromPrimitive, ToPrimitive};
 use num_traits::{FromPrimitive, ToPrimitive};
 
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive, Clone, Copy)]
 #[repr(usize)]
 pub enum FunctionIndex {
     WriteFuncIndex,

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -12,7 +12,7 @@ use types::{
 use engine_shared::{gas::Gas, stored_value::StoredValue};
 use engine_storage::global_state::StateReader;
 
-use super::{args::Args, Error, Runtime};
+use super::{args::Args, scoped_timer::ScopedTimer, Error, Runtime};
 use crate::resolvers::v1_function_index::FunctionIndex;
 
 impl<'a, R> Externals for Runtime<'a, R>
@@ -26,6 +26,7 @@ where
         args: RuntimeArgs,
     ) -> Result<Option<RuntimeValue>, Trap> {
         let func = FunctionIndex::try_from(index).expect("unknown function index");
+        let mut scoped_timer = ScopedTimer::new(func);
         match func {
             FunctionIndex::ReadFuncIndex => {
                 // args(0) = pointer to key in Wasm memory
@@ -40,7 +41,8 @@ where
                 // args(0) = pointer to key in Wasm memory
                 // args(1) = size of key in Wasm memory
                 // args(2) = pointer to output size (output param)
-                let (key_ptr, key_size, output_size_ptr) = Args::parse(args)?;
+                let (key_ptr, key_size, output_size_ptr): (_, u32, _) = Args::parse(args)?;
+                scoped_timer.add_property("key_size", key_size.to_string());
                 let ret = self.read_local(key_ptr, key_size, output_size_ptr)?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
@@ -49,7 +51,8 @@ where
                 // args(0) = pointer to amount of keys (output)
                 // args(1) = pointer to amount of serialized bytes (output)
                 let (total_keys_ptr, result_size_ptr) = Args::parse(args)?;
-                let ret = self.load_named_keys(total_keys_ptr, result_size_ptr)?;
+                let ret =
+                    self.load_named_keys(total_keys_ptr, result_size_ptr, &mut scoped_timer)?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
 
@@ -58,7 +61,8 @@ where
                 // args(1) = size of key
                 // args(2) = pointer to value
                 // args(3) = size of value
-                let (key_ptr, key_size, value_ptr, value_size) = Args::parse(args)?;
+                let (key_ptr, key_size, value_ptr, value_size): (_, _, _, u32) = Args::parse(args)?;
+                scoped_timer.add_property("value_size", value_size.to_string());
                 self.write(key_ptr, key_size, value_ptr, value_size)?;
                 Ok(None)
             }
@@ -68,7 +72,10 @@ where
                 // args(1) = size of key
                 // args(2) = pointer to value
                 // args(3) = size of value
-                let (key_bytes_ptr, key_bytes_size, value_ptr, value_size) = Args::parse(args)?;
+                let (key_bytes_ptr, key_bytes_size, value_ptr, value_size): (_, u32, _, u32) =
+                    Args::parse(args)?;
+                scoped_timer.add_property("key_bytes_size", key_bytes_size.to_string());
+                scoped_timer.add_property("value_size", value_size.to_string());
                 self.write_local(key_bytes_ptr, key_bytes_size, value_ptr, value_size)?;
                 Ok(None)
             }
@@ -88,7 +95,9 @@ where
                 // args(1) = size of key
                 // args(2) = pointer to value
                 // args(3) = size of value
-                let (key_bytes_ptr, key_bytes_size, value_ptr, value_size) = Args::parse(args)?;
+                let (key_bytes_ptr, key_bytes_size, value_ptr, value_size): (_, u32, _, _) =
+                    Args::parse(args)?;
+                scoped_timer.add_property("key_bytes_size", key_bytes_size.to_string());
                 self.add_local(key_bytes_ptr, key_bytes_size, value_ptr, value_size)?;
                 Ok(None)
             }
@@ -97,7 +106,8 @@ where
                 // args(0) = pointer to uref destination in Wasm memory
                 // args(1) = pointer to initial value
                 // args(2) = size of initial value
-                let (uref_ptr, value_ptr, value_size) = Args::parse(args)?;
+                let (uref_ptr, value_ptr, value_size): (_, _, u32) = Args::parse(args)?;
+                scoped_timer.add_property("value_size", value_size.to_string());
                 self.new_uref(uref_ptr, value_ptr, value_size)?;
                 Ok(None)
             }
@@ -115,6 +125,7 @@ where
                 // args(1) = pointer to destination in Wasm memory
                 // args(2) = size of destination pointer memory
                 let (index, dest_ptr, dest_size): (u32, _, u32) = Args::parse(args)?;
+                scoped_timer.add_property("dest_size", dest_size.to_string());
                 let ret = self.get_arg(index as usize, dest_ptr, dest_size as usize)?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
@@ -123,7 +134,7 @@ where
                 // args(0) = pointer to value
                 // args(1) = size of value
                 let (value_ptr, value_size): (_, u32) = Args::parse(args)?;
-
+                scoped_timer.add_property("value_size", value_size.to_string());
                 Err(self.ret(value_ptr, value_size as usize))
             }
 
@@ -135,12 +146,17 @@ where
                 // args(4) = pointer to result size (output)
                 let (key_ptr, key_size, args_ptr, args_size, result_size_ptr): (_, _, _, u32, _) =
                     Args::parse(args)?;
+                scoped_timer.add_property("args_size", args_size.to_string());
 
                 let key_contract: Key = self.key_from_mem(key_ptr, key_size)?;
                 let args_bytes: Vec<u8> = self.bytes_from_mem(args_ptr, args_size as usize)?;
 
-                let ret =
-                    self.call_contract_host_buffer(key_contract, args_bytes, result_size_ptr)?;
+                let ret = self.call_contract_host_buffer(
+                    key_contract,
+                    args_bytes,
+                    result_size_ptr,
+                    &mut scoped_timer,
+                )?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
 
@@ -157,6 +173,7 @@ where
                     u32,
                     u32,
                 ) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
                 let ret = self.load_key(
                     name_ptr,
                     name_size,
@@ -170,7 +187,8 @@ where
             FunctionIndex::HasKeyFuncIndex => {
                 // args(0) = pointer to key name in Wasm memory
                 // args(1) = size of key name
-                let (name_ptr, name_size) = Args::parse(args)?;
+                let (name_ptr, name_size): (_, u32) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
                 let result = self.has_key(name_ptr, name_size)?;
                 Ok(Some(RuntimeValue::I32(result)))
             }
@@ -180,7 +198,8 @@ where
                 // args(1) = size of key name
                 // args(2) = pointer to key in Wasm memory
                 // args(3) = size of key
-                let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
+                let (name_ptr, name_size, key_ptr, key_size): (_, u32, _, _) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
                 self.put_key(name_ptr, name_size, key_ptr, key_size)?;
                 Ok(None)
             }
@@ -188,7 +207,8 @@ where
             FunctionIndex::RemoveKeyFuncIndex => {
                 // args(0) = pointer to key name in Wasm memory
                 // args(1) = size of key name
-                let (name_ptr, name_size) = Args::parse(args)?;
+                let (name_ptr, name_size): (_, u32) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
                 self.remove_key(name_ptr, name_size)?;
                 Ok(None)
             }
@@ -216,41 +236,57 @@ where
             FunctionIndex::StoreFnIndex => {
                 // args(0) = pointer to function name in Wasm memory
                 // args(1) = size of the name
-                // args(2) = pointer to additional unforgable names
-                //           to be saved with the function body
-                // args(3) = size of the additional unforgable names
+                // args(2) = pointer to named keys to be saved with the function body
+                // args(3) = size of the named keys
                 // args(4) = pointer to a Wasm memory where we will save
                 //           uref address of the new function
-                let (name_ptr, name_size, urefs_ptr, urefs_size, hash_ptr) = Args::parse(args)?;
-                let _uref_type: u32 = urefs_size;
+                let (name_ptr, name_size, named_keys_ptr, named_keys_size, uref_addr_ptr): (
+                    _,
+                    u32,
+                    _,
+                    u32,
+                    _,
+                ) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
                 let fn_bytes = self.get_function_by_name(name_ptr, name_size)?;
-                let uref_bytes = self
+                let contract_size = named_keys_size as usize + fn_bytes.len();
+                scoped_timer.add_property("contract_size", contract_size.to_string());
+                let named_keys_bytes = self
                     .memory
-                    .get(urefs_ptr, urefs_size as usize)
+                    .get(named_keys_ptr, named_keys_size as usize)
                     .map_err(Error::Interpreter)?;
-                let urefs = bytesrepr::deserialize(uref_bytes).map_err(Error::BytesRepr)?;
-                let contract_hash = self.store_function(fn_bytes, urefs)?;
-                self.function_address(contract_hash, hash_ptr)?;
+                let named_keys =
+                    bytesrepr::deserialize(named_keys_bytes).map_err(Error::BytesRepr)?;
+                let contract_hash = self.store_function(fn_bytes, named_keys)?;
+                self.function_address(contract_hash, uref_addr_ptr)?;
                 Ok(None)
             }
 
             FunctionIndex::StoreFnAtHashIndex => {
                 // args(0) = pointer to function name in Wasm memory
                 // args(1) = size of the name
-                // args(2) = pointer to additional unforgable names
-                //           to be saved with the function body
-                // args(3) = size of the additional unforgable names
+                // args(2) = pointer to named keys to be saved with the function body
+                // args(3) = size of the named keys
                 // args(4) = pointer to a Wasm memory where we will save
                 //           hash of the new function
-                let (name_ptr, name_size, urefs_ptr, urefs_size, hash_ptr) = Args::parse(args)?;
-                let _uref_type: u32 = urefs_size;
+                let (name_ptr, name_size, named_keys_ptr, named_keys_size, hash_ptr): (
+                    _,
+                    u32,
+                    _,
+                    u32,
+                    _,
+                ) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
                 let fn_bytes = self.get_function_by_name(name_ptr, name_size)?;
-                let uref_bytes = self
+                let contract_size = named_keys_size as usize + fn_bytes.len();
+                scoped_timer.add_property("contract_size", contract_size.to_string());
+                let named_keys_bytes = self
                     .memory
-                    .get(urefs_ptr, urefs_size as usize)
+                    .get(named_keys_ptr, named_keys_size as usize)
                     .map_err(Error::Interpreter)?;
-                let urefs = bytesrepr::deserialize(uref_bytes).map_err(Error::BytesRepr)?;
-                let contract_hash = self.store_function_at_hash(fn_bytes, urefs)?;
+                let named_keys =
+                    bytesrepr::deserialize(named_keys_bytes).map_err(Error::BytesRepr)?;
+                let contract_hash = self.store_function_at_hash(fn_bytes, named_keys)?;
                 self.function_address(contract_hash, hash_ptr)?;
                 Ok(None)
             }
@@ -421,8 +457,15 @@ where
                 // args(1) = size of name in Wasm memory
                 // args(2) = pointer to key in Wasm memory
                 // args(3) = size of key
-                let (name_ptr, name_size, key_ptr, key_size) = Args::parse(args)?;
-                let ret = self.upgrade_contract_at_uref(name_ptr, name_size, key_ptr, key_size)?;
+                let (name_ptr, name_size, key_ptr, key_size): (_, u32, _, _) = Args::parse(args)?;
+                scoped_timer.add_property("name_size", name_size.to_string());
+                let ret = self.upgrade_contract_at_uref(
+                    name_ptr,
+                    name_size,
+                    key_ptr,
+                    key_size,
+                    &mut scoped_timer,
+                )?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
 
@@ -445,13 +488,15 @@ where
             FunctionIndex::ReadHostBufferIndex => {
                 // args(0) = pointer to Wasm memory where to write size.
                 let (dest_ptr, dest_size, bytes_written_ptr): (_, u32, _) = Args::parse(args)?;
+                scoped_timer.add_property("dest_size", dest_size.to_string());
                 let ret = self.read_host_buffer(dest_ptr, dest_size as usize, bytes_written_ptr)?;
                 Ok(Some(RuntimeValue::I32(api_error::i32_from(ret))))
             }
 
             #[cfg(feature = "test-support")]
             FunctionIndex::PrintIndex => {
-                let (text_ptr, text_size) = Args::parse(args)?;
+                let (text_ptr, text_size): (_, u32) = Args::parse(args)?;
+                scoped_timer.add_property("text_size", text_size.to_string());
                 self.print(text_ptr, text_size)?;
                 Ok(None)
             }

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -2,6 +2,7 @@ mod args;
 mod externals;
 mod mint_internal;
 mod proof_of_stake_internal;
+mod scoped_timer;
 mod standard_payment_internal;
 
 use std::{
@@ -37,6 +38,7 @@ use crate::{
     runtime_context::RuntimeContext,
     Address,
 };
+use scoped_timer::ScopedTimer;
 
 pub struct Runtime<'a, R> {
     system_contract_cache: SystemContractCache,
@@ -2067,13 +2069,17 @@ where
         key: Key,
         args_bytes: Vec<u8>,
         result_size_ptr: u32,
+        scoped_timer: &mut ScopedTimer,
     ) -> Result<Result<(), ApiError>, Error> {
         if !self.can_write_to_host_buffer() {
             // Exit early if the host buffer is already occupied
             return Ok(Err(ApiError::HostBufferFull));
         }
 
-        let result = self.call_contract(key, args_bytes)?;
+        scoped_timer.pause();
+        let result = self.call_contract(key, args_bytes);
+        scoped_timer.unpause();
+        let result = result?;
         let result_size = result.inner_bytes().len() as u32; // considered to be safe
 
         // leave the host buffer set to `None` if there's nothing to write there
@@ -2095,7 +2101,18 @@ where
         &mut self,
         total_keys_ptr: u32,
         result_size_ptr: u32,
+        scoped_timer: &mut ScopedTimer,
     ) -> Result<Result<(), ApiError>, Trap> {
+        scoped_timer.add_property(
+            "names_total_length",
+            self.context
+                .named_keys()
+                .keys()
+                .map(|name| name.len())
+                .sum::<usize>()
+                .to_string(),
+        );
+
         if !self.can_write_to_host_buffer() {
             // Exit early if the host buffer is already occupied
             return Ok(Err(ApiError::HostBufferFull));
@@ -2701,17 +2718,25 @@ where
         name_size: u32,
         key_ptr: u32,
         key_size: u32,
+        scoped_timer: &mut ScopedTimer,
     ) -> Result<Result<(), ApiError>, Trap> {
         let key = self.key_from_mem(key_ptr, key_size)?;
         let named_keys = match self.context.read_gs(&key)? {
             None => Err(Error::KeyNotFound(key)),
-            Some(StoredValue::Contract(contract)) => Ok(contract.named_keys().clone()),
+            Some(StoredValue::Contract(contract)) => {
+                let old_contract_size =
+                    contract.named_keys().serialized_length() + contract.bytes().len();
+                scoped_timer.add_property("old_contract_size", old_contract_size.to_string());
+                Ok(contract.named_keys().clone())
+            }
             Some(_) => Err(Error::FunctionNotFound(format!(
                 "Value at {:?} is not a contract",
                 key
             ))),
         }?;
         let bytes = self.get_function_by_name(name_ptr, name_size)?;
+        let new_contract_size = named_keys.serialized_length() + bytes.len();
+        scoped_timer.add_property("new_contract_size", new_contract_size.to_string());
         match self
             .context
             .upgrade_contract_at_uref(key, bytes, named_keys)

--- a/execution-engine/engine-core/src/runtime/scoped_timer.rs
+++ b/execution-engine/engine-core/src/runtime/scoped_timer.rs
@@ -1,0 +1,141 @@
+use std::{
+    collections::BTreeMap,
+    mem,
+    time::{Duration, Instant},
+};
+
+use engine_shared::logging::log_host_function_metrics;
+
+use crate::resolvers::v1_function_index::FunctionIndex;
+
+enum PauseState {
+    NotStarted,
+    Started(Instant),
+    Completed(Duration),
+}
+
+impl PauseState {
+    fn new() -> Self {
+        PauseState::NotStarted
+    }
+
+    fn activate(&mut self) {
+        match self {
+            PauseState::NotStarted => {
+                *self = PauseState::Started(Instant::now());
+            }
+            _ => panic!("PauseState must be NotStarted"),
+        }
+    }
+
+    fn complete(&mut self) {
+        match self {
+            PauseState::Started(start) => {
+                *self = PauseState::Completed(start.elapsed());
+            }
+            _ => panic!("Pause must already be active"),
+        }
+    }
+
+    fn duration(&self) -> Duration {
+        match self {
+            PauseState::NotStarted => Duration::default(),
+            PauseState::Completed(duration) => *duration,
+            PauseState::Started(start) => start.elapsed(),
+        }
+    }
+}
+
+pub(super) struct ScopedTimer {
+    start: Instant,
+    pause_state: PauseState,
+    function_index: FunctionIndex,
+    properties: BTreeMap<&'static str, String>,
+}
+
+impl ScopedTimer {
+    pub fn new(function_index: FunctionIndex) -> Self {
+        ScopedTimer {
+            start: Instant::now(),
+            pause_state: PauseState::new(),
+            function_index,
+            properties: BTreeMap::new(),
+        }
+    }
+
+    pub fn add_property(&mut self, key: &'static str, value: String) {
+        assert!(self.properties.insert(key, value).is_none());
+    }
+
+    /// Can be called once only to effectively pause the running timer.  `unpause` can likewise be
+    /// called once if the timer has already been paused.
+    pub fn pause(&mut self) {
+        self.pause_state.activate();
+    }
+
+    pub fn unpause(&mut self) {
+        self.pause_state.complete();
+    }
+
+    fn duration(&self) -> Duration {
+        self.start.elapsed() - self.pause_state.duration()
+    }
+}
+
+impl Drop for ScopedTimer {
+    fn drop(&mut self) {
+        let host_function = match self.function_index {
+            FunctionIndex::GasFuncIndex => return,
+            FunctionIndex::WriteFuncIndex => "host_function_write",
+            FunctionIndex::WriteLocalFuncIndex => "host_function_write_local",
+            FunctionIndex::ReadFuncIndex => "host_function_read_value",
+            FunctionIndex::ReadLocalFuncIndex => "host_function_read_value_local",
+            FunctionIndex::AddFuncIndex => "host_function_add",
+            FunctionIndex::AddLocalFuncIndex => "host_function_add_local",
+            FunctionIndex::NewFuncIndex => "host_function_new_uref",
+            FunctionIndex::RetFuncIndex => "host_function_ret",
+            FunctionIndex::CallContractFuncIndex => "host_function_call_contract",
+            FunctionIndex::GetArgFuncIndex => "host_function_get_arg",
+            FunctionIndex::GetKeyFuncIndex => "host_function_get_key",
+            FunctionIndex::HasKeyFuncIndex => "host_function_has_key",
+            FunctionIndex::PutKeyFuncIndex => "host_function_put_key",
+            FunctionIndex::StoreFnIndex => "host_function_store_function",
+            FunctionIndex::StoreFnAtHashIndex => "host_function_store_function_at_hash",
+            FunctionIndex::IsValidURefFnIndex => "host_function_is_valid_uref",
+            FunctionIndex::RevertFuncIndex => "host_function_revert",
+            FunctionIndex::AddAssociatedKeyFuncIndex => "host_function_add_associated_key",
+            FunctionIndex::RemoveAssociatedKeyFuncIndex => "host_function_remove_associated_key",
+            FunctionIndex::UpdateAssociatedKeyFuncIndex => "host_function_update_associated_key",
+            FunctionIndex::SetActionThresholdFuncIndex => "host_function_set_action_threshold",
+            FunctionIndex::LoadNamedKeysFuncIndex => "host_function_load_named_keys",
+            FunctionIndex::RemoveKeyFuncIndex => "host_function_remove_key",
+            FunctionIndex::GetCallerIndex => "host_function_get_caller",
+            FunctionIndex::GetBlocktimeIndex => "host_function_get_blocktime",
+            FunctionIndex::CreatePurseIndex => "host_function_create_purse",
+            FunctionIndex::TransferToAccountIndex => "host_function_transfer_to_account",
+            FunctionIndex::TransferFromPurseToAccountIndex => {
+                "host_function_transfer_from_purse_to_account"
+            }
+            FunctionIndex::TransferFromPurseToPurseIndex => {
+                "host_function_transfer_from_purse_to_purse"
+            }
+            FunctionIndex::GetBalanceIndex => "host_function_get_balance",
+            FunctionIndex::GetPhaseIndex => "host_function_get_phase",
+            FunctionIndex::UpgradeContractAtURefIndex => "host_function_upgrade_contract_at_uref",
+            FunctionIndex::GetSystemContractIndex => "host_function_get_system_contract",
+            FunctionIndex::GetMainPurseIndex => "host_function_get_main_purse",
+            FunctionIndex::GetArgSizeFuncIndex => "host_function_get_arg_size",
+            FunctionIndex::ReadHostBufferIndex => "host_function_read_host_buffer",
+            #[cfg(feature = "test-support")]
+            FunctionIndex::PrintIndex => "host_function_print",
+        };
+
+        let mut properties = mem::take(&mut self.properties);
+        properties.insert(
+            "duration_in_seconds",
+            format!("{:.06e}", self.duration().as_secs_f64()),
+        );
+
+        log_host_function_metrics(host_function, properties);
+    }
+}

--- a/execution-engine/engine-shared/src/logging/mod.rs
+++ b/execution-engine/engine-shared/src/logging/mod.rs
@@ -162,3 +162,27 @@ pub fn log_metric(
 
     logger.log(&record);
 }
+
+/// Logs the metrics associated with the specified host function.
+pub fn log_host_function_metrics(host_function: &str, mut properties: BTreeMap<&str, String>) {
+    let logger = log::logger();
+
+    let metadata = Metadata::builder()
+        .target(METRIC_METADATA_TARGET)
+        .level(Level::Info)
+        .build();
+
+    if !logger.enabled(&metadata) {
+        return;
+    }
+
+    let default_message = format!("{} {:?}", host_function, properties);
+    properties.insert(DEFAULT_MESSAGE_KEY, default_message);
+
+    let record = Record::builder()
+        .metadata(metadata)
+        .key_values(&properties)
+        .build();
+
+    logger.log(&record);
+}

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -7,19 +7,21 @@ edition = "2018"
 [dependencies]
 base16 = "0.2.1"
 clap = "2"
-contract = { path = "../contract",  package = "casperlabs-contract", features = ["std"] }
+contract = { path = "../contract",  package = "casperlabs-contract" }
 crossbeam-channel = "0.4.0"
 engine-core = { path = "../engine-core", package = "casperlabs-engine-core" }
 engine-grpc-server = { path = "../engine-grpc-server", package = "casperlabs-engine-grpc-server" }
+engine-shared = { path = "../engine-shared", package = "casperlabs-engine-shared" }
 engine-test-support = { path = "../engine-test-support", package = "casperlabs-engine-test-support" }
 env_logger = "0.7.1"
 grpc = "0.6.1"
 log = "0.4.8"
+rand = "0.7.3"
+serde_json = "1"
 types = { path = "../types", package = "casperlabs-types", features = ["std"] }
 
 [dev-dependencies]
 criterion = "0.3.0"
-engine-shared = { path = "../engine-shared", package = "casperlabs-engine-shared" }
 engine-storage = { path = "../engine-storage", package = "casperlabs-engine-storage" }
 engine-wasm-prep = { path = "../engine-wasm-prep", package = "casperlabs-engine-wasm-prep" }
 lazy_static = "1"
@@ -29,6 +31,7 @@ tempfile = "3"
 wabt = "0.9.2"
 
 [features]
+default = ["contract/std", "contract/test-support", "engine-core/test-support", "engine-test-support/test-support"]
 enable-bonding = ["engine-test-support/enable-bonding"]
 use-as-wasm = ["engine-test-support/use-as-wasm"]
 use-system-contracts = ["engine-test-support/use-system-contracts"]
@@ -55,6 +58,12 @@ bench = false
 [[bin]]
 name = "concurrent-executor"
 path = "src/profiling/concurrent_executor.rs"
+test = false
+bench = false
+
+[[bin]]
+name = "host-function-metrics"
+path = "src/profiling/host_function_metrics.rs"
 test = false
 bench = false
 

--- a/execution-engine/engine-tests/src/profiling/README.md
+++ b/execution-engine/engine-tests/src/profiling/README.md
@@ -27,7 +27,7 @@ To profile `simple-transfer` using `perf` and open the flamegraph in Firefox, fo
 * Run:
     ```bash
     cd CasperLabs/execution-engine/
-    make build-contracts
+    make build-contracts-rs
     cd engine-tests/
     cargo build --release --bin state-initializer
     cargo build --release --bin simple-transfer
@@ -119,4 +119,21 @@ For logging, again set the `RUST_LOG` env var:
 
 ```bash
 RUST_LOG=concurrent_executor=info ./concurrent_executor.sh 8 8 200
+```
+
+---
+
+# `host-function-metrics`
+
+This tool generates CSV files containing metrics for the host functions callable by Wasm smart contracts and which are currently unmetered.
+
+Note that running the tool with the default 10,000 repetitions can take in excess of half an hour to complete.
+
+```bash
+cd CasperLabs/execution-engine/
+make build-contracts-rs
+cd engine-tests/
+cargo build --release --bin state-initializer
+cargo build --release --bin host-function-metrics
+../target/release/state-initializer --data-dir=../target | ../target/release/host-function-metrics --data-dir=../target --output-dir=../target/host-function-metrics
 ```

--- a/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
+++ b/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
@@ -96,18 +96,6 @@ fn request_count_arg() -> Arg<'static, 'static> {
         .help(REQUEST_COUNT_ARG_HELP)
 }
 
-fn parse_hash(encoded_hash: &str) -> Vec<u8> {
-    base16::decode(encoded_hash).expect("Expected a valid, hex-encoded hash")
-}
-
-fn parse_count(encoded_thread_count: &str) -> usize {
-    let count: usize = encoded_thread_count
-        .parse()
-        .expect("Expected an integral count");
-    assert!(count > 0, "Expected count > 0");
-    count
-}
-
 struct Args {
     socket: String,
     pre_state_hash: Vec<u8>,
@@ -132,15 +120,15 @@ impl Args {
             .to_string();
         let pre_state_hash = arg_matches
             .value_of(PRE_STATE_HASH_ARG_NAME)
-            .map(parse_hash)
+            .map(profiling::parse_hash)
             .expect("Expected a pre-state hash");
         let thread_count = arg_matches
             .value_of(THREAD_COUNT_ARG_NAME)
-            .map(parse_count)
+            .map(profiling::parse_count)
             .expect("Expected thread count");
         let request_count = arg_matches
             .value_of(REQUEST_COUNT_ARG_NAME)
-            .map(parse_count)
+            .map(profiling::parse_count)
             .expect("Expected request count");
 
         Args {

--- a/execution-engine/engine-tests/src/profiling/host_function_metrics.rs
+++ b/execution-engine/engine-tests/src/profiling/host_function_metrics.rs
@@ -1,0 +1,333 @@
+//! This executable is for outputting metrics on each of the EE host functions.
+//!
+//! In order to set up the required global state, the `state-initializer` should have been run
+//! first.
+
+use std::{
+    collections::BTreeMap,
+    env,
+    fs::{self, File},
+    io::{self, Write},
+    iter,
+    path::{Path, PathBuf},
+    process::Command,
+    str::FromStr,
+};
+
+use clap::{crate_version, App, Arg};
+use log::LevelFilter;
+use rand::{self, Rng};
+use serde_json::Value;
+
+use engine_core::engine_state::EngineConfig;
+use engine_shared::logging::{self, Settings};
+use engine_test_support::internal::{
+    DeployItemBuilder, ExecuteRequestBuilder, LmdbWasmTestBuilder,
+};
+use types::{ApiError, U512};
+
+use casperlabs_engine_tests::profiling;
+
+const ABOUT: &str =
+    "Executes a contract which logs metrics for all host functions.  Note that the \
+     'state-initializer' executable should be run first to set up the required global state.";
+
+const EXECUTE_AS_SUBPROCESS_ARG: &str = "execute-as-subprocess";
+
+const ROOT_HASH_ARG_NAME: &str = "root-hash";
+const ROOT_HASH_ARG_VALUE_NAME: &str = "HEX-ENCODED HASH";
+const ROOT_HASH_ARG_HELP: &str =
+    "Initial root hash; the output of running the 'state-initializer' executable";
+
+const REPETITIONS_ARG_NAME: &str = "repetitions";
+const REPETITIONS_ARG_SHORT: &str = "r";
+const REPETITIONS_ARG_DEFAULT: &str = "10000";
+const REPETITIONS_ARG_VALUE_NAME: &str = "NUM";
+const REPETITIONS_ARG_HELP: &str = "Number of repetitions of each host function call";
+
+const OUTPUT_DIR_ARG_NAME: &str = "output-dir";
+const OUTPUT_DIR_ARG_SHORT: &str = "o";
+const OUTPUT_DIR_ARG_VALUE_NAME: &str = "DIR";
+const OUTPUT_DIR_ARG_HELP: &str =
+    "Path to output directory.  It will be created if it doesn't exist.  If unspecified, the \
+    current working directory will be used";
+
+const HOST_FUNCTION_METRICS_CONTRACT: &str = "host_function_metrics.wasm";
+const PAYMENT_AMOUNT: u64 = profiling::ACCOUNT_1_INITIAL_AMOUNT - 1_000_000_000;
+const EXPECTED_REVERT_VALUE: u16 = 10;
+const CSV_HEADER: &str = "args,n_exec,total_elapsed_time";
+
+fn execute_as_subprocess_arg() -> Arg<'static, 'static> {
+    Arg::with_name(EXECUTE_AS_SUBPROCESS_ARG)
+        .long(EXECUTE_AS_SUBPROCESS_ARG)
+        .hidden(true)
+}
+
+fn root_hash_arg() -> Arg<'static, 'static> {
+    Arg::with_name(ROOT_HASH_ARG_NAME)
+        .value_name(ROOT_HASH_ARG_VALUE_NAME)
+        .help(ROOT_HASH_ARG_HELP)
+}
+
+fn repetitions_arg() -> Arg<'static, 'static> {
+    Arg::with_name(REPETITIONS_ARG_NAME)
+        .long(REPETITIONS_ARG_NAME)
+        .short(REPETITIONS_ARG_SHORT)
+        .default_value(REPETITIONS_ARG_DEFAULT)
+        .value_name(REPETITIONS_ARG_VALUE_NAME)
+        .help(REPETITIONS_ARG_HELP)
+}
+
+fn output_dir_arg() -> Arg<'static, 'static> {
+    Arg::with_name(OUTPUT_DIR_ARG_NAME)
+        .long(OUTPUT_DIR_ARG_NAME)
+        .short(OUTPUT_DIR_ARG_SHORT)
+        .value_name(OUTPUT_DIR_ARG_VALUE_NAME)
+        .help(OUTPUT_DIR_ARG_HELP)
+}
+
+#[derive(Debug)]
+struct Args {
+    execute_as_subprocess: bool,
+    root_hash: Option<String>,
+    repetitions: usize,
+    output_dir: PathBuf,
+    data_dir: PathBuf,
+}
+
+impl Args {
+    fn new() -> Self {
+        let exe_name = profiling::exe_name();
+        let data_dir_arg = profiling::data_dir_arg();
+        let arg_matches = App::new(&exe_name)
+            .version(crate_version!())
+            .about(ABOUT)
+            .arg(execute_as_subprocess_arg())
+            .arg(root_hash_arg())
+            .arg(repetitions_arg())
+            .arg(output_dir_arg())
+            .arg(data_dir_arg)
+            .get_matches();
+        let execute_as_subprocess = arg_matches.is_present(EXECUTE_AS_SUBPROCESS_ARG);
+        let root_hash = arg_matches
+            .value_of(ROOT_HASH_ARG_NAME)
+            .map(ToString::to_string);
+        let repetitions = arg_matches
+            .value_of(REPETITIONS_ARG_NAME)
+            .map(profiling::parse_count)
+            .expect("should have repetitions");
+        let output_dir = match arg_matches.value_of(OUTPUT_DIR_ARG_NAME) {
+            Some(dir) => PathBuf::from_str(dir).expect("Expected a valid unicode path"),
+            None => env::current_dir().expect("Expected to be able to access current working dir"),
+        };
+        let data_dir = profiling::data_dir(&arg_matches);
+        Args {
+            execute_as_subprocess,
+            root_hash,
+            repetitions,
+            output_dir,
+            data_dir,
+        }
+    }
+}
+
+/// Executes the host-function-metrics contract repeatedly to generate metrics in stdout.
+fn run_test(root_hash: Vec<u8>, repetitions: usize, data_dir: &Path) {
+    let log_settings = Settings::new(LevelFilter::Warn).with_metrics_enabled(true);
+    let _ = logging::initialize(log_settings);
+
+    let account_1_public_key = profiling::account_1_public_key();
+    let account_2_public_key = profiling::account_2_public_key();
+
+    let engine_config = EngineConfig::new()
+        .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
+        .with_enable_bonding(cfg!(feature = "enable-bonding"));
+
+    let mut test_builder = LmdbWasmTestBuilder::open(data_dir, engine_config, root_hash);
+
+    let mut rng = rand::thread_rng();
+
+    for _ in 0..repetitions {
+        let seed: u64 = rng.gen();
+        let random_bytes_length: usize = rng.gen_range(0, 10_000);
+        let mut random_bytes = vec![0_u8; random_bytes_length];
+        rng.fill(random_bytes.as_mut_slice());
+
+        let deploy = DeployItemBuilder::new()
+            .with_address(account_1_public_key)
+            .with_deploy_hash(rng.gen())
+            .with_session_code(
+                HOST_FUNCTION_METRICS_CONTRACT,
+                (
+                    seed,
+                    (random_bytes, account_1_public_key, account_2_public_key),
+                ),
+            )
+            .with_empty_payment_bytes((U512::from(PAYMENT_AMOUNT),))
+            .with_authorization_keys(&[account_1_public_key])
+            .build();
+        let exec_request = ExecuteRequestBuilder::new()
+            .push_deploy(deploy.clone())
+            .build();
+
+        test_builder.exec(exec_request);
+        // Should revert with User error 10.
+        let error_msg = test_builder
+            .exec_error_message(0)
+            .expect("should have error message");
+        assert!(
+            error_msg.contains(&format!("{:?}", ApiError::User(EXPECTED_REVERT_VALUE))),
+            error_msg
+        );
+    }
+}
+
+#[derive(Debug)]
+struct Metrics {
+    duration: String,
+    others: BTreeMap<String, String>,
+}
+
+fn gather_metrics(stdout: String) -> BTreeMap<String, Vec<Metrics>> {
+    const PAYLOAD_KEY: &str = "payload=";
+    const DESCRIPTION_KEY: &str = "description";
+    const HOST_FUNCTION_PREFIX: &str = "host_function_";
+    const PROPERTIES_KEY: &str = "properties";
+    const DURATION_KEY: &str = "duration_in_seconds";
+    const MESSAGE_KEY: &str = "message";
+    const MESSAGE_TEMPLATE_KEY: &str = "message_template";
+
+    let mut result = BTreeMap::new();
+
+    for line in stdout.lines() {
+        if let Some(index) = line.find(PAYLOAD_KEY) {
+            let (_, payload_slice) = line.split_at(index + PAYLOAD_KEY.len());
+            let mut payload =
+                serde_json::from_str::<Value>(payload_slice).expect("payload should parse as JSON");
+
+            let description = payload
+                .get_mut(DESCRIPTION_KEY)
+                .expect("payload should have description field")
+                .take();
+            let function_id = description
+                .as_str()
+                .expect("description field should parse as string")
+                .split(' ')
+                .next()
+                .expect("description field should consist of function name followed by a space");
+            if !function_id.starts_with(HOST_FUNCTION_PREFIX) {
+                continue;
+            }
+            let function_name = function_id
+                .split_at(HOST_FUNCTION_PREFIX.len())
+                .1
+                .to_string();
+
+            let metrics_vec = result.entry(function_name).or_insert_with(|| vec![]);
+
+            let mut properties: BTreeMap<String, String> = serde_json::from_value(
+                payload
+                    .get_mut(PROPERTIES_KEY)
+                    .expect("payload should have properties field")
+                    .take(),
+            )
+            .expect("properties should parse as pairs of strings");
+
+            let duration = properties
+                .remove(DURATION_KEY)
+                .expect("properties should have a duration entry");
+            let _ = properties.remove(MESSAGE_KEY);
+            let _ = properties.remove(MESSAGE_TEMPLATE_KEY);
+
+            let metrics = Metrics {
+                duration,
+                others: properties,
+            };
+            metrics_vec.push(metrics);
+        }
+    }
+
+    result
+}
+
+fn generate_csv(function_name: String, metrics_vec: Vec<Metrics>, output_dir: &Path) {
+    let file_path = output_dir.join(format!("{}.csv", function_name));
+    let mut file = File::create(&file_path)
+        .unwrap_or_else(|_| panic!("should create {}", file_path.display()));
+
+    writeln!(file, "{}", CSV_HEADER)
+        .unwrap_or_else(|_| panic!("should write to {}", file_path.display()));
+
+    for metrics in metrics_vec {
+        write!(file, "\"(").unwrap_or_else(|_| panic!("should write to {}", file_path.display()));
+        let no_other_metrics = metrics.others.is_empty();
+        for (_metric_key, metric_value) in metrics.others {
+            write!(file, "{},", metric_value)
+                .unwrap_or_else(|_| panic!("should write to {}", file_path.display()));
+        }
+        if no_other_metrics {
+            write!(file, ",").unwrap_or_else(|_| panic!("should write to {}", file_path.display()));
+        }
+        writeln!(file, ")\",1,{}", metrics.duration)
+            .unwrap_or_else(|_| panic!("should write to {}", file_path.display()));
+    }
+}
+
+fn main() {
+    let args = Args::new();
+
+    // If the required initial root hash wasn't passed as a command line arg, expect to read it in
+    // from stdin to allow for it to be piped from the output of 'state-initializer'.
+    let (root_hash, root_hash_read_from_stdin) = match args.root_hash {
+        Some(root_hash) => (root_hash, false),
+        None => {
+            let mut input = String::new();
+            let _ = io::stdin().read_line(&mut input);
+            (input.trim_end().to_string(), true)
+        }
+    };
+
+    // We're running as a subprocess - execute the test to output the metrics to stdout.
+    if args.execute_as_subprocess {
+        return run_test(
+            profiling::parse_hash(&root_hash),
+            args.repetitions,
+            &args.data_dir,
+        );
+    }
+
+    // We're running as the top-level process - invoke the current exe as a subprocess to capture
+    // its stdout.
+    let subprocess_flag = format!("--{}", EXECUTE_AS_SUBPROCESS_ARG);
+    let mut subprocess_args = env::args().chain(iter::once(subprocess_flag));
+    let mut subprocess = Command::new(
+        subprocess_args
+            .next()
+            .expect("should get current executable's full path"),
+    );
+    subprocess.args(subprocess_args);
+    if root_hash_read_from_stdin {
+        subprocess.arg(root_hash);
+    }
+
+    let subprocess_output = subprocess
+        .output()
+        .expect("should run current executable as a subprocess");
+
+    let stdout = String::from_utf8(subprocess_output.stdout).expect("should be valid UTF-8");
+    if !subprocess_output.status.success() {
+        let stderr = String::from_utf8(subprocess_output.stderr).expect("should be valid UTF-8");
+        panic!(
+            "\nFailed to execute as subprocess:\n{}\n\n{}\n\n",
+            stdout, stderr
+        );
+    }
+
+    let all_metrics = gather_metrics(stdout);
+    let output_dir = &args.output_dir;
+    fs::create_dir_all(output_dir)
+        .unwrap_or_else(|_| panic!("should create {}", output_dir.display()));
+    for (function_id, metrics_vec) in all_metrics {
+        generate_csv(function_id, metrics_vec, &args.output_dir);
+    }
+}

--- a/execution-engine/engine-tests/src/profiling/mod.rs
+++ b/execution-engine/engine-tests/src/profiling/mod.rs
@@ -2,6 +2,7 @@ use std::{env, path::PathBuf, str::FromStr};
 
 use clap::{Arg, ArgMatches};
 
+use engine_test_support::DEFAULT_ACCOUNT_INITIAL_BALANCE;
 use types::{account::PublicKey, U512};
 
 const DATA_DIR_ARG_NAME: &str = "data-dir";
@@ -12,7 +13,7 @@ const DATA_DIR_ARG_HELP: &str = "Directory in which persistent data is stored [d
                                  working directory]";
 
 const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
-const ACCOUNT_1_INITIAL_AMOUNT: u64 = 1_000_000_000;
+pub const ACCOUNT_1_INITIAL_AMOUNT: u64 = DEFAULT_ACCOUNT_INITIAL_BALANCE - 1_000_000_000;
 const ACCOUNT_2_ADDR: PublicKey = PublicKey::ed25519_from([2u8; 32]);
 
 pub fn exe_name() -> String {
@@ -39,6 +40,16 @@ pub fn data_dir(arg_matches: &ArgMatches) -> PathBuf {
         Some(dir) => PathBuf::from_str(dir).expect("Expected a valid unicode path"),
         None => env::current_dir().expect("Expected to be able to access current working dir"),
     }
+}
+
+pub fn parse_hash(encoded_hash: &str) -> Vec<u8> {
+    base16::decode(encoded_hash).expect("Expected a valid, hex-encoded hash")
+}
+
+pub fn parse_count(count_as_str: &str) -> usize {
+    let count: usize = count_as_str.parse().expect("Expected an integral count");
+    assert!(count > 0, "Expected count > 0");
+    count
 }
 
 pub fn account_1_public_key() -> PublicKey {

--- a/execution-engine/engine-tests/src/profiling/simple_transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple_transfer.rs
@@ -50,10 +50,6 @@ fn verbose_arg() -> Arg<'static, 'static> {
         .help(VERBOSE_ARG_HELP)
 }
 
-fn parse_hash(encoded_hash: &str) -> Vec<u8> {
-    base16::decode(encoded_hash).expect("Expected a valid, hex-encoded hash")
-}
-
 #[derive(Debug)]
 struct Args {
     root_hash: Option<Vec<u8>>,
@@ -72,7 +68,9 @@ impl Args {
             .arg(data_dir_arg)
             .arg(verbose_arg())
             .get_matches();
-        let root_hash = arg_matches.value_of(ROOT_HASH_ARG_NAME).map(parse_hash);
+        let root_hash = arg_matches
+            .value_of(ROOT_HASH_ARG_NAME)
+            .map(profiling::parse_hash);
         let data_dir = profiling::data_dir(&arg_matches);
         let verbose = arg_matches.is_present(VERBOSE_ARG_NAME);
         Args {
@@ -91,7 +89,7 @@ fn main() {
     let root_hash = args.root_hash.unwrap_or_else(|| {
         let mut input = String::new();
         let _ = io::stdin().read_line(&mut input);
-        parse_hash(input.trim_end())
+        profiling::parse_hash(input.trim_end())
     });
 
     let account_1_public_key = profiling::account_1_public_key();


### PR DESCRIPTION
### Overview
This PR adds a tool which can generate CSV files of metrics for each of the FFI host functions.  The format of the output files and rationale for generating them is detailed in [Benchmarking and modeling runtime](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/369230053/Benchmarking+and+modeling+runtime).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-638

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.

### Notes
Details on running the tool are in the [profiling README](https://github.com/Fraser999/CasperLabs/tree/EE-638-host-function-instrumentation/execution-engine/engine-tests/src/profiling#host-function-metrics).  Note that running the tool with the default 10,000 repetitions can take in excess of half an hour to complete.  To test with just 3 iterations, do:
```
cd CasperLabs/execution-engine/
make build-contracts-rs
cd engine-tests/
cargo build --release --bin state-initializer
cargo build --release --bin host-function-metrics
../target/release/state-initializer -d=../target | ../target/release/host-function-metrics -d=../target -o=../target/host-function-metrics -r=3
```
The resulting CSV files will be found in `target/host-function-metrics`.