### PR TITLE
EE-989: Contract headers tests

### DIFF
--- a/execution-engine/contracts/test/groups/Cargo.toml
+++ b/execution-engine/contracts/test/groups/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "groups"
+version = "0.1.0"
+authors = ["Michał Papierski <michal@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "groups"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["contract/std"]
+
+[dependencies]
+contract = { path = "../../../contract", package = "casperlabs-contract" }
+types = { path = "../../../types", package = "casperlabs-types" }

--- a/execution-engine/contracts/test/groups/src/main.rs
+++ b/execution-engine/contracts/test/groups/src/main.rs
@@ -1,0 +1,169 @@
+#![no_std]
+#![no_main]
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    string::{String, ToString},
+    vec::Vec,
+};
+
+use core::convert::TryInto;
+
+use contract::{
+    contract_api::{runtime, storage},
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use types::{
+    contract_header::{EntryPoint, EntryPointAccess, EntryPointType},
+    runtime_args, ApiError, CLType, ContractRef, Key, Parameter, RuntimeArgs, SemVer, URef,
+};
+
+const VERSION_1_0_0: SemVer = SemVer::new(1, 0, 0);
+const METADATA_HASH_KEY: &str = "metadata_hash_key";
+const METADATA_ACCESS_KEY: &str = "metadata_access_key";
+const RESTRICTED_CONTRACT: &str = "restricted_contract";
+const RESTRICTED_SESSION: &str = "restricted_session";
+const RESTRICTED_SESSION_CALLER: &str = "restricted_session_caller";
+const RESTRICTED_CONTRACT_CALLER: &str = "restricted_contract_caller";
+
+#[no_mangle]
+pub extern "C" fn restricted_session() {}
+
+#[no_mangle]
+pub extern "C" fn restricted_contract() {}
+
+#[no_mangle]
+pub extern "C" fn restricted_session_caller() {
+    let metadata_hash: Key = runtime::get_named_arg("metadata_hash")
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
+
+    let metadata_ref = ContractRef::Hash(metadata_hash.into_hash().unwrap());
+    runtime::call_versioned_contract::<()>(
+        metadata_ref,
+        SemVer::V1_0_0,
+        RESTRICTED_SESSION,
+        runtime_args! {},
+    );
+}
+
+#[no_mangle]
+pub extern "C" fn restricted_contract_caller() {
+    let metadata_hash: Key = runtime::get_named_arg("metadata_hash")
+        .unwrap_or_revert_with(ApiError::MissingArgument)
+        .unwrap_or_revert_with(ApiError::InvalidArgument);
+    runtime::call_versioned_contract::<()>(
+        metadata_hash.try_into().unwrap(),
+        SemVer::V1_0_0,
+        RESTRICTED_CONTRACT,
+        runtime_args! {},
+    );
+}
+
+fn create_group(metadata_hash: Key, access_uref: URef) -> URef {
+    let new_uref_1 = storage::new_uref(());
+    runtime::put_key("saved_uref", new_uref_1.into());
+
+    let mut existing_urefs = BTreeSet::new();
+    existing_urefs.insert(new_uref_1);
+
+    let new_urefs = storage::create_contract_user_group(
+        metadata_hash,
+        access_uref,
+        "Group 1",
+        1,
+        existing_urefs,
+    )
+    .unwrap_or_revert();
+    assert_eq!(new_urefs.len(), 1);
+    new_urefs[0]
+}
+
+/// Restricted uref comes from creating a group and will be assigned to a smart contract
+fn create_entrypoints_1() -> BTreeMap<String, EntryPoint> {
+    let mut entrypoints = BTreeMap::new();
+    let restricted_session = EntryPoint::new(
+        Vec::new(),
+        CLType::I32,
+        EntryPointAccess::groups(&["Group 1"]),
+        EntryPointType::Session,
+    );
+    entrypoints.insert(RESTRICTED_SESSION.to_string(), restricted_session);
+
+    let restricted_contract = EntryPoint::new(
+        Vec::new(),
+        CLType::I32,
+        EntryPointAccess::groups(&["Group 1"]),
+        EntryPointType::Contract,
+    );
+    entrypoints.insert(RESTRICTED_CONTRACT.to_string(), restricted_contract);
+
+    let restricted_session_caller = EntryPoint::new(
+        vec![Parameter::new("metadata_hash", CLType::Key)],
+        CLType::I32,
+        EntryPointAccess::Public,
+        EntryPointType::Session,
+    );
+    entrypoints.insert(
+        RESTRICTED_SESSION_CALLER.to_string(),
+        restricted_session_caller,
+    );
+
+    let restricted_contract = EntryPoint::new(
+        Vec::new(),
+        CLType::I32,
+        EntryPointAccess::groups(&["Group 1"]),
+        EntryPointType::Contract,
+    );
+    entrypoints.insert(RESTRICTED_CONTRACT.to_string(), restricted_contract);
+
+    let restricted_contract_caller = EntryPoint::new(
+        Vec::new(),
+        CLType::I32,
+        EntryPointAccess::groups(&["Group 1"]),
+        EntryPointType::Contract,
+    );
+    entrypoints.insert(
+        RESTRICTED_CONTRACT_CALLER.to_string(),
+        restricted_contract_caller,
+    );
+
+    entrypoints
+}
+
+fn install_version_1(metadata_hash: Key, access_uref: URef, restricted_uref: URef) {
+    let contract_named_keys = {
+        let contract_variable = storage::new_uref(0);
+
+        let mut named_keys = BTreeMap::new();
+        named_keys.insert("contract_named_key".to_string(), contract_variable.into());
+        named_keys.insert("restricted_uref".to_string(), restricted_uref.into());
+        named_keys
+    };
+
+    let entrypoints = create_entrypoints_1();
+    storage::add_contract_version(
+        metadata_hash,
+        access_uref,
+        VERSION_1_0_0,
+        entrypoints,
+        contract_named_keys,
+    )
+    .unwrap_or_revert();
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    // Session contract
+    let (contract_hash, access_uref) = storage::create_contract_metadata_at_hash();
+
+    runtime::put_key(METADATA_HASH_KEY, contract_hash);
+    runtime::put_key(METADATA_ACCESS_KEY, access_uref.into());
+
+    let restricted_uref = create_group(contract_hash, access_uref);
+
+    install_version_1(contract_hash, access_uref, restricted_uref);
+}

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -44,7 +44,7 @@ use types::{
     bytesrepr::{self, ToBytes},
     system_contract_errors::mint,
     system_contract_type::PROOF_OF_STAKE,
-    AccessRights, BlockTime, CLValue, EntryPointAccess, EntryPointType, Key, Phase,
+    AccessRights, BlockTime, CLValue, ContractMetadata, EntryPoint, EntryPointType, Key, Phase,
     ProtocolVersion, RuntimeArgs, URef, KEY_HASH_LENGTH, U512, UREF_ADDR_LENGTH,
 };
 
@@ -88,21 +88,26 @@ pub struct EngineState<S> {
     state: S,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum GetModuleResult {
-    Session(Module),
+    Session {
+        module: Module,
+        metadata: ContractMetadata,
+        entrypoint: EntryPoint,
+    },
     Contract {
         module: Module,
         base_key: Key,
         named_keys: BTreeMap<String, Key>,
-        entry_point_type: EntryPointType,
+        metadata: ContractMetadata,
+        entrypoint: EntryPoint,
     },
 }
 
 impl GetModuleResult {
     pub fn take_module(self) -> Module {
         match self {
-            GetModuleResult::Session(module) => module,
+            GetModuleResult::Session { module, .. } => module,
             GetModuleResult::Contract { module, .. } => module,
         }
     }
@@ -452,7 +457,8 @@ where
                         phase,
                         protocol_data,
                         system_contract_cache,
-                        EntryPointType::Session,
+                        ContractMetadata::default(),
+                        EntryPoint::default(),
                     )?;
 
                     runtime
@@ -739,7 +745,11 @@ where
         match deploy_item {
             ExecutableDeployItem::ModuleBytes { module_bytes, .. } => {
                 let module = preprocessor.preprocess(&module_bytes)?;
-                Ok(GetModuleResult::Session(module))
+                Ok(GetModuleResult::Session {
+                    module,
+                    metadata: ContractMetadata::default(),
+                    entrypoint: EntryPoint::default(),
+                })
             }
             ExecutableDeployItem::StoredContractByHash { hash, .. } => {
                 let hash_len = hash.len();
@@ -757,7 +767,11 @@ where
                     correlation_id,
                     protocol_version,
                 )?;
-                Ok(GetModuleResult::Session(module))
+                Ok(GetModuleResult::Session {
+                    module,
+                    metadata: ContractMetadata::default(),
+                    entrypoint: EntryPoint::default(),
+                })
             }
             ExecutableDeployItem::StoredContractByName { name, .. } => {
                 let stored_contract_key = account.named_keys().get(name).ok_or_else(|| {
@@ -774,7 +788,11 @@ where
                     correlation_id,
                     protocol_version,
                 )?;
-                Ok(GetModuleResult::Session(module))
+                Ok(GetModuleResult::Session {
+                    module,
+                    metadata: ContractMetadata::default(),
+                    entrypoint: EntryPoint::default(),
+                })
             }
             ExecutableDeployItem::StoredContractByURef { uref, .. } => {
                 let len = uref.len();
@@ -821,7 +839,11 @@ where
                     correlation_id,
                     protocol_version,
                 )?;
-                Ok(GetModuleResult::Session(module))
+                Ok(GetModuleResult::Session {
+                    module,
+                    metadata: ContractMetadata::default(),
+                    entrypoint: EntryPoint::default(),
+                })
             }
             ExecutableDeployItem::StoredVersionedContractByName {
                 name,
@@ -844,12 +866,6 @@ where
                     .get_method(entry_point)
                     .ok_or_else(|| error::Error::Exec(execution::Error::NoSuchMethod))?;
 
-                if method_entrypoint.access() != &EntryPointAccess::Public {
-                    // TODO(mpapierski): Support `EntryPointAccess::Group` and unify validation from
-                    // `call_versioned_contract`
-                    return Err(error::Error::Exec(execution::Error::NoSuchMethod));
-                }
-
                 let (module, contract) = self.get_module_from_key(
                     tracking_copy,
                     contract_header.contract_key(),
@@ -858,12 +874,17 @@ where
                 )?;
 
                 match method_entrypoint.entry_point_type() {
-                    EntryPointType::Session => Ok(GetModuleResult::Session(module)),
+                    EntryPointType::Session => Ok(GetModuleResult::Session {
+                        module,
+                        metadata: contract_metadata.clone(),
+                        entrypoint: method_entrypoint.clone(),
+                    }),
                     EntryPointType::Contract => Ok(GetModuleResult::Contract {
                         module,
                         base_key: contract_header.contract_key(),
                         named_keys: contract.take_named_keys(),
-                        entry_point_type: method_entrypoint.entry_point_type(),
+                        metadata: contract_metadata.clone(),
+                        entrypoint: method_entrypoint.clone(),
                     }),
                 }
             }
@@ -886,12 +907,6 @@ where
                     .get_method(entry_point)
                     .ok_or_else(|| error::Error::Exec(execution::Error::NoSuchMethod))?;
 
-                if method_entrypoint.access() != &EntryPointAccess::Public {
-                    // TODO(mpapierski): Support `EntryPointAccess::Group` and unify validation from
-                    // `call_versioned_contract`
-                    return Err(error::Error::Exec(execution::Error::NoSuchMethod));
-                }
-
                 let (module, contract) = self.get_module_from_key(
                     tracking_copy,
                     contract_header.contract_key(),
@@ -900,12 +915,17 @@ where
                 )?;
 
                 match method_entrypoint.entry_point_type() {
-                    EntryPointType::Session => Ok(GetModuleResult::Session(module)),
+                    EntryPointType::Session => Ok(GetModuleResult::Session {
+                        module,
+                        metadata: contract_metadata.clone(),
+                        entrypoint: method_entrypoint.clone(),
+                    }),
                     EntryPointType::Contract => Ok(GetModuleResult::Contract {
                         module,
                         base_key: contract_header.contract_key(),
                         named_keys: contract.take_named_keys(),
-                        entry_point_type: method_entrypoint.entry_point_type(),
+                        metadata: contract_metadata.clone(),
+                        entrypoint: method_entrypoint.clone(),
                     }),
                 }
             }
@@ -1245,7 +1265,11 @@ where
                     correlation_id,
                     &protocol_version,
                 )
-                .map(|(module, _contract)| GetModuleResult::Session(module))
+                .map(|(module, _contract)| GetModuleResult::Session {
+                    module,
+                    metadata: ContractMetadata::default(),
+                    entrypoint: EntryPoint::default(),
+                })
             } else {
                 self.get_module(
                     Rc::clone(&tracking_copy),
@@ -1268,21 +1292,32 @@ where
             // payment_code_spec_2: execute payment code
             let phase = Phase::Payment;
 
-            let (payment_module, payment_context, mut payment_named_keys, entry_point_type) =
-                match payment_module {
-                    GetModuleResult::Session(module) => (
-                        module,
-                        base_key,
-                        account.named_keys().clone(),
-                        EntryPointType::Session,
-                    ),
-                    GetModuleResult::Contract {
-                        module,
-                        base_key,
-                        named_keys,
-                        entry_point_type,
-                    } => (module, base_key, named_keys, entry_point_type),
-                };
+            let (
+                payment_module,
+                payment_context,
+                mut payment_named_keys,
+                payment_metadata,
+                payment_entrypoint,
+            ) = match payment_module {
+                GetModuleResult::Session {
+                    module,
+                    metadata,
+                    entrypoint,
+                } => (
+                    module,
+                    base_key,
+                    account.named_keys().clone(),
+                    metadata,
+                    entrypoint,
+                ),
+                GetModuleResult::Contract {
+                    module,
+                    base_key,
+                    named_keys,
+                    metadata,
+                    entrypoint,
+                } => (module, base_key, named_keys, metadata, entrypoint),
+            };
 
             let payment_args = match payment.clone().take_args() {
                 Ok(args) => args,
@@ -1314,7 +1349,8 @@ where
                     phase,
                     protocol_data,
                     system_contract_cache,
-                    entry_point_type,
+                    payment_metadata.clone(),
+                    payment_entrypoint.clone(),
                 ) {
                     Ok((_instance, runtime)) => runtime,
                     Err(error) => {
@@ -1323,6 +1359,13 @@ where
                 };
 
                 let effects_snapshot = tracking_copy.borrow().effect();
+
+                if let Err(error) = runtime
+                    .validate_entry_point_access(&payment_metadata, &payment_entrypoint.access())
+                {
+                    return Ok(ExecutionResult::precondition_failure(Error::Exec(error)));
+                }
+
                 match runtime.call_host_standard_payment() {
                     Ok(()) => ExecutionResult::Success {
                         effect: runtime.context().effect(),
@@ -1353,7 +1396,8 @@ where
                     phase,
                     protocol_data,
                     system_contract_cache,
-                    EntryPointType::Session,
+                    payment_metadata,
+                    payment_entrypoint,
                 )
             }
         };
@@ -1406,21 +1450,32 @@ where
 
         // session_code_spec_2: execute session code
 
-        let (session_module, session_context, session_named_keys, session_entry_point_type) =
-            match session_module {
-                GetModuleResult::Session(module) => (
-                    module,
-                    base_key,
-                    account.named_keys().clone(),
-                    EntryPointType::Session,
-                ),
-                GetModuleResult::Contract {
-                    module,
-                    base_key,
-                    named_keys,
-                    entry_point_type,
-                } => (module, base_key, named_keys, entry_point_type),
-            };
+        let (
+            session_module,
+            session_context,
+            session_named_keys,
+            session_metadata,
+            session_entrypoint,
+        ) = match session_module {
+            GetModuleResult::Session {
+                module,
+                metadata,
+                entrypoint,
+            } => (
+                module,
+                base_key,
+                account.named_keys().clone(),
+                metadata,
+                entrypoint,
+            ),
+            GetModuleResult::Contract {
+                module,
+                base_key,
+                named_keys,
+                metadata,
+                entrypoint,
+            } => (module, base_key, named_keys, metadata, entrypoint),
+        };
 
         let session_args = match session.clone().take_args() {
             Ok(args) => args,
@@ -1460,7 +1515,8 @@ where
                 Phase::Session,
                 protocol_data,
                 system_contract_cache,
-                session_entry_point_type,
+                session_metadata,
+                session_entrypoint,
             )
         };
 

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -73,6 +73,12 @@ pub fn validate_entry_point_access_with(
     validator: impl Fn(&URef) -> bool,
 ) -> Result<(), Error> {
     if let EntryPointAccess::Groups(groups) = access {
+        if groups.is_empty() {
+            // Exits early in a special case of empty list of groups regardless of the group
+            // checking logic below it.
+            return Err(Error::InvalidContext);
+        }
+
         let find_result = groups.iter().find(|g| {
             metadata
                 .groups()

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -24,8 +24,8 @@ use types::{
     account::{
         ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure, Weight,
     },
-    AccessRights, BlockTime, CLValue, EntryPointType, Key, Phase, ProtocolVersion, RuntimeArgs,
-    URef, KEY_LOCAL_SEED_LENGTH,
+    AccessRights, BlockTime, CLValue, ContractMetadata, EntryPoint, Key, Phase, ProtocolVersion,
+    RuntimeArgs, URef, KEY_LOCAL_SEED_LENGTH,
 };
 
 use super::{attenuate_uref_for_account, Address, Error, RuntimeContext};
@@ -132,7 +132,8 @@ fn mock_runtime_context<'a>(
         CorrelationId::new(),
         Phase::Session,
         Default::default(),
-        EntryPointType::Session,
+        ContractMetadata::default(),
+        EntryPoint::default(),
     )
 }
 
@@ -464,7 +465,8 @@ fn contract_key_addable_valid() {
         CorrelationId::new(),
         PHASE,
         Default::default(),
-        EntryPointType::Session,
+        ContractMetadata::default(),
+        EntryPoint::default(),
     );
 
     let uref_name = "NewURef".to_owned();
@@ -527,7 +529,8 @@ fn contract_key_addable_invalid() {
         CorrelationId::new(),
         PHASE,
         Default::default(),
-        EntryPointType::Session,
+        ContractMetadata::default(),
+        EntryPoint::default(),
     );
 
     let uref_name = "NewURef".to_owned();

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/contract_headers.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/contract_headers.rs
@@ -82,8 +82,7 @@ impl From<ContractHeader> for state::ContractHeader {
             let mut method_entry = state::ContractHeader_MethodEntry::new();
             method_entry.set_name(name.to_string());
             method_entry.set_entrypoint(entrypoint.into());
-            res.mut_methods()
-                .push(method_entry);
+            res.mut_methods().push(method_entry);
         }
         res
     }
@@ -94,7 +93,10 @@ impl TryFrom<state::ContractHeader> for ContractHeader {
     fn try_from(mut value: state::ContractHeader) -> Result<ContractHeader, Self::Error> {
         let mut methods = BTreeMap::new();
         for mut method_entry in value.take_methods().into_iter() {
-            methods.insert(method_entry.take_name(), method_entry.take_entrypoint().try_into()?);
+            methods.insert(
+                method_entry.take_name(),
+                method_entry.take_entrypoint().try_into()?,
+            );
         }
 
         let contract_key = value.take_contract_key().try_into()?;

--- a/execution-engine/engine-test-support/src/internal/exec_with_return.rs
+++ b/execution-engine/engine-test-support/src/internal/exec_with_return.rs
@@ -15,8 +15,8 @@ use engine_shared::{gas::Gas, newtypes::CorrelationId};
 use engine_storage::{global_state::StateProvider, protocol_data::ProtocolData};
 use engine_wasm_prep::Preprocessor;
 use types::{
-    account::PublicKey, bytesrepr::FromBytes, BlockTime, CLTyped, CLValue, EntryPointType, Key,
-    Phase, ProtocolVersion, URef, U512,
+    account::PublicKey, bytesrepr::FromBytes, BlockTime, CLTyped, CLValue, ContractMetadata,
+    EntryPoint, Key, Phase, ProtocolVersion, URef, U512,
 };
 
 use crate::internal::{utils, WasmTestBuilder, DEFAULT_WASM_COSTS};
@@ -106,7 +106,8 @@ where
         correlation_id,
         phase,
         protocol_data,
-        EntryPointType::Session,
+        ContractMetadata::default(),
+        EntryPoint::default(),
     );
 
     let wasm_bytes = utils::read_wasm_file_bytes(wasm_file);

--- a/execution-engine/engine-tests/src/test/contract_headers.rs
+++ b/execution-engine/engine-tests/src/test/contract_headers.rs
@@ -1,0 +1,121 @@
+use engine_test_support::{
+    internal::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_PAYMENT,
+        DEFAULT_RUN_GENESIS_REQUEST,
+    },
+    DEFAULT_ACCOUNT_ADDR,
+};
+use types::{runtime_args, Key, RuntimeArgs, SemVer};
+
+const CONTRACT_HEADERS: &str = "contract_headers.wasm";
+const METADATA_HASH_KEY: &str = "metadata_hash_key";
+const METADATA_ACCESS_KEY: &str = "metadata_access_key";
+const STEP_1: i32 = 5;
+const STEP_2: i32 = 6;
+const STEP_3: i32 = 42;
+
+#[ignore]
+#[test]
+fn should_calling_session_and_contract_has_correct_context() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_HEADERS, ()).build();
+
+    let exec_request_2 = {
+        let args = runtime_args! {};
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                "session_code_test",
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    let exec_request_3 = {
+        let args = runtime_args! {};
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                "contract_code_test",
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    let exec_request_4 = {
+        let args = runtime_args! {};
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                "add_new_key_as_session",
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([4; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    builder.exec(exec_request_3).expect_success().commit();
+
+    builder.exec(exec_request_4).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let _foo = builder
+        .get_exec_response(3)
+        .expect("should have exec response");
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let new_key = account
+        .named_keys()
+        .get("new_key")
+        .expect("new key should be there");
+}

--- a/execution-engine/engine-tests/src/test/groups.rs
+++ b/execution-engine/engine-tests/src/test/groups.rs
@@ -17,10 +17,11 @@ const METADATA_ACCESS_KEY: &str = "metadata_access_key";
 const RESTRICTED_SESSION: &str = "restricted_session";
 const RESTRICTED_CONTRACT: &str = "restricted_contract";
 const RESTRICTED_SESSION_CALLER: &str = "restricted_session_caller";
-const RESTRICTED_CONTRACT_CALLER: &str = "restricted_contract_caller";
+const UNRESTRICTED_CONTRACT_CALLER: &str = "unrestricted_contract_caller";
 const METADATA_HASH_ARG: &str = "metadata_hash";
 const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+const RESTRICTED_CONTRACT_CALLER_AS_SESSION: &str = "restricted_contract_caller_as_session";
 
 lazy_static! {
     static ref TRANSFER_1_AMOUNT: U512 = U512::from(250_000_000) + 1000;
@@ -442,7 +443,7 @@ fn should_call_group_restricted_contract_from_wrong_account() {
 
 #[ignore]
 #[test]
-fn should_call_group_restricted_contract_caller() {
+fn should_call_group_unrestricted_contract_caller() {
     // This test runs a contract that's after every call extends the same key with
     // more data
     let exec_request_1 =
@@ -479,7 +480,7 @@ fn should_call_group_restricted_contract_caller() {
             .with_stored_versioned_contract_by_name(
                 METADATA_HASH_KEY,
                 SemVer::V1_0_0,
-                RESTRICTED_CONTRACT_CALLER,
+                UNRESTRICTED_CONTRACT_CALLER,
                 args,
             )
             .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
@@ -497,4 +498,200 @@ fn should_call_group_restricted_contract_caller() {
         .as_account()
         .cloned()
         .expect("should be account");
+}
+
+#[ignore]
+#[test]
+fn should_call_unrestricted_contract_caller_from_different_account() {
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        (ACCOUNT_1_ADDR, *TRANSFER_1_AMOUNT),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_3 = {
+        // This inserts metadata as an argument because this test
+        // can work from different accounts which might not have the same keys in their session
+        // code.
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_stored_versioned_contract_by_hash(
+                metadata_hash.into_hash().expect("should be hash"),
+                SemVer::V1_0_0,
+                UNRESTRICTED_CONTRACT_CALLER,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_3).expect_success().commit();
+}
+
+#[ignore]
+#[test]
+fn should_call_group_restricted_contract_as_session() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        (ACCOUNT_1_ADDR, *TRANSFER_1_AMOUNT),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_3 = {
+        // This inserts metadata as an argument because this test
+        // can work from different accounts which might not have the same keys in their session
+        // code.
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_hash(
+                metadata_hash.into_hash().expect("should be hash"),
+                SemVer::V1_0_0,
+                RESTRICTED_CONTRACT_CALLER_AS_SESSION,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([4; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_3).expect_success().commit();
+}
+
+#[ignore]
+#[test]
+fn should_call_group_restricted_contract_as_session_from_wrong_account() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        (ACCOUNT_1_ADDR, *TRANSFER_1_AMOUNT),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_3 = {
+        // This inserts metadata as an argument because this test
+        // can work from different accounts which might not have the same keys in their session
+        // code.
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_stored_versioned_contract_by_hash(
+                metadata_hash.into_hash().expect("should be hash"),
+                SemVer::V1_0_0,
+                RESTRICTED_CONTRACT_CALLER_AS_SESSION,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([4; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_3).commit();
+
+    let response = builder
+        .get_exec_responses()
+        .last()
+        .expect("should have last response");
+    assert_eq!(response.len(), 1);
+    let exec_response = response.last().expect("should have response");
+    let error = exec_response.as_error().expect("should have error");
+    assert_matches!(error, Error::Exec(execution::Error::InvalidContext));
 }

--- a/execution-engine/engine-tests/src/test/groups.rs
+++ b/execution-engine/engine-tests/src/test/groups.rs
@@ -1,0 +1,500 @@
+use assert_matches::assert_matches;
+use lazy_static::lazy_static;
+
+use engine_core::{engine_state::Error, execution};
+use engine_test_support::{
+    internal::{
+        DeployItemBuilder, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_PAYMENT,
+        DEFAULT_RUN_GENESIS_REQUEST,
+    },
+    DEFAULT_ACCOUNT_ADDR,
+};
+use types::{account::PublicKey, runtime_args, Key, RuntimeArgs, SemVer, U512};
+
+const CONTRACT_GROUPS: &str = "groups.wasm";
+const METADATA_HASH_KEY: &str = "metadata_hash_key";
+const METADATA_ACCESS_KEY: &str = "metadata_access_key";
+const RESTRICTED_SESSION: &str = "restricted_session";
+const RESTRICTED_CONTRACT: &str = "restricted_contract";
+const RESTRICTED_SESSION_CALLER: &str = "restricted_session_caller";
+const RESTRICTED_CONTRACT_CALLER: &str = "restricted_contract_caller";
+const METADATA_HASH_ARG: &str = "metadata_hash";
+const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
+
+lazy_static! {
+    static ref TRANSFER_1_AMOUNT: U512 = U512::from(250_000_000) + 1000;
+    static ref TRANSFER_2_AMOUNT: U512 = U512::from(750);
+    static ref TRANSFER_2_AMOUNT_WITH_ADV: U512 = *DEFAULT_PAYMENT + *TRANSFER_2_AMOUNT;
+    static ref TRANSFER_TOO_MUCH: U512 = U512::from(u64::max_value());
+    static ref ACCOUNT_1_INITIAL_BALANCE: U512 = *DEFAULT_PAYMENT;
+}
+#[ignore]
+#[test]
+fn should_call_group_restricted_session() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_2 = {
+        // This inserts metadata as an argument because this test
+        // can work from different accounts which might not have the same keys in their session
+        // code.
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                RESTRICTED_SESSION,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let _account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+}
+
+#[ignore]
+#[test]
+fn should_call_group_restricted_session_caller() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_2 = {
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                RESTRICTED_SESSION_CALLER,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let _account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+}
+
+#[test]
+#[ignore]
+fn should_not_call_restricted_session_from_wrong_account() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        (ACCOUNT_1_ADDR, *TRANSFER_1_AMOUNT),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_3 = {
+        let args = runtime_args! {};
+        let deploy = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_stored_versioned_contract_by_hash(
+                metadata_hash.into_hash().expect("should be hash"),
+                SemVer::V1_0_0,
+                RESTRICTED_SESSION,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_3).commit();
+
+    let _account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let response = builder
+        .get_exec_responses()
+        .last()
+        .expect("should have last response");
+    assert_eq!(response.len(), 1);
+    let exec_response = response.last().expect("should have response");
+    let error = exec_response.as_error().expect("should have error");
+    assert_matches!(error, Error::Exec(execution::Error::InvalidContext));
+}
+
+#[test]
+#[ignore]
+fn should_not_call_restricted_session_caller_from_wrong_account() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        (ACCOUNT_1_ADDR, *TRANSFER_1_AMOUNT),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_3 = {
+        let args = runtime_args! {
+            "metadata_hash"=> metadata_hash.clone(),
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_stored_versioned_contract_by_hash(
+                metadata_hash.into_hash().expect("should be hash"),
+                SemVer::V1_0_0,
+                RESTRICTED_SESSION_CALLER,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_3).commit();
+
+    let _account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let response = builder
+        .get_exec_responses()
+        .last()
+        .expect("should have last response");
+    assert_eq!(response.len(), 1);
+    let exec_response = response.last().expect("should have response");
+    let error = exec_response.as_error().expect("should have error");
+    assert_matches!(error, Error::Exec(execution::Error::InvalidContext));
+}
+
+#[ignore]
+#[test]
+fn should_call_group_restricted_contract() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_2 = {
+        // This inserts metadata as an argument because this test
+        // can work from different accounts which might not have the same keys in their session
+        // code.
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                RESTRICTED_CONTRACT,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let _account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+}
+
+#[ignore]
+#[test]
+fn should_call_group_restricted_contract_from_wrong_account() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+    let exec_request_2 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_TRANSFER_TO_ACCOUNT,
+        (ACCOUNT_1_ADDR, *TRANSFER_1_AMOUNT),
+    )
+    .build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_3 = {
+        // This inserts metadata as an argument because this test
+        // can work from different accounts which might not have the same keys in their session
+        // code.
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(ACCOUNT_1_ADDR)
+            .with_stored_versioned_contract_by_hash(
+                metadata_hash.into_hash().expect("should be hash"),
+                SemVer::V1_0_0,
+                RESTRICTED_CONTRACT,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[ACCOUNT_1_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+
+    builder.exec(exec_request_3).commit();
+
+    let response = builder
+        .get_exec_responses()
+        .last()
+        .expect("should have last response");
+    assert_eq!(response.len(), 1);
+    let exec_response = response.last().expect("should have response");
+    let error = exec_response.as_error().expect("should have error");
+    assert_matches!(error, Error::Exec(execution::Error::InvalidContext));
+}
+
+#[ignore]
+#[test]
+fn should_call_group_restricted_contract_caller() {
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 =
+        ExecuteRequestBuilder::standard(DEFAULT_ACCOUNT_ADDR, CONTRACT_GROUPS, ()).build();
+
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
+
+    builder.exec(exec_request_1).expect_success().commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+
+    let metadata_hash = account
+        .named_keys()
+        .get(METADATA_HASH_KEY)
+        .expect("should have contract metadata");
+    let _access_uref = account
+        .named_keys()
+        .get(METADATA_ACCESS_KEY)
+        .expect("should have metadata hash");
+
+    let exec_request_2 = {
+        let args = runtime_args! {
+            METADATA_HASH_ARG => *metadata_hash,
+        };
+        let deploy = DeployItemBuilder::new()
+            .with_address(DEFAULT_ACCOUNT_ADDR)
+            .with_stored_versioned_contract_by_name(
+                METADATA_HASH_KEY,
+                SemVer::V1_0_0,
+                RESTRICTED_CONTRACT_CALLER,
+                args,
+            )
+            .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR])
+            .with_deploy_hash([3; 32])
+            .build();
+
+        ExecuteRequestBuilder::new().push_deploy(deploy).build()
+    };
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let _account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .cloned()
+        .expect("should be account");
+}

--- a/execution-engine/engine-tests/src/test/mod.rs
+++ b/execution-engine/engine-tests/src/test/mod.rs
@@ -3,6 +3,7 @@ mod contract_context;
 mod deploy;
 mod examples;
 mod explorer;
+mod groups;
 mod regression;
 mod system_contracts;
 mod upgrade;


### PR DESCRIPTION
### Overview

Extends and verifies functionality of group restricted contract entrypoints. Adds tests to call restricted contracts in various setups. (i.e. deploy calls session calls contract, etc,). Includes curious cases of contracts restricted with empty groups (effectively private contracts) and ensures that they're callable directly from inside (as in using `fn()` without `call_versioned_contract`), but not outside.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-989

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
