### PR TITLE
[Master] ECO-327: Testing framework to support deploys with a custom block time.

### DIFF
--- a/execution-engine/engine-test-support/src/session.rs
+++ b/execution-engine/engine-test-support/src/session.rs
@@ -79,6 +79,12 @@ impl SessionBuilder {
         self
     }
 
+    /// Returns `self` with the provided block time set.
+    pub fn with_block_time(mut self, block_time: u64) -> Self {
+        self.er_builder = self.er_builder.with_block_time(block_time);
+        self
+    }
+
     /// Builds the [`Session`].
     pub fn build(self) -> Session {
         let mut rng = rand::thread_rng();


### PR DESCRIPTION
### Overview
This adds the ability to change a block time in the `SessionBuilder` in testing framework. It publishes already existing function.  

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-327