### PR TITLE
TNET-15: Fix voting matrix init highway

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
@@ -59,7 +59,8 @@ class FinalityDetectorVotingMatrix[F[_]: Concurrent: Log: AncestorsStorage] priv
                   for {
                     _ <- if (votedBranchIsDifferentEra)
                           Log[F].debug(
-                            s"${PrettyPrinter.buildString(message.messageHash) -> "Message"} from ${message.eraId -> "era"} votes on an LFB child ${PrettyPrinter
+                            s"${PrettyPrinter.buildString(message.messageHash) -> "Message"} from ${PrettyPrinter
+                              .buildString(message.eraId)                      -> "era"} votes on an LFB child ${PrettyPrinter
                               .buildString(lfbChildHash)                       -> "hash"} from a different era."
                           )
                         else

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
@@ -12,7 +12,6 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.models.Message
 import io.casperlabs.models.Message.{JRank, MainRank}
 import io.casperlabs.storage.dag.{AncestorsStorage, DagRepresentation}
-import io.casperlabs.shared.ByteStringPrettyPrinter.byteStringShow
 import scala.collection.mutable.{IndexedSeq => MutableSeq}
 
 object VotingMatrix {

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/VotingMatrix.scala
@@ -12,7 +12,7 @@ import io.casperlabs.catscontrib.MonadThrowable
 import io.casperlabs.models.Message
 import io.casperlabs.models.Message.{JRank, MainRank}
 import io.casperlabs.storage.dag.{AncestorsStorage, DagRepresentation}
-
+import io.casperlabs.shared.ByteStringPrettyPrinter.byteStringShow
 import scala.collection.mutable.{IndexedSeq => MutableSeq}
 
 object VotingMatrix {
@@ -57,9 +57,30 @@ object VotingMatrix {
       weights    = block.weightMap
       validators = weights.keySet.toArray
       // Assigns numeric identifiers 0, ..., N-1 to all validators
-      validatorsToIndex            = validators.zipWithIndex.toMap
-      n                            = validators.size
-      latestMessagesOfHonestVoters <- dag.latestMessagesHonestValidators
+      validatorsToIndex = validators.zipWithIndex.toMap
+      n                 = validators.size
+      latestMessagesOfHonestVoters <- if (!isHighway)
+                                       dag.latestMessagesHonestValidators.map(_.toSeq)
+                                     else {
+                                       // Get the honest votes in eras that vote on a child of the LFB.
+                                       for {
+                                         childHashes <- dag.getMainChildren(lfbHash)
+                                         childMessages <- childHashes.toList.traverse(
+                                                           dag.lookupUnsafe(_)
+                                                         )
+                                         childEraIds = childMessages
+                                           .filter(_.isBlock)
+                                           .map(_.eraId)
+                                           .distinct
+                                         honestVoters <- childEraIds.traverse { eraId =>
+                                                          dag
+                                                            .latestInEra(eraId)
+                                                            .flatMap(
+                                                              _.latestMessagesHonestValidators
+                                                            )
+                                                        }
+                                       } yield honestVoters.map(_.toSeq).flatten
+                                     }
       // On which child of LFB validators vote on.
       voteOnLFBChild <- latestMessagesOfHonestVoters.toList
                          .traverse {
@@ -84,7 +105,7 @@ object VotingMatrix {
                               .traverse {
                                 case (v, voteValue) =>
                                   FinalityDetectorUtil
-                                    .levelZeroMsgsOfValidator(dag, v, voteValue.messageHash)
+                                    .levelZeroMsgsOfValidator(dag, v, voteValue, isHighway)
                                     .map(
                                       _.lastOption
                                         .map(b => (v, (voteValue.messageHash, b.jRank)))
@@ -95,8 +116,8 @@ object VotingMatrix {
         validatorsToIndex,
         firstLevelZeroVotes.get
       )
-      latestMessagesToUpdated = latestMessagesOfHonestVoters.filterKeys { k =>
-        firstLevelZeroVotes.contains(k) && validatorsToIndex.contains(k)
+      latestMessagesToUpdated = latestMessagesOfHonestVoters.collect {
+        case (v, m) if firstLevelZeroVotes.contains(v) && validatorsToIndex.contains(v) => m
       }
       state = VotingMatrixState(
         MutableSeq.fill(n, n)(Message.asJRank(0L)),
@@ -108,7 +129,7 @@ object VotingMatrix {
 
       implicit0(votingMatrix: VotingMatrix[F]) <- of[F](state)
       // Apply the incremental update step to update voting matrix by taking M := V(i)latest
-      _ <- latestMessagesToUpdated.values.toList.traverse { b =>
+      _ <- latestMessagesToUpdated.toList.traverse { b =>
             for {
               panorama <- FinalityDetectorUtil
                            .panoramaOfBlockByValidators[F](dag, b, lfb, validators.toSet)

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
@@ -9,7 +9,7 @@ import io.casperlabs.models.Message.{JRank, MainRank}
 import io.casperlabs.models.{Message, Weight}
 import io.casperlabs.storage.dag.DagRepresentation
 import io.casperlabs.casper.validation.Validation
-
+import io.casperlabs.shared.ByteStringPrettyPrinter.byteStringShow
 import scala.annotation.tailrec
 import scala.collection.mutable.{IndexedSeq => MutableSeq}
 
@@ -184,14 +184,15 @@ package object votingmatrix {
                       }
                       .map(_.groupBy(_._1).mapValues(_.map(_._2)))
                       .map { consensusValueToHonestValidators =>
-                        if (consensusValueToHonestValidators.isEmpty)
+                        if (consensusValueToHonestValidators.isEmpty) {
                           // After filtering out equivocators we don't have any honest votes.
                           none[CommitteeWithConsensusValue]
-                        else {
+                        } else {
                           // Get most support voteBranch and its support weight
                           val mostSupport = consensusValueToHonestValidators
                             .mapValues(_.map(weightMap.getOrElse(_, Zero)).sum)
                             .maxBy(_._2)
+
                           val (voteValue, supportingWeight) = mostSupport
                           // Get the voteBranch's supporters
                           val supporters = consensusValueToHonestValidators(voteValue)

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageExecutor.scala
@@ -116,7 +116,7 @@ class MessageExecutor[F[_]: Concurrent: Log: Time: Metrics: BlockStorage: DagSto
 
                   for {
                     _ <- Log[F].info(
-                          s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}. Orphaned ${orphaned.size} messages."
+                          s"New last finalized block hashes are ${lfbStr -> null}, ${finalizedStr -> null}. Orphaned ${orphanedBlockHashes.size} messages."
                         )
                     _ <- DeployBuffer[F]
                           .removeFinalizedDeploys(finalizedBlockHashes + newLFB)

--- a/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/dag/DagStorage.scala
@@ -110,6 +110,15 @@ trait TipRepresentation[F[_]] {
   def latestMessage(validator: Validator): F[Set[Message]]
   def latestMessageHashes: F[Map[Validator, Set[BlockHash]]]
   def latestMessages: F[Map[Validator, Set[Message]]]
+
+  // Returns latest messages from honest validators
+  def latestMessagesHonestValidators(implicit A: Applicative[F]): F[Map[Validator, Message]] =
+    latestMessages.map { latestMessages =>
+      latestMessages.collect {
+        case (v, messages) if messages.size == 1 =>
+          (v, messages.head)
+      }
+    }
 }
 
 trait EraTipRepresentation[F[_]] extends TipRepresentation[F] {


### PR DESCRIPTION
### Overview
The voting matrix thought everyone was dishonest and got initialised with empty votes every time. That was fine during eras because subsequent blocks could fill them in, but around the switch blocks it could mean that the matrix was stuck in an empty state.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-15

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
