### PR TITLE
[ECO-384] Explorer Enhancements

### DIFF
--- a/explorer/ui/package.json
+++ b/explorer/ui/package.json
@@ -79,6 +79,11 @@
       "pre-commit": "lint-staged"
     }
   },
+  "prettier": {
+    "singleQuote": true,
+    "arrowParens": "avoid",
+    "trailingComma": "none"
+  },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
       "prettier --single-quote --write",

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -156,7 +156,7 @@ export class BlockDAG extends React.Component<Props, {}> {
    * would re-render with no SVG at all.
    */
   componentDidUpdate() {
-    this.renderGraph(this.props.hideBlockHashToggleStore?.isPressed, this.props.hideBlockHashToggleStore?.isPressed);
+    this.renderGraph(this.props.hideBallotsToggleStore?.isPressed, this.props.hideBlockHashToggleStore?.isPressed);
   }
 
   renderGraph(hideBallot?: boolean, hideBlockHash?: boolean) {

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -23,7 +23,7 @@ export interface Props extends RouteComponentProps<{}> {
 }
 
 @observer
-class _BlockList extends RefreshableComponent<Props, {}> {
+class _BlockList extends React.Component<Props, {}> {
   constructor(props: Props) {
     super(props);
     let maxRank = parseInt(props.maxRank || '') || 0;
@@ -37,9 +37,8 @@ class _BlockList extends RefreshableComponent<Props, {}> {
   }
 
   componentWillUnmount() {
-    super.componentWillUnmount();
     // release websocket if necessary
-    this.props.dag.toggleableSubscriber.unsubscribe();
+    this.props.dag.toggleableSubscriber.unsubscribeAndFree();
   }
 
   render() {
@@ -53,7 +52,15 @@ class _BlockList extends RefreshableComponent<Props, {}> {
         }
         refresh={() => this.refresh()}
         subscribeToggleStore={dag.toggleableSubscriber.subscribeToggleStore}
-        headers={['Block Hash', 'j-Rank', 'm-Rank', 'Timestamp', 'Validator', 'Type', 'Key Block Hash']}
+        headers={[
+          'Block Hash',
+          'j-Rank',
+          'm-Rank',
+          'Timestamp',
+          'Validator',
+          'Type',
+          'Key Block Hash'
+        ]}
         rows={dag.blocks}
         renderRow={(block: BlockInfo) => {
           const header = block.getSummary()!.getHeader()!;
@@ -69,9 +76,13 @@ class _BlockList extends RefreshableComponent<Props, {}> {
                 <Timestamp timestamp={header.getTimestamp()} />
               </td>
               <td>{shortHash(header.getValidatorPublicKey_asU8())}</td>
-              <td><BlockType header={header} /></td>
               <td>
-                <Link to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}>
+                <BlockType header={header} />
+              </td>
+              <td>
+                <Link
+                  to={Pages.block(encodeBase16(header.getKeyBlockHash_asU8()))}
+                >
                   {shortHash(header.getKeyBlockHash_asU8())}
                 </Link>
               </td>

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -18,9 +18,11 @@ import { BondedValidatorsTable } from './BondedValidatorsTable';
 import { ToggleButton } from './ToggleButton';
 import { BlockType, BlockRole, FinalityIcon } from './BlockDetails';
 
+const DEFAULT_DEPTH = 100;
+
 /** Show the tips of the DAG. */
 @observer
-class _Explorer extends RefreshableComponent<Props, {}> {
+class _Explorer extends React.Component<Props, {}> {
   constructor(props: Props) {
     super(props);
     this.refreshWithDepthAndMaxRank(props.maxRank, props.depth);
@@ -28,7 +30,7 @@ class _Explorer extends RefreshableComponent<Props, {}> {
 
   refreshWithDepthAndMaxRank(maxRankStr: string | null, depthStr: string | null) {
     let maxRank = parseInt(maxRankStr || '') || 0;
-    let depth = parseInt(depthStr || '') || 10;
+    let depth = parseInt(depthStr || '') || DEFAULT_DEPTH;
     this.props.dag.updateMaxRankAndDepth(maxRank, depth);
     this.props.dag.refreshBlockDagAndSetupSubscriber();
   }
@@ -45,7 +47,6 @@ class _Explorer extends RefreshableComponent<Props, {}> {
   }
 
   componentWillUnmount() {
-    super.componentWillUnmount();
     // release websocket if necessary
     this.props.dag.toggleableSubscriber.unsubscribe();
   }
@@ -102,7 +103,9 @@ class _Explorer extends RefreshableComponent<Props, {}> {
               depth={dag.depth}
               onDepthChange={d => {
                 dag.depth = d;
-                this.refresh();
+                this.props.history.push(
+                  Pages.explorerWithMaxRankAndDepth(dag.maxRank, dag.depth)
+                );
               }}
               width="100%"
               height="600"

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -28,7 +28,10 @@ class _Explorer extends React.Component<Props, {}> {
     this.refreshWithDepthAndMaxRank(props.maxRank, props.depth);
   }
 
-  refreshWithDepthAndMaxRank(maxRankStr: string | null, depthStr: string | null) {
+  refreshWithDepthAndMaxRank(
+    maxRankStr: string | null,
+    depthStr: string | null
+  ) {
     let maxRank = parseInt(maxRankStr || '') || 0;
     let depth = parseInt(depthStr || '') || DEFAULT_DEPTH;
     this.props.dag.updateMaxRankAndDepth(maxRank, depth);
@@ -48,7 +51,7 @@ class _Explorer extends React.Component<Props, {}> {
 
   componentWillUnmount() {
     // release websocket if necessary
-    this.props.dag.toggleableSubscriber.unsubscribe();
+    this.props.dag.toggleableSubscriber.unsubscribeAndFree();
   }
 
   render() {
@@ -65,7 +68,9 @@ class _Explorer extends React.Component<Props, {}> {
               }
               blocks={dag.blocks}
               refresh={() => this.refresh()}
-              subscribeToggleStore={dag.toggleableSubscriber.subscribeToggleStore}
+              subscribeToggleStore={
+                dag.toggleableSubscriber.subscribeToggleStore
+              }
               hideBallotsToggleStore={dag.hideBallotsToggleStore}
               hideBlockHashToggleStore={dag.hideBlockHashToggleStore}
               footerMessage={
@@ -92,7 +97,7 @@ class _Explorer extends React.Component<Props, {}> {
                 if (
                   current &&
                   current.getSummary()!.getBlockHash_asB64() ===
-                  block.getSummary()!.getBlockHash_asB64()
+                    block.getSummary()!.getBlockHash_asB64()
                 ) {
                   dag.selectedBlock = undefined;
                 } else {
@@ -240,12 +245,12 @@ class BlockDetails extends React.Component<
           title={`Block ${shortHash(id)}`}
           headers={[]}
           rows={attrs}
-          renderRow={(attr, i) =>
+          renderRow={(attr, i) => (
             <tr key={i}>
               <th>{attr[0]}</th>
               <td>{attr[1]}</td>
             </tr>
-          }
+          )}
           footerMessage="Click the links to select the parents and children."
         />
       </div>

--- a/explorer/ui/src/components/Validators.tsx
+++ b/explorer/ui/src/components/Validators.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { observer } from 'mobx-react';
 import { RefreshableComponent, shortHash } from './Utils';
 import DataTable from './DataTable';
-import ValidatorsContainer, { ValidatorInfo } from '../containers/ValidatorsContainer';
+import ValidatorsContainer, {
+  ValidatorInfo
+} from '../containers/ValidatorsContainer';
 import { base64to16, encodeBase16 } from 'casperlabs-sdk';
 import { Link } from 'react-router-dom';
 import Pages from './Pages';
 import Timestamp from './TimeStamp';
 
 interface Props {
-  validatorsContainer: ValidatorsContainer
+  validatorsContainer: ValidatorsContainer;
 }
 
 @observer
@@ -19,7 +21,7 @@ class Validators extends RefreshableComponent<Props, {}> {
   }
 
   componentWillUnmount(): void {
-    this.props.validatorsContainer.toggleableSubscriber.unsubscribe();
+    this.props.validatorsContainer.toggleableSubscriber.unsubscribeAndFree();
   }
 
   refresh(): void {

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -54,7 +54,7 @@ export class DagStep {
 }
 
 export class DagContainer {
-  @observable blocks: IObservableArray<BlockInfo> = observable.array([], { deep: true });
+  @observable blocks: IObservableArray<BlockInfo> | null = null;
   @observable selectedBlock: BlockInfo | undefined = undefined;
   @observable depth = 10;
   @observable maxRank = 0;
@@ -161,7 +161,7 @@ export class DagContainer {
             }
             remainingBlocks.splice(i, 0, block);
             runInAction(() => {
-              this.blocks.replace(remainingBlocks);
+              this.blocks = observable.array(remainingBlocks);
             });
           } else {
             // otherwise ignore the new block and do nothing
@@ -201,11 +201,13 @@ export class DagContainer {
   }
 
   private async refreshBlockDag() {
+    // show loading spinner
+    this.blocks = null;
     await this.errors.capture(
       this.casperService
         .getBlockInfos(this.depth, this.maxRank)
         .then(blocks => {
-          this.blocks.replace(blocks);
+          this.blocks = observable.array(blocks);
         })
     );
 

--- a/explorer/ui/src/containers/ToggleableSubscriber.ts
+++ b/explorer/ui/src/containers/ToggleableSubscriber.ts
@@ -29,15 +29,19 @@ export class ToggleableSubscriber {
     private forceRefresh: () => void
   ) {
     // so that change of subscribeToggleStore can trigger `setUpSubscriber`
-    reaction(() => this.subscribeToggleStore.isPressed && this.additionalEnable(), () => {
-      this.setUpSubscriber();
-    }, {
-      fireImmediately: false,
-      delay: 100
-    });
+    reaction(
+      () => this.subscribeToggleStore.isPressed && this.additionalEnable(),
+      () => {
+        this.setUpSubscriber();
+      },
+      {
+        fireImmediately: false,
+        delay: 100
+      }
+    );
   }
 
-  unsubscribe(){
+  unsubscribe() {
     if (this.subscriberState === SubscribeState.ON) {
       this.eventsSubscriber!.unsubscribe();
     }
@@ -53,7 +57,6 @@ export class ToggleableSubscriber {
     }
   }
 
-
   private get subscriberState(): SubscribeState {
     if (!this.eventsSubscriber) {
       return SubscribeState.UN_INIT;
@@ -66,7 +69,8 @@ export class ToggleableSubscriber {
 
   @action
   setUpSubscriber() {
-    let subscribeToggleEnabled = this.subscribeToggleStore.isPressed && this.additionalEnable();
+    let subscribeToggleEnabled =
+      this.subscribeToggleStore.isPressed && this.additionalEnable();
     if (subscribeToggleEnabled) {
       // enable subscriber
       const subscriberState = this.subscriberState;

--- a/explorer/ui/src/containers/ToggleableSubscriber.ts
+++ b/explorer/ui/src/containers/ToggleableSubscriber.ts
@@ -37,9 +37,19 @@ export class ToggleableSubscriber {
     });
   }
 
-  unsubscribe() {
+  unsubscribe(){
     if (this.subscriberState === SubscribeState.ON) {
       this.eventsSubscriber!.unsubscribe();
+    }
+  }
+
+  unsubscribeAndFree() {
+    if (this.subscriberState === SubscribeState.ON) {
+      this.eventsSubscriber!.unsubscribe();
+      // free eventsSubscriber before unmount component
+      // so that when user re-visit the page from other page,
+      // it won't call this.forceRefresh
+      this.eventsSubscriber = null;
     }
   }
 


### PR DESCRIPTION
### Overview
This PR adds two features and fix two bugs.

#### features:
1. make default depth of rank to be 100 messages and have the user choice retained when the user refreshes the browser
2. In place filter ballots so that blocks keep in the same position in the DAG after filtering

#### bugs
1. When open Explorer, the DAG will show `No Blocks to Show` instead of loading spinner. 
2. Before unmounting the Explorer component, we should free eventsSubscriber, so that when we revisit it next time, it won't call this.forceRefresh. Otherwise, we will request data and render DAG twice. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-384

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
