### PR TITLE
NO-TICKET Fixing directories for python client copy to artifacts.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -927,7 +927,7 @@ steps:
   image: "casperlabs/buildenv:latest"
   commands:
   - "make build-python-client"
-  - "cp client-py/dist/casperlabs* ../artifacts/${DRONE_BRANCH}"
+  - "cp client-py/dist/casperlabs* artifacts/${DRONE_BRANCH}"
   when:
     ref:
     - refs/tags/v*

--- a/.drone.yml
+++ b/.drone.yml
@@ -655,7 +655,7 @@ steps:
   image: "casperlabs/buildenv:latest"
   commands:
   - "make build-python-client"
-  - "cp client-py/dist/casperlabs* ../artifacts/${DRONE_BRANCH}"
+  - "cp client-py/dist/casperlabs* artifacts/${DRONE_BRANCH}"
   when:
     branch:
     - dev


### PR DESCRIPTION
Correct path in `.drone.yml` for copying python client to artifacts.

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.