### PR TITLE
[NO-TICKET] Enable GA only in clarity.casperlabs.io and testnet-explorer.casperlabs.io.

### DIFF
--- a/explorer/ui/src/components/App.tsx
+++ b/explorer/ui/src/components/App.tsx
@@ -310,8 +310,14 @@ function useQuery() {
   return new URLSearchParams(useLocation().search);
 }
 
+// The white list of hostname that enable GA.
+const HOSTNAME_WHITE_LIST = ['testnet-explorer.casperlabs.io', 'clarity.casperlabs.io'];
 
-ReactGA.initialize("UA-133833104-1");
+const ENABLE_GA = HOSTNAME_WHITE_LIST.includes(window.location.hostname);
+
+if (ENABLE_GA) {
+  ReactGA.initialize("UA-133833104-1");
+}
 
 // the hook to send pageView to GA.
 function usePageViews() {
@@ -319,7 +325,9 @@ function usePageViews() {
 
   useEffect(
     () => {
-      ReactGA.pageview(location.pathname);
+      if (ENABLE_GA) {
+        ReactGA.pageview(location.pathname);
+      }
     },
     [location]
   );


### PR DESCRIPTION
### Overview
As the title said. Cherry-pick from dev branch so that clarity instance of LRT will no longer container GA.

### Which JIRA ticket does this PR relate to?
No ticket. 

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
