### PR TITLE
NDSC-62: gen-keys.sh prints public key hash into validator-id and account-id

### DIFF
--- a/hack/key-management/Dockerfile
+++ b/hack/key-management/Dockerfile
@@ -1,4 +1,5 @@
 FROM alpine as build
+
 RUN apk add --no-cache git make g++; \
     cd /tmp; \
     git clone https://github.com/maandree/libkeccak.git; \
@@ -6,13 +7,25 @@ RUN apk add --no-cache git make g++; \
     cd /tmp/libkeccak; git checkout 1.2; make install; ldconfig; \
     cd /tmp/sha3sum; make;
 
+RUN cd /tmp; \
+    git clone https://github.com/BLAKE2/BLAKE2.git; \
+    cd /tmp/BLAKE2/b2sum; make;
+
+
+
 FROM alpine
+
 RUN apk add --no-cache openssl && mkdir -p -- "/usr/local/include"
+
 COPY --from=build /tmp/libkeccak/libkeccak.so /usr/local/lib/libkeccak.so.1.2
 RUN ln -sf -- "/usr/local/lib/libkeccak.so.1.2" "/usr/local/lib/libkeccak.so.1" && ln -sf -- "/usr/local/lib/libkeccak.so.1.2" "/usr/local/lib/libkeccak.so"
 COPY --from=build /tmp/libkeccak/libkeccak.a /usr/local/lib/libkeccak.a
 COPY --from=build /tmp/libkeccak/libkeccak.h /usr/local/include
 COPY --from=build /tmp/libkeccak/libkeccak-legacy.h /usr/local/include
+
 COPY --from=build /tmp/sha3sum/keccak-256sum /usr/local/bin
+
+COPY --from=build /tmp/BLAKE2/b2sum/b2sum /usr/local/bin
+
 COPY gen-keys.sh /
 ENTRYPOINT [ "/gen-keys.sh" ]

--- a/hack/key-management/docker-gen-account-keys.sh
+++ b/hack/key-management/docker-gen-account-keys.sh
@@ -5,7 +5,9 @@ set -e
 $(dirname $0)/docker-gen-keys.sh "$1"
 cd "$1"
 rm node*
-mv validator-pk account-id
-mv validator-pk-hex account-id-hex
+mv validator-pk account-pk
+mv validator-pk-hex account-pk-hex
+mv validator-id account-id
+mv validator-id-hex account-id-hex
 mv validator-public.pem account-public.pem
 mv validator-private.pem account-private.pem

--- a/hack/key-management/docker-gen-account-keys.sh
+++ b/hack/key-management/docker-gen-account-keys.sh
@@ -5,7 +5,7 @@ set -e
 $(dirname $0)/docker-gen-keys.sh "$1"
 cd "$1"
 rm node*
-mv validator-id account-id
-mv validator-id-hex account-id-hex
+mv validator-pk account-id
+mv validator-pk-hex account-id-hex
 mv validator-public.pem account-public.pem
 mv validator-private.pem account-private.pem

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -40,8 +40,8 @@ fi
 
 if [[ "$1" == "--test" ]]; then
     if [[ -f "$OUTPUT_DIR/node-id" ]] && \
-       [[ -f "$OUTPUT_DIR/validator-id" ]] && \
-       [[ -f "$OUTPUT_DIR/validator-id-hex" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-pk" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-pk-hex" ]] && \
        [[ -f "$OUTPUT_DIR/node.key.pem" ]] && \
        [[ -f "$OUTPUT_DIR/node.certificate.pem" ]] && \
        [[ -f "$OUTPUT_DIR/validator-private.pem" ]] && \

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -42,6 +42,8 @@ if [[ "$1" == "--test" ]]; then
     if [[ -f "$OUTPUT_DIR/node-id" ]] && \
        [[ -f "$OUTPUT_DIR/validator-pk" ]] && \
        [[ -f "$OUTPUT_DIR/validator-pk-hex" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-id" ]] && \
+       [[ -f "$OUTPUT_DIR/validator-id-hex" ]] && \
        [[ -f "$OUTPUT_DIR/node.key.pem" ]] && \
        [[ -f "$OUTPUT_DIR/node.certificate.pem" ]] && \
        [[ -f "$OUTPUT_DIR/validator-private.pem" ]] && \

--- a/hack/key-management/gen-keys.sh
+++ b/hack/key-management/gen-keys.sh
@@ -32,9 +32,10 @@ handle_exit() {
 # node.certificate.pem  # TLS certificate used for node-to-node interaction encryption
 #                       # derived from node.key.pem
 # node.key.pem          # secp256r1 private key
-# validator-id          # validator ID, used to run as a validator for validating transactions, used in bonds.txt file
-#                       # derived from validator.public.pem
-# validator-id-hex      # validator ID in hex, derived from validator.public.pem
+# validator-id          # validator ID in base64 format, derived from validator.public.pem by hashing it together with the algorithm name
+# validator-id-hex      # validator ID in base16 format
+# validator-pk          # validator public key in base64 format
+# validator-pk-hex      # validator public key in base16 format
 # validator-private.pem # ed25519 private key
 # validator-public.pem  # ed25519 public key
 #
@@ -65,13 +66,14 @@ openssl genpkey -algorithm Ed25519 -out "$OUTPUT_DIR/validator-private.pem"
 openssl pkey -in "$OUTPUT_DIR/validator-private.pem" -pubout -out "$OUTPUT_DIR/validator-public.pem"
 
 # Extract raw public key from PEM file to serve as a validator ID
-openssl pkey -outform DER -pubout -in "$OUTPUT_DIR/validator-private.pem" | tail -c +13 | openssl base64 | tr -d '\n' > "$OUTPUT_DIR/validator-id"
+openssl pkey -outform DER -pubout -in "$OUTPUT_DIR/validator-private.pem" | tail -c +13 | openssl base64 | tr -d '\n' > "$OUTPUT_DIR/validator-pk"
 
 # Assert validator-id is 32 bytes long
-VALIDATOR_ID_BASE64=$(cat "$OUTPUT_DIR/validator-id")
-VALIDATOR_ID_HEX=$(echo "$VALIDATOR_ID_BASE64" | openssl base64 -d | hexdump -ve '/1 "%02x" ')
-echo $VALIDATOR_ID_HEX > "$OUTPUT_DIR/validator-id-hex"
-VALIDATOR_BYTES=$((${#VALIDATOR_ID_HEX} / 2))
+VALIDATOR_PK_BASE64=$(cat "$OUTPUT_DIR/validator-pk")
+VALIDATOR_PK_HEX=$(echo "$VALIDATOR_PK_BASE64" | openssl base64 -d | hexdump -ve '/1 "%02x" ')
+echo $VALIDATOR_PK_HEX > "$OUTPUT_DIR/validator-pk-hex"
+
+VALIDATOR_BYTES=$((${#VALIDATOR_PK_HEX} / 2))
 if [ $VALIDATOR_BYTES -ne 32 ]
     then
         echo "ERROR: validator-id must be 32 bytes length, got" "$VALIDATOR_BYTES" "bytes instead"

--- a/hack/key-management/gen-keys.sh
+++ b/hack/key-management/gen-keys.sh
@@ -76,9 +76,16 @@ echo $VALIDATOR_PK_HEX > "$OUTPUT_DIR/validator-pk-hex"
 VALIDATOR_BYTES=$((${#VALIDATOR_PK_HEX} / 2))
 if [ $VALIDATOR_BYTES -ne 32 ]
     then
-        echo "ERROR: validator-id must be 32 bytes length, got" "$VALIDATOR_BYTES" "bytes instead"
+        echo "ERROR: validator-pk must be 32 bytes length, got" "$VALIDATOR_BYTES" "bytes instead"
         exit 1
 fi
+
+# Derive validator public key hash.
+VALIDATOR_ALGO_HEX=$(echo -n "ED25519" | xxd -p)
+VALIDATOR_ID_INPUT_HEX=$(echo ${VALIDATOR_ALGO_HEX}00${VALIDATOR_PK_HEX})
+echo $VALIDATOR_ID_INPUT_HEX | xxd -p -r | b2sum -a blake2b -l 256 | tr -d ' -' > "$OUTPUT_DIR/validator-id-hex"
+cat "$OUTPUT_DIR/validator-id-hex" | xxd -p -r | openssl base64 > "$OUTPUT_DIR/validator-id"
+
 
 # Generate private TLS key in PEM format
 openssl ecparam -name secp256r1 -genkey -noout -out "$OUTPUT_DIR/secp256r1-private.pem"


### PR DESCRIPTION
### Overview
The `validator-id-hex` and `account-id-hex` files are regularly used with CLI. These parameters should be changed to use account hashes, instead of public keys. The key generator tool will print the hashes into these files, and public keys go into `[validator|account]-pk[-hex]` instead (no real reason to keep them, but it makes it easier to see that we have both).

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDSC-62

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
