### PR TITLE
NODE-1363: Separate read and write connection timeout. Name the pools.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -137,7 +137,7 @@ package object effects {
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
     val writeXaConfig =
-      mkConfig("write", poolSize = 1, foreignKeys = true, connectionTimeout = 60.seconds)
+      mkConfig("write", poolSize = 1, foreignKeys = true, connectionTimeout = 30.seconds)
 
     // Using a separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -95,9 +95,13 @@ package object effects {
     val readThreads   = conf.server.dbReadThreads.value
     val writeThreads  = conf.server.dbWriteThreads.value
     val readPoolSize  = conf.server.dbReadConnections.value
-    val writePoolSize = 1
 
-    def mkConfig(poolSize: Int, foreignKeys: Boolean) = {
+    def mkConfig(
+        poolName: String,
+        poolSize: Int,
+        foreignKeys: Boolean,
+        connectionTimeout: FiniteDuration
+    ) = {
       val config = new HikariConfig()
       config.setDriverClassName("org.sqlite.JDBC")
       config.setJdbcUrl(s"jdbc:sqlite:${serverDataDir.resolve("sqlite.db")}")
@@ -116,33 +120,35 @@ package object effects {
       // NODE-1019 will add logging, maybe we'll learn more.
       config.addDataSourceProperty("busy_timeout", "5000")
       config.addDataSourceProperty("journal_mode", "WAL")
+      config.setConnectionTimeout(connectionTimeout.toMillis)
+      config.setPoolName(s"${poolName}-pool")
       config
     }
+
+    def mkTransactor(config: HikariConfig, threads: Int) =
+      HikariTransactor
+        .fromHikariConfig[Task](
+          config,
+          connectEC(config.getPoolName, config.getMaximumPoolSize, threads),
+          Blocker.liftExecutionContext(transactEC(config.getPoolName, config.getMaximumPoolSize))
+        )
 
     // Using a connection pool with maximum size of 1 for writers because with the default settings we got SQLITE_BUSY errors.
     // The SQLite docs say the driver is thread safe, but only one connection should be made per process
     // (the file locking mechanism depends on process IDs, closing one connection would invalidate the locks for all of them).
-    val writeXaconfig = mkConfig(writePoolSize, foreignKeys = true)
+    val writeXaConfig =
+      mkConfig("write", poolSize = 1, foreignKeys = true, connectionTimeout = 60.seconds)
 
     // Using a separate Transactor for read operations because
     // we use fs2.Stream as a return type in some places which hold an opened connection
     // preventing acquiring a connection in other places if we use a connection pool with size of 1.
-    val readXaconfig = mkConfig(readPoolSize, foreignKeys = false)
+    val readXaConfig =
+      mkConfig("read", poolSize = readPoolSize, foreignKeys = false, connectionTimeout = 30.seconds)
 
     // Hint: Use config.setLeakDetectionThreshold(10000) to detect connection leaking
     for {
-      writeXa <- HikariTransactor
-                  .fromHikariConfig[Task](
-                    writeXaconfig,
-                    connectEC("write", writePoolSize, writeThreads),
-                    Blocker.liftExecutionContext(transactEC("write", writePoolSize))
-                  )
-      readXa <- HikariTransactor
-                 .fromHikariConfig[Task](
-                   readXaconfig,
-                   connectEC("read", readPoolSize, readThreads),
-                   Blocker.liftExecutionContext(transactEC("read", readPoolSize))
-                 )
+      writeXa <- mkTransactor(writeXaConfig, writeThreads)
+      readXa  <- mkTransactor(readXaConfig, readThreads)
     } yield (writeXa, readXa)
   }
 }


### PR DESCRIPTION
### Overview
We get exceptions such as this:
```
Uncaught Exception : ex=io.grpc.StatusRuntimeException: INTERNAL: HikariPool-2 - Connection is not available, request timed out after 30000ms.
```
Unfortunately that makes it ~impossible~ to tell if it's the read or the write pool. 

Although looking at [HikairConfig.poolName](https://github.com/openbouquet/HikariCP/blob/master/src/main/java/com/zaxxer/hikari/HikariConfig.java#L751) the `-2` in the message it means it must be the reader pool as that's the one we create 2nd.

~Raised the write timeout to 60s~ because there's only 1 connection in the pool and it's probably important to try to not fail writes if possible, and named the pools, so that would [show up](https://github.com/openbouquet/HikariCP/blob/master/src/main/java/com/zaxxer/hikari/pool/HikariPool.java#L213) in the message.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NODE-1363

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
