### PR TITLE
HWY-48: Implement a generic synchronizer

### DIFF
--- a/execution-engine/Cargo.toml
+++ b/execution-engine/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "consensus/consensus-protocol",
     "consensus/consensus-service",
     "consensus/pothole",
+    "consensus/synchronizer",
     "contract",
     "contracts/[!.]*/*",
     "engine-core",

--- a/execution-engine/consensus/synchronizer/Cargo.toml
+++ b/execution-engine/consensus/synchronizer/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "synchronizer"
+version = "0.1.0"
+authors = ["Bartłomiej Kamiński <bart@casperlabs.io>"]
+edition = "2018"
+description = "A generic synchronizer for consensus protocols - an object capable of tracking missing dependencies and resolving them by communicating with other nodes"
+
+[dependencies]

--- a/execution-engine/consensus/synchronizer/src/lib.rs
+++ b/execution-engine/consensus/synchronizer/src/lib.rs
@@ -1,0 +1,164 @@
+mod traits;
+
+use traits::{ConsensusProtocol, DependencySpec, HandleNewItemResult, ItemWithId, NodeId};
+
+use std::collections::HashMap;
+
+/// Data associated with an item in the queue that is still missing some dependencies
+#[derive(Debug)]
+struct QueueItem<N, C: ConsensusProtocol> {
+    original_sender: N,
+    item: <C::DepSpec as DependencySpec>::Item,
+    dependencies: C::DepSpec,
+}
+
+/// The main synchronizer struct - controlling which items have unresolved dependencies and
+/// handling requests and responses regarding dependency resolution
+#[derive(Debug, Default)]
+pub struct Synchronizer<N: NodeId, C: ConsensusProtocol> {
+    dependency_queue: HashMap<<C::DepSpec as DependencySpec>::ItemId, QueueItem<N, C>>,
+}
+
+/// Messages that can be sent and handled by the synchronizer
+#[derive(Debug)]
+pub enum SynchronizerMessage<D: DependencySpec> {
+    DependencyRequest(D::DependencyDescription),
+    NewItem(D::ItemId, D::Item),
+}
+
+/// Struct aggregating the results of satisfying a new dependency for the items in the queue
+#[derive(Debug)]
+struct SatisfiedDependenciesResult<N: NodeId, C: ConsensusProtocol> {
+    messages: Vec<(N, SynchronizerMessage<C::DepSpec>)>,
+    satisfied_deps: Vec<ItemWithId<C::DepSpec>>,
+}
+
+impl<N: NodeId, C: ConsensusProtocol> Synchronizer<N, C> {
+    /// Creates a new synchronizer
+    pub fn new() -> Self {
+        Self {
+            dependency_queue: Default::default(),
+        }
+    }
+
+    /// Handles a synchronizer message; returns new messages to be sent
+    pub fn handle_message(
+        &mut self,
+        consensus: &mut C,
+        sender: N,
+        message: SynchronizerMessage<C::DepSpec>,
+    ) -> Vec<(N, SynchronizerMessage<C::DepSpec>)> {
+        match message {
+            SynchronizerMessage::DependencyRequest(dependency_descr) => {
+                self.handle_dependency_request(consensus, sender, dependency_descr)
+            }
+            SynchronizerMessage::NewItem(item_id, item) => {
+                self.handle_new_item(consensus, sender, item_id, item)
+            }
+        }
+    }
+
+    fn handle_dependency_request(
+        &mut self,
+        consensus: &mut C,
+        sender: N,
+        dependency_descr: <C::DepSpec as DependencySpec>::DependencyDescription,
+    ) -> Vec<(N, SynchronizerMessage<C::DepSpec>)> {
+        if let Some(ItemWithId { item_id, item }) = consensus.get_dependency(&dependency_descr) {
+            vec![(sender, SynchronizerMessage::NewItem(item_id, item))]
+        } else {
+            // TODO: handle the case when we don't have the requested dependency; currently we'll
+            // just ignore the request
+            // TBD: or maybe it shouldn't even happen, because we shouldn't be sending messages for
+            // which we don't have all the dependencies?
+            vec![]
+        }
+    }
+
+    fn handle_new_item(
+        &mut self,
+        consensus: &mut C,
+        sender: N,
+        item_id: <C::DepSpec as DependencySpec>::ItemId,
+        item: <C::DepSpec as DependencySpec>::Item,
+    ) -> Vec<(N, SynchronizerMessage<C::DepSpec>)> {
+        match consensus.handle_new_item(item_id.clone(), item.clone()) {
+            HandleNewItemResult::Accepted => {
+                let SatisfiedDependenciesResult {
+                    messages,
+                    satisfied_deps,
+                } = self.collect_satisfied_dependencies(item_id);
+                for ItemWithId { item_id, item } in satisfied_deps {
+                    match consensus.handle_new_item(item_id, item) {
+                        HandleNewItemResult::Accepted => (),
+                        _ => panic!("dependencies for an item should already have been satisfied, but weren't!")
+                    }
+                }
+                messages
+            }
+            HandleNewItemResult::Invalid => vec![], // TODO: should we do something here?
+            HandleNewItemResult::DependenciesMissing(mut deps) => {
+                let next_dependency = deps.next_dependency();
+                self.dependency_queue.insert(
+                    item_id,
+                    QueueItem {
+                        original_sender: sender.clone(),
+                        item,
+                        dependencies: deps,
+                    },
+                );
+                next_dependency
+                    .into_iter()
+                    .map(|dep| (sender.clone(), SynchronizerMessage::DependencyRequest(dep)))
+                    .collect()
+            }
+        }
+    }
+
+    fn collect_satisfied_dependencies(
+        &mut self,
+        new_item_id: <C::DepSpec as DependencySpec>::ItemId,
+    ) -> SatisfiedDependenciesResult<N, C> {
+        let messages = self
+            .dependency_queue
+            .iter_mut()
+            .filter_map(|(_, qitem)| {
+                if qitem.dependencies.resolve_dependency(new_item_id.clone()) {
+                    qitem
+                        .dependencies
+                        .next_dependency()
+                        .map(|dep| (qitem.original_sender.clone(), dep))
+                } else {
+                    None
+                }
+            })
+            .map(|(sender, dep)| (sender, SynchronizerMessage::DependencyRequest(dep)))
+            .collect::<Vec<_>>();
+        let satisfied_ids = self
+            .dependency_queue
+            .iter()
+            .filter_map(|(item_id, qitem)| {
+                if qitem.dependencies.all_resolved() {
+                    Some(item_id.clone())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        let satisfied_deps = satisfied_ids
+            .into_iter()
+            .filter_map(|item_id| {
+                self.dependency_queue
+                    .remove(&item_id)
+                    .map(|qitem| ItemWithId {
+                        item_id,
+                        item: qitem.item,
+                    })
+            })
+            .collect();
+        SatisfiedDependenciesResult {
+            messages,
+            satisfied_deps,
+        }
+    }
+}

--- a/execution-engine/consensus/synchronizer/src/lib.rs
+++ b/execution-engine/consensus/synchronizer/src/lib.rs
@@ -134,13 +134,8 @@ impl<N: NodeId, C: ProtocolState> Synchronizer<N, C> {
         let satisfied_ids = self
             .dependency_queue
             .iter()
-            .filter_map(|(item_id, qitem)| {
-                if qitem.dependencies.all_resolved() {
-                    Some(item_id.clone())
-                } else {
-                    None
-                }
-            })
+            .filter(|(_, qitem)| qitem.dependencies.all_resolved())
+            .map(|(item_id, _)| item_id.clone())
             .collect::<Vec<_>>();
         let satisfied_deps = satisfied_ids
             .into_iter()

--- a/execution-engine/consensus/synchronizer/src/lib.rs
+++ b/execution-engine/consensus/synchronizer/src/lib.rs
@@ -1,6 +1,6 @@
 mod traits;
 
-use traits::{DependencySpec, HandleNewItemResult, ItemWithId, NodeId, ProtocolState};
+pub use traits::{DependencySpec, HandleNewItemResult, ItemWithId, NodeId, ProtocolState};
 
 use std::collections::HashMap;
 

--- a/execution-engine/consensus/synchronizer/src/traits.rs
+++ b/execution-engine/consensus/synchronizer/src/traits.rs
@@ -1,0 +1,68 @@
+use std::{fmt::Debug, hash::Hash};
+
+pub trait Item: Clone + Debug {}
+impl<T> Item for T where T: Clone + Debug {}
+
+pub trait NodeId: Clone + Debug {}
+impl<T> NodeId for T where T: Clone + Debug {}
+
+pub trait Identifier: Clone + Debug + Eq + Ord + Hash {}
+impl<T> Identifier for T where T: Clone + Debug + Eq + Ord + Hash {}
+
+/// Trait for structures that can represent dependency requirements for an item.
+/// A struct implementing this trait can yield all the dependencies in a sequence via
+/// `next_dependency` and is able to track which dependencies are still not resolved.
+pub trait DependencySpec: Clone + Debug {
+    /// a type that describes a requirement for resolving dependencies of an item
+    type DependencyDescription: Debug;
+    /// an item that can satisfy a dependency
+    type Item: Item;
+    /// a small piece of data uniquely identifying an Item
+    type ItemId: Identifier;
+
+    /// Returns a next dependency to ask for
+    fn next_dependency(&mut self) -> Option<Self::DependencyDescription>;
+
+    /// called when `item_id` is received - returns whether the dependency was relevant (ie.,
+    /// whether this was actually a dependency of this item)
+    fn resolve_dependency(&mut self, item_id: Self::ItemId) -> bool;
+
+    /// Returns whether all the dependencies are resolved
+    fn all_resolved(&self) -> bool;
+}
+
+/// A result of calling `ConsensusProtocol::handle_new_item`
+#[derive(Debug)]
+pub enum HandleNewItemResult<D: DependencySpec> {
+    Accepted,
+    DependenciesMissing(D),
+    Invalid,
+}
+
+/// A helper type to reduce type complexity in some method definitions
+#[derive(Debug)]
+pub struct ItemWithId<D: DependencySpec> {
+    pub item_id: D::ItemId,
+    pub item: D::Item,
+}
+
+/// Trait abstracting a consensus protocol interface with respect to dependency resolution. Some
+/// messages of a consensus protocol can depend on other messages or other items - this interface
+/// makes it possible for the protocol to signal missing dependencies and let the synchronizer
+/// resolve them.
+pub trait ConsensusProtocol {
+    type DepSpec: DependencySpec;
+
+    /// To be called when the synchronizer is asked for a missing dependency by another node.
+    fn get_dependency(
+        &self,
+        dep: &<Self::DepSpec as DependencySpec>::DependencyDescription,
+    ) -> Option<ItemWithId<Self::DepSpec>>;
+
+    /// To be called when the synchronizer receives a new item from another node.
+    fn handle_new_item(
+        &mut self,
+        item_id: <Self::DepSpec as DependencySpec>::ItemId,
+        item: <Self::DepSpec as DependencySpec>::Item,
+    ) -> HandleNewItemResult<Self::DepSpec>;
+}

--- a/execution-engine/consensus/synchronizer/src/traits.rs
+++ b/execution-engine/consensus/synchronizer/src/traits.rs
@@ -50,7 +50,7 @@ pub struct ItemWithId<D: DependencySpec> {
 /// messages of a consensus protocol can depend on other messages or other items - this interface
 /// makes it possible for the protocol to signal missing dependencies and let the synchronizer
 /// resolve them.
-pub trait ConsensusProtocol {
+pub trait ProtocolState {
     type DepSpec: DependencySpec;
 
     /// To be called when the synchronizer is asked for a missing dependency by another node.

--- a/execution-engine/consensus/synchronizer/tests/structs.rs
+++ b/execution-engine/consensus/synchronizer/tests/structs.rs
@@ -62,7 +62,7 @@ impl DependencySpec for MissingDeps {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct Dag {
     heads: BTreeMap<NodeId, DagIndex>,
     nodes: BTreeMap<DagIndex, DagNode>,

--- a/execution-engine/consensus/synchronizer/tests/structs.rs
+++ b/execution-engine/consensus/synchronizer/tests/structs.rs
@@ -1,0 +1,127 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    mem,
+};
+
+use synchronizer::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct NodeId(pub &'static str);
+
+impl From<&'static str> for NodeId {
+    fn from(s: &'static str) -> Self {
+        Self(s)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DagIndex(NodeId, usize);
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct DagNode {
+    pub data: Option<String>,
+    pub parents: BTreeSet<DagIndex>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MissingDeps {
+    to_be_returned: BTreeSet<DagIndex>,
+    returned_deps: BTreeSet<DagIndex>,
+}
+
+impl MissingDeps {
+    pub fn new(deps: BTreeSet<DagIndex>) -> Self {
+        Self {
+            to_be_returned: deps,
+            returned_deps: BTreeSet::new(),
+        }
+    }
+}
+
+impl DependencySpec for MissingDeps {
+    type DependencyDescription = DagIndex;
+    type ItemId = DagIndex;
+    type Item = DagNode;
+
+    fn next_dependency(&mut self) -> Option<Self::DependencyDescription> {
+        let mut deps = mem::take(&mut self.to_be_returned).into_iter();
+        let next_dep = deps.next();
+        self.to_be_returned = deps.collect();
+        if let Some(dep) = next_dep {
+            self.returned_deps.insert(dep);
+        }
+        next_dep
+    }
+
+    fn resolve_dependency(&mut self, dep: DagIndex) -> bool {
+        self.to_be_returned.remove(&dep) || self.returned_deps.remove(&dep)
+    }
+
+    fn all_resolved(&self) -> bool {
+        self.to_be_returned.is_empty() && self.returned_deps.is_empty()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Dag {
+    heads: BTreeMap<NodeId, DagIndex>,
+    nodes: BTreeMap<DagIndex, DagNode>,
+}
+
+impl ProtocolState for Dag {
+    type DepSpec = MissingDeps;
+
+    fn get_dependency(&self, dep: &DagIndex) -> Option<ItemWithId<MissingDeps>> {
+        self.nodes.get(dep).map(|node| ItemWithId {
+            item_id: *dep,
+            item: node.clone(),
+        })
+    }
+
+    fn handle_new_item(
+        &mut self,
+        item_id: DagIndex,
+        item: DagNode,
+    ) -> HandleNewItemResult<MissingDeps> {
+        match self.nodes.get(&item_id) {
+            Some(existing_item) if existing_item == &item => HandleNewItemResult::Accepted,
+            Some(_) => HandleNewItemResult::Invalid,
+            None => {
+                let missing_parents = item
+                    .parents
+                    .iter()
+                    .filter(|&parent| !self.nodes.contains_key(parent))
+                    .cloned()
+                    .collect::<BTreeSet<_>>();
+                if missing_parents.is_empty() {
+                    self.nodes.insert(item_id, item);
+                    self.heads.insert(item_id.0, item_id);
+                    HandleNewItemResult::Accepted
+                } else {
+                    HandleNewItemResult::DependenciesMissing(MissingDeps::new(missing_parents))
+                }
+            }
+        }
+    }
+}
+
+impl Dag {
+    pub fn new() -> Self {
+        Self {
+            heads: BTreeMap::new(),
+            nodes: BTreeMap::new(),
+        }
+    }
+
+    pub fn create_node(&mut self, our_id: NodeId, data: Option<String>) -> (DagIndex, DagNode) {
+        let new_index = DagIndex(
+            our_id,
+            self.heads.get(&our_id).map(|index| index.1).unwrap_or(0),
+        );
+        let parents = self.heads.values().cloned().collect();
+        let node = DagNode { data, parents };
+        self.nodes.insert(new_index, node.clone());
+        self.heads.insert(our_id, new_index);
+        (new_index, node)
+    }
+}

--- a/execution-engine/consensus/synchronizer/tests/tests.rs
+++ b/execution-engine/consensus/synchronizer/tests/tests.rs
@@ -1,0 +1,104 @@
+mod structs;
+
+use std::collections::HashMap;
+
+use synchronizer::{Synchronizer, SynchronizerMessage};
+
+use structs::{Dag, DagIndex, DagNode, MissingDeps, NodeId};
+
+#[derive(Debug)]
+struct Node {
+    our_id: NodeId,
+    dag: Dag,
+    synchronizer: Synchronizer<NodeId, Dag>,
+}
+
+impl Node {
+    fn new(our_id: NodeId) -> Self {
+        Self {
+            our_id,
+            dag: Dag::new(),
+            synchronizer: Synchronizer::new(),
+        }
+    }
+
+    fn create_vertex(&mut self, data: Option<String>) -> (DagIndex, DagNode) {
+        self.dag.create_node(self.our_id, data)
+    }
+
+    fn handle_message(
+        &mut self,
+        sender: NodeId,
+        msg: SynchronizerMessage<MissingDeps>,
+    ) -> Vec<(NodeId, SynchronizerMessage<MissingDeps>)> {
+        self.synchronizer.handle_message(&mut self.dag, sender, msg)
+    }
+}
+
+#[derive(Debug)]
+struct Nodes(HashMap<&'static str, Node>);
+
+impl Nodes {
+    fn new(ids: Vec<&'static str>) -> Self {
+        Self(
+            ids.into_iter()
+                .map(|nid| (nid, Node::new(nid.into())))
+                .collect(),
+        )
+    }
+
+    fn node(&self, id: &'static str) -> &Node {
+        self.0.get(id).unwrap()
+    }
+
+    fn node_mut(&mut self, id: &'static str) -> &mut Node {
+        self.0.get_mut(id).unwrap()
+    }
+}
+
+#[test]
+fn test_synchronizer() {
+    let mut nodes = Nodes::new(vec!["Alice", "Bob", "Carol"]);
+
+    let (index, item) = nodes
+        .node_mut("Alice")
+        .create_vertex(Some("alice_data".to_owned()));
+
+    // let Bob handle the new item from Alice - should get accepted and no new messages should be
+    // generated
+    assert!(nodes
+        .node_mut("Bob")
+        .handle_message("Alice".into(), SynchronizerMessage::NewItem(index, item))
+        .is_empty());
+
+    let (index, item) = nodes
+        .node_mut("Bob")
+        .create_vertex(Some("bob_data".to_owned()));
+    assert_eq!(item.parents.len(), 1);
+
+    // Carol will handle Bob's message - but his item will depend on Alice's item, which Carol
+    // doesn't have yet, so she should request it
+    let mut messages = nodes
+        .node_mut("Carol")
+        .handle_message("Bob".into(), SynchronizerMessage::NewItem(index, item));
+    assert_eq!(messages.len(), 1);
+    let (target, message) = messages.pop().unwrap();
+    assert_eq!(target, "Bob".into());
+
+    // Bob will now handle Carol's request - he should respond with a new item message
+    let mut response = nodes
+        .node_mut(target.0)
+        .handle_message("Carol".into(), message);
+    assert_eq!(response.len(), 1);
+    let (target, message) = response.pop().unwrap();
+    assert_eq!(target, "Carol".into());
+
+    // Carol should now handle Bob's response and complete her DAG
+    assert!(nodes
+        .node_mut(target.0)
+        .handle_message("Bob".into(), message)
+        .is_empty());
+
+    // Bob's and Carol's DAGs should now be consistent
+    assert_eq!(nodes.node("Bob").dag, nodes.node("Carol").dag);
+}


### PR DESCRIPTION
### Overview
This provides a module that is able to track the dependencies of consensus protocol messages/items. It's required as a part of the pluggable consensus protocol implementation.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-48

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
