### PR TITLE
EE-923: add .travis.yml to project generated by cargo-casperlabs

### DIFF
--- a/execution-engine/cargo-casperlabs/README.md
+++ b/execution-engine/cargo-casperlabs/README.md
@@ -43,7 +43,7 @@ my_project/
 │   ├── Cargo.toml
 │   ├── rust-toolchain
 │   └── src
-│       └── lib.rs
+│       └── main.rs
 ├── tests
 │   ├── build.rs
 │   ├── Cargo.toml

--- a/execution-engine/cargo-casperlabs/README.md
+++ b/execution-engine/cargo-casperlabs/README.md
@@ -44,16 +44,18 @@ my_project/
 │   ├── rust-toolchain
 │   └── src
 │       └── lib.rs
-└── tests
-    ├── build.rs
-    ├── Cargo.toml
-    ├── rust-toolchain
-    ├── src
-    │   └── integration_tests.rs
-    └── wasm
-        ├── mint_install.wasm
-        ├── pos_install.wasm
-        └── standard_payment.wasm
+├── tests
+│   ├── build.rs
+│   ├── Cargo.toml
+│   ├── rust-toolchain
+│   ├── src
+│   │   └── integration_tests.rs
+│   └── wasm
+│       ├── mint_install.wasm
+│       ├── pos_install.wasm
+│       ├── standard_payment_install.wasm
+│       └── standard_payment.wasm
+└── .travis.yml
 ```
 
 ### Building the contract

--- a/execution-engine/cargo-casperlabs/build.rs
+++ b/execution-engine/cargo-casperlabs/build.rs
@@ -7,7 +7,7 @@ use std::{
 trait Package {
     const ROOT: &'static str;
     const CARGO_TOML: &'static str;
-    const LIB_RS: &'static str;
+    const MAIN_RS: &'static str;
     const WASM_FILENAME: &'static str;
 }
 
@@ -16,7 +16,7 @@ struct MintInstall;
 impl Package for MintInstall {
     const ROOT: &'static str = "../contracts/system/mint-install";
     const CARGO_TOML: &'static str = "../contracts/system/mint-install/Cargo.toml";
-    const LIB_RS: &'static str = "../contracts/system/mint-install/src/lib.rs";
+    const MAIN_RS: &'static str = "../contracts/system/mint-install/src/main.rs";
     const WASM_FILENAME: &'static str = "mint_install.wasm";
 }
 
@@ -25,7 +25,7 @@ struct PosInstall;
 impl Package for PosInstall {
     const ROOT: &'static str = "../contracts/system/pos-install";
     const CARGO_TOML: &'static str = "../contracts/system/pos-install/Cargo.toml";
-    const LIB_RS: &'static str = "../contracts/system/pos-install/src/lib.rs";
+    const MAIN_RS: &'static str = "../contracts/system/pos-install/src/main.rs";
     const WASM_FILENAME: &'static str = "pos_install.wasm";
 }
 
@@ -34,7 +34,7 @@ struct StandardPayment;
 impl Package for StandardPayment {
     const ROOT: &'static str = "../contracts/system/standard-payment";
     const CARGO_TOML: &'static str = "../contracts/system/standard-payment/Cargo.toml";
-    const LIB_RS: &'static str = "../contracts/system/standard-payment/src/lib.rs";
+    const MAIN_RS: &'static str = "../contracts/system/standard-payment/src/bin/main.rs";
     const WASM_FILENAME: &'static str = "standard_payment.wasm";
 }
 
@@ -43,7 +43,7 @@ struct StandardPaymentInstall;
 impl Package for StandardPaymentInstall {
     const ROOT: &'static str = "../contracts/system/standard-payment-install";
     const CARGO_TOML: &'static str = "../contracts/system/standard-payment-install/Cargo.toml";
-    const LIB_RS: &'static str = "../contracts/system/standard-payment-install/src/lib.rs";
+    const MAIN_RS: &'static str = "../contracts/system/standard-payment-install/src/main.rs";
     const WASM_FILENAME: &'static str = "standard_payment_install.wasm";
 }
 
@@ -54,7 +54,7 @@ const NEW_WASM_DIR: &str = "wasm";
 fn build_package<T: Package>() {
     // Watch contract source files for changes.
     println!("cargo:rerun-if-changed={}", T::CARGO_TOML);
-    println!("cargo:rerun-if-changed={}", T::LIB_RS);
+    println!("cargo:rerun-if-changed={}", T::MAIN_RS);
 
     // Full path to the cargo binary.
     let cargo = env::var("CARGO").expect("env var 'CARGO' should be set");

--- a/execution-engine/cargo-casperlabs/src/main.rs
+++ b/execution-engine/cargo-casperlabs/src/main.rs
@@ -14,6 +14,7 @@ pub mod common;
 mod contract_package;
 pub mod dependency;
 mod tests_package;
+mod travis_yml;
 
 const APP_NAME: &str = "cargo-casperlabs";
 const ABOUT: &str =
@@ -151,6 +152,8 @@ fn main() {
     tests_package::add_build_rs();
     tests_package::replace_main_rs();
     tests_package::copy_wasm_files();
+
+    travis_yml::create();
 }
 
 #[cfg(test)]

--- a/execution-engine/cargo-casperlabs/src/main.rs
+++ b/execution-engine/cargo-casperlabs/src/main.rs
@@ -143,7 +143,7 @@ fn main() {
     contract_package::run_cargo_new();
     contract_package::update_cargo_toml();
     contract_package::add_rust_toolchain();
-    contract_package::replace_main_rs();
+    contract_package::update_main_rs();
     contract_package::add_config();
 
     tests_package::run_cargo_new();

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -61,7 +61,7 @@ const BUILD_RS_CONTENTS: &str = r#"use std::{env, fs, path::PathBuf, process::Co
 
 const CONTRACT_ROOT: &str = "../contract";
 const CONTRACT_CARGO_TOML: &str = "../contract/Cargo.toml";
-const CONTRACT_LIB_RS: &str = "../contract/src/lib.rs";
+const CONTRACT_MAIN_RS: &str = "../contract/src/main.rs";
 const BUILD_ARGS: [&str; 2] = ["build", "--release"];
 const WASM_FILENAME: &str = "contract.wasm";
 const ORIGINAL_WASM_DIR: &str = "../contract/target/wasm32-unknown-unknown/release";
@@ -70,7 +70,7 @@ const NEW_WASM_DIR: &str = "wasm";
 fn main() {
     // Watch contract source files for changes.
     println!("cargo:rerun-if-changed={}", CONTRACT_CARGO_TOML);
-    println!("cargo:rerun-if-changed={}", CONTRACT_LIB_RS);
+    println!("cargo:rerun-if-changed={}", CONTRACT_MAIN_RS);
 
     // Build the contract.
     let output = Command::new("cargo")

--- a/execution-engine/cargo-casperlabs/src/travis_yml.rs
+++ b/execution-engine/cargo-casperlabs/src/travis_yml.rs
@@ -1,0 +1,12 @@
+use crate::{common, ARGS};
+
+const FILENAME: &str = ".travis.yml";
+const CONTENTS: &str = r#"language: rust
+script:
+  - cd tests && cargo build
+  - cd tests && cargo test
+"#;
+
+pub fn create() {
+    common::write_file(ARGS.root_path().join(FILENAME), CONTENTS);
+}

--- a/execution-engine/engine-core/build.rs
+++ b/execution-engine/engine-core/build.rs
@@ -7,7 +7,7 @@ use std::{
 trait Package {
     const ROOT: &'static str;
     const CARGO_TOML: &'static str;
-    const LIB_RS: &'static str;
+    const MAIN_RS: &'static str;
     const WASM_FILENAME: &'static str;
 }
 
@@ -16,7 +16,7 @@ struct StandardPayment;
 impl Package for StandardPayment {
     const ROOT: &'static str = "../contracts/system/standard-payment-install";
     const CARGO_TOML: &'static str = "../contracts/system/standard-payment-install/Cargo.toml";
-    const LIB_RS: &'static str = "../contracts/system/standard-payment-install/src/lib.rs";
+    const MAIN_RS: &'static str = "../contracts/system/standard-payment-install/src/min.rs";
     const WASM_FILENAME: &'static str = "standard_payment_install.wasm";
 }
 
@@ -27,7 +27,7 @@ const NEW_WASM_DIR: &str = "wasm";
 fn build_package<T: Package>() {
     // Watch contract source files for changes.
     println!("cargo:rerun-if-changed={}", T::CARGO_TOML);
-    println!("cargo:rerun-if-changed={}", T::LIB_RS);
+    println!("cargo:rerun-if-changed={}", T::MAIN_RS);
 
     // Full path to the cargo binary.
     let cargo = env::var("CARGO").expect("env var 'CARGO' should be set");


### PR DESCRIPTION
### Overview
This adds a basic .travis.yml to projects generated by cargo-casperlabs.

It also changes the type of generated project for the contract from `lib` to `bin` and applies link time optimization as per our own contracts now.  This reduces the size of `contract.wasm` from ~1.8 MB to ~300kB.

There is also a small fix for the tool's own build script, which was set up to watch for changes to the system contracts' old paths (from when they were `lib` targets rather than `bin` ones), and a similar fix for the build script for engine-core.  Without the fix, these crates are both constantly deemed out of date by the compiler, triggering rebuilding even when nothing has changed in them.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-923

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
