### PR TITLE
TNET-23: MatchError: null

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/IterantFromReactivePublisher.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/IterantFromReactivePublisher.scala
@@ -1,0 +1,194 @@
+package io.casperlabs.comm.gossiping
+
+// A copy of https://github.com/monix/monix/blob/3.0.0/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromReactivePublisher.scala#L60
+// until https://github.com/monix/monix/issues/1180 is fixed.
+
+import cats.effect.Async
+import monix.execution.atomic.Atomic
+import monix.execution.atomic.PaddingStrategy.LeftRight128
+import monix.execution.rstreams.SingleAssignSubscription
+import monix.tail.Iterant
+import monix.tail.Iterant.{Last, Next, NextBatch, Scope}
+import monix.tail.batches.Batch
+import org.reactivestreams.{Publisher, Subscriber, Subscription}
+import scala.annotation.tailrec
+import scala.collection.immutable.Queue
+
+private[gossiping] object IterantFromReactivePublisher {
+
+  /**
+    * Implementation for `Iterant.fromReactivePublisher`.
+    */
+  def apply[F[_], A](pub: Publisher[A], requestCount: Int, eagerBuffer: Boolean)(
+      implicit F: Async[F]
+  ): Iterant[F, A] =
+    if (requestCount < 1) {
+      Iterant.raiseError(new IllegalArgumentException("requestSize must be greater than 1"))
+    } else {
+      val acquire =
+        F.delay {
+          val out = new IterantSubscriber[F, A](requestCount, eagerBuffer)
+          pub.subscribe(out)
+          out
+        }
+
+      Scope[F, IterantSubscriber[F, A], A](acquire, _.start, (out, _) => F.delay(out.cancel()))
+    }
+
+  private final class IterantSubscriber[F[_], A](bufferSize: Int, eagerBuffer: Boolean)(
+      implicit F: Async[F]
+  ) extends Subscriber[A] {
+
+    private[this] val sub   = SingleAssignSubscription()
+    private[this] val state = Atomic.withPadding(null: State[F, A], LeftRight128)
+
+    def start: F[Iterant[F, A]] =
+      F.async { cb =>
+        if (state.compareAndSet(null, Empty(bufferSize))) {
+          sub.request(
+            // Requesting unlimited?
+            if (bufferSize < Int.MaxValue) bufferSize.toLong
+            else Long.MaxValue
+          )
+        }
+        // Go, go, go
+        take(cb)
+      }
+
+    private[this] val generate: (Int => F[Iterant[F, A]]) = {
+      if (eagerBuffer) {
+        val task = F.async[Iterant[F, A]](take)
+        toReceive => { if (toReceive == 0) sub.request(bufferSize.toLong); task }
+      } else { toReceive =>
+        F.async { cb =>
+          if (toReceive == 0) sub.request(bufferSize.toLong); take(cb)
+        }
+      }
+    }
+
+    private def decrementToReceive(toReceive: Int, n: Int): Int =
+      if (bufferSize < Int.MaxValue) {
+        val value = toReceive - n
+        if (value < 0)
+          throw new IllegalArgumentException("Received more events than requested")
+        else
+          value
+      } else {
+        toReceive
+      }
+
+    private def updateToReceive(toReceive: Int): Int =
+      if (toReceive == 0) bufferSize
+      else toReceive
+
+    @tailrec def onNext(a: A): Unit =
+      state.get match {
+        case current @ Enqueue(queue, length, toReceive) =>
+          if (!state.compareAndSet(current, Enqueue(queue.enqueue(a), length + 1, toReceive)))
+            onNext(a)
+
+        case current @ Take(cb, toReceive) =>
+          val toReceive2 = decrementToReceive(toReceive, 1)
+          if (!state.compareAndSet(current, Empty(updateToReceive(toReceive2))))
+            onNext(a)
+          else
+            cb(Right(Next(a, generate(toReceive2))))
+
+        case Canceled =>
+          () // was canceled, ignore event
+
+        case Stop(_) =>
+          // TODO:
+          throw new IllegalStateException("onComplete/onError after onNext is not allowed")
+      }
+
+    @tailrec private def finish(fa: Iterant[F, A]): Unit =
+      state.get match {
+        case current @ Enqueue(queue, length, _) =>
+          val update: Iterant[F, A] = length match {
+            case 0 => fa
+            case 1 =>
+              val elem = queue.dequeue._1
+              if (fa == Iterant.empty) Last(elem)
+              else Next(elem, F.pure(fa))
+            case _ =>
+              NextBatch[F, A](Batch.fromSeq(queue), F.pure(fa))
+          }
+
+          if (!state.compareAndSet(current, Stop(update))) {
+            finish(fa)
+          }
+
+        case current @ Take(cb, _) =>
+          if (state.compareAndSet(current, Stop(fa)))
+            cb(Right(fa))
+          else
+            finish(fa)
+
+        case Canceled =>
+          () // was canceled, ignore event
+
+        case Stop(_) =>
+          throw new IllegalStateException("was already completed")
+      }
+
+    def onError(ex: Throwable): Unit =
+      finish(Iterant.raiseError(ex))
+
+    def onComplete(): Unit =
+      finish(Iterant.empty)
+
+    private def take(cb: Either[Throwable, Iterant[F, A]] => Unit): Unit =
+      state.get match {
+        case current @ Enqueue(queue, length, toReceive) =>
+          if (length == 0) {
+            val update = Take(cb, toReceive)
+            if (!state.compareAndSet(current, update)) take(cb)
+          } else {
+            val toReceive2 = decrementToReceive(toReceive, length)
+            if (state.compareAndSet(current, Empty(updateToReceive(toReceive2)))) {
+              val stream = length match {
+                case 1 => Next(queue.dequeue._1, generate(toReceive2))
+                case _ => NextBatch(Batch.fromSeq(queue), generate(toReceive2))
+              }
+              cb(Right(stream))
+            } else {
+              take(cb) // retry
+            }
+          }
+
+        case Stop(fa) =>
+          cb(Right(fa))
+
+        case Canceled =>
+          () // canceled, ignore event
+
+        case Take(_, _) =>
+          cb(Left(new IllegalStateException("Back-pressure contract violation!")))
+      }
+
+    def onSubscribe(s: Subscription): Unit =
+      sub := s
+
+    def cancel(): Unit =
+      state.getAndSet(Canceled) match {
+        case Canceled | Stop(_) => ()
+        case _                  => sub.cancel()
+      }
+  }
+
+  private sealed abstract class State[+F[_], +A]
+
+  private final case class Stop[F[_], A](fa: Iterant[F, A]) extends State[F, A]
+
+  private final case class Enqueue[F[_], A](queue: Queue[A], length: Int, toReceive: Int)
+      extends State[F, A]
+
+  private final case class Take[F[_], A](cb: Either[Nothing, Iterant[F, A]] => Unit, toReceive: Int)
+      extends State[F, A]
+
+  private case object Canceled extends State[Nothing, Nothing]
+
+  private def Empty[F[_], A](toReceive: Int): State[F, A] =
+    Enqueue(Queue.empty, 0, toReceive)
+}

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/ObservableIterant.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/ObservableIterant.scala
@@ -28,7 +28,12 @@ object ObservableIterant {
         }
 
       def toIterant[A](obs: Observable[A]) =
-        Iterant.fromReactivePublisher[F, A](obs.toReactivePublisher)
+        // Iterant.fromReactivePublisher[F, A](obs.toReactivePublisher)
+        IterantFromReactivePublisher(
+          obs.toReactivePublisher,
+          requestCount = 128,
+          eagerBuffer = true
+        )
     }
 
   object syntax {

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ObservableIterantSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ObservableIterantSpec.scala
@@ -1,12 +1,13 @@
 package io.casperlabs.comm.gossiping
 
 import monix.eval.Task
-import monix.execution.Scheduler
+import monix.execution.{Cancelable, Scheduler}
 import monix.reactive.Observable
 import monix.reactive.observers.Subscriber
+import monix.tail.Iterant
 import org.scalatest._
-import monix.execution.Cancelable
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 class ObservableIterantSpec extends FlatSpec {
 

--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/ObservableIterantSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/ObservableIterantSpec.scala
@@ -1,0 +1,29 @@
+package io.casperlabs.comm.gossiping
+
+import monix.eval.Task
+import monix.execution.Scheduler
+import monix.reactive.Observable
+import monix.reactive.observers.Subscriber
+import org.scalatest._
+import monix.execution.Cancelable
+import scala.concurrent.duration._
+
+class ObservableIterantSpec extends FlatSpec {
+
+  import Scheduler.Implicits.global
+
+  behavior of "toIterant"
+
+  it should "not have a race condition (TNET-23)" in {
+    val obs = new Observable[Nothing] {
+      override def unsafeSubscribeFn(subscriber: Subscriber[Nothing]): Cancelable = {
+        subscriber.onComplete()
+        Cancelable.empty
+      }
+    }
+
+    val it = ObservableIterant.default[Task].toIterant(obs)
+
+    it.toListL.runSyncUnsafe(1.second)
+  }
+}

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -86,7 +86,7 @@ sync-max-bonding-rate = 1.0
 sync-max-depth-ancestors-request = 5
 
 # Maximum number of parallel synchronizations to run at any time.
-sync-max-parallel = 5
+sync-max-parallel = 7
 
 # Disable DAG shape validations during synchronization.
 sync-disable-validations = true
@@ -116,7 +116,7 @@ init-sync-max-block-count = 1000000
 periodic-sync-round-period = "60second"
 
 # Maximum number of parallel block downloads initiated by the download manager.
-download-max-parallel-blocks = 2
+download-max-parallel-blocks = 8
 
 # Maximum number of parallel deploy downloads initiated by the download manager.
 download-max-parallel-deploys = 2
@@ -137,7 +137,7 @@ relay-max-parallel-blocks = 5
 relay-block-chunk-consumer-timeout = "10second"
 
 # Maximum number of blocks to try to validate at any time.
-validate-max-parallel-blocks = 2
+validate-max-parallel-blocks = 8
 
 # Use this flag to clear the blockStorage and dagStorage
 clean-block-storage = false
@@ -173,7 +173,7 @@ db-read-connections = 10
 parallelism-cpu-multiplier = 1.0
 
 # Minimum parallelism.
-min-parallelism = 4
+min-parallelism = 8
 
 # io.casperlabs.node.configuration.Configuration.BlockStorage
 [blockstorage]


### PR DESCRIPTION
### Overview
We get `MatchError: null` from Monix under random circumstances.

The PR includes a copy of [IterantFromReactivePublisher](https://github.com/monix/monix/blob/3.0.0/monix-tail/shared/src/main/scala/monix/tail/internal/IterantFromReactivePublisher.scala) to be able to apply a fix.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-23

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Reported the issue at https://github.com/monix/monix/issues/1180
