### PR TITLE
Use u32 in ValidatorIndex.

### DIFF
--- a/execution-engine/consensus/highway-core/src/validators.rs
+++ b/execution-engine/consensus/highway-core/src/validators.rs
@@ -2,10 +2,10 @@ use std::{collections::HashMap, hash::Hash, iter::FromIterator};
 
 /// The index of a validator, in a list of all validators, ordered by ID.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-pub struct ValidatorIndex(pub u16);
+pub struct ValidatorIndex(pub u32);
 
-impl From<u16> for ValidatorIndex {
-    fn from(idx: u16) -> Self {
+impl From<u32> for ValidatorIndex {
+    fn from(idx: u32) -> Self {
         ValidatorIndex(idx)
     }
 }
@@ -32,7 +32,7 @@ pub struct Validators<VID: Eq + Hash> {
 
 impl<VID: Eq + Hash> Validators<VID> {
     pub fn contains(&self, idx: ValidatorIndex) -> bool {
-        self.validators.len() > idx.0.into()
+        self.validators.len() as u32 > idx.0
     }
 }
 
@@ -43,7 +43,7 @@ impl<VID: Ord + Hash + Clone> FromIterator<(VID, u64)> for Validators<VID> {
         let index_by_id = validators
             .iter()
             .enumerate()
-            .map(|(idx, val)| (val.id.clone(), ValidatorIndex(idx as u16)))
+            .map(|(idx, val)| (val.id.clone(), ValidatorIndex(idx as u32)))
             .collect();
         Validators {
             index_by_id,

--- a/execution-engine/consensus/highway-core/src/vote.rs
+++ b/execution-engine/consensus/highway-core/src/vote.rs
@@ -40,7 +40,7 @@ impl<C: Context> Panorama<C> {
 
     /// Returns the observation for the given validator. Panics if the index is out of range.
     pub fn get(&self, idx: ValidatorIndex) -> &Observation<C> {
-        &self.0[usize::from(idx.0)]
+        &self.0[idx.0 as usize]
     }
 
     /// Returns `true` if there is no correct observation yet.
@@ -53,13 +53,13 @@ impl<C: Context> Panorama<C> {
         self.0
             .iter()
             .enumerate()
-            .map(|(idx, obs)| (ValidatorIndex(idx as u16), obs))
+            .map(|(idx, obs)| (ValidatorIndex(idx as u32), obs))
     }
 
     /// Updates this panorama by adding one vote. Assumes that all justifications of that vote are
     /// already seen.
     pub fn update(&mut self, idx: ValidatorIndex, obs: Observation<C>) {
-        self.0[usize::from(idx.0)] = obs;
+        self.0[idx.0 as usize] = obs;
     }
 }
 


### PR DESCRIPTION
### Overview
This removes the limit of 65536 validators. The conversions should still be safe: If you try to execute this with a higher number of validators on a 16-bit machine, allocation of the weights vector would fail.

### Which JIRA ticket does this PR relate to?
None; just this discussion: https://github.com/CasperLabs/CasperLabs/pull/1968#discussion_r426535990

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] ~If this PR adds a new feature, it includes tests related to this feature.~
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
