### PR TITLE
TNET-3: Add new counter metrics to count blocks in the storage.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -44,7 +44,7 @@ trait HighwayFixture
   ): Unit = {
     val ctx   = TestScheduler()
     val timer = SchedulerEffect.timer[Task](ctx)
-    withCombinedStorages(ctx, numStorages = validators.size) { dbs =>
+    withCombinedStorages(numStorages = validators.size) { dbs =>
       Task.async[Unit] { cb =>
         val fix = f(timer)(validators zip dbs)
         // TestScheduler allows us to manually forward time.

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -125,7 +125,7 @@ package object effects {
       config
     }
 
-    def mkTransactor(config: HikariConfig, threads: Int) =
+    def mkTransactor(config: HikariConfig, threads: Int): Resource[Task, HikariTransactor[Task]] =
       HikariTransactor
         .fromHikariConfig[Task](
           config,

--- a/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/SQLiteStorage.scala
@@ -214,5 +214,6 @@ object SQLiteStorage {
       override def getEvents(minId: Long, maxId: Long): fs2.Stream[F, Event] =
         eventStorage.getEvents(minId, maxId)
 
+      override def blockCount: F[Long] = blockStorage.blockCount
     }
 }

--- a/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/BlockStorage.scala
@@ -54,6 +54,8 @@ trait BlockStorageReader[F[_]] extends BlockStorageWriter[F] {
 
   def isEmpty: F[Boolean]
 
+  def blockCount: F[Long]
+
   def apply(
       blockHash: BlockHash
   )(
@@ -157,7 +159,11 @@ object BlockStorage {
         blockHash: BlockHash,
         blockMsgWithTransform: BlockMsgWithTransform
     ): F[Unit] =
-      incAndMeasure("put", super.put(blockHash, blockMsgWithTransform))
+      incrementTotalBlocksCount() *>
+        incAndMeasure("put", super.put(blockHash, blockMsgWithTransform))
+
+    protected[storage] def incrementTotalBlocksCount(delta: Long = 1): F[Unit] =
+      m.incrementCounter("blocks", delta)
 
     abstract override def checkpoint(): F[Unit] =
       incAndMeasure("checkpoint", super.checkpoint())

--- a/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/block/CachingBlockStorage.scala
@@ -97,6 +97,8 @@ class CachingBlockStorage[F[_]: Sync](
 
   override def close(): F[Unit] =
     underlying.close()
+
+  override def blockCount: F[Long] = underlying.blockCount
 }
 
 object CachingBlockStorage {

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -258,5 +258,7 @@ object CachingBlockStorageTest {
       override def clear(): Task[Unit] = ???
 
       override def close(): Task[Unit] = ???
+
+      override def blockCount: Task[Long] = underlyingBlockStorage.blockCount
     }
 }


### PR DESCRIPTION
### Overview
Adds new metrics (full name `casperlabs_block_storage_sqlite_blocks_*`) to count total block count in the storage. On restart, the metric is reinitialized with the count of blocks in the storage.

The reason to introduce a new metric, rather than reusing already existing one(s), is that current metrics have couple of invariants that would be violated if we had them reinitialized with DB count:
1) The current counter metric is tracked for both cache and sqlite. They should be equal. On restart we would only establish the sqlite one. 
2) Total blocks inserted metric should be a sum of blocks downloaded and blocks created. If we had it established with the DB blocks count that invariant would have been violated (we can't differentiate which blocks were downloaded vs created just by looking at the DB).

@TomVasile We will have to replace the Grafana metric with this one once it's deployed.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-3

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
