### PR TITLE
EE-996: Removing reliance on scala client folder for python client contracts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,6 +290,10 @@ client/src/main/resources/%.wasm: .make/contracts/%
 	mkdir -p $(dir $@)
 	cp execution-engine/target/wasm32-unknown-unknown/release/$*.wasm $@
 
+# Compile a contract and put it in the CLI client so they get packaged with the PyPi package.
+client-py/casperlabs_client/%.wasm: .make/contracts/%
+	cp execution-engine/target/wasm32-unknown-unknown/release/$*.wasm $@
+
 # Compile a contract and put it in the node resources so they get packaged with the JAR.
 node/src/main/resources/chainspec/genesis/%.wasm: .make/contracts/%
 	cp execution-engine/target/wasm32-unknown-unknown/release/$*.wasm $@
@@ -303,15 +307,20 @@ build-client: \
 	.make/sbt-stage/client
 
 build-python-client: \
-	build-client-contracts \
+	build-client-py-contracts \
 	$(PROTO_SRC) \
 	$(shell find ./client-py/ -name "*.py"|grep -v _grpc.py)
-	cd client-py && pipenv sync && pipenv run ./build.sh
+	client-py/build.sh
 
 build-client-contracts: \
 	client/src/main/resources/bonding.wasm \
 	client/src/main/resources/unbonding.wasm \
 	client/src/main/resources/transfer_to_account_u512.wasm
+
+build-client-py-contracts: \
+    client-py/casperlabs_client/bonding.wasm \
+    client-py/casperlabs_client/unbonding.wasm \
+    client-py/casperlabs_client/transfer_to_account_u512.wasm
 
 build-node: \
 	.make/sbt-stage/node

--- a/client-py/build.sh
+++ b/client-py/build.sh
@@ -6,4 +6,18 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd ${DIR}
 
 rm -rf dist/*
-python setup.py sdist
+
+# Verify .wasm has been generated
+count=`ls -1 casperlabs_client/*.wasm 2>/dev/null | wc -l`
+if [ $count == 0 ]
+then
+  echo "--------------------------------------------"
+  echo "REQUIRED FILES MISSING"
+  echo ".wasm files have not been built"
+  echo "Run with 'make build-python-client' in root"
+  echo "--------------------------------------------"
+  exit 1
+fi
+
+pipenv sync
+pipenv run python setup.py sdist


### PR DESCRIPTION
Updated `client-py/build.sh` to setup and run in `pipenv` and check if `*.wasm` was built.
Updated root `Makefile` to build and copy contracts for python client without using scala client folders.

https://casperlabs.atlassian.net/browse/EE-996

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
