### PR TITLE
highway-core: Add Vertex::values.

### DIFF
--- a/execution-engine/consensus/highway-core/src/active_validator.rs
+++ b/execution-engine/consensus/highway-core/src/active_validator.rs
@@ -26,8 +26,8 @@ impl<C: Context> ActiveValidator<C> {
     }
 
     /// Propose a new block with the given parent and consensus value.
-    pub fn propose(&self, state: &State<C>, value: C::ConsensusValue) -> Vec<Effect<C>> {
-        todo!("{:?}, {:?}", state, value)
+    pub fn propose(&self, state: &State<C>, values: Vec<C::ConsensusValue>) -> Vec<Effect<C>> {
+        todo!("{:?}, {:?}", state, values)
         // vec![Effect::NewVertex(Vertex::Vote(vote))]
     }
 }

--- a/execution-engine/consensus/highway-core/src/block.rs
+++ b/execution-engine/consensus/highway-core/src/block.rs
@@ -8,5 +8,5 @@ pub struct Block<C: Context> {
     /// The total number of ancestors, i.e. the height in the blockchain.
     pub height: u64,
     /// The payload, e.g. a list of transactions.
-    pub value: C::ConsensusValue,
+    pub values: Vec<C::ConsensusValue>,
 }

--- a/execution-engine/consensus/highway-core/src/state.rs
+++ b/execution-engine/consensus/highway-core/src/state.rs
@@ -75,12 +75,12 @@ impl<C: Context> State<C> {
 
     fn wire_vote(&self, hash: C::VoteHash) -> Option<WireVote<C>> {
         let vote = self.votes.get(&hash)?.clone();
-        let value = self.blocks.get(&hash).map(|block| block.value.clone());
+        let values = self.blocks.get(&hash).map(|block| block.values.clone());
         Some(WireVote {
             hash,
             panorama: vote.panorama.clone(),
             sender: self.params.validators.id_of(vote.sender_idx).clone(),
-            value,
+            values,
             seq_number: vote.seq_number,
         })
     }
@@ -106,14 +106,14 @@ impl<C: Context> State<C> {
         }
         let hash = wvote.hash.clone();
         let fork_choice: Option<C::VoteHash> = self.fork_choice(&wvote.panorama);
-        let block = if let Some(value) = wvote.value {
+        let block = if let Some(values) = wvote.values {
             let height = fork_choice
                 .as_ref()
                 .map_or(0, |hash| self.blocks[hash].height + 1);
             let block = Block {
                 parent: fork_choice,
                 height,
-                value,
+                values,
             };
             self.blocks.insert(hash.clone(), block);
             hash.clone()

--- a/execution-engine/consensus/highway-core/src/vertex.rs
+++ b/execution-engine/consensus/highway-core/src/vertex.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use crate::{evidence::Evidence, traits::Context, validators::ValidatorIndex, vote::Panorama};
 
 /// A dependency of a `Vertex` that can be satisfied by one or more other vertices.
@@ -16,12 +18,27 @@ pub enum Vertex<C: Context> {
     Evidence(Evidence<C>),
 }
 
+impl<C: Context> Vertex<C> {
+    /// Returns an iterator over all consensus values mentioned in this vertex.
+    ///
+    /// These need to be validated before passing the vertex into the protocol state. E.g. if
+    /// `C::ConsensusValue` is a transaction, it should be validated first (correct signature,
+    /// structure, gas limit, etc.). If it is a hash of a transaction, the transaction should be
+    /// obtained _and_ validated. Only after that, the vertex can be considered valid.
+    pub fn values<'a>(&'a self) -> Box<dyn Iterator<Item = &'a C::ConsensusValue> + 'a> {
+        match self {
+            Vertex::Vote(wvote) => Box::new(wvote.values.iter().flat_map(|v| v.iter())),
+            Vertex::Evidence(_) => Box::new(iter::empty()),
+        }
+    }
+}
+
 /// A vote as it is sent over the wire, possibly containing a new block.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WireVote<C: Context> {
     pub hash: C::VoteHash,
     pub panorama: Panorama<C::VoteHash>,
     pub sender: C::ValidatorId,
-    pub value: Option<C::ConsensusValue>,
+    pub values: Option<Vec<C::ConsensusValue>>,
     pub seq_number: u64,
 }


### PR DESCRIPTION
### Overview

Make it easy for the user to retrieve the consensus values in a vertex.

If those values are deploy _hashes_, that allows the upper layers to
download the corresponding deploys before adding the vertex to the
protocol state.
_Provide a brief description of what this PR does, and why it's needed._

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-30

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
