### PR TITLE
TNET-24: Periodic data directory metrics.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -144,6 +144,8 @@ class NodeRuntime private[node] (
                                           )
       _ <- Resource.liftF(runRdmbsMigrations(conf.server.dataDir))
 
+      _ <- effects.periodicStorageSizeMetrics(conf)
+
       implicit0(
         storage: SQLiteStorage.CombinedStorage[Task]
       ) <- Resource.liftF(

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -179,8 +179,8 @@ package object effects {
 
     val update = for {
       (dataDirSize, sqliteSize) <- getSizes
-      _                         <- Metrics[F].setGauge("data-dir-size", dataDirSize)
-      _                         <- Metrics[F].setGauge("sqlite-size", sqliteSize)
+      _                         <- Metrics[F].setGauge("data-dir-size-bytes", dataDirSize)
+      _                         <- Metrics[F].setGauge("sqlite-size-bytes", sqliteSize)
       _                         <- Timer[F].sleep(updatePeriod)
     } yield ()
 


### PR DESCRIPTION
### Overview
Adds periodic metrics about the data directory and the SQLite data size.

```console
$ make node-0/metrics | grep casperlabs_storage
# TYPE casperlabs_storage_sqlite_size gauge
casperlabs_storage_sqlite_size 5000984.0
# TYPE casperlabs_storage_data_dir_size gauge
casperlabs_storage_data_dir_size 5007706.0
```

You can approximate the global state size as the difference between the two.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-24

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
