### PR TITLE
NO-TICKET Adding missing grpc-tools to Pipfile and adding sync to Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,7 @@ build-python-client: \
 	build-client-contracts \
 	$(PROTO_SRC) \
 	$(shell find ./client-py/ -name "*.py"|grep -v _grpc.py)
-	cd client-py && pipenv run ./build.sh
+	cd client-py && pipenv sync && pipenv run ./build.sh
 
 build-client-contracts: \
 	client/src/main/resources/bonding.wasm \

--- a/client-py/Pipfile
+++ b/client-py/Pipfile
@@ -15,7 +15,8 @@ cryptography = "==2.8"
 pycryptodome = "==3.9.4"
 grpcio-tools = ">=1.20"
 pytest = ">=4.4"
-in-place = "*"
+in-place = ">=0.4.0"
+grpc-tools = "*"
 
 [requires]
 python_version = "3.7"

--- a/client-py/Pipfile.lock
+++ b/client-py/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0fe069d04346746015ab3d567674b1980bd250757fc2a72f5629f0fc0af280b7"
+            "sha256": "eceafee231f40cfa7ba87a8a47c85ea05633a35a9d2398a2394d1874556d6eba"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -89,6 +89,13 @@
             ],
             "index": "pypi",
             "version": "==1.4"
+        },
+        "grpc-tools": {
+            "hashes": [
+                "sha256:ea9e5150560f5109819dddf40d2f318d1f226939d74a13cd3dc2e860e78de551"
+            ],
+            "index": "pypi",
+            "version": "==0.0.1"
         },
         "grpcio": {
             "hashes": [


### PR DESCRIPTION
Added missing grpc_tools to Pipfile.
Added pipenv sync to root Makefile

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
