### PR TITLE
NODE-1371: Prevent repeated traversals to add sources.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -448,7 +448,10 @@ trait DownloadManagerImpl[F[_]] extends DownloadManager[F] { self =>
           existing.copy(
             sources = existing.sources + source,
             relay = existing.relay || relay,
-            maybeWatcher = Some(downloadFeedback)
+            maybeWatcher = Some(downloadFeedback),
+            // A new ping should mean this item can now be considered again;
+            // also stops `addSource` from traversing it repeatedly.
+            isError = false
           ) -> downloadFeedback
         }
       } getOrElse {


### PR DESCRIPTION
### Overview
@arcolife had issues with OutOfMemory errors in LRT3. I loaded the 18Gb heapdump (didn't have any restrictions on it) and had a look around. What stood out was some lambda function in the `DownloadManager`:
![image](https://user-images.githubusercontent.com/2684603/79326494-d3522d00-7f0a-11ea-9ea4-62493563e577.png)

An instance of that lambda has 3 parameters:
![image](https://user-images.githubusercontent.com/2684603/79326555-eebd3800-7f0a-11ea-9dbc-cb14df812ff3.png)

Which I think might correspond the [schedule](https://github.com/CasperLabs/CasperLabs/blob/dev/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala#L330) method being called from [traversing](https://github.com/CasperLabs/CasperLabs/blob/dev/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala#L334) over the ancestors.

A reasonable explanation is that `addSource` will [traverse](https://github.com/CasperLabs/CasperLabs/blob/dev/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala#L166) the ancestors repeatedly, because once the `isError` switch is flipped they don't get cleared until they succeed. The PR changes that so that a new scheduling resets that flag to `false`, thus stopping subsequent visits.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1371

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I was trying to check if the `isError` was indeed `true` but VisualVM just crashed.
