### PR TITLE
TNET-10: Only download deploy hash as part of partial blocks

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/BlockDownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/BlockDownloadManager.scala
@@ -157,7 +157,7 @@ class BlockDownloadManagerImpl[F[_]](
       val req = GetBlockChunkedRequest(
         blockHash = blockHash,
         acceptedCompressionAlgorithms = Seq("lz4"),
-        excludeDeployBodies = partialBlocksEnabled
+        onlyIncludeDeployHashes = partialBlocksEnabled
       )
       stub.getBlockChunked(req)
     }

--- a/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/BlockImplicits.scala
@@ -35,13 +35,23 @@ object BlockImplicits {
     def getSummary: BlockSummary =
       BlockSummary(block.blockHash, block.header, block.signature)
 
-    /** Serve the block without deploys in it. Used when deploy gossiping is enabled. */
+    /** Serve the block without deploy bodies in it, but keep the header. Used when deploy gossiping is enabled. */
     def clearDeployBodies: Block = block.update(
       _.body.deploys := block.getBody.deploys
         .map(
           processedDeploy => processedDeploy.withDeploy(processedDeploy.getDeploy.clearBody)
         )
     )
+
+    /** Serve the block without deploy body or header in it, only keep the hash. Used when deploy gossiping is enabled. */
+    def clearDeploysExceptHash: Block =
+      block.update(
+        _.body.deploys := block.getBody.deploys
+          .map(
+            processedDeploy =>
+              processedDeploy.withDeploy(Deploy(processedDeploy.getDeploy.deployHash))
+          )
+      )
 
     /** Fill in the deploy bodies from a list of deploys fetched separately. */
     def withDeploys(deploys: List[Deploy]): Block = {

--- a/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
+++ b/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
@@ -106,7 +106,10 @@ message GetBlockChunkedRequest {
     bytes block_hash = 1;
     uint32 chunk_size = 2;
     repeated string accepted_compression_algorithms = 3;
+    // Download the processed deploys without their bodies.
     bool exclude_deploy_bodies = 4;
+    // Download the processed deploys with only the hash, no body, header and approvals.
+    bool only_include_deploy_hashes = 5;
 }
 
 message StreamDeploysChunkedRequest {


### PR DESCRIPTION
### Overview
Changes the partial block downloads to only ask for deploy hashes, not even headers.

Builds on https://github.com/CasperLabs/CasperLabs/pull/1896

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-10

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
