### PR TITLE
TNET-17: No swimlane traversal for honest

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/dag/DagOperations.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/dag/DagOperations.scala
@@ -515,12 +515,13 @@ object DagOperations {
   def panoramaOfMessage[F[_]: MonadThrowable](
       dag: DagLookup[F],
       message: Message,
-      erasObservedBehavior: LocalDagView[Message]
+      erasObservedBehavior: LocalDagView[Message],
+      usingIndirectJustifications: Boolean = false
   ): F[MessageJPast[Message]] =
     message.justifications.toList
       .map(_.latestBlockHash)
       .traverse(dag.lookupUnsafe(_))
-      .flatMap(messageJPast[F](dag, _, erasObservedBehavior))
+      .flatMap(messageJPast[F](dag, _, erasObservedBehavior, usingIndirectJustifications))
 
   /**
     * Calculates panorama of a set of justifications.
@@ -540,19 +541,18 @@ object DagOperations {
   def messageJPast[F[_]: MonadThrowable](
       dag: DagLookup[F],
       justifications: List[Message],
-      erasObservedBehavior: LocalDagView[Message]
+      erasObservedBehavior: LocalDagView[Message],
+      // The code here can handle indirect justifications by traversing the swimlane but it can be slow
+      // if validator A hasn't seen a block from validator B and we need to traverse full eras to find that there
+      // was nothing in A's j-past pointing at B. Since we are at the moment using direct jusitifications in blocks,
+      // we can just  assume that if they aren't present then they haven't seen anything and move on.
+      usingIndirectJustifications: Boolean = false
   ): F[MessageJPast[Message]] = {
 
     type EraId = ByteString
 
     import ObservedValidatorBehavior._
     import EraObservedBehavior._
-
-    // The code here can handle indirect justifications by traversing the swimlane but it can be slow
-    // if validator A hasn't seen a block from validator B and we need to traverse full eras to find that there
-    // was nothing in A's j-past pointing at B. Since we are at the moment using direct jusitifications in blocks,
-    // we can just  assume that if they aren't present then they haven't seen anything and move on.
-    val usingDirectJustifications = true
 
     // Map a message's direct justifications to a map that represents its j-past-cone view.
     val toEraMap: List[Message] => Map[EraId, Map[ByteString, Set[Message]]] =
@@ -600,7 +600,7 @@ object DagOperations {
                       import io.casperlabs.shared.Sorting.jRankOrdering
                       // Since we know that validator is honest we can pick the newest message.
                       honest(validator, messages.maxBy(_.jRank)).pure[F]
-                    } else if (usingDirectJustifications) {
+                    } else if (!usingIndirectJustifications) {
                       // Since we aren't using indirect justifications, we can trust that the
                       // creator of this block hasn't seen anything from this validator in this era.
                       empty(validator).pure[F]

--- a/casper/src/test/scala/io/casperlabs/casper/dag/DagOperationsTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/dag/DagOperationsTest.scala
@@ -572,7 +572,8 @@ class DagOperationsTest
         latestMessages <- DagOperations.panoramaOfMessage[Task](
                            dag,
                            b2Message,
-                           localDagView
+                           localDagView,
+                           usingIndirectJustifications = true
                          )
         latestGenesisMessageHashes = latestMessages
           .latestMessagesInEra(genesis.blockHash)
@@ -678,7 +679,8 @@ class DagOperationsTest
         latestMessages <- DagOperations.panoramaOfMessage[Task](
                            dag,
                            c3Message,
-                           localDagView
+                           localDagView,
+                           usingIndirectJustifications = true
                          )
         latestGenesisMessageHashes = latestMessages
           .latestMessagesInEra(genesis.blockHash)
@@ -980,7 +982,8 @@ class DagOperationsTest
         jpastCone <- DagOperations.panoramaOfMessage[Task](
                       dag,
                       d1Message,
-                      localDagView
+                      localDagView,
+                      usingIndirectJustifications = true
                     )
         latestGenesisMessageHashes = jpastCone
           .latestMessagesInEra(genesis.blockHash)
@@ -1101,7 +1104,8 @@ class DagOperationsTest
         jpastCone <- DagOperations.panoramaOfMessage[Task](
                       dag,
                       d1Message,
-                      localDagView
+                      localDagView,
+                      usingIndirectJustifications = true
                     )
 
         latestGenesisMessageHashes = jpastCone


### PR DESCRIPTION
### Overview
On LRT3 at a certain height the `fromJustifications_messageJPast` metric becomes really slow. We haven't seen any equivocations, so it could be the only other scenario where `DagOperations.messageJPast` traverses the swimlane of a validator, and that's when the validating node has seen something from that validator but the block doesn't cite it, which can only happen if the creator of that block hasn't seen anything from it.

Since we have honest nodes here and we are using direct justifications, the PR disables the fallback on traversing the swimlane to try and find a message in the j-past cone. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-17

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
