### PR TITLE
HWY-51: integrate Pothole and synchronizer with consensus-protocol

### DIFF
--- a/execution-engine/consensus/consensus-protocol/Cargo.toml
+++ b/execution-engine/consensus/consensus-protocol/Cargo.toml
@@ -11,6 +11,7 @@ license-file = "../LICENSE"
 
 [dependencies]
 anyhow = "1.0.28"
+derive_more = "0.99"
 highway = { path = "../highway-core", version = "0.1.0", package = "highway-core" }
 pothole = { path = "../pothole", version = "0.1.0", package = "pothole" }
 synchronizer = { path = "../synchronizer", version = "0.1.0", package = "synchronizer" }

--- a/execution-engine/consensus/consensus-protocol/Cargo.toml
+++ b/execution-engine/consensus/consensus-protocol/Cargo.toml
@@ -11,4 +11,6 @@ license-file = "../LICENSE"
 
 [dependencies]
 anyhow = "1.0.28"
-highway = { path="../highway-core", version = "0.1.0", package = "highway-core"}
+highway = { path = "../highway-core", version = "0.1.0", package = "highway-core" }
+pothole = { path = "../pothole", version = "0.1.0", package = "pothole" }
+synchronizer = { path = "../synchronizer", version = "0.1.0", package = "synchronizer" }

--- a/execution-engine/consensus/consensus-protocol/src/impls/mod.rs
+++ b/execution-engine/consensus/consensus-protocol/src/impls/mod.rs
@@ -1,0 +1,1 @@
+mod pothole;

--- a/execution-engine/consensus/consensus-protocol/src/impls/pothole.rs
+++ b/execution-engine/consensus/consensus-protocol/src/impls/pothole.rs
@@ -1,0 +1,193 @@
+use std::{
+    collections::{BTreeSet, VecDeque},
+    hash::Hash,
+    marker::PhantomData,
+    mem,
+    ops::{Deref, DerefMut},
+};
+
+use pothole::{Block, BlockIndex, Pothole, PotholeResult};
+
+use synchronizer::{
+    DependencySpec, HandleNewItemResult, ItemWithId, NodeId, ProtocolState, Synchronizer,
+    SynchronizerMessage,
+};
+
+use crate::{ConsensusContext, ConsensusProtocol, ConsensusProtocolResult, TimerId};
+
+#[derive(Debug)]
+pub enum PotholeMessage<B> {
+    NewBlock(BlockIndex, B),
+}
+
+#[derive(Debug)]
+pub struct PotholeWrapper<B: Block> {
+    finalized_block_queue: VecDeque<(BlockIndex, B)>,
+    pothole: Pothole<B>,
+}
+
+impl<B: Block> PotholeWrapper<B> {
+    pub fn new(pothole: Pothole<B>) -> Self {
+        Self {
+            pothole,
+            finalized_block_queue: Default::default(),
+        }
+    }
+
+    pub fn poll(&mut self) -> Option<(BlockIndex, B)> {
+        self.finalized_block_queue.pop_front()
+    }
+}
+
+impl<B: Block> Deref for PotholeWrapper<B> {
+    type Target = Pothole<B>;
+
+    fn deref(&self) -> &Pothole<B> {
+        &self.pothole
+    }
+}
+
+impl<B: Block> DerefMut for PotholeWrapper<B> {
+    fn deref_mut(&mut self) -> &mut Pothole<B> {
+        &mut self.pothole
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PotholeDepSpec<B> {
+    to_request: BTreeSet<BlockIndex>,
+    requested: BTreeSet<BlockIndex>,
+    _block: PhantomData<B>,
+}
+
+impl<B> PotholeDepSpec<B> {
+    pub fn new(deps: BTreeSet<BlockIndex>) -> Self {
+        Self {
+            to_request: deps,
+            requested: Default::default(),
+            _block: PhantomData,
+        }
+    }
+}
+
+impl<B: Block + Hash + Eq> DependencySpec for PotholeDepSpec<B> {
+    type DependencyDescription = BlockIndex;
+    type ItemId = BlockIndex;
+    type Item = B;
+
+    fn next_dependency(&mut self) -> Option<BlockIndex> {
+        let mut deps = mem::take(&mut self.to_request).into_iter();
+        let next_dep = deps.next();
+        self.to_request = deps.collect();
+        if let Some(dep) = next_dep {
+            self.requested.insert(dep);
+        }
+        next_dep
+    }
+
+    fn resolve_dependency(&mut self, dep: BlockIndex) -> bool {
+        self.to_request.remove(&dep) || self.requested.remove(&dep)
+    }
+
+    fn all_resolved(&self) -> bool {
+        self.to_request.is_empty() && self.requested.is_empty()
+    }
+}
+
+impl<B: Block + Hash + Eq> ProtocolState for PotholeWrapper<B> {
+    type DepSpec = PotholeDepSpec<B>;
+
+    fn get_dependency(&self, dep: &BlockIndex) -> Option<ItemWithId<PotholeDepSpec<B>>> {
+        self.pothole
+            .chain()
+            .get_block(*dep)
+            .map(|block| ItemWithId {
+                item_id: *dep,
+                item: block.clone(),
+            })
+    }
+
+    fn handle_new_item(
+        &mut self,
+        item_id: BlockIndex,
+        item: B,
+    ) -> HandleNewItemResult<PotholeDepSpec<B>> {
+        match self.pothole.handle_new_block(item_id, item) {
+            Ok(messages) => {
+                for message in messages {
+                    match message {
+                        PotholeResult::FinalizedBlock(index, block) => {
+                            self.finalized_block_queue.push_back((index, block));
+                        }
+                        _ => (),
+                    }
+                }
+                HandleNewItemResult::Accepted
+            }
+            Err(deps) => HandleNewItemResult::DependenciesMissing(PotholeDepSpec::new(deps)),
+        }
+    }
+}
+
+pub struct PotholeContext<N, B> {
+    _n: PhantomData<N>,
+    _b: PhantomData<B>,
+}
+
+impl<N: NodeId, B: Block + Hash + Eq> ConsensusContext for PotholeContext<N, B> {
+    type ConsensusValue = B;
+    type Message = (N, SynchronizerMessage<PotholeDepSpec<B>>);
+}
+
+#[derive(Debug)]
+pub struct PotholeWithSynchronizer<N: NodeId, B: Block + Hash + Eq> {
+    pothole: PotholeWrapper<B>,
+    synchronizer: Synchronizer<N, PotholeWrapper<B>>,
+}
+
+impl<N: NodeId, B: Block + Hash + Eq> PotholeWithSynchronizer<N, B> {
+    pub fn new(pothole: Pothole<B>) -> Self {
+        Self {
+            pothole: PotholeWrapper::new(pothole),
+            synchronizer: Synchronizer::new(),
+        }
+    }
+}
+
+impl<N: NodeId, B: Block + Hash + Eq> ConsensusProtocol<PotholeContext<N, B>>
+    for PotholeWithSynchronizer<N, B>
+{
+    fn handle_message(
+        &mut self,
+        msg: (N, SynchronizerMessage<PotholeDepSpec<B>>),
+    ) -> Result<Vec<ConsensusProtocolResult<PotholeContext<N, B>>>, anyhow::Error> {
+        let (sender, msg) = msg;
+        Ok(self
+            .synchronizer
+            .handle_message(&mut self.pothole, sender, msg)
+            .into_iter()
+            .map(ConsensusProtocolResult::CreatedNewMessage)
+            .collect())
+    }
+
+    fn handle_timer(
+        &mut self,
+        timer_id: TimerId,
+    ) -> Result<Vec<ConsensusProtocolResult<PotholeContext<N, B>>>, anyhow::Error> {
+        Ok(self
+            .pothole
+            .handle_timer(timer_id.0)
+            .into_iter()
+            .filter_map(|pothole_result| match pothole_result {
+                PotholeResult::ScheduleTimer(timer_id, instant) => Some(ConsensusProtocolResult::<
+                    PotholeContext<N, B>,
+                >::ScheduleTimer(
+                    instant,
+                    TimerId(timer_id),
+                )),
+                // TODO: handle requests for new blocks!
+                _ => None,
+            })
+            .collect())
+    }
+}

--- a/execution-engine/consensus/consensus-protocol/src/impls/pothole.rs
+++ b/execution-engine/consensus/consensus-protocol/src/impls/pothole.rs
@@ -138,7 +138,7 @@ impl<N: NodeId, B: Block + Hash + Eq> PotholeWithSynchronizer<N, B> {
     }
 }
 
-fn into_consenus_result<N: NodeId, B: Block + Hash + Eq>(
+fn into_consensus_result<N: NodeId, B: Block + Hash + Eq>(
     pothole_result: PotholeResult<B>,
 ) -> Option<ConsensusProtocolResult<PotholeContext<N, B>>> {
     match pothole_result {
@@ -146,7 +146,9 @@ fn into_consenus_result<N: NodeId, B: Block + Hash + Eq>(
             ConsensusProtocolResult::ScheduleTimer(instant, TimerId(timer_id)),
         ),
         PotholeResult::CreateNewBlock => Some(ConsensusProtocolResult::CreateNewBlock),
-        _ => None,
+        PotholeResult::FinalizedBlock(_, block) => {
+            Some(ConsensusProtocolResult::FinalizedBlock(block))
+        }
     }
 }
 
@@ -174,7 +176,7 @@ impl<N: NodeId, B: Block + Hash + Eq> ConsensusProtocol<PotholeContext<N, B>>
             .pothole
             .handle_timer(timer_id.0)
             .into_iter()
-            .filter_map(into_consenus_result)
+            .filter_map(into_consensus_result)
             .collect())
     }
 }

--- a/execution-engine/consensus/consensus-protocol/src/impls/pothole.rs
+++ b/execution-engine/consensus/consensus-protocol/src/impls/pothole.rs
@@ -3,11 +3,10 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     mem,
-    ops::{Deref, DerefMut},
 };
 
+use derive_more::{Deref, DerefMut};
 use pothole::{Block, BlockIndex, Pothole, PotholeResult};
-
 use synchronizer::{
     DependencySpec, HandleNewItemResult, ItemWithId, NodeId, ProtocolState, Synchronizer,
     SynchronizerMessage,
@@ -20,9 +19,11 @@ pub enum PotholeMessage<B> {
     NewBlock(BlockIndex, B),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deref, DerefMut)]
 pub struct PotholeWrapper<B: Block> {
     finalized_block_queue: VecDeque<(BlockIndex, B)>,
+    #[deref]
+    #[deref_mut]
     pothole: Pothole<B>,
 }
 
@@ -36,20 +37,6 @@ impl<B: Block> PotholeWrapper<B> {
 
     pub fn poll(&mut self) -> Option<(BlockIndex, B)> {
         self.finalized_block_queue.pop_front()
-    }
-}
-
-impl<B: Block> Deref for PotholeWrapper<B> {
-    type Target = Pothole<B>;
-
-    fn deref(&self) -> &Pothole<B> {
-        &self.pothole
-    }
-}
-
-impl<B: Block> DerefMut for PotholeWrapper<B> {
-    fn deref_mut(&mut self) -> &mut Pothole<B> {
-        &mut self.pothole
     }
 }
 

--- a/execution-engine/consensus/consensus-protocol/src/lib.rs
+++ b/execution-engine/consensus/consensus-protocol/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 use std::{hash::Hash, time::Instant};
 
+mod impls;
 mod protocol_state;
 mod synchronizer;
 
@@ -41,15 +42,15 @@ pub enum ConsensusProtocolResult<Ctx: ConsensusContext> {
 pub trait ConsensusProtocol<Ctx: ConsensusContext> {
     /// Handle an incoming message (like NewVote, RequestDependency).
     fn handle_message(
-        &self,
+        &mut self,
         msg: Ctx::Message,
-    ) -> Result<ConsensusProtocolResult<Ctx>, anyhow::Error>;
+    ) -> Result<Vec<ConsensusProtocolResult<Ctx>>, anyhow::Error>;
 
     /// Triggers consensus' timer.
     fn handle_timer(
-        &self,
+        &mut self,
         timer_id: TimerId,
-    ) -> Result<ConsensusProtocolResult<Ctx>, anyhow::Error>;
+    ) -> Result<Vec<ConsensusProtocolResult<Ctx>>, anyhow::Error>;
 }
 
 #[cfg(test)]
@@ -99,9 +100,9 @@ mod example {
         for DagSynchronizerState<VIdU64, DummyVertex, DeployHash, P>
     {
         fn handle_message(
-            &self,
+            &mut self,
             msg: <HighwayContext as ConsensusContext>::Message,
-        ) -> Result<ConsensusProtocolResult<HighwayContext>, Error> {
+        ) -> Result<Vec<ConsensusProtocolResult<HighwayContext>>, Error> {
             match msg {
                 HighwayMessage::RequestVertex(_v_id) => unimplemented!(),
                 HighwayMessage::NewVertex(_vertex) => unimplemented!(),
@@ -109,9 +110,9 @@ mod example {
         }
 
         fn handle_timer(
-            &self,
+            &mut self,
             _timer_id: TimerId,
-        ) -> Result<ConsensusProtocolResult<HighwayContext>, Error> {
+        ) -> Result<Vec<ConsensusProtocolResult<HighwayContext>>, Error> {
             unimplemented!()
         }
     }

--- a/execution-engine/consensus/consensus-protocol/src/lib.rs
+++ b/execution-engine/consensus/consensus-protocol/src/lib.rs
@@ -37,6 +37,7 @@ pub enum ConsensusProtocolResult<Ctx: ConsensusContext> {
     InvalidIncomingMessage(Ctx::Message, anyhow::Error),
     ScheduleTimer(Instant, TimerId),
     CreateNewBlock,
+    FinalizedBlock(Ctx::ConsensusValue),
 }
 
 /// An API for a single instance of the consensus.

--- a/execution-engine/consensus/consensus-protocol/src/lib.rs
+++ b/execution-engine/consensus/consensus-protocol/src/lib.rs
@@ -36,6 +36,7 @@ pub enum ConsensusProtocolResult<Ctx: ConsensusContext> {
     CreatedNewMessage(Ctx::Message),
     InvalidIncomingMessage(Ctx::Message, anyhow::Error),
     ScheduleTimer(Instant, TimerId),
+    CreateNewBlock,
 }
 
 /// An API for a single instance of the consensus.

--- a/execution-engine/consensus/consensus-service/src/consensus_service.rs
+++ b/execution-engine/consensus/consensus-service/src/consensus_service.rs
@@ -74,6 +74,7 @@ where
                                     unimplemented!()
                                 }
                                 ConsensusProtocolResult::CreateNewBlock => unimplemented!(),
+                                ConsensusProtocolResult::FinalizedBlock(_block) => unimplemented!(),
                             })
                             .collect()
                     })
@@ -103,6 +104,9 @@ where
                                         unimplemented!()
                                     }
                                     ConsensusProtocolResult::CreateNewBlock => unimplemented!(),
+                                    ConsensusProtocolResult::FinalizedBlock(_block) => {
+                                        unimplemented!()
+                                    }
                                 })
                                 .collect()
                         })

--- a/execution-engine/consensus/consensus-service/src/consensus_service.rs
+++ b/execution-engine/consensus/consensus-service/src/consensus_service.rs
@@ -39,7 +39,7 @@ struct EraInstance<Id> {
 
 /// API between the reactor and consensus component.
 pub trait ConsensusService {
-    fn handle_event(&mut self, event: Event) -> Result<Effect<Event>, ConsensusServiceError>;
+    fn handle_event(&mut self, event: Event) -> Result<Vec<Effect<Event>>, ConsensusServiceError>;
 }
 
 struct EraSupervisor<C: ConsensusContext> {
@@ -53,45 +53,60 @@ impl<C: ConsensusContext> ConsensusService for EraSupervisor<C>
 where
     C::Message: TryFrom<MessageWireFormat> + Into<MessageWireFormat>,
 {
-    fn handle_event(&mut self, event: Event) -> Result<Effect<Event>, ConsensusServiceError> {
+    fn handle_event(&mut self, event: Event) -> Result<Vec<Effect<Event>>, ConsensusServiceError> {
         match event {
-            Event::Timer(era_id, timer_id) => match self.active_eras.get(&era_id) {
+            Event::Timer(era_id, timer_id) => match self.active_eras.get_mut(&era_id) {
                 None => todo!("Handle missing eras."),
                 Some(consensus) => consensus
                     .handle_timer(timer_id)
-                    .map(|result| match result {
-                        ConsensusProtocolResult::InvalidIncomingMessage(_msg, _error) => {
-                            unimplemented!()
-                        }
-                        ConsensusProtocolResult::CreatedNewMessage(out_msg) => {
-                            let _wire_msg: MessageWireFormat = out_msg.into();
-                            todo!("Create an effect to broadcast new msg")
-                        }
-                        ConsensusProtocolResult::ScheduleTimer(_delay, _timer_id) => {
-                            unimplemented!()
-                        }
+                    .map(|result_vec| {
+                        result_vec
+                            .into_iter()
+                            .map(|result| match result {
+                                ConsensusProtocolResult::InvalidIncomingMessage(_msg, _error) => {
+                                    unimplemented!()
+                                }
+                                ConsensusProtocolResult::CreatedNewMessage(out_msg) => {
+                                    let _wire_msg: MessageWireFormat = out_msg.into();
+                                    todo!("Create an effect to broadcast new msg")
+                                }
+                                ConsensusProtocolResult::ScheduleTimer(_delay, _timer_id) => {
+                                    unimplemented!()
+                                }
+                                ConsensusProtocolResult::CreateNewBlock => unimplemented!(),
+                            })
+                            .collect()
                     })
                     .map_err(ConsensusServiceError::InternalError),
             },
-            Event::IncomingMessage(wire_msg) => match self.active_eras.get(&wire_msg.era_id) {
+            Event::IncomingMessage(wire_msg) => match self.active_eras.get_mut(&wire_msg.era_id) {
                 None => todo!("Handle missing eras."),
                 Some(consensus) => {
                     let message: C::Message = wire_msg
                         .try_into()
                         .map_err(|_| ConsensusServiceError::InvalidFormat("".to_string()))?;
-                    let _ = consensus
+                    consensus
                         .handle_message(message)
-                        .map(|result| match result {
-                            ConsensusProtocolResult::InvalidIncomingMessage(_msg, _error) => {}
-                            ConsensusProtocolResult::CreatedNewMessage(out_msg) => {
-                                let _wire_msg: MessageWireFormat = out_msg.into();
-                                todo!("Create an effect to broadcast new msg")
-                            }
-                            ConsensusProtocolResult::ScheduleTimer(_delay, _timer_id) => {
-                                unimplemented!()
-                            }
-                        });
-                    Ok(Effect::Nothing)
+                        .map(|result_vec| {
+                            result_vec
+                                .into_iter()
+                                .map(|result| match result {
+                                    ConsensusProtocolResult::InvalidIncomingMessage(
+                                        _msg,
+                                        _error,
+                                    ) => unimplemented!(),
+                                    ConsensusProtocolResult::CreatedNewMessage(out_msg) => {
+                                        let _wire_msg: MessageWireFormat = out_msg.into();
+                                        todo!("Create an effect to broadcast new msg")
+                                    }
+                                    ConsensusProtocolResult::ScheduleTimer(_delay, _timer_id) => {
+                                        unimplemented!()
+                                    }
+                                    ConsensusProtocolResult::CreateNewBlock => unimplemented!(),
+                                })
+                                .collect()
+                        })
+                        .map_err(ConsensusServiceError::InternalError)
                 }
             },
         }

--- a/execution-engine/consensus/consensus-service/src/traits.rs
+++ b/execution-engine/consensus/consensus-service/src/traits.rs
@@ -9,7 +9,6 @@ use std::time::Instant;
 pub enum Effect<Ev> {
     DelayEvent(Instant, TimerId),
     NewMessage(Ev),
-    Nothing,
 }
 
 //TODO: Stopgap structs that will be replaced with actual wire models.

--- a/execution-engine/consensus/pothole/src/chain.rs
+++ b/execution-engine/consensus/pothole/src/chain.rs
@@ -32,12 +32,15 @@ impl<B> Chain<B> {
 
     /// Inserts a new block at a given index. Returns the block that was already at this index, if
     /// any.
-    pub fn insert(&mut self, index: BlockIndex, block: B) -> Option<B> {
-        let result = self.blocks.insert(index, block);
-        if index >= self.next_block {
-            self.next_block = index + 1;
+    /// An Err() result means that the block wasn't the next one supposed to be inserted; the next
+    /// expected index is returned along with the block
+    pub fn insert(&mut self, index: BlockIndex, block: B) -> Result<Option<B>, BlockIndex> {
+        if index > self.next_block {
+            return Err(self.next_block);
         }
-        result
+        let result = self.blocks.insert(index, block);
+        self.next_block += 1;
+        Ok(result)
     }
 
     /// Returns the reference to the last known block.

--- a/execution-engine/consensus/pothole/tests/mock_network/node.rs
+++ b/execution-engine/consensus/pothole/tests/mock_network/node.rs
@@ -102,7 +102,13 @@ impl Node {
                 vec![]
             }
             NetworkMessage::NewFinalizedBlock(index, block) => {
-                self.pothole.handle_new_block(index, block)
+                match self.pothole.handle_new_block(index, block) {
+                    Ok(msgs) => msgs,
+                    Err(next_index) => panic!(
+                        "{} should've received index {:?}, got {:?}",
+                        self.our_id, next_index, index
+                    ),
+                }
             }
         }
     }


### PR DESCRIPTION
### Overview
This adds code that integrates Pothole and the `synchronizer` crate with `consensus-protocol`, thus demonstrating how various parts of the consensus component can come together and letting us decide whether this is the approach we want to pursue.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-51

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
