### PR TITLE
EE-993: upgrade wasmi and related deps

### DIFF
--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -32,13 +32,13 @@ mint = { version = "0.2.1", path = "../mint", package = "casperlabs-mint" }
 proof-of-stake = { version = "0.2.1", path = "../proof-of-stake", package = "casperlabs-proof-of-stake" }
 num-derive = "0.3.0"
 num-traits = "0.2.10"
-parity-wasm = "0.31.3"
-pwasm-utils = "0.6.2"
+parity-wasm = "0.41.0"
+pwasm-utils = "0.12.0"
 rand = "0.7.2"
 rand_chacha = "0.2.1"
 standard-payment = { version = "0.2.1", path = "../standard-payment", package = "casperlabs-standard-payment" }
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
-wasmi = "0.4.2"
+wasmi = "0.6.2"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/execution-engine/engine-core/src/engine_state/system_contract_cache.rs
+++ b/execution-engine/engine-core/src/engine_state/system_contract_cache.rs
@@ -43,7 +43,7 @@ mod tests {
     use std::sync::Mutex;
 
     use lazy_static::lazy_static;
-    use parity_wasm::elements::{Module, ModuleNameSection, NameSection, Section};
+    use parity_wasm::elements::{Module, ModuleNameSubsection, NameSection, Section};
 
     use crate::{
         engine_state::system_contract_cache::SystemContractCache,
@@ -221,7 +221,7 @@ mod tests {
         };
         let initial_module = Module::default();
         let updated_module = {
-            let section = NameSection::Module(ModuleNameSection::new("a_mod"));
+            let section = NameSection::new(Some(ModuleNameSubsection::new("a_mod")), None, None);
             let sections = vec![Section::Name(section)];
             Module::new(sections)
         };
@@ -251,7 +251,7 @@ mod tests {
         };
         let initial_module = Module::default();
         let updated_module = {
-            let section = NameSection::Module(ModuleNameSection::new("a_mod"));
+            let section = NameSection::new(Some(ModuleNameSubsection::new("a_mod")), None, None);
             let sections = vec![Section::Name(section)];
             Module::new(sections)
         };

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -37,7 +37,7 @@ types = { version = "0.4.1", path = "../types", package = "casperlabs-types", fe
 protoc-rust-grpc = "0.6.1"
 
 [dev-dependencies]
-parity-wasm = "0.31.3"
+parity-wasm = "0.41.0"
 rand = "0.7.2"
 
 [features]

--- a/execution-engine/engine-shared/Cargo.toml
+++ b/execution-engine/engine-shared/Cargo.toml
@@ -20,7 +20,7 @@ lazy_static = "1.4.0"
 libc = "0.2.66"
 log = { version = "0.4.8", features = ["std", "serde", "kv_unstable"] }
 num = { version = "0.2.0", default-features = false }
-parity-wasm = "0.31.3"
+parity-wasm = "0.41.0"
 proptest = "0.9.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/execution-engine/engine-storage/Cargo.toml
+++ b/execution-engine/engine-storage/Cargo.toml
@@ -17,7 +17,7 @@ failure = "0.1.6"
 lmdb = "0.8.0"
 parking_lot = "0.10.0"
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std", "gens"] }
-wasmi = "0.4.2"
+wasmi = "0.6.2"
 
 [dev-dependencies]
 lazy_static = "1"

--- a/execution-engine/engine-wasm-prep/Cargo.toml
+++ b/execution-engine/engine-wasm-prep/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/CasperLabs/CasperLabs/tree/master/execution-eng
 license-file = "../../LICENSE"
 
 [dependencies]
-parity-wasm = "0.31.3"
+parity-wasm = "0.41.0"
 proptest = "0.9.4"
-pwasm-utils = "0.6.2"
+pwasm-utils = "0.12.0"
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std"] }


### PR DESCRIPTION
### Overview
This upgrades our wasmi dependencies in preparation for benchmarking the interpreter's handling of individual Wasm opcodes.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-993

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
