### PR TITLE
HWY-34: Add skip lists for blocks and votes.

### DIFF
--- a/execution-engine/consensus/highway-core/src/block.rs
+++ b/execution-engine/consensus/highway-core/src/block.rs
@@ -3,27 +3,50 @@ use crate::{state::State, traits::Context};
 /// A block: Chains of blocks are the consensus values in the CBC Casper sense.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Block<C: Context> {
-    /// The hash of the block's parent, or `None` for height-0 blocks.
-    pub parent: Option<C::VoteHash>,
     /// The total number of ancestors, i.e. the height in the blockchain.
     pub height: u64,
     /// The payload, e.g. a list of transactions.
     pub values: Vec<C::ConsensusValue>,
+    /// A skip list index of the block's ancestors.
+    ///
+    /// For every `p = 1 << i` that divides `height`, this contains an `i`-th entry pointing to the
+    /// ancestor with `height - p`.
+    pub skip_idx: Vec<C::VoteHash>,
 }
 
 impl<C: Context> Block<C> {
     /// Creates a new block with the given parent and values. Panics if parent does not exist.
     pub fn new(
-        parent: Option<C::VoteHash>,
+        parent_hash: Option<C::VoteHash>,
         values: Vec<C::ConsensusValue>,
         state: &State<C>,
     ) -> Block<C> {
-        let parent_plus_one = |hash| state.block(hash).height + 1;
-        let height = parent.as_ref().map_or(0, parent_plus_one);
+        let (parent, mut skip_idx) = match parent_hash {
+            None => return Block::initial(values),
+            Some(hash) => (state.block(&hash), vec![hash]),
+        };
+        let height = parent.height + 1;
+        for i in 0..height.trailing_zeros() as usize {
+            let ancestor = state.block(&skip_idx[i]);
+            skip_idx.push(ancestor.skip_idx[i].clone());
+        }
         Block {
-            parent,
             height,
             values,
+            skip_idx,
+        }
+    }
+
+    /// Returns the block's parent, or `None` if it has height 0.
+    pub fn parent(&self) -> Option<&C::VoteHash> {
+        self.skip_idx.first()
+    }
+
+    fn initial(values: Vec<C::ConsensusValue>) -> Block<C> {
+        Block {
+            height: 0,
+            values,
+            skip_idx: vec![],
         }
     }
 }

--- a/execution-engine/consensus/highway-core/src/state.rs
+++ b/execution-engine/consensus/highway-core/src/state.rs
@@ -109,7 +109,7 @@ impl<C: Context> State<C> {
         self.update_panorama(&wvote);
         let hash = wvote.hash.clone();
         let fork_choice = self.fork_choice(&wvote.panorama).cloned();
-        let (vote, opt_values) = Vote::new(wvote, fork_choice.as_ref());
+        let (vote, opt_values) = Vote::new(wvote, fork_choice.as_ref(), self);
         if let Some(values) = opt_values {
             let block = Block::new(fork_choice, values, self);
             self.blocks.insert(hash.clone(), block);
@@ -194,19 +194,17 @@ impl<C: Context> State<C> {
 
     /// Returns the hash of the message with the given sequence number from the sender of `hash`.
     /// Panics if the sequence number is higher than that of the vote with `hash`.
-    fn find_in_swimlane<'a>(
-        &'a self,
-        mut hash: &'a C::VoteHash,
-        seq_number: u64,
-    ) -> &'a C::VoteHash {
-        let mut vote = self.vote(hash);
-        assert!(vote.seq_number >= seq_number);
-        while vote.seq_number != seq_number {
-            // Unwrap: We only import votes that see the sender's previous message as correct.
-            hash = vote.panorama.get(vote.sender).correct().unwrap();
-            vote = self.vote(hash);
+    fn find_in_swimlane<'a>(&'a self, hash: &'a C::VoteHash, seq_number: u64) -> &'a C::VoteHash {
+        let vote = self.vote(hash);
+        if vote.seq_number == seq_number {
+            return hash;
         }
-        hash
+        assert!(vote.seq_number > seq_number);
+        let diff = vote.seq_number - seq_number;
+        // We want to make the greatest step 2^i such that 2^i <= diff.
+        let max_i = (diff + 1).next_power_of_two().trailing_zeros() as usize - 1;
+        let i = max_i.min(vote.skip_idx.len() - 1);
+        self.find_in_swimlane(&vote.skip_idx[i], seq_number)
     }
 
     /// Returns `pan` is valid, i.e. it contains the latest votes of some substate of `self`.
@@ -232,13 +230,10 @@ impl<C: Context> State<C> {
 
     /// Returns `true` if `pan` sees the sender of `hash` as correct, and sees that vote.
     fn sees_correct(&self, pan: &Panorama<C>, hash: &C::VoteHash) -> bool {
-        match &pan.get(self.vote(hash).sender) {
-            Observation::Faulty | Observation::None => false,
-            Observation::Correct(seen_hash) => {
-                // TODO: Use skip lists, not recursion.
-                seen_hash == hash || self.sees_correct(&self.vote(seen_hash).panorama, hash)
-            }
-        }
+        let vote = self.vote(hash);
+        pan.get(vote.sender).correct().map_or(false, |latest_hash| {
+            hash == self.find_in_swimlane(latest_hash, vote.seq_number)
+        })
     }
 
     /// Returns whether `obs_l` can come later in time than `obs_r`.
@@ -385,6 +380,31 @@ mod tests {
 
         // The state's own panorama has been updated correctly.
         assert_eq!(state.panorama, panorama(["F", "b2", "c0"]));
+        Ok(())
+    }
+
+    #[test]
+    fn find_in_swimlane() -> Result<(), AddVoteError<TestContext>> {
+        let mut state = State::new(NUM_VALIDATORS);
+        let a = ["a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7", "a8", "a9"];
+        state.add_vote(vote(a[0], ALICE, ["_", "_", "_"]).val(vec!["a"]))?;
+        for i in 1..a.len() {
+            state.add_vote(vote(a[i], ALICE, [a[i - 1], "_", "_"]))?;
+        }
+
+        // The predecessor with sequence number i should always equal a[i].
+        for j in (a.len() - 2)..a.len() {
+            for i in 0..j {
+                assert_eq!(&a[i], state.find_in_swimlane(&a[j], i as u64));
+            }
+        }
+
+        // The skip list index of a[k] includes a[k - 2^i] for each i such that 2^i divides k.
+        assert_eq!(&["a8"], &state.vote(&"a9").skip_idx.as_ref());
+        assert_eq!(
+            &["a7", "a6", "a4", "a0"],
+            &state.vote(&"a8").skip_idx.as_ref()
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
### Overview
Add skip lists for blocks and votes, to traverse the swimlane/block ancestry in logarithmic time.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-34

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
