### PR TITLE
[ECO-{379,390}] Explorer Enhance.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/FinalityDetectorUtilTest.scala
@@ -180,7 +180,7 @@ class FinalityDetectorUtilTest
 
   it should "find orphans across eras" in withCombinedStorage() { implicit storage =>
     // The switch block doesn't have B in its justification, but later
-    // when another block is finalized in the child era, C should be
+    // when another block is finalized in the child era, B should be
     // marked as an orphan.
     //
     // G = A = | S

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -443,7 +443,7 @@ const toGraph = (blocks: BlockInfo[]) => {
           isJustification: false,
           isFinalized: (isChildFinalized || isChildBallot) && isFinalized(target.block),
           // if child is an orphaned block, the link should be highlighted with OrphanedLineColor
-          isOrphaned: !isChildBallot && isChildOrphaned
+          isOrphaned: isChildOrphaned
         };
       });
 
@@ -458,8 +458,7 @@ const toGraph = (blocks: BlockInfo[]) => {
           isMainParent: false,
           isJustification: true,
           isFinalized: (isChildFinalized || isChildBallot) && isFinalized(target.block),
-          // if child is an orphaned block, the link should be highlighted with OrphanedLineColor
-          isOrphaned: !isChildBallot && isChildOrphaned
+          isOrphaned: false
         };
       });
 
@@ -532,7 +531,7 @@ const isFinalized = (block: BlockInfo) =>
   block.getStatus()!.getFinality() === BlockInfo.Status.Finality.FINALIZED;
 
 const isOrphaned = (block: BlockInfo) =>
-  block.getStatus()!.getFinality() === BlockInfo.Status.Finality.ORPHANED;
+  isBlock(block) && block.getStatus()!.getFinality() === BlockInfo.Status.Finality.ORPHANED;
 
 const validatorHash = (block: BlockInfo) =>
   encodeBase16(

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -3,7 +3,6 @@ import { observer } from 'mobx-react';
 import {
   LinkButton,
   ListInline,
-  RefreshableComponent,
   shortHash
 } from './Utils';
 import { BlockDAG } from './BlockDAG';
@@ -255,25 +254,6 @@ class BlockDetails extends React.Component<
         />
       </div>
     );
-  }
-
-  componentDidMount() {
-    // Scroll into view so people realize it's there.
-    this.scrollToBlockDetails();
-  }
-
-  scrollToBlockDetails() {
-    let container = $(this.ref!);
-    let offset = container.offset()!;
-    let height = container.height()!;
-    $('html, body')
-      .stop()
-      .animate(
-        {
-          scrollTop: offset.top + height
-        },
-        1000
-      );
   }
 }
 

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -115,11 +115,11 @@ class _Explorer extends React.Component<Props, {}> {
               height="600"
             />
           </div>
-          {dag.selectedBlock && (
+          {dag.selectedBlock && dag.blocks != null && (
             <div className="col-sm-12 col-lg-4">
               <BlockDetails
                 block={dag.selectedBlock}
-                blocks={dag.blocks!}
+                blocks={dag.blocks}
                 onSelect={blockHashBase16 => {
                   dag.selectByBlockHashBase16(blockHashBase16);
                 }}

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -100,9 +100,7 @@ export class DagContainer {
 
   async selectByBlockHashBase16(blockHashBase16: string) {
     let selectedBlock = this.blocks!.find(
-      x =>
-        encodeBase16(x.getSummary()!.getBlockHash_asU8()) ===
-        blockHashBase16
+      x => encodeBase16(x.getSummary()!.getBlockHash_asU8()) === blockHashBase16
     );
     if (selectedBlock) {
       this.selectedBlock = selectedBlock;
@@ -212,8 +210,8 @@ export class DagContainer {
   }
 
   private async refreshBlockDag() {
-    // show loading spinner
-    this.blocks = null;
+    // todo: (ECO-399) Use a more elegant loading style to indicate it is loading
+    // or maybe spin the loading button so that the user can know it is refreshing.
     await this.errors.capture(
       this.casperService
         .getBlockInfos(this.depth, this.maxRank)

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -171,7 +171,16 @@ export class DagContainer {
     } else if (event.hasNewFinalizedBlock()) {
       const directFinalizedBlockHash = event.getNewFinalizedBlock()!.getBlockHash_asB64();
 
-      let finalizedBlocks = new Set(event.getNewFinalizedBlock()!.getIndirectlyFinalizedBlockHashesList_asB64());
+      const orphanedBlocks = new Set(
+        event
+          .getNewFinalizedBlock()!
+          .getIndirectlyOrphanedBlockHashesList_asB64()
+      );
+      const finalizedBlocks = new Set(
+        event
+          .getNewFinalizedBlock()!
+          .getIndirectlyFinalizedBlockHashesList_asB64()
+      );
       finalizedBlocks.add(directFinalizedBlockHash);
 
       let updatedLastFinalizedBlock = false;
@@ -179,6 +188,8 @@ export class DagContainer {
         let bh = block.getSummary()!.getBlockHash_asB64();
         if (finalizedBlocks.has(bh)) {
           block.getStatus()?.setFinality(BlockInfo.Status.Finality.FINALIZED);
+        } else if (orphanedBlocks.has(bh)) {
+          block.getStatus()?.setFinality(BlockInfo.Status.Finality.ORPHANED);
         }
         if (!updatedLastFinalizedBlock && bh === directFinalizedBlockHash) {
           this.lastFinalizedBlock = block;


### PR DESCRIPTION
### Overview
This PR introduces 2 improvements.
1. Orphaned blocks should be highlighted with red arrows. And it also use the subscribed finalized block event to update orphaned blocks in realtime. 
![demo](http://recordit.co/LFqI7SGHmp.gif)

2. Optimize Explorer render efficiency. 


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-379
https://casperlabs.atlassian.net/browse/ECO-390

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
