### PR TITLE
EE-956: add feature to disable unstable lib features

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -131,6 +131,26 @@ steps:
       - "**/casperlabs-engine-grpc-server.spec"
       - "**/rustfmt.toml"
 
+- name: rust-compile-docs-stable-pr
+  commands:
+  - "cd execution-engine/"
+  - "make setup-stable-rs"
+  - "make build-docs-stable-rs"
+  image: "casperlabs/buildenv:latest"
+  failure: "ignore"
+  when:
+    event:
+    - pull_request
+    changeset:
+      includes:
+      - "**/.drone.yml"
+      - "**/**.rs"
+      - "**/**.proto"
+      - "**/Cargo.lock"
+      - "**/Cargo.toml"
+      - "**/casperlabs-engine-grpc-server.spec"
+      - "**/rustfmt.toml"
+
 - name: as-compile-test-pr
   commands:
   - "cd execution-engine"

--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -1,8 +1,3 @@
-cargo-features = [
-    "profile-overrides",
-    "named-profiles",
-]
-
 [workspace]
 
 members = [

--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -72,6 +72,21 @@ TOOL_WASM_DIR             = cargo-casperlabs/wasm
 ENGINE_CORE_TARGET_DIR    = engine-core/target
 ENGINE_CORE_WASM_DIR      = engine-core/wasm
 
+CRATES_WITH_DOCS_RS_MANIFEST_TABLE = \
+	contract \
+	engine-core \
+	engine-grpc-server \
+	engine-shared \
+	engine-storage \
+	engine-test-support \
+	engine-wasm-prep \
+	mint \
+	proof-of-stake \
+	standard-payment \
+	types
+
+CRATES_WITH_DOCS_RS_MANIFEST_TABLE := $(patsubst %, doc-stable/%, $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE))
+
 .PHONY: all
 all: build build-contracts
 
@@ -189,8 +204,15 @@ audit:
 	$(CARGO) generate-lockfile
 	$(CARGO) audit
 
+.PHONY: build-docs-stable-rs
+build-docs-stable-rs: $(CRATES_WITH_DOCS_RS_MANIFEST_TABLE)
+
+doc-stable/%:
+	$(CARGO) +stable doc $(CARGO_FLAGS) --manifest-path "$*/Cargo.toml" --features "no-unstable-features" --no-deps
+
 .PHONY: check-rs
 check-rs: \
+	build-docs-stable-rs \
 	build \
 	check-format \
 	lint \
@@ -262,6 +284,10 @@ setup-rs: rust-toolchain
 	$(RUSTUP) update
 	$(RUSTUP) toolchain install $(RUST_TOOLCHAIN)
 	$(RUSTUP) target add --toolchain $(RUST_TOOLCHAIN) wasm32-unknown-unknown
+
+.PHONY: setup-stable-rs
+setup-stable-rs: RUST_TOOLCHAIN := stable
+setup-stable-rs: setup-rs
 
 .PHONY: setup-nightly-rs
 setup-nightly-rs: RUST_TOOLCHAIN := nightly

--- a/execution-engine/contract/Cargo.toml
+++ b/execution-engine/contract/Cargo.toml
@@ -14,6 +14,7 @@ license-file = "../../LICENSE"
 default = []
 std = ["casperlabs-types/std"]
 test-support = []
+no-unstable-features = ["std", "casperlabs-types/no-unstable-features"]
 
 [dependencies]
 casperlabs-types = { version = "0.4.1", path = "../types" }
@@ -23,3 +24,6 @@ wee_alloc = "0.4.5"
 
 [dev-dependencies]
 version-sync = "0.8"
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/contract/src/lib.rs
+++ b/execution-engine/contract/src/lib.rs
@@ -55,12 +55,9 @@
 //! submodules.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(
-    alloc_error_handler,
-    alloc_layout_extra,
-    allocator_api,
-    core_intrinsics,
-    lang_items
+#![cfg_attr(
+    not(feature = "std"),
+    feature(alloc_error_handler, core_intrinsics, lang_items)
 )]
 #![doc(html_root_url = "https://docs.rs/casperlabs-contract/0.4.1")]
 #![doc(

--- a/execution-engine/contracts/system/standard-payment-install/Cargo.toml
+++ b/execution-engine/contracts/system/standard-payment-install/Cargo.toml
@@ -13,6 +13,7 @@ test = false
 
 [features]
 std = ["contract/std", "types/std"]
+no-unstable-features = ["contract/no-unstable-features", "types/no-unstable-features"]
 
 [dependencies]
 contract = { path = "../../../contract", package = "casperlabs-contract" }

--- a/execution-engine/engine-core/Cargo.toml
+++ b/execution-engine/engine-core/Cargo.toml
@@ -47,3 +47,16 @@ proptest = "0.9.4"
 
 [features]
 test-support = []
+no-unstable-features = [
+    "contract/no-unstable-features",
+    "engine-shared/no-unstable-features",
+    "engine-storage/no-unstable-features",
+    "engine-wasm-prep/no-unstable-features",
+    "mint/no-unstable-features",
+    "proof-of-stake/no-unstable-features",
+    "standard-payment/no-unstable-features",
+    "types/no-unstable-features"
+]
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/engine-core/build.rs
+++ b/execution-engine/engine-core/build.rs
@@ -49,6 +49,10 @@ fn build_package<T: Package>() {
         target_dir.to_str().expect("Expected valid unicode")
     ));
 
+    if env::var("CARGO_FEATURE_NO_UNSTABLE_FEATURES").is_ok() {
+        build_args.push("--features=no-unstable-features".to_string());
+    }
+
     // Build the contract.
     let output = Command::new(cargo)
         .current_dir(T::ROOT)

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -76,12 +76,6 @@ impl From<mint::Error> for Error {
     }
 }
 
-impl From<!> for Error {
-    fn from(error: !) -> Self {
-        match error {}
-    }
-}
-
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RootNotFound(Blake2bHash);
 

--- a/execution-engine/engine-core/src/execution/error.rs
+++ b/execution-engine/engine-core/src/execution/error.rs
@@ -77,12 +77,6 @@ pub enum Error {
 
 impl wasmi::HostError for Error {}
 
-impl From<!> for Error {
-    fn from(error: !) -> Self {
-        match error {}
-    }
-}
-
 impl From<wasmi::Error> for Error {
     fn from(error: wasmi::Error) -> Self {
         match error

--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(never_type)]
-
 pub mod engine_state;
 pub mod execution;
 pub mod resolvers;

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -44,7 +44,7 @@ impl CountingDb {
 }
 
 impl StateReader<Key, StoredValue> for CountingDb {
-    type Error = !;
+    type Error = String;
     fn read(
         &self,
         _correlation_id: CorrelationId,

--- a/execution-engine/engine-grpc-server/Cargo.toml
+++ b/execution-engine/engine-grpc-server/Cargo.toml
@@ -42,6 +42,13 @@ rand = "0.7.2"
 
 [features]
 test-support = ["engine-core/test-support"]
+no-unstable-features = [
+    "engine-core/no-unstable-features",
+    "engine-shared/no-unstable-features",
+    "engine-storage/no-unstable-features",
+    "engine-wasm-prep/no-unstable-features",
+    "types/no-unstable-features"
+]
 
 [[bin]]
 name = "casperlabs-engine-grpc-server"
@@ -62,3 +69,6 @@ assets = [
 	["packaging/casperlabs-engine-grpc-server.service", "/lib/systemd/system/casperlabs-engine-grpc-server.service", "644"],
 	["../target/release/casperlabs-engine-grpc-server", "/usr/bin/casperlabs-engine-grpc-server", "755"]
 ]
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/engine-shared/Cargo.toml
+++ b/execution-engine/engine-shared/Cargo.toml
@@ -28,6 +28,9 @@ types = { version = "0.4.1", path = "../types", package = "casperlabs-types", fe
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 wabt = "0.9.2"
 
+[features]
+no-unstable-features = ["engine-wasm-prep/no-unstable-features", "types/no-unstable-features"]
+
 [[test]]
 name = "trace-level-metrics-disabled"
 path = "tests/logging/trace_level_metrics_disabled.rs"
@@ -55,3 +58,6 @@ path = "tests/logging/logging_disabled_metrics_enabled.rs"
 [[test]]
 name = "logging-disabled-metrics-disabled"
 path = "tests/logging/logging_disabled_metrics_disabled.rs"
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/engine-shared/src/lib.rs
+++ b/execution-engine/engine-shared/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(never_type)]
-
 pub mod additive_map;
 #[macro_use]
 pub mod gas;

--- a/execution-engine/engine-shared/tests/logging/debug_level_metrics_enabled.rs
+++ b/execution-engine/engine-shared/tests/logging/debug_level_metrics_enabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-shared/tests/logging/error_level_metrics_disabled.rs
+++ b/execution-engine/engine-shared/tests/logging/error_level_metrics_disabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-shared/tests/logging/info_level_metrics_disabled.rs
+++ b/execution-engine/engine-shared/tests/logging/info_level_metrics_disabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-shared/tests/logging/logging_disabled_metrics_disabled.rs
+++ b/execution-engine/engine-shared/tests/logging/logging_disabled_metrics_disabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-shared/tests/logging/logging_disabled_metrics_enabled.rs
+++ b/execution-engine/engine-shared/tests/logging/logging_disabled_metrics_enabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-shared/tests/logging/trace_level_metrics_disabled.rs
+++ b/execution-engine/engine-shared/tests/logging/trace_level_metrics_disabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-shared/tests/logging/warn_level_metrics_enabled.rs
+++ b/execution-engine/engine-shared/tests/logging/warn_level_metrics_enabled.rs
@@ -1,5 +1,3 @@
-#![feature(drain_filter)]
-
 mod common;
 
 use lazy_static::lazy_static;

--- a/execution-engine/engine-storage/Cargo.toml
+++ b/execution-engine/engine-storage/Cargo.toml
@@ -24,3 +24,13 @@ lazy_static = "1"
 proptest = "0.9.4"
 rand = "0.7.2"
 tempfile = "3"
+
+[features]
+no-unstable-features = [
+    "engine-shared/no-unstable-features",
+    "engine-wasm-prep/no-unstable-features",
+    "types/no-unstable-features"
+]
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/engine-storage/src/lib.rs
+++ b/execution-engine/engine-storage/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(never_type)]
-
 // modules
 pub mod error;
 pub mod global_state;

--- a/execution-engine/engine-test-support/Cargo.toml
+++ b/execution-engine/engine-test-support/Cargo.toml
@@ -34,3 +34,15 @@ enable-bonding = []
 use-as-wasm = []
 use-system-contracts = []
 test-support = ["engine-core/test-support", "engine-grpc-server/test-support", "contract/test-support"]
+no-unstable-features = [
+    "contract/no-unstable-features",
+    "engine-core/no-unstable-features",
+    "engine-grpc-server/no-unstable-features",
+    "engine-shared/no-unstable-features",
+    "engine-storage/no-unstable-features",
+    "engine-wasm-prep/no-unstable-features",
+    "types/no-unstable-features"
+]
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/engine-tests/Cargo.toml
+++ b/execution-engine/engine-tests/Cargo.toml
@@ -36,6 +36,16 @@ default = ["contract/std", "contract/test-support", "engine-core/test-support", 
 enable-bonding = ["engine-test-support/enable-bonding"]
 use-as-wasm = ["engine-test-support/use-as-wasm"]
 use-system-contracts = ["engine-test-support/use-system-contracts"]
+no-unstable-features = [
+    "contract/no-unstable-features",
+    "engine-core/no-unstable-features",
+    "engine-grpc-server/no-unstable-features",
+    "engine-shared/no-unstable-features",
+    "engine-storage/no-unstable-features",
+    "engine-test-support/no-unstable-features",
+    "engine-wasm-prep/no-unstable-features",
+    "types/no-unstable-features"
+]
 
 [lib]
 bench = false

--- a/execution-engine/engine-wasm-prep/Cargo.toml
+++ b/execution-engine/engine-wasm-prep/Cargo.toml
@@ -15,3 +15,9 @@ parity-wasm = "0.41.0"
 proptest = "0.9.4"
 pwasm-utils = "0.12.0"
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types", features = ["std"] }
+
+[features]
+no-unstable-features = ["types/no-unstable-features"]
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/mint/Cargo.toml
+++ b/execution-engine/mint/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 
 [features]
 std = ["types/std"]
+no-unstable-features = ["types/no-unstable-features"]
 
 [dependencies]
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types" }
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/proof-of-stake/Cargo.toml
+++ b/execution-engine/proof-of-stake/Cargo.toml
@@ -11,7 +11,11 @@ license-file = "../../LICENSE"
 
 [features]
 std = ["types/std"]
+no-unstable-features = ["types/no-unstable-features"]
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types" }
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/publish.sh
+++ b/execution-engine/publish.sh
@@ -9,7 +9,7 @@ EE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 # should remain ordered from least-dependent to most.
 #
 # Note: 'cargo-casperlabs' is treated specially since it needs '--allow-dirty' passed to the publish call
-PACKAGE_DIRS=( types contract engine-wasm-prep engine-shared engine-storage engine-core engine-grpc-server engine-test-support )
+PACKAGE_DIRS=( types contract engine-wasm-prep mint proof-of-stake standard-payment engine-shared engine-storage engine-core engine-grpc-server engine-test-support )
 
 run_curl() {
     set +e
@@ -75,9 +75,11 @@ publish() {
     else
         printf "Publishing '%s'\n" $CRATE_NAME
         pushd $EE_DIR/$DIR_IN_EE
-        cargo publish
+        cargo publish $2
         popd
         printf "Published '%s' at version %s\n" $CRATE_NAME $DEV_VERSION
+        printf "Sleeping for 60 seconds...\n"
+        sleep 60
     fi
     printf "================================================================================\n\n"
 }

--- a/execution-engine/standard-payment/Cargo.toml
+++ b/execution-engine/standard-payment/Cargo.toml
@@ -11,6 +11,10 @@ license-file = "../../LICENSE"
 
 [features]
 std = ["types/std"]
+no-unstable-features = ["types/no-unstable-features"]
 
 [dependencies]
 types = { version = "0.4.1", path = "../types", package = "casperlabs-types" }
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/types/Cargo.toml
+++ b/execution-engine/types/Cargo.toml
@@ -14,6 +14,7 @@ license-file = "../../LICENSE"
 default = ["base16/alloc"]
 std = ["base16/std"]
 gens = ["std", "proptest/std"]
+no-unstable-features = []
 
 [dependencies]
 base16 = { version = "0.2.1", default-features = false }
@@ -30,3 +31,6 @@ uint = { version = "0.8.2", default-features = false, features = [] }
 [dev-dependencies]
 proptest = "0.9.4"
 version-sync = "0.8"
+
+[package.metadata.docs.rs]
+features = ["no-unstable-features"]

--- a/execution-engine/types/src/key.rs
+++ b/execution-engine/types/src/key.rs
@@ -342,6 +342,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(feature = "no-unstable-features", ignore)]
     fn abuse_vec_key() {
         // Prefix is 2^32-1 = shouldn't allocate that much
         let bytes: Vec<u8> = vec![255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/execution-engine/types/src/key.rs
+++ b/execution-engine/types/src/key.rs
@@ -342,7 +342,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(feature = "no-unstable-features", ignore)]
     fn abuse_vec_key() {
         // Prefix is 2^32-1 = shouldn't allocate that much
         let bytes: Vec<u8> = vec![255, 255, 255, 255, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];

--- a/execution-engine/types/src/lib.rs
+++ b/execution-engine/types/src/lib.rs
@@ -6,7 +6,10 @@
 //! the crate's `std` feature.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(specialization, try_reserve)]
+#![cfg_attr(
+    not(feature = "no-unstable-features"),
+    feature(min_specialization, try_reserve)
+)]
 #![doc(html_root_url = "https://docs.rs/casperlabs-types/0.4.1")]
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/CasperLabs/CasperLabs/dev/images/CasperLabs_Logo_Favicon_RGB_50px.png",


### PR DESCRIPTION
### Overview
This adds a feature named `no-unstable-features` to all published crates (and engine-tests) which disables/works around all usages of unstable lib features.  The main motivation here is to ensure we can build docs for all these crates using stable Rust, which in turn ensures that when publishing a new version, the docs.rs build will succeed.

As per [the docs.rs documentation](https://docs.rs/about#metadata), the PR adds a `[package.metadata.docs.rs]` table to each relevant crate's manifest, specifying that docs.rs should build the crate's docs using the new feature.

**NOTE**: despite this feature allowing us to build using stable Rust, we should not normally do so.  See the notes on `types` below.

With `no-unstable-features` enabled, the changes across the crates are as follows:
* `types`:
    * `min_specialization` unstable feature is disabled and we lose the specializations of `ToBytes` and `FromBytes` for `Vec<u8>` and arrays of `u8`.  **NOTE: this is known to have a serious detrimental effect on performance**
    * `try_reserve` unstable feature is disabled.  ~**NOTE: [`Vec::try_reserve_exact()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.try_reserve_exact) is replaced by `Vec::reserve_exact()` in `FromBytes for Vec<T>`, which can allow malicious or malformed serialized data to cause the EE to terminate with a SIGABRT due to memory overallocation**~  A fallible version of `Vec::with_capacity()` is used as a workaround, and should be removed as soon as `Vec::try_reserve_exact()` becomes stable
* `contract`:
    * enables `std` feature, meaning all unstable features (`alloc_error_handler`, `core_intrinsics` and `lang_items`) are not required and hence disabled.  Note that since docs.rs will build the docs with `std` enabled, the resulting docs will not show [`ALLOC`](https://docs.rs/casperlabs-contract/0.4.1/casperlabs_contract/static.ALLOC.html) nor [`handlers`](https://docs.rs/casperlabs-contract/0.4.1/casperlabs_contract/handlers/index.html).  I don't feel this will be a problem, as I don't think contract writers will be needing to look for the docs on these.  They should just silently work when the contract writer doesn't enable the `std` feature.
* all other crates where the feature was added simply enables the feature in dependent crates

Other changes are as follows:
* the `specialization` unstable feature (which allows unsound code) in `types` is replaced by the `min_specialization` one (which does not). For further info, see rust-lang/rust#68970
* the only contract to have the `no-unstable-features` feature added is `standard-payment-install`, as that is a build dependency of `engine-core`, and must be able to be built with stable Rust.  The feature _could_ be added to all contracts, but there doesn't seem to be any advantage in doing so
* `engine-core` had the `never_type` unstable feature removed, since it was only needed to support a test case in `tracking_copy`
* `engine-shared` and `engine-storage` had the `never_type` unstable feature removed, since it was unused
* `engine-shared` logging tests had the `drain_filter` unstable feature removed, and the use of [`Vec::drain_filter()`](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.drain_filter) replaced by a more verbose approach
* the main Cargo.toml had the `profile-overrides` and `named-profiles` unstable features removed, since they are unneeded
* the EE Makefile was updated to include a target which builds all published crates' docs using stable Rust.  This target was added to .drone.yml to be run for PRs
* the `publish.sh` script was updated as per previous feedback

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/EE-956

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
