### PR TITLE
TNET-26: Don't spend time downloading ballots and empty blocks.

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/BlockDownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/BlockDownloadManager.scala
@@ -129,4 +129,16 @@ class BlockDownloadManagerImpl[F[_]](
     Iterant.liftF(itF).flatten
   }
   override def parseDownloadable(bytes: Array[Byte]) = Block.parseFrom(bytes)
+
+  override def fetchAndRestore(source: Node, summary: BlockSummary): F[Block] =
+    if (summary.getHeader.deployCount == 0) {
+      Block()
+        .withBlockHash(summary.blockHash)
+        .withHeader(summary.getHeader)
+        .withSignature(summary.getSignature)
+        .withBody(Block.Body())
+        .pure[F]
+    } else {
+      super.fetchAndRestore(source, summary)
+    }
 }


### PR DESCRIPTION
### Overview
Blocks and ballots have no deploys, so the `BlockSummary` has is all we need, we can skip the download.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-26

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
