### PR TITLE
TNET-6: Add an option to Python client to output event stream in binary format.

### DIFF
--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -18,7 +18,7 @@ from casperlabs_client import (
     DEFAULT_INTERNAL_PORT,
     bundled_contract,
 )
-from casperlabs_client.utils import hexify
+from casperlabs_client.utils import hexify, jsonify
 from casperlabs_client.abi import ABI
 from casperlabs_client.crypto import (
     read_pem_key,
@@ -381,9 +381,10 @@ def stream_events_command(casperlabs_client, args):
         **subscribed_events,
     )
     for event in stream:
-        now = datetime.datetime.now()
-        print(f"------------- {now.strftime('%Y-%m-%d %H:%M:%S')} -------------")
-        print(hexify(event))
+        if args.format == "binary":
+            print(base64.b64encode(event.SerializeToString()))
+        else:
+            print(jsonify(event))
 
 
 def check_directory(path):
@@ -627,6 +628,7 @@ def cli(*arguments) -> int:
         [('--deploy-orphaned',), dict(action='store_true', help='Deploy orphaned')],
         [('-k', '--account-public-key'), dict(action='append', help='Filter by (possibly multiple) account public key(s)')],
         [('-d', '--deploy-hash'), dict(action='append', help='Filter by (possibly multiple) deploy hash(es)')],
+        [('-f', '--format'), dict(  required=False, default='json', choices=('json', 'binary') ,help='Choose output format (binary, json).')],
         [('--min-event-id',), dict(required=False, default=0, type=int, help="Supports replaying events from a given ID. If the value is 0, it it will subscribe to future events; if it's non-zero, it will replay all past events from that ID, without subscribing to new. To catch up with events from the beginning, start from 1.")],
     ])
     # fmt:on

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -382,9 +382,11 @@ def stream_events_command(casperlabs_client, args):
     )
     for event in stream:
         if args.format == "binary":
-            print(base64.b64encode(event.SerializeToString()))
-        else:
+            print(base64.b64encode(event.SerializeToString()).decode())
+        if args.format == "json":
             print(jsonify(event))
+        else:
+            print(hexify(event))
 
 
 def check_directory(path):
@@ -628,7 +630,7 @@ def cli(*arguments) -> int:
         [('--deploy-orphaned',), dict(action='store_true', help='Deploy orphaned')],
         [('-k', '--account-public-key'), dict(action='append', help='Filter by (possibly multiple) account public key(s)')],
         [('-d', '--deploy-hash'), dict(action='append', help='Filter by (possibly multiple) deploy hash(es)')],
-        [('-f', '--format'), dict(  required=False, default='json', choices=('json', 'binary') ,help='Choose output format (binary, json).')],
+        [('-f', '--format'), dict(  required=False, default='json', choices=('json', 'binary') ,help='Choose output format (binary, json). Defaults to hex representation.')],
         [('--min-event-id',), dict(required=False, default=0, type=int, help="Supports replaying events from a given ID. If the value is 0, it it will subscribe to future events; if it's non-zero, it will replay all past events from that ID, without subscribing to new. To catch up with events from the beginning, start from 1.")],
     ])
     # fmt:on

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -383,7 +383,7 @@ def stream_events_command(casperlabs_client, args):
     for event in stream:
         if args.format == "binary":
             print(base64.b64encode(event.SerializeToString()).decode())
-        if args.format == "json":
+        elif args.format == "json":
             print(jsonify(event))
         else:
             print(hexify(event))
@@ -630,7 +630,7 @@ def cli(*arguments) -> int:
         [('--deploy-orphaned',), dict(action='store_true', help='Deploy orphaned')],
         [('-k', '--account-public-key'), dict(action='append', help='Filter by (possibly multiple) account public key(s)')],
         [('-d', '--deploy-hash'), dict(action='append', help='Filter by (possibly multiple) deploy hash(es)')],
-        [('-f', '--format'), dict(  required=False, default='json', choices=('json', 'binary') ,help='Choose output format (binary, json). Defaults to hex representation.')],
+        [('-f', '--format'), dict(required=False, default='hexify', choices=('json', 'binary', 'hexify') ,help='Choose output format. Defaults to hex representation.')],
         [('--min-event-id',), dict(required=False, default=0, type=int, help="Supports replaying events from a given ID. If the value is 0, it it will subscribe to future events; if it's non-zero, it will replay all past events from that ID, without subscribing to new. To catch up with events from the beginning, start from 1.")],
     ])
     # fmt:on

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/cli.py
@@ -630,7 +630,7 @@ def cli(*arguments) -> int:
         [('--deploy-orphaned',), dict(action='store_true', help='Deploy orphaned')],
         [('-k', '--account-public-key'), dict(action='append', help='Filter by (possibly multiple) account public key(s)')],
         [('-d', '--deploy-hash'), dict(action='append', help='Filter by (possibly multiple) deploy hash(es)')],
-        [('-f', '--format'), dict(required=False, default='hexify', choices=('json', 'binary', 'hexify') ,help='Choose output format. Defaults to hex representation.')],
+        [('-f', '--format'), dict(required=False, default='text', choices=('json', 'binary', 'text') ,help='Choose output format. Defaults to text representation.')],
         [('--min-event-id',), dict(required=False, default=0, type=int, help="Supports replaying events from a given ID. If the value is 0, it it will subscribe to future events; if it's non-zero, it will replay all past events from that ID, without subscribing to new. To catch up with events from the beginning, start from 1.")],
     ])
     # fmt:on

--- a/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
+++ b/integration-testing/client/CasperLabsClient/casperlabs_client/utils.py
@@ -3,6 +3,7 @@ import time
 import ssl
 import pkg_resources
 import google.protobuf.text_format
+import google.protobuf.json_format
 from . import abi
 from . import casper_pb2 as casper
 from . import consensus_pb2 as consensus
@@ -19,6 +20,10 @@ def hexify(o):
     Convert protobuf message to text format with cryptographic keys and signatures in base 16.
     """
     return google.protobuf.text_format.MessageToString(o)
+
+
+def jsonify(o):
+    return google.protobuf.json_format.MessageToJson(o)
 
 
 def bundled_contract(file_name):


### PR DESCRIPTION
### Overview
As in the title. If `--format binary` then events are printed in the binary base64 encoded. Defaults to JSON.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-6

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
