### PR TITLE
TNET-13: Initial sync should not reset rank to 0 if all peers fail in a round

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImpl.scala
@@ -97,7 +97,7 @@ class InitialSynchronizationForwardImpl[F[_]: Parallel: Log: Timer](
       // 2. wait handles from DownloadManager
       // 3. max rank from a batch
       type S = (Set[ByteString], Vector[WaitHandle[F]], Long)
-      val emptyS: S = (Set.empty, Vector.empty, -1)
+      val emptyS: S = (Set.empty, Vector.empty, jRank.toLong)
 
       for {
         gossipService <- connector(peer)
@@ -164,7 +164,7 @@ class InitialSynchronizationForwardImpl[F[_]: Parallel: Log: Timer](
       // 3. nodes failed to respond
       // 4. max synced rank from the previous round
       type S = (Int, List[Node], Set[Node], Int)
-      val emptyS: S = (0, Nil, failed, -1)
+      val emptyS: S = (0, Nil, failed, rank)
       for {
         _ <- F.whenA(nodes.isEmpty && failed.nonEmpty)(
               Log[F].error("Failed to run initial sync - no more nodes to try") >>

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -1478,13 +1478,13 @@ class GrpcGossipServiceSpec
     "streamDagSliceBlockSummariesSpec" when {
       "called with a min and max rank" should {
         /* Abstracts over streamDagSlice RPC test, parameters are dag, start and end ranks */
-        def test(task: (Vector[BlockSummary], Int, Int) => Task[Unit]): Unit =
+        def test(task: (Vector[BlockSummary], Long, Long) => Task[Unit]): Unit =
           forAll(genSummaryDagFromGenesis) { dag =>
-            val minRank = dag.map(_.jRank).min.toInt
-            val maxRank = dag.map(_.jRank).max.toInt
+            val minRank = dag.map(_.jRank).min
+            val maxRank = dag.map(_.jRank).max
 
-            val startGen: Gen[Int] = Gen.choose(minRank, math.max(maxRank - 1, minRank))
-            val endGen: Gen[Int]   = startGen.flatMap(start => Gen.choose(start, maxRank))
+            val startGen: Gen[Long] = Gen.choose(minRank, math.max(maxRank - 1, minRank))
+            val endGen: Gen[Long]   = startGen.flatMap(start => Gen.choose(start, maxRank))
 
             forAll(startGen, endGen) { (startRank, endRank) =>
               runTestUnsafe(TestData(dag))(task(dag, startRank, endRank))

--- a/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
+++ b/protobuf/io/casperlabs/comm/gossiping/gossiping.proto
@@ -145,7 +145,7 @@ message Chunk {
 }
 
 message StreamDagSliceBlockSummariesRequest {
-    uint32 start_rank = 1;
+    uint64 start_rank = 1;
     // Inclusive
-    uint32 end_rank   = 2;
+    uint64 end_rank   = 2;
 }


### PR DESCRIPTION
### Overview
When all peers failed in a round of initial sync attempt of 100 ranks, the synchronizer went back to -1, which meant it was checking the existence of all the block headers so far and looked stuck.

This carried the risk that if after a restart the node starts to sync with only the bootstrap and anything wrong happens it goes through a long process of futile syncing until it reaches where it was before.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-13

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
