### PR TITLE
HWY-31, HWY-32: Panorama validation.

### DIFF
--- a/execution-engine/consensus/highway-core/Cargo.toml
+++ b/execution-engine/consensus/highway-core/Cargo.toml
@@ -9,3 +9,5 @@ repository = "https://github.com/CasperLabs/CasperLabs"
 license-file = "../LICENSE"
 
 [dependencies]
+displaydoc = "0.1.6"
+thiserror = "1.0.17"

--- a/execution-engine/consensus/highway-core/src/block.rs
+++ b/execution-engine/consensus/highway-core/src/block.rs
@@ -1,4 +1,4 @@
-use crate::traits::Context;
+use crate::{state::State, traits::Context};
 
 /// A block: Chains of blocks are the consensus values in the CBC Casper sense.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -9,4 +9,21 @@ pub struct Block<C: Context> {
     pub height: u64,
     /// The payload, e.g. a list of transactions.
     pub values: Vec<C::ConsensusValue>,
+}
+
+impl<C: Context> Block<C> {
+    /// Creates a new block with the given parent and values. Panics if parent does not exist.
+    pub fn new(
+        parent: Option<C::VoteHash>,
+        values: Vec<C::ConsensusValue>,
+        state: &State<C>,
+    ) -> Block<C> {
+        let parent_plus_one = |hash| state.block(hash).height + 1;
+        let height = parent.as_ref().map_or(0, parent_plus_one);
+        Block {
+            parent,
+            height,
+            values,
+        }
+    }
 }

--- a/execution-engine/consensus/highway-core/src/evidence.rs
+++ b/execution-engine/consensus/highway-core/src/evidence.rs
@@ -1,4 +1,4 @@
-use crate::{traits::Context, vertex::WireVote};
+use crate::{traits::Context, validators::ValidatorIndex, vertex::WireVote};
 
 /// Evidence that a validator is faulty.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -11,9 +11,9 @@ impl<C: Context> Evidence<C> {
     // TODO: Verify whether the evidence is conclusive. Or as part of deserialization?
 
     /// Returns the ID of the faulty validator.
-    pub(crate) fn perpetrator(&self) -> &C::ValidatorId {
+    pub(crate) fn perpetrator(&self) -> ValidatorIndex {
         match self {
-            Evidence::Equivocation(vote0, _) => &vote0.sender,
+            Evidence::Equivocation(vote0, _) => vote0.sender,
         }
     }
 }

--- a/execution-engine/consensus/highway-core/src/highway.rs
+++ b/execution-engine/consensus/highway-core/src/highway.rs
@@ -1,0 +1,100 @@
+use std::time::Duration;
+
+use crate::{
+    evidence::Evidence,
+    state::{AddVoteError, State},
+    traits::Context,
+    validators::Validators,
+    vertex::{Dependency, Vertex, WireVote},
+};
+
+/// The result of trying to add a vertex to the protocol highway.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AddVertexOutcome<C: Context> {
+    /// The vertex was successfully added.
+    Success,
+    /// The vertex could not be added because it is missing a dependency. The vertex itself is
+    /// returned, together with the missing dependency.
+    MissingDependency(Vertex<C>, Dependency<C>),
+    /// The vertex is invalid and cannot be added to the protocol highway at all.
+    // TODO: Distinction — is it the vertex creator's attributable fault?
+    Invalid(Vertex<C>),
+}
+
+impl<C: Context> From<AddVoteError<C>> for AddVertexOutcome<C> {
+    fn from(err: AddVoteError<C>) -> Self {
+        // TODO: debug!("Invalid vote: {}", err);
+        Self::Invalid(Vertex::Vote(err.wvote))
+    }
+}
+
+#[derive(Debug)]
+pub struct HighwayParams<C: Context> {
+    /// The protocol instance ID. This needs to be unique, to prevent replay attacks.
+    // TODO: Add this to every `WireVote`?
+    instance_id: C::InstanceId,
+    /// The validator IDs and weight map.
+    validators: Validators<C::ValidatorId>,
+    /// The duration of a single tick.
+    tick_length: Duration,
+}
+
+/// A passive instance of the Highway protocol, containing its local highway.
+///
+/// Both observers and active validators must instantiate this, pass in all incoming vertices from
+/// peers, and use a [FinalityDetector](../finality_detector/struct.FinalityDetector.html) to
+/// determine the outcome of the consensus process.
+#[derive(Debug)]
+pub struct Highway<C: Context> {
+    /// The parameters that remain constant for the duration of this consensus instance.
+    params: HighwayParams<C>,
+    /// The abstract protocol state.
+    state: State<C>,
+}
+
+impl<C: Context> Highway<C> {
+    /// Try to add an incoming vertex to the protocol highway.
+    ///
+    /// If the vertex is invalid, or if there are dependencies that need to be added first, returns
+    /// `Invalid` resp. `MissingDependency`.
+    pub fn add_vertex(&mut self, vertex: Vertex<C>) -> AddVertexOutcome<C> {
+        match vertex {
+            Vertex::Vote(vote) => self.add_vote(vote),
+            Vertex::Evidence(evidence) => self.add_evidence(evidence),
+        }
+    }
+
+    /// Returns a vertex that satisfies the dependency, if available.
+    ///
+    /// If we send a vertex to a peer who is missing a dependency, they will ask us for it. In that
+    /// case, `get_dependency` will always return `Some`, unless the peer is faulty.
+    pub fn get_dependency(&self, dependency: Dependency<C>) -> Option<Vertex<C>> {
+        let state = &self.state;
+        match dependency {
+            Dependency::Vote(hash) => state.wire_vote(hash).map(Vertex::Vote),
+            Dependency::Evidence(idx) => state.opt_evidence(idx).cloned().map(Vertex::Evidence),
+        }
+    }
+
+    fn add_vote(&mut self, wvote: WireVote<C>) -> AddVertexOutcome<C> {
+        if !self.params.validators.contains(wvote.sender) {
+            return AddVertexOutcome::Invalid(Vertex::Vote(wvote));
+        }
+        if let Some(dep) = self.state.missing_dependency(&wvote.panorama) {
+            return AddVertexOutcome::MissingDependency(Vertex::Vote(wvote), dep);
+        }
+        // If the vote is invalid, `add_vote` returns it as an error.
+        let opt_wvote = self.state.add_vote(wvote).err();
+        opt_wvote.map_or(AddVertexOutcome::Success, AddVertexOutcome::from)
+    }
+
+    fn add_evidence(&mut self, evidence: Evidence<C>) -> AddVertexOutcome<C> {
+        // TODO: Validate evidence. Signatures, sequence numbers, etc.
+        if self.params.validators.contains(evidence.perpetrator()) {
+            self.state.add_evidence(evidence);
+            AddVertexOutcome::Success
+        } else {
+            AddVertexOutcome::Invalid(Vertex::Evidence(evidence))
+        }
+    }
+}

--- a/execution-engine/consensus/highway-core/src/lib.rs
+++ b/execution-engine/consensus/highway-core/src/lib.rs
@@ -29,11 +29,12 @@
 
 pub mod active_validator;
 pub mod finality_detector;
-pub mod state;
+pub mod highway;
 pub mod traits;
 pub mod vertex;
 
 mod block;
 mod evidence;
+mod state;
 mod validators;
 mod vote;

--- a/execution-engine/consensus/highway-core/src/state.rs
+++ b/execution-engine/consensus/highway-core/src/state.rs
@@ -298,6 +298,8 @@ mod tests {
         type InstanceId = &'static str;
     }
 
+    /// Converts a string to an observation: "F" means faulty, "_" means none, and other strings
+    /// are used as the identifier ("hash") of a correct vote.
     fn to_obs(s: &&'static str) -> Observation<TestContext> {
         match *s {
             "_" => Observation::None,
@@ -306,11 +308,12 @@ mod tests {
         }
     }
 
+    /// Creates a panorama based on observation descriptions as in `to_obs`.
     fn panorama(observations: [&'static str; 3]) -> Panorama<TestContext> {
         Panorama(observations.iter().map(to_obs).collect())
     }
 
-    /// Creates a new vote. The hash should be a letter, followed by the sequence number.
+    /// Creates a new ballot vote. The hash must be a letter, followed by the sequence number.
     fn vote(
         hash: &'static str,
         sender: ValidatorIndex,
@@ -326,12 +329,14 @@ mod tests {
     }
 
     impl WireVote<TestContext> {
+        /// Adds values to the vote, turning it into a new block.
         fn val(mut self, values: Vec<&'static str>) -> Self {
             self.values = Some(values);
             self
         }
     }
 
+    /// Returns the cause of the error, dropping the `WireVote`.
     fn vote_err(err: AddVoteError<TestContext>) -> VoteError {
         err.cause
     }

--- a/execution-engine/consensus/highway-core/src/state.rs
+++ b/execution-engine/consensus/highway-core/src/state.rs
@@ -1,35 +1,40 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
+
+use displaydoc::Display;
+use thiserror::Error;
 
 use crate::{
     block::Block,
     evidence::Evidence,
     traits::Context,
-    validators::{ValidatorIndex, Validators},
-    vertex::{Dependency, Vertex, WireVote},
+    validators::ValidatorIndex,
+    vertex::{Dependency, WireVote},
     vote::{Observation, Panorama, Vote},
 };
 
-/// The result of trying to add a vertex to the protocol state.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AddVertexOutcome<C: Context> {
-    /// The vertex was successfully added.
-    Success,
-    /// The vertex could not be added because it is missing a dependency. The vertex itself is
-    /// returned, together with the missing dependency.
-    MissingDependency(Vertex<C>, Dependency<C>),
-    /// The vertex is invalid and cannot be added to the protocol state at all.
-    // TODO: Distinction — is it the vertex creator's attributable fault?
-    Invalid(Vertex<C>),
+/// An error that occurred when trying to add a vote.
+#[derive(Debug, Error)]
+#[error("{:?}", .cause)]
+pub struct AddVoteError<C: Context> {
+    /// The invalid vote that was not added to the protocol state.
+    pub wvote: WireVote<C>,
+    /// The reason the vote is invalid.
+    #[source]
+    pub cause: VoteError,
 }
 
-#[derive(Debug)]
-pub struct StateParams<C: Context> {
-    /// The protocol instance ID. This needs to be unique, to prevent replay attacks.
-    instance_id: C::InstanceId,
-    /// The validator IDs and weight map.
-    validators: Validators<C::ValidatorId>,
-    /// The duration of a single tick.
-    tick_length: Duration,
+#[derive(Debug, Display, Error, PartialEq)]
+pub enum VoteError {
+    /// The vote's panorama is inconsistent.
+    Panorama,
+    /// The vote contains the wrong sequence number.
+    SequenceNumber,
+}
+
+impl<C: Context> WireVote<C> {
+    fn with_error(self, cause: VoteError) -> AddVoteError<C> {
+        AddVoteError { wvote: self, cause }
+    }
 }
 
 /// A passive instance of the Highway protocol, containing its local state.
@@ -39,8 +44,6 @@ pub struct StateParams<C: Context> {
 /// determine the outcome of the consensus process.
 #[derive(Debug)]
 pub struct State<C: Context> {
-    /// The parameters that remain constant for the duration of this consensus instance.
-    params: StateParams<C>,
     /// All votes imported so far, by hash.
     // TODO: HashMaps prevent deterministic tests.
     votes: HashMap<C::VoteHash, Vote<C>>,
@@ -48,101 +51,337 @@ pub struct State<C: Context> {
     blocks: HashMap<C::VoteHash, Block<C>>,
     /// Evidence to prove a validator malicious, by index.
     evidence: HashMap<ValidatorIndex, Evidence<C>>,
+    /// The full panorama, corresponding to the complete protocol state.
+    panorama: Panorama<C>,
 }
 
 impl<C: Context> State<C> {
-    /// Try to add an incoming vertex to the protocol state.
-    ///
-    /// If the vertex is invalid, or if there are dependencies that need to be added first, returns
-    /// `Invalid` resp. `MissingDependency`.
-    pub fn add_vertex(&mut self, vertex: Vertex<C>) -> AddVertexOutcome<C> {
-        match vertex {
-            Vertex::Vote(vote) => self.add_vote(vote),
-            Vertex::Evidence(evidence) => self.add_evidence(evidence),
+    pub fn new(num_validators: usize) -> State<C> {
+        State {
+            votes: HashMap::new(),
+            blocks: HashMap::new(),
+            evidence: HashMap::new(),
+            panorama: Panorama::new(num_validators),
         }
     }
 
-    /// Returns a vertex that satisfies the dependency, if available.
-    ///
-    /// If we send a vertex to a peer who is missing a dependency, they will ask us for it. In that
-    /// case, `get_dependency` will always return `Some`, unless the peer is faulty.
-    pub fn get_dependency(&self, dependency: Dependency<C>) -> Option<Vertex<C>> {
-        match dependency {
-            Dependency::Evidence(idx) => self.evidence.get(&idx).cloned().map(Vertex::Evidence),
-            Dependency::Vote(hash) => self.wire_vote(hash).map(Vertex::Vote),
-        }
+    /// Returns evidence against validator nr. `idx`, if present.
+    pub fn opt_evidence(&self, idx: ValidatorIndex) -> Option<&Evidence<C>> {
+        self.evidence.get(&idx)
     }
 
-    fn wire_vote(&self, hash: C::VoteHash) -> Option<WireVote<C>> {
-        let vote = self.votes.get(&hash)?.clone();
-        let values = self.blocks.get(&hash).map(|block| block.values.clone());
+    /// Returns whether evidence against validator nr. `idx` is known.
+    pub fn has_evidence(&self, idx: ValidatorIndex) -> bool {
+        self.evidence.contains_key(&idx)
+    }
+
+    /// Returns the vote with the given hash, if present.
+    pub fn opt_vote(&self, hash: &C::VoteHash) -> Option<&Vote<C>> {
+        self.votes.get(hash)
+    }
+
+    /// Returns whether the vote with the given hash is known.
+    pub fn has_vote(&self, hash: &C::VoteHash) -> bool {
+        self.votes.contains_key(hash)
+    }
+
+    /// Returns the vote with the given hash. Panics if not found.
+    pub fn vote(&self, hash: &C::VoteHash) -> &Vote<C> {
+        self.opt_vote(hash).unwrap()
+    }
+
+    /// Returns the block contained in the vote with the given hash, if present.
+    pub fn opt_block(&self, hash: &C::VoteHash) -> Option<&Block<C>> {
+        self.blocks.get(hash)
+    }
+
+    /// Returns the block contained in the vote with the given hash. Panics if not found.
+    pub fn block(&self, hash: &C::VoteHash) -> &Block<C> {
+        self.opt_block(hash).unwrap()
+    }
+
+    /// Adds the vote to the protocol state, or returns an error if it is invalid.
+    /// Panics if dependencies are not satisfied.
+    pub fn add_vote(&mut self, wvote: WireVote<C>) -> Result<(), AddVoteError<C>> {
+        if let Err(err) = self.validate_vote(&wvote) {
+            return Err(wvote.with_error(err));
+        }
+        self.update_panorama(&wvote);
+        let hash = wvote.hash.clone();
+        let fork_choice = self.fork_choice(&wvote.panorama).cloned();
+        let (vote, opt_values) = Vote::new(wvote, fork_choice.as_ref());
+        if let Some(values) = opt_values {
+            let block = Block::new(fork_choice, values, self);
+            self.blocks.insert(hash.clone(), block);
+        }
+        self.votes.insert(hash, vote);
+        Ok(())
+    }
+
+    pub fn add_evidence(&mut self, evidence: Evidence<C>) {
+        let idx = evidence.perpetrator();
+        self.evidence.insert(idx, evidence);
+    }
+
+    pub fn wire_vote(&self, hash: C::VoteHash) -> Option<WireVote<C>> {
+        let vote = self.opt_vote(&hash)?.clone();
+        let opt_block = self.opt_block(&hash);
+        let values = opt_block.map(|block| block.values.clone());
         Some(WireVote {
             hash,
             panorama: vote.panorama.clone(),
-            sender: self.params.validators.id_of(vote.sender_idx).clone(),
+            sender: vote.sender,
             values,
             seq_number: vote.seq_number,
         })
     }
 
-    fn missing_dependency(&self, vote: &WireVote<C>) -> Option<Dependency<C>> {
-        for (idx, observation) in vote.panorama.0.iter().enumerate() {
-            match observation {
-                Observation::Faulty if !self.evidence.contains_key(&idx.into()) => {
-                    return Some(Dependency::Evidence(idx.into()));
+    /// Returns the first missing dependency of the panorama, or `None` if all are satisfied.
+    pub fn missing_dependency(&self, panorama: &Panorama<C>) -> Option<Dependency<C>> {
+        let missing_dep = |(idx, obs)| self.missing_obs_dep(idx, obs);
+        panorama.enumerate().filter_map(missing_dep).next()
+    }
+
+    /// Returns an error if `wvote` is invalid.
+    fn validate_vote(&self, wvote: &WireVote<C>) -> Result<(), VoteError> {
+        let sender = wvote.sender;
+        // Check that the panorama is consistent.
+        if (wvote.values.is_none() && wvote.panorama.is_empty())
+            || !self.is_panorama_valid(&wvote.panorama)
+        {
+            return Err(VoteError::Panorama);
+        }
+        // Check that the vote's sequence number is one more than the sender's previous one.
+        let expected_seq_number = match wvote.panorama.get(sender) {
+            Observation::Faulty => return Err(VoteError::Panorama),
+            Observation::None => 0,
+            Observation::Correct(hash) => 1 + self.vote(hash).seq_number,
+        };
+        if wvote.seq_number != expected_seq_number {
+            return Err(VoteError::SequenceNumber);
+        }
+        Ok(())
+    }
+
+    /// Update `self.panorama` with an incoming vote. Panics if dependencies are missing.
+    ///
+    /// If the new vote is valid, it will just add `Observation::Correct(wvote.hash)` to the
+    /// panorama. If it represents an equivocation, it adds `Observation::Faulty` and updates
+    /// `self.evidence`.
+    fn update_panorama(&mut self, wvote: &WireVote<C>) {
+        let sender = wvote.sender;
+        let new_obs = match (self.panorama.get(sender), wvote.panorama.get(sender)) {
+            (Observation::Faulty, _) => Observation::Faulty,
+            (obs0, obs1) if obs0 == obs1 => Observation::Correct(wvote.hash.clone()),
+            (Observation::None, _) => panic!("missing own previous vote"),
+            (Observation::Correct(hash0), _) => {
+                if !self.has_evidence(sender) {
+                    let prev0 = self.find_in_swimlane(hash0, wvote.seq_number);
+                    let wvote0 = self.wire_vote(prev0.clone()).unwrap();
+                    self.add_evidence(Evidence::Equivocation(wvote0, wvote.clone()));
                 }
-                Observation::Correct(hash) if !self.votes.contains_key(hash) => {
-                    return Some(Dependency::Vote(hash.clone()));
-                }
-                _ => (),
+                Observation::Faulty
+            }
+        };
+        self.panorama.update(wvote.sender, new_obs);
+    }
+
+    fn fork_choice(&self, pan: &Panorama<C>) -> Option<&C::VoteHash> {
+        // TODO! For now, just agrees with the first correct vote.
+        let hash = pan.0.iter().filter_map(Observation::correct).next()?;
+        Some(&self.vote(hash).block)
+    }
+
+    /// Returns the hash of the message with the given sequence number from the sender of `hash`.
+    fn find_in_swimlane<'a>(
+        &'a self,
+        mut hash: &'a C::VoteHash,
+        seq_number: u64,
+    ) -> &'a C::VoteHash {
+        loop {
+            let vote = self.vote(hash);
+            if vote.seq_number == seq_number {
+                return hash;
+            }
+            hash = match vote.panorama.get(vote.sender) {
+                Observation::Correct(new_hash) => new_hash,
+                Observation::None => return hash,
+                _ => panic!("message cannot accuse its own sender"),
             }
         }
-        None
     }
 
-    fn add_vote(&mut self, wvote: WireVote<C>) -> AddVertexOutcome<C> {
-        if let Some(dep) = self.missing_dependency(&wvote) {
-            return AddVertexOutcome::MissingDependency(Vertex::Vote(wvote), dep);
+    /// Returns `pan` is valid, i.e. it contains the latest votes of some substate of `self`.
+    fn is_panorama_valid(&self, pan: &Panorama<C>) -> bool {
+        pan.enumerate().all(|(idx, observation)| {
+            match observation {
+                Observation::None => true,
+                Observation::Faulty => self.has_evidence(idx),
+                Observation::Correct(hash) => match self.opt_vote(hash) {
+                    Some(vote) => vote.sender == idx && self.panorama_geq(pan, &vote.panorama),
+                    None => false, // Unknown vote. Not a substate of `state`.
+                },
+            }
+        })
+    }
+
+    /// Returns whether `pan_l` can possibly come later in time than `pan_r`, i.e. it can see
+    /// every honest message and every fault seen by `other`.
+    fn panorama_geq(&self, pan_l: &Panorama<C>, pan_r: &Panorama<C>) -> bool {
+        let mut pairs_iter = pan_l.0.iter().zip(&pan_r.0);
+        pairs_iter.all(|(obs_l, obs_r)| self.obs_geq(obs_l, obs_r))
+    }
+
+    /// Returns `true` if `pan` sees the sender of `hash` as correct, and sees that vote.
+    fn sees_correct(&self, pan: &Panorama<C>, hash: &C::VoteHash) -> bool {
+        match &pan.get(self.vote(hash).sender) {
+            Observation::Faulty | Observation::None => false,
+            Observation::Correct(seen_hash) => {
+                // TODO: Use skip lists, not recursion.
+                seen_hash == hash || self.sees_correct(&self.vote(seen_hash).panorama, hash)
+            }
         }
-        let hash = wvote.hash.clone();
-        let fork_choice: Option<C::VoteHash> = self.fork_choice(&wvote.panorama);
-        let block = if let Some(values) = wvote.values {
-            let height = fork_choice
-                .as_ref()
-                .map_or(0, |hash| self.blocks[hash].height + 1);
-            let block = Block {
-                parent: fork_choice,
-                height,
-                values,
-            };
-            self.blocks.insert(hash.clone(), block);
-            hash.clone()
-        } else {
-            // If the vote didn't introduce a new block, it votes for the fork choice itself.
-            fork_choice.unwrap()
-        };
-        // TODO: Validation; e.g. invalid sender.
-        let sender_idx = self.params.validators.index_of(&wvote.sender).unwrap();
-        let vote = Vote {
-            panorama: wvote.panorama,
-            seq_number: wvote.seq_number,
-            sender_idx,
-            block,
-        };
-        self.votes.insert(hash, vote);
-        AddVertexOutcome::Success
     }
 
-    fn add_evidence(&mut self, evidence: Evidence<C>) -> AddVertexOutcome<C> {
-        if let Some(idx) = self.params.validators.index_of(evidence.perpetrator()) {
-            self.evidence.insert(idx, evidence);
-        } else {
-            return AddVertexOutcome::Invalid(Vertex::Evidence(evidence));
+    /// Returns whether `obs_l` can come later in time than `obs_r`.
+    fn obs_geq(&self, obs_l: &Observation<C>, obs_r: &Observation<C>) -> bool {
+        match (obs_l, obs_r) {
+            (Observation::Faulty, _) | (_, Observation::None) => true,
+            (Observation::Correct(hash0), Observation::Correct(hash1)) => {
+                hash0 == hash1 || self.sees_correct(&self.vote(hash0).panorama, hash1)
+            }
+            (_, _) => false,
         }
-        AddVertexOutcome::Success
     }
 
-    fn fork_choice(&self, panorama: &Panorama<C::VoteHash>) -> Option<C::VoteHash> {
-        todo!("{:?}", panorama)
+    /// Returns the missing dependency if `obs` is referring to a vertex we don't know yet.
+    fn missing_obs_dep(&self, idx: ValidatorIndex, obs: &Observation<C>) -> Option<Dependency<C>> {
+        match obs {
+            Observation::Faulty if !self.has_evidence(idx) => Some(Dependency::Evidence(idx)),
+            Observation::Correct(hash) if !self.has_vote(hash) => {
+                Some(Dependency::Vote(hash.clone()))
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::traits::ValidatorSecret;
+
+    use super::*;
+
+    const NUM_VALIDATORS: usize = 3;
+
+    const ALICE: ValidatorIndex = ValidatorIndex(0);
+    const BOB: ValidatorIndex = ValidatorIndex(1);
+    const CAROL: ValidatorIndex = ValidatorIndex(2);
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct TestContext;
+
+    #[derive(Debug)]
+    struct TestSecret(u64);
+
+    impl ValidatorSecret for TestSecret {
+        type Signature = u64;
+
+        fn sign(&self, _data: &[u8]) -> Vec<u8> {
+            unimplemented!()
+        }
+    }
+
+    impl Context for TestContext {
+        type ConsensusValue = &'static str;
+        type ValidatorId = &'static str;
+        type ValidatorSecret = TestSecret;
+        type VoteHash = &'static str;
+        type InstanceId = &'static str;
+    }
+
+    fn to_obs(s: &&'static str) -> Observation<TestContext> {
+        match *s {
+            "_" => Observation::None,
+            "F" => Observation::Faulty,
+            s => Observation::Correct(s),
+        }
+    }
+
+    fn panorama(observations: [&'static str; 3]) -> Panorama<TestContext> {
+        Panorama(observations.iter().map(to_obs).collect())
+    }
+
+    /// Creates a new vote. The hash should be a letter, followed by the sequence number.
+    fn vote(
+        hash: &'static str,
+        sender: ValidatorIndex,
+        observations: [&'static str; 3],
+    ) -> WireVote<TestContext> {
+        WireVote {
+            hash,
+            panorama: panorama(observations),
+            sender,
+            values: None,
+            seq_number: hash[1..].parse().unwrap(),
+        }
+    }
+
+    impl WireVote<TestContext> {
+        fn val(mut self, values: Vec<&'static str>) -> Self {
+            self.values = Some(values);
+            self
+        }
+    }
+
+    fn vote_err(err: AddVoteError<TestContext>) -> VoteError {
+        err.cause
+    }
+
+    #[test]
+    fn add_vote() -> Result<(), AddVoteError<TestContext>> {
+        let mut state = State::new(NUM_VALIDATORS);
+
+        // Create votes as follows:
+        //
+        // Alice: a0 ————— a1
+        //                /
+        // Bob:   b0 —— b1
+        //          \  /
+        // Carol:    c0
+        state.add_vote(vote("a0", ALICE, ["_", "_", "_"]).val(vec!["a"]))?;
+        state.add_vote(vote("b0", BOB, ["_", "_", "_"]).val(vec!["b"]))?;
+        state.add_vote(vote("c0", CAROL, ["_", "b0", "_"]))?;
+        state.add_vote(vote("b1", BOB, ["_", "b0", "c0"]))?;
+        state.add_vote(vote("a1", ALICE, ["a0", "b1", "c0"]))?;
+
+        // Wrong sequence number: Carol hasn't produced c1 yet.
+        let opt_err = state.add_vote(vote("c2", CAROL, ["_", "b1", "c0"])).err();
+        assert_eq!(Some(VoteError::SequenceNumber), opt_err.map(vote_err));
+        // Inconsistent panorama: If you see b1, you have to see c0, too.
+        let opt_err = state.add_vote(vote("c1", CAROL, ["_", "b1", "_"])).err();
+        assert_eq!(Some(VoteError::Panorama), opt_err.map(vote_err));
+
+        // Alice has not equivocated yet, and not produced message A1.
+        let missing = state.missing_dependency(&panorama(["F", "b1", "c0"]));
+        assert_eq!(Some(Dependency::Evidence(ALICE)), missing);
+        let missing = state.missing_dependency(&panorama(["A1", "b1", "c0"]));
+        assert_eq!(Some(Dependency::Vote("A1")), missing);
+
+        // Alice equivocates: A1 doesn't see a1.
+        state.add_vote(vote("A1", ALICE, ["a0", "b1", "c0"]))?;
+        assert!(state.has_evidence(ALICE));
+
+        let missing = state.missing_dependency(&panorama(["F", "b1", "c0"]));
+        assert_eq!(None, missing);
+        let missing = state.missing_dependency(&panorama(["A1", "b1", "c0"]));
+        assert_eq!(None, missing);
+
+        // Bob can see the equivocation.
+        state.add_vote(vote("b2", BOB, ["F", "b1", "c0"]))?;
+
+        // The state's own panorama has been updated correctly.
+        assert_eq!(state.panorama, panorama(["F", "b2", "c0"]));
+        Ok(())
     }
 }

--- a/execution-engine/consensus/highway-core/src/traits.rs
+++ b/execution-engine/consensus/highway-core/src/traits.rs
@@ -20,8 +20,9 @@ pub trait ValidatorSecret: Debug {
 }
 
 /// The collection of types the user can choose for cryptography, IDs, transactions, etc.
-// TODO: The `Clone` trait bound makes `#[derive(Clone)]` work for `Block`...
-pub trait Context: Clone + Debug {
+// TODO: These trait bounds make `#[derive(...)]` work for types with a `C: Context` type
+// parameter. Split this up or replace the derives with explicit implementations.
+pub trait Context: Clone + Debug + PartialEq {
     /// The consensus value type, e.g. a list of transactions.
     type ConsensusValue: ConsensusValueT;
     /// Unique identifiers for validators.

--- a/execution-engine/consensus/highway-core/src/validators.rs
+++ b/execution-engine/consensus/highway-core/src/validators.rs
@@ -2,10 +2,10 @@ use std::{collections::HashMap, hash::Hash, iter::FromIterator};
 
 /// The index of a validator, in a list of all validators, ordered by ID.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ValidatorIndex(pub usize);
+pub struct ValidatorIndex(pub u16);
 
-impl From<usize> for ValidatorIndex {
-    fn from(idx: usize) -> Self {
+impl From<u16> for ValidatorIndex {
+    fn from(idx: u16) -> Self {
         ValidatorIndex(idx)
     }
 }
@@ -31,12 +31,8 @@ pub struct Validators<VID: Eq + Hash> {
 }
 
 impl<VID: Eq + Hash> Validators<VID> {
-    pub fn index_of(&self, id: &VID) -> Option<ValidatorIndex> {
-        self.index_by_id.get(id).cloned()
-    }
-
-    pub fn id_of(&self, idx: ValidatorIndex) -> &VID {
-        &self.validators[idx.0].id
+    pub fn contains(&self, idx: ValidatorIndex) -> bool {
+        self.validators.len() > idx.0.into()
     }
 }
 
@@ -47,7 +43,7 @@ impl<VID: Ord + Hash + Clone> FromIterator<(VID, u64)> for Validators<VID> {
         let index_by_id = validators
             .iter()
             .enumerate()
-            .map(|(idx, val)| (val.id.clone(), ValidatorIndex(idx)))
+            .map(|(idx, val)| (val.id.clone(), ValidatorIndex(idx as u16)))
             .collect();
         Validators {
             index_by_id,

--- a/execution-engine/consensus/highway-core/src/vertex.rs
+++ b/execution-engine/consensus/highway-core/src/vertex.rs
@@ -37,8 +37,8 @@ impl<C: Context> Vertex<C> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct WireVote<C: Context> {
     pub hash: C::VoteHash,
-    pub panorama: Panorama<C::VoteHash>,
-    pub sender: C::ValidatorId,
+    pub panorama: Panorama<C>,
+    pub sender: ValidatorIndex,
     pub values: Option<Vec<C::ConsensusValue>>,
     pub seq_number: u64,
 }

--- a/execution-engine/consensus/highway-core/src/vote.rs
+++ b/execution-engine/consensus/highway-core/src/vote.rs
@@ -1,30 +1,104 @@
-use crate::{
-    traits::{Context, HashT},
-    validators::ValidatorIndex,
-};
+use crate::{traits::Context, validators::ValidatorIndex, vertex::WireVote};
 
 /// The observed behavior of a validator at some point in time.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Observation<VH: HashT> {
+pub enum Observation<C: Context> {
     /// No vote by that validator was observed yet.
     None,
     /// The validator's latest vote.
-    Correct(VH),
+    Correct(C::VoteHash),
     /// The validator has been seen
     Faulty,
 }
 
+impl<C: Context> Observation<C> {
+    /// Returns the vote hash, if this is a correct observation.
+    pub fn correct(&self) -> Option<&C::VoteHash> {
+        match self {
+            Self::None | Self::Faulty => None,
+            Self::Correct(hash) => Some(hash),
+        }
+    }
+
+    fn is_correct(&self) -> bool {
+        match self {
+            Self::None | Self::Faulty => false,
+            Self::Correct(_) => true,
+        }
+    }
+}
+
 /// The observed behavior of all validators at some point in time.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Panorama<VH: HashT>(pub Vec<Observation<VH>>);
+pub struct Panorama<C: Context>(pub Vec<Observation<C>>);
+
+impl<C: Context> Panorama<C> {
+    /// Creates a new, empty panorama.
+    pub fn new(num_validators: usize) -> Panorama<C> {
+        Panorama(vec![Observation::None; num_validators])
+    }
+
+    /// Returns the observation for the given validator. Panics if the index is out of range.
+    pub fn get(&self, idx: ValidatorIndex) -> &Observation<C> {
+        &self.0[usize::from(idx.0)]
+    }
+
+    /// Returns `true` if there is no correct observation yet.
+    pub fn is_empty(&self) -> bool {
+        !self.0.iter().any(Observation::is_correct)
+    }
+
+    /// Returns an iterator over all observations, by validator index.
+    pub fn enumerate(&self) -> impl Iterator<Item = (ValidatorIndex, &Observation<C>)> {
+        self.0
+            .iter()
+            .enumerate()
+            .map(|(idx, obs)| (ValidatorIndex(idx as u16), obs))
+    }
+
+    /// Updates this panorama by adding one vote. Assumes that all justifications of that vote are
+    /// already seen.
+    pub fn update(&mut self, idx: ValidatorIndex, obs: Observation<C>) {
+        self.0[usize::from(idx.0)] = obs;
+    }
+}
 
 /// A vote sent to or received from the network.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Vote<C: Context> {
-    pub panorama: Panorama<C::VoteHash>,
-    // Omitted: Signature, etc.
+    // TODO: Signature
+    /// The list of latest messages and faults observed by the sender of this message.
+    pub panorama: Panorama<C>,
+    /// The number of earlier messages by the same sender.
     pub seq_number: u64,
-    pub sender_idx: ValidatorIndex,
+    /// The validator who created and sent this vote.
+    pub sender: ValidatorIndex,
     /// The block this is a vote for. Either it or its parent must be the fork choice.
     pub block: C::VoteHash,
+}
+
+impl<C: Context> Vote<C> {
+    /// Creates a new `Vote` from the `WireVote`, and returns the values if it contained any.
+    /// Values must be stored as a block, with the same hash.
+    pub fn new(
+        wvote: WireVote<C>,
+        fork_choice: Option<&C::VoteHash>,
+    ) -> (Vote<C>, Option<Vec<C::ConsensusValue>>) {
+        let block = if wvote.values.is_some() {
+            wvote.hash // A vote with a new block votes for itself.
+        } else {
+            // If the vote didn't introduce a new block, it votes for the fork choice itself.
+            // `Highway::add_vote` checks that the panorama is not empty.
+            fork_choice
+                .cloned()
+                .expect("nonempty panorama has nonempty fork choice")
+        };
+        let vote = Vote {
+            panorama: wvote.panorama,
+            seq_number: wvote.seq_number,
+            sender: wvote.sender,
+            block,
+        };
+        (vote, wvote.values)
+    }
 }


### PR DESCRIPTION
### Overview
Validate panoramas of incoming messages, keep track of the panorama corresponding to the full local protocol state (this is what would be used when creating a new proposal or witness), and detect equivocations.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-31
https://casperlabs.atlassian.net/browse/HWY-32

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
