### PR TITLE
OP-1266: run pipelines against branches prefixed with feature-

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -856,7 +856,7 @@ trigger:
   - "testing*"
   - trying
   - staging
-  - NODE-659-rdbms-epic # temporary, remove after NODE-659-rdbms-epic merged to dev
+  - "feature-*"
 
 ---
 kind: pipeline
@@ -894,6 +894,7 @@ trigger:
   - "testing*"
   - trying
   - staging
+  - "feature-*"
 
 depends_on:
 - build-bors-merge
@@ -958,6 +959,7 @@ trigger:
   - "testing*"
   - trying
   - staging
+  - "feature-*"
 
 depends_on:
 - build-bors-merge


### PR DESCRIPTION
### Overview
This PR allows drone and bors to run against PRs to branches prefixed with `feature-`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1266

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
