### PR TITLE
EE-985: improve host-function instrumentation

### DIFF
--- a/execution-engine/contracts/profiling/host-function-metrics/src/lib.rs
+++ b/execution-engine/contracts/profiling/host-function-metrics/src/lib.rs
@@ -19,7 +19,7 @@ use types::{
 const MIN_FUNCTION_NAME_LENGTH: usize = 1;
 const MAX_FUNCTION_NAME_LENGTH: usize = 100;
 
-const NAMED_KEY_COUNT: usize = 10;
+const NAMED_KEY_COUNT: usize = 100;
 const MIN_NAMED_KEY_NAME_LENGTH: usize = 10;
 // TODO - consider increasing to e.g. 1_000 once https://casperlabs.atlassian.net/browse/EE-966 is
 //        resolved.
@@ -54,16 +54,24 @@ impl From<Error> for ApiError {
     }
 }
 
-fn create_random_names(seed: u64) -> impl Iterator<Item = String> {
-    let mut rng = SmallRng::seed_from_u64(seed);
+fn create_random_names<'a>(rng: &'a mut SmallRng) -> impl Iterator<Item = String> + 'a {
     iter::repeat_with(move || {
         let key_length: usize = rng.gen_range(MIN_NAMED_KEY_NAME_LENGTH, MAX_NAMED_KEY_NAME_LENGTH);
-        (&mut rng)
-            .sample_iter(&Alphanumeric)
+        rng.sample_iter(&Alphanumeric)
             .take(key_length)
             .collect::<String>()
     })
     .take(NAMED_KEY_COUNT)
+}
+
+fn truncate_named_keys(
+    named_keys: BTreeMap<String, Key>,
+    rng: &mut SmallRng,
+) -> BTreeMap<String, Key> {
+    let truncated_len = rng.gen_range(1, named_keys.len() + 1);
+    let mut vec = named_keys.into_iter().collect::<Vec<_>>();
+    vec.truncate(truncated_len);
+    vec.into_iter().collect()
 }
 
 // Executes the named key functions from the `runtime` module and most of the functions from the
@@ -78,8 +86,9 @@ fn large_function() {
 
     let uref = storage::new_uref(random_bytes.clone());
 
+    let mut rng = SmallRng::seed_from_u64(seed);
     let mut key_name = String::new();
-    for random_name in create_random_names(seed) {
+    for random_name in create_random_names(&mut rng) {
         key_name = random_name;
         runtime::put_key(&key_name, Key::from(uref));
     }
@@ -117,7 +126,8 @@ fn large_function() {
     storage::write_local(key_name.clone(), VALUE_FOR_ADDITION_1);
     storage::add_local(key_name, VALUE_FOR_ADDITION_2);
 
-    runtime::ret(CLValue::from_t(named_keys).unwrap_or_revert());
+    let keys_to_return = truncate_named_keys(named_keys, &mut rng);
+    runtime::ret(CLValue::from_t(keys_to_return).unwrap_or_revert());
 }
 
 fn small_function() {
@@ -155,7 +165,7 @@ pub extern "C" fn call() {
         contract_ref.into_uref().unwrap_or_revert(),
     );
 
-    // Store large function with 10 named keys under a URef, then execute it.
+    // Store large function with some named keys under a URef, then execute it.
     contract_ref = storage::store_function(&large_function_name, named_keys.clone());
     let _ = runtime::call_contract::<_, BTreeMap<String, Key>>(
         contract_ref.clone(),
@@ -178,7 +188,7 @@ pub extern "C" fn call() {
         contract_ref.into_uref().unwrap_or_revert(),
     );
 
-    // Store small function with 10 named keys under a URef, then execute it.
+    // Store small function with some named keys under a URef, then execute it.
     contract_ref = storage::store_function(&small_function_name, named_keys.clone());
     runtime::call_contract::<_, ()>(contract_ref.clone(), ());
     runtime::upgrade_contract_at_uref(


### PR DESCRIPTION
### Overview
This adds a further arg to `ret`'s instrumentation (i.e. the count of embedded `URef`s in the returned value), and renames the `ScopedTimer` to `ScopedInstrumenter`.  It also updates the host-function-metrics contract to embed a variable number of `URef`s (between 0 and 99 inclusive) in a value being returned via `ret`.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-985

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
