### PR TITLE
NDSC-56: Rename account public key to hash

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -138,5 +138,5 @@ object PrettyPrinter extends ByteStringPrettyPrinter {
     s"Deployment threshold ${at.deploymentThreshold}, Key management threshold: ${at.keyManagementThreshold}"
 
   def buildString(d: consensus.Deploy): String =
-    s"Deploy ${buildStringNoLimit(d.deployHash)} (${buildStringNoLimit(d.getHeader.accountPublicKey)})"
+    s"Deploy ${buildStringNoLimit(d.deployHash)} (account ${buildStringNoLimit(d.getHeader.accountHash)})"
 }

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -579,7 +579,7 @@ object ProtoUtil {
       .withPayment(Deploy.Code().withWasm(sessionCode))
     val h = Deploy
       .Header()
-      .withAccountPublicKey(ByteString.copyFrom(pk))
+      .withAccountHash(ByteString.copyFrom(Ed25519.publicKeyHash(pk)))
       .withTimestamp(timestamp)
       .withBodyHash(protoHash(b))
       .withTtlMillis(ttl.toMillis.toInt)
@@ -615,10 +615,11 @@ object ProtoUtil {
       payment <- toPayload(d.getBody.payment)
     } yield {
       ipc.DeployItem(
-        address = d.getHeader.accountPublicKey,
+        address = d.getHeader.accountHash,
         session = session,
         payment = payment,
         gasPrice = GAS_PRICE,
+        // TODO (NDSC-57): Send hashes instead of keys.
         authorizationKeys = d.approvals.map(_.approverPublicKey),
         deployHash = d.deployHash
       )

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -584,7 +584,7 @@ abstract class HashSetCasperTest
         .withHeader(
           deployDatas(1).getHeader
             .withTimestamp(deployDatas(0).getHeader.timestamp)
-            .withAccountPublicKey(deployDatas(0).getHeader.accountPublicKey)
+            .withAccountHash(deployDatas(0).getHeader.accountHash)
         ) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
       _            <- nodes(0).deployBuffer.addDeploy(deployDatas(0))
       signedBlock1 <- nodes(0).propose()

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -408,13 +408,15 @@ object DeployRuntime {
         deployConfig.paymentAmount.map(bigIntArg("amount", _)).toList
       )
 
+    val accountHash = Ed25519.publicKeyHash(from)
+
     consensus
       .Deploy()
       .withHeader(
         consensus.Deploy
           .Header()
           .withTimestamp(System.currentTimeMillis)
-          .withAccountPublicKey(ByteString.copyFrom(from))
+          .withAccountHash(ByteString.copyFrom(accountHash))
           .withGasPrice(deployConfig.gasPrice)
           .withTtlMillis(deployConfig.timeToLive.getOrElse(0))
           .withDependencies(deployConfig.dependencies)

--- a/crypto/src/main/scala/io/casperlabs/crypto/keys.scala
+++ b/crypto/src/main/scala/io/casperlabs/crypto/keys.scala
@@ -26,13 +26,15 @@ object Keys {
 
   sealed trait PrivateKeyTag
   type PrivateKey = Array[Byte] @@ PrivateKeyTag
-
   def PrivateKey(a: Array[Byte]): PrivateKey = a.asInstanceOf[PrivateKey]
 
   sealed trait SignatureTag
   type Signature = Array[Byte] @@ SignatureTag
-
   def Signature(a: Array[Byte]): Signature = a.asInstanceOf[Signature]
+
+  sealed trait PublicKeyHashTag
+  type PublicKeyHash = Array[Byte] @@ PublicKeyHashTag
+  def PublicKeyHash(a: Array[Byte]): PublicKeyHash = a.asInstanceOf[PublicKeyHash]
 
   sealed trait ParseError { self =>
     def errorMessage: String

--- a/crypto/src/main/scala/io/casperlabs/crypto/signatures/SignatureAlgorithm.scala
+++ b/crypto/src/main/scala/io/casperlabs/crypto/signatures/SignatureAlgorithm.scala
@@ -2,12 +2,14 @@ package io.casperlabs.crypto.signatures
 
 import java.io.StringReader
 
-import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey, Signature}
+import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey, PublicKeyHash, Signature}
 import io.casperlabs.crypto.codec.Base64
+import io.casperlabs.crypto.hash.Blake2b256
 import org.bouncycastle.openssl.PEMKeyPair
 
 import scala.util.control.NonFatal
 import scala.util.{Random, Try}
+import java.nio.charset.StandardCharsets
 
 /**
   * Useful links:
@@ -54,6 +56,16 @@ sealed trait SignatureAlgorithm {
     val signature = sign(a, privateKey)
     verify(a, signature, publicKey)
   }
+
+  /** Compute a unique hash from the algorithm name and a public key, used for accounts. */
+  def publicKeyHash(publicKey: PublicKey): PublicKeyHash =
+    PublicKeyHash(Blake2b256.hash(PublicKeyHashPrefix ++ publicKey))
+
+  private val PublicKeyHashPrefix = {
+    val separator = Array[Byte](0)
+    val nameBytes = name.toUpperCase.getBytes(StandardCharsets.UTF_8)
+    nameBytes ++ separator
+  }
 }
 
 object SignatureAlgorithm {
@@ -75,7 +87,6 @@ object SignatureAlgorithm {
     */
   object Ed25519 extends SignatureAlgorithm {
 
-    import io.casperlabs.crypto.codec.Base64
     import org.abstractj.kalium.keys.{SigningKey, VerifyKey}
 
     override def name: String = "ed25519"

--- a/crypto/src/test/scala/io/casperlabs/crypto/signatures/Ed25519Test.scala
+++ b/crypto/src/test/scala/io/casperlabs/crypto/signatures/Ed25519Test.scala
@@ -6,6 +6,7 @@ import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
 import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
 
 import scala.util.Random
+import io.casperlabs.crypto.hash.Blake2b256
 
 class Ed25519Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Ed25519") {
@@ -76,6 +77,16 @@ class Ed25519Test extends FunSpec with Matchers with BeforeAndAfterEach with App
       Random.nextBytes(data)
       val signature = Ed25519.sign(data, sec)
       Ed25519.verify(data, signature, pub) shouldBe true
+    }
+
+    it("calculates the public key hash") {
+      val (_, pk) = Ed25519.newKeyPair
+      val name    = "ED25519".getBytes
+      val sep     = Base16.decode("00")
+      val bytes   = name ++ sep ++ pk
+      val hash    = Blake2b256.hash(bytes)
+
+      Ed25519.publicKeyHash(pk) shouldBe hash
     }
   }
 }

--- a/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/EventStream.scala
@@ -75,6 +75,7 @@ object EventStream {
         import Event.Value._
 
         val accountFilter: ByteString => Boolean =
+          // TODO (NDSC-58): Rename fields in the API.
           request.getDeployFilter.accountPublicKeys.toSet match {
             case keys if keys.nonEmpty => keys.contains
             case _                     => _ => true
@@ -87,7 +88,7 @@ object EventStream {
           }
 
         def deployFilter(d: Deploy) =
-          accountFilter(d.getHeader.accountPublicKey) && deployHashFilter(d.deployHash)
+          accountFilter(d.getHeader.accountHash) && deployHashFilter(d.deployHash)
 
         event => {
           event.value match {

--- a/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/GraphQLBlockTypes.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/graphql/schema/blocks/types/GraphQLBlockTypes.scala
@@ -84,7 +84,7 @@ class GraphQLBlockTypes(
         "account",
         AccountType,
         "Account related information".some,
-        resolve = c => c.value.getHeader.accountPublicKey
+        resolve = c => c.value.getHeader.accountHash
       ),
       Field(
         "timestamp",
@@ -177,6 +177,7 @@ class GraphQLBlockTypes(
     "AccountInfo",
     "Account related information",
     () =>
+      // TODO (NDSC-61): Remove public key fields, add hash.
       fields[Unit, AccountKey](
         Field(
           "publicKeyBase16",

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -36,7 +36,7 @@ message Deploy {
         // Removed the nonce.
         reserved 2;
         // Identifying the Account is the key used to sign the Deploy.
-        bytes account_public_key = 1;
+        bytes account_hash = 1;
         // Current time milliseconds.
         uint64 timestamp = 3;
         // Conversion rate between the cost of Wasm opcodes and the motes sent by the `payment_code`.


### PR DESCRIPTION
### Overview
Renames `Deploy.Header.account_public_key` to `account_hash`.
Adds method to calculate the hash in Scala.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDSC-56

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Leaves the Python client and Clarity broken.