### PR TITLE
EE-974: Remove map from protobuf.

### DIFF
--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/contract_headers.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/contract_headers.rs
@@ -78,9 +78,12 @@ impl From<ContractHeader> for state::ContractHeader {
         res.set_contract_key(value.contract_key().into());
         res.set_protocol_version(value.protocol_version().into());
 
-        for (name, entry_point) in value.take_methods().into_iter() {
+        for (name, entrypoint) in value.take_methods().into_iter() {
+            let mut method_entry = state::ContractHeader_MethodEntry::new();
+            method_entry.set_name(name.to_string());
+            method_entry.set_entrypoint(entrypoint.into());
             res.mut_methods()
-                .insert(name.to_string(), entry_point.into());
+                .push(method_entry);
         }
         res
     }
@@ -90,8 +93,8 @@ impl TryFrom<state::ContractHeader> for ContractHeader {
     type Error = ParsingError;
     fn try_from(mut value: state::ContractHeader) -> Result<ContractHeader, Self::Error> {
         let mut methods = BTreeMap::new();
-        for (method_name, entry_point) in value.take_methods() {
-            methods.insert(method_name, entry_point.try_into()?);
+        for mut method_entry in value.take_methods().into_iter() {
+            methods.insert(method_entry.take_name(), method_entry.take_entrypoint().try_into()?);
         }
 
         let contract_key = value.take_contract_key().try_into()?;

--- a/protobuf/io/casperlabs/casper/consensus/state.proto
+++ b/protobuf/io/casperlabs/casper/consensus/state.proto
@@ -39,8 +39,12 @@ message ContractHeader {
             Contract contract = 6;
         }
     }
-    
-    map<string, EntryPoint> methods = 1;
+
+    message MethodEntry {
+        string name = 1;
+        EntryPoint entrypoint = 2;
+    }
+    repeated MethodEntry methods = 1;
     Key contract_key = 2;
     ProtocolVersion protocol_version = 3;
 }


### PR DESCRIPTION
Removed map as it's order may be nondeterministic as according to the
documentation[1].

> Wire format ordering and map iteration ordering of map values is
> undefined, so you cannot rely on your map items being in a
> particular order.

[1]: https://developers.google.com/protocol-buffers/docs/proto3#maps

Raised by @goral09 in previous PR https://github.com/CasperLabs/CasperLabs/pull/1914/files#r417333314

### Overview
https://casperlabs.atlassian.net/browse/EE-974

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-974

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
