### PR TITLE
TNET-25: Fix initial sync download fallback.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/InitialSynchronizationForwardImpl.scala
@@ -65,27 +65,21 @@ class InitialSynchronizationForwardImpl[F[_]: Parallel: Log: Timer](
      *           \ J - K -|- L
      * */
     def schedule(peer: Node, summary: BlockSummary): F[WaitHandle[F]] = {
-      val download = downloadManager.scheduleDownload(summary, peer, relay = false)
+      val trySchedule = downloadManager.scheduleDownload(summary, peer, relay = false)
 
-      // Map over the wait handle returned by the schedule without waiting on it,
-      // so that we can schedule the rest of them (some of it can be downloaddd in parallel).
-      download.map { handle =>
-        // Attach an error handler to the handle.
-        handle.recoverWith {
-          case GossipError.MissingDependencies(_, missing) =>
-            for {
-              missingDag <- synchronizer.syncDag(peer, missing.toSet).rethrow
-              missingHandles <- missingDag.traverse { dep =>
-                                 downloadManager.scheduleDownload(dep, peer, relay = false)
-                               }
-              // Wait for all these extra backfilling downloads to finish.
-              _ <- missingHandles.sequence
-              // Now try the original download again.
-              retryHandle <- download
-              // Whoever is waiting on `handle` now has to wait on the `retryHandle` instead.
-              _ <- retryHandle
-            } yield ()
-        }
+      trySchedule.recoverWith {
+        case GossipError.MissingDependencies(_, missing) =>
+          // The scheduling failed. Create another wait handle by doing a normal synchronization.
+          for {
+            missingDag <- synchronizer.syncDag(peer, missing.toSet).rethrow
+            missingHandles <- missingDag.traverse { dep =>
+                               downloadManager.scheduleDownload(dep, peer, relay = false)
+                             }
+            // Wait for all these extra backfilling downloads to finish.
+            _ <- missingHandles.sequence
+            // Now try the schedule the original again, and return the handle to be waited upon.
+            handle <- trySchedule
+          } yield handle
       }
     }
 


### PR DESCRIPTION
### Overview
Unfortunately I made a mistake in my original attempt to cirumvent this scenario in https://github.com/CasperLabs/CasperLabs/pull/1628 and applied the error handling at the wrong level.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-25

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
