### PR TITLE
OP-1265 Reducing CI Integration Tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -478,6 +478,7 @@ steps:
   depends_on:
   - docker-build-key-bors
 
+# Release Branch Only
 - name: run-integration-tests-parallel-0
   commands:
   - "cd integration-testing"
@@ -492,12 +493,12 @@ steps:
     path: "/tmp"
   when:
     branch:
-    - staging
-    - trying
+    - release-*
   depends_on:
   - docker-build-ee-int-bors
   - docker-build-explorer-bors
 
+# Release Branch Only
 - name: run-integration-tests-parallel-1
   commands:
   - "cd integration-testing"
@@ -512,12 +513,12 @@ steps:
     path: "/tmp"
   when:
     branch:
-    - staging
-    - trying
+    - release-*
   depends_on:
   - docker-build-ee-int-bors
   - docker-build-explorer-bors
 
+# Release Branch Only
 - name: run-integration-tests-parallel-2
   commands:
   - "cd integration-testing"
@@ -532,12 +533,12 @@ steps:
     path: "/tmp"
   when:
     branch:
-    - staging
-    - trying
+    - release-*
   depends_on:
   - docker-build-ee-int-bors
   - docker-build-explorer-bors
 
+# Release Branch Only
 - name: run-integration-tests-serial-3
   commands:
   - "cd integration-testing"
@@ -552,12 +553,32 @@ steps:
     path: "/tmp"
   when:
     branch:
-    - staging
-    - trying
+    - release-*
   depends_on:
   - run-integration-tests-parallel-0
   - run-integration-tests-parallel-1
   - run-integration-tests-parallel-2
+
+# Dev branch only
+- name: run-integration-tests
+  commands:
+  - "cd integration-testing"
+  - "./docker_run_tests.sh --unique_run_num 5"
+  environment:
+    _JAVA_OPTIONS: "-Xms2G -Xmx2G -XX:MaxMetaspaceSize=1G"
+  image: "casperlabs/buildenv:latest"
+  volumes:
+  - name: docker_sock
+    path: "/var/run/docker.sock"
+  - name: temp
+    path: "/tmp"
+  when:
+    branch:
+    - staging
+    - trying
+  depends_on:
+  - docker-build-ee-int-bors
+  - docker-build-explorer-bors
 
 # The below section is for post-bors push webhooks
 - name: rust-compile-for-make

--- a/integration-testing/run_tests.sh
+++ b/integration-testing/run_tests.sh
@@ -39,6 +39,10 @@ case ${UNIQUE_RUN_NUM} in
   [3])
   pipenv run pytest -k "not R0 and not R1 and not R2" ${PYTEST_ARGS} ${TEST_RUN_ARGS}
   ;;
+  [5])
+  # Using 5 as special code for dev CI to only run one test
+  pipenv run pytest -k "test_clarity" ${PYTEST_ARGS} ${TEST_RUN_ARGS}
+  ;;
   *)
   pipenv run pytest ${PYTEST_ARGS} ${TEST_RUN_ARGS}
   ;;


### PR DESCRIPTION
Running all tests in release branches.
Running only test_clarity in dev.

https://casperlabs.atlassian.net/browse/OP-1265

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
