### PR TITLE
OP-1281: fix publish python client to github release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1016,12 +1016,8 @@ steps:
   - "pipenv run python3 setup.py sdist"
   - "cp dist/casperlabs* ../../../artifacts/${DRONE_BRANCH}"
   when:
-    branch:
-    - dev
-    - release-*
-    - master
-    event:
-    - push
+    ref:
+    - refs/tags/v*
   depends_on:
     - package-ee-tag
 


### PR DESCRIPTION
### Overview
There was a copy paste error when we first introduced building the python client to the tagging pipeline. This makes it run properly on tagged releases.

### Which JIRA ticket does this PR relate to?
_Add the link here. Create a ticket and link it here if one does not exist._

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes

Tested in my branch here: https://github.com/TomVasile/CasperLabs/releases/tag/v0.test.python.github.release
