### PR TITLE
[TNET-20, ECO-381] Using Stored version Faucet in Clarity.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -335,7 +335,7 @@ build-explorer: \
 
 build-explorer-contracts: \
 	explorer/contracts/transfer_to_account_u512.wasm \
-	explorer/contracts/faucet.wasm
+	explorer/contracts/faucet_stored.wasm
 
 # Get the .proto files for REST annotations for Github. This is here for reference about what to get from where, the files are checked in.
 # There were alternatives, like adding a reference to a Maven project called `googleapis-commons-protos` but it had version conflicts.

--- a/explorer/Dockerfile
+++ b/explorer/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:12.5.0-stretch-slim
 
 COPY contracts/transfer_to_account_u512.wasm /app/contracts/transfer.wasm
-COPY contracts/faucet.wasm /app/contracts/faucet.wasm
+COPY contracts/faucet_stored.wasm /app/contracts/faucet_stored.wasm
 
 COPY server/node_modules /app/server/node_modules
 # Copying the local projects because after a build the server node_modules contains symlinks.
@@ -17,5 +17,5 @@ ENV TRANSFER_AMOUNT=1000000000
 ENV GAS_PRICE=10
 # The link to graphql playground, used in Home page of UI.
 ENV UI_GRAPHQL_URL=http://devnet-graphql.casperlabs.io:40403/graphql
-ENV FAUCET_CONTRACT_PATH=/app/contracts/faucet.wasm
+ENV FAUCET_CONTRACT_PATH=/app/contracts/faucet_stored.wasm
 ENTRYPOINT node server.js

--- a/explorer/sdk/src/lib/Args.ts
+++ b/explorer/sdk/src/lib/Args.ts
@@ -59,7 +59,20 @@ export const BigIntValue = toValue<bigint | JSBI>((value, x) => {
   return value;
 });
 
-export function Args(...args: Array<[string, CLValueInstance]>): Deploy.Arg[] {
+export const StringValue = toValue<string>((value, x) => {
+  const t = new CLType();
+  t.setSimpleType(CLType.Simple.STRING);
+
+  const v = new CLValueInstance.Value();
+  v.setStrValue(x)
+
+  value.setClType(t);
+  value.setValue(v);
+
+  return value;
+});
+
+export function Args(...args: [string, CLValueInstance][]): Deploy.Arg[] {
   return args.map(x => {
     const [name, value] = x;
     const arg = new Deploy.Arg();

--- a/explorer/sdk/src/lib/DeployUtil.ts
+++ b/explorer/sdk/src/lib/DeployUtil.ts
@@ -46,7 +46,7 @@ export function makeDeploy(
   paymentWasm: ByteArray | null,
   paymentAmount: bigint | JSBI,
   accountPublicKey: ByteArray,
-  dependencies?: Uint8Array[]
+  dependencies: Uint8Array[] = []
 ): Deploy {
   const sessionCode = new Deploy.Code();
   if (type === ContractType.WASM) {
@@ -74,10 +74,7 @@ export function makeDeploy(
   header.setBodyHash(protoHash(body));
   // we will remove gasPrice eventually
   header.setGasPrice(1);
-
-  if(dependencies && dependencies.length > 0){
-    header.setDependenciesList(dependencies);
-  }
+  header.setDependenciesList(dependencies);
 
   const deploy = new Deploy();
   deploy.setBody(body);

--- a/explorer/sdk/src/lib/DeployUtil.ts
+++ b/explorer/sdk/src/lib/DeployUtil.ts
@@ -11,24 +11,50 @@ import { protoHash } from './Contracts';
 
 export enum ContractType {
   WASM = 'WASM',
-  Hash = 'Hash'
+  Hash = 'Hash',
+  Name = 'Name'
 }
 
-// If EE receives a deploy with no payment bytes,
-// then it will use host-side functionality equivalent to running the standard payment contract
-export const makeDeploy = (
+// The following two methods definition guarantee that session is a string iff its contract type is ContractType.Name
+// See https://stackoverflow.com/questions/39700093/variable-return-types-based-on-string-literal-type-argument for detail
+export function makeDeploy(
   args: Deploy.Arg[],
-  type: ContractType,
+  type: ContractType.Hash | ContractType.WASM,
   session: ByteArray,
   paymentWasm: ByteArray | null,
   paymentAmount: bigint | JSBI,
-  accountPublicKey: ByteArray
-): Deploy => {
+  accountPublicKey: ByteArray,
+  dependencies?: Uint8Array[]
+): Deploy;
+
+export function makeDeploy(
+  args: Deploy.Arg[],
+  type: ContractType.Name,
+  sessionName: string,
+  paymentWasm: ByteArray | null,
+  paymentAmount: bigint | JSBI,
+  accountPublicKey: ByteArray,
+  dependencies?: Uint8Array[]
+): Deploy;
+
+// If EE receives a deploy with no payment bytes,
+// then it will use host-side functionality equivalent to running the standard payment contract
+export function makeDeploy(
+  args: Deploy.Arg[],
+  type: ContractType,
+  session: ByteArray | string,
+  paymentWasm: ByteArray | null,
+  paymentAmount: bigint | JSBI,
+  accountPublicKey: ByteArray,
+  dependencies?: Uint8Array[]
+): Deploy {
   const sessionCode = new Deploy.Code();
   if (type === ContractType.WASM) {
     sessionCode.setWasm(session);
-  } else {
+  } else if (type === ContractType.Hash) {
     sessionCode.setHash(session);
+  }else{
+    sessionCode.setName(session as string);
   }
   sessionCode.setArgsList(args);
   if (paymentWasm === null) {
@@ -48,6 +74,10 @@ export const makeDeploy = (
   header.setBodyHash(protoHash(body));
   // we will remove gasPrice eventually
   header.setGasPrice(1);
+
+  if(dependencies && dependencies.length > 0){
+    header.setDependenciesList(dependencies);
+  }
 
   const deploy = new Deploy();
   deploy.setBody(body);

--- a/explorer/sdk/src/services/CasperService.ts
+++ b/explorer/sdk/src/services/CasperService.ts
@@ -40,8 +40,11 @@ export default class CasperService {
   constructor(
     // Point at either at a URL on a different port where grpcwebproxy is listening,
     // or use nginx to serve the UI files, the API and gRPC all on the same port without CORS.
-    private url: string
-  ) {}
+    private url: string,
+    private transport: grpc.TransportFactory = (options) => grpc.CrossBrowserHttpTransport({ withCredentials: false })(options),
+  ) {
+
+  }
 
   public deploy(deploy: Deploy) {
     return new Promise<void>((resolve, reject) => {
@@ -50,6 +53,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.Deploy, {
         host: this.url,
+        transport: this.transport,
         request: deployRequest,
 
         onEnd: (res) => {
@@ -70,6 +74,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.GetDeployInfo, {
         host: this.url,
+        transport: this.transport,
         request,
         onEnd: res => {
           if (res.status === grpc.Code.OK) {
@@ -97,6 +102,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.ListDeployInfos, {
         host: this.url,
+        transport: this.transport,
         request,
         onEnd: res => {
           if (res.status === grpc.Code.OK) {
@@ -124,6 +130,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.GetBlockInfo, {
         host: this.url,
+        transport: this.transport,
         request,
         onEnd: res => {
           if (res.status === grpc.Code.OK) {
@@ -146,6 +153,7 @@ export default class CasperService {
 
       grpc.invoke(GrpcCasperService.StreamBlockInfos, {
         host: this.url,
+        transport: this.transport,
         request,
         onMessage: msg => {
           blocks.push(msg as BlockInfo);
@@ -170,6 +178,7 @@ export default class CasperService {
 
       grpc.invoke(GrpcCasperService.StreamBlockDeploys, {
         host: this.url,
+        transport: this.transport,
         request,
         onMessage: msg => {
           deploys.push(msg as Block.ProcessedDeploy);
@@ -196,6 +205,7 @@ export default class CasperService {
 
       grpc.invoke(GrpcCasperService.StreamBlockInfos, {
         host: this.url,
+        transport: this.transport,
         request,
         onMessage: msg => {
           if (!resolved) {
@@ -220,6 +230,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.GetBlockState, {
         host: this.url,
+        transport: this.transport,
         request,
         onEnd: res => {
           if (res.status === grpc.Code.OK) {
@@ -240,6 +251,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.BatchGetBlockState, {
         host: this.url,
+        transport: this.transport,
         request,
         onEnd: res => {
           if (res.status === grpc.Code.OK) {
@@ -315,6 +327,7 @@ export default class CasperService {
 
       grpc.unary(GrpcCasperService.GetLastFinalizedBlockInfo, {
         host: this.url,
+        transport: this.transport,
         request,
         onEnd: res => {
           if (res.status === grpc.Code.OK) {
@@ -330,7 +343,8 @@ export default class CasperService {
   subscribeEvents(subscribeTopics: SubscribeTopics): Observable<Event> {
     return new Observable(obs => {
       const client = grpc.client(GrpcCasperService.StreamEvents, {
-        host: this.url
+        host: this.url,
+        transport: this.transport
       });
       client.onMessage((msg: Event) => {
         obs.next(msg);

--- a/explorer/server/.env
+++ b/explorer/server/.env
@@ -8,7 +8,7 @@ SERVER_USE_TLS=false
 
 # Location of the faucet contract during development. Produce them with the following command:
 # make build-explorer-contracts
-FAUCET_CONTRACT_PATH=../contracts/faucet.wasm
+FAUCET_CONTRACT_PATH=../contracts/faucet_stored.wasm
 PAYMENT_CONTRACT_PATH=../contracts/standard_payment.wasm
 
 # Got to send some payment for the faucet deploys

--- a/explorer/server/src/StoredFaucetService.ts
+++ b/explorer/server/src/StoredFaucetService.ts
@@ -52,6 +52,8 @@ export class StoredFaucetService {
       const state = await this.checkState();
       if (state) {
         this.storedFaucetFinalized = true;
+        // we don't need to set dependency anymore
+        this.deployHash = null;
         clearInterval(timeInterval);
       }
     }, 10 * 1000);

--- a/explorer/server/src/StoredFaucetService.ts
+++ b/explorer/server/src/StoredFaucetService.ts
@@ -73,7 +73,7 @@ export class StoredFaucetService {
       const LFB = await this.casperService.getLastFinalizedBlockInfo();
       const blockHash = LFB.getSummary()!.getBlockHash_asU8();
       const stateQuery = new StateQuery();
-      stateQuery.setKeyBase16(encodeBase16(this.faucetContract.getPublicKey()));
+      stateQuery.setKeyBase16(encodeBase16(this.contractKeys.publicKey));
       stateQuery.setKeyVariant(StateQuery.KeyVariant.ADDRESS);
       stateQuery.setPathSegmentsList(["faucet"]);
 

--- a/explorer/server/src/StoredFaucetService.ts
+++ b/explorer/server/src/StoredFaucetService.ts
@@ -1,0 +1,86 @@
+import { StateQuery } from "casperlabs-grpc/io/casperlabs/node/api/casper_pb";
+import { CasperService, Contracts, DeployHash, DeployUtil, encodeBase16 } from "casperlabs-sdk";
+import { ByteArray, SignKeyPair } from "tweetnacl-ts";
+import { CallFaucet, StoredFaucet } from "./lib/Contracts";
+import DeployService from "./services/DeployService";
+
+export class StoredFaucetService {
+  private deployHash: ByteArray | null = null;
+
+  // indicate whether the deploy of the stored version Faucet has been finalized,
+  // if finalized, we no longer need set dependencies when calling stored version contract
+  private storedFaucetFinalized: boolean = false;
+
+  constructor(
+    private faucetContract: Contracts.BoundContract,
+    private contractKeys: SignKeyPair,
+    private paymentAmount: bigint,
+    private transformAmount: bigint,
+    private deployService: DeployService,
+    private casperService: CasperService
+  ) {
+    this.periodCheckState();
+  }
+
+  async callStoredFaucet(accountPublicKey: ByteArray): Promise<DeployHash> {
+    if (!this.storedFaucetFinalized && !this.deployHash) {
+      const state = await this.checkState();
+      if (state) {
+        this.storedFaucetFinalized = true;
+      } else {
+        const deploy = this.faucetContract.deploy(StoredFaucet.args(), this.paymentAmount);
+        await this.deployService.deploy(deploy);
+        this.deployHash = deploy.getDeployHash_asU8();
+      }
+    }
+
+    const dependencies = [];
+    if (this.deployHash) {
+      dependencies.push(this.deployHash);
+    }
+    const deployByName = DeployUtil.makeDeploy(CallFaucet.args(accountPublicKey, this.transformAmount), DeployUtil.ContractType.Name, "faucet", null, this.paymentAmount, this.contractKeys.publicKey, dependencies);
+    const signedDeploy = DeployUtil.signDeploy(deployByName, this.contractKeys);
+    await this.deployService.deploy(signedDeploy);
+    return signedDeploy.getDeployHash_asU8();
+  }
+
+  /**
+   * Check whether stored version faucet has been finalised every 10 seconds.
+   */
+  private async periodCheckState() {
+    setInterval(async () => {
+      const state = await this.checkState();
+      if (!state) {
+        // if we restart blockchain but forget to restart Clarity instance
+        // we need set storedFaucetFinalized false, and set deploy null
+        // so that next time we will deploy stored version faucet again.
+        if(this.storedFaucetFinalized && this.deployHash){
+          this.deployHash = null;
+        }
+        this.storedFaucetFinalized = false;
+      } else {
+        this.storedFaucetFinalized = true;
+      }
+    }, 10 * 1000);
+  }
+
+  /**
+   * Check whether the global state of LFB contains the key "faucet" under the faucet account.
+   * If it contains, we know that we can call stored version faucet by name
+   */
+  private async checkState() {
+    try {
+      const LFB = await this.casperService.getLastFinalizedBlockInfo();
+      const blockHash = LFB.getSummary()!.getBlockHash_asU8();
+      const stateQuery = new StateQuery();
+      stateQuery.setKeyBase16(encodeBase16(this.faucetContract.getPublicKey()));
+      stateQuery.setKeyVariant(StateQuery.KeyVariant.ADDRESS);
+      stateQuery.setPathSegmentsList(["faucet"]);
+
+      const state = await this.casperService.getBlockState(blockHash, stateQuery);
+      return state;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/explorer/server/src/lib/Contracts.ts
+++ b/explorer/server/src/lib/Contracts.ts
@@ -1,11 +1,19 @@
 import { Deploy } from "casperlabs-grpc/io/casperlabs/casper/consensus/consensus_pb";
 import { Args, ByteArray } from "casperlabs-sdk";
 
-export class Faucet {
+export class CallFaucet {
   public static args(accountPublicKey: ByteArray, amount: bigint): Deploy.Arg[] {
     return Args.Args(
       ["account", Args.BytesValue(accountPublicKey)],
       ["amount", Args.BigIntValue(amount)]
+    );
+  }
+}
+
+export class StoredFaucet {
+  public static args(): Deploy.Arg[] {
+    return Args.Args(
+      ["destination", Args.StringValue("hash")]
     );
   }
 }

--- a/explorer/server/src/server.ts
+++ b/explorer/server/src/server.ts
@@ -1,4 +1,4 @@
-import { Contracts, Keys } from "casperlabs-sdk";
+import { CasperService, Contracts, Keys } from "casperlabs-sdk";
 import dotenv from "dotenv";
 import express from "express";
 import jwt from "express-jwt";
@@ -9,8 +9,9 @@ import path from "path";
 import { decodeBase64 } from "tweetnacl-util";
 // TODO: Everything in config.json could come from env vars.
 import config from "./config.json";
-import { Faucet } from "./lib/Contracts";
 import DeployService from "./services/DeployService";
+import { StoredFaucetService } from './StoredFaucetService';
+import { NodeHttpTransport } from '@improbable-eng/grpc-web-node-http-transport';
 
 // https://auth0.com/docs/quickstart/spa/vanillajs/02-calling-an-api
 // https://github.com/auth0/express-jwt
@@ -28,7 +29,7 @@ const contractKeys =
     process.env.FAUCET_ACCOUNT_PRIVATE_KEY_PATH!);
 
 // Faucet contract and deploy factory.
-const faucet = new Contracts.BoundContract(
+const storedFaucet = new Contracts.BoundContract(
   new Contracts.Contract(
     process.env.FAUCET_CONTRACT_PATH!
   ),
@@ -47,6 +48,8 @@ const nodeUrls = urls.split(';')
 
 // gRPC client to the node.
 const deployService = new DeployService(nodeUrls);
+const casperService = new CasperService(nodeUrls[0], NodeHttpTransport());
+const storedFaucetService = new StoredFaucetService(storedFaucet,contractKeys, paymentAmount, transferAmount, deployService, casperService);
 
 const app = express();
 
@@ -123,16 +126,13 @@ app.post("/api/faucet", checkJwt, (req, res) => {
     throw Error("The 'accountPublicKeyBase64' is missing.");
   }
 
-  // Prepare the signed deploy.
   const accountPublicKey = decodeBase64(accountPublicKeyBase64);
-  const deploy = faucet.deploy(Faucet.args(accountPublicKey, transferAmount), paymentAmount);
 
   // Send the deploy to the node and return the deploy hash to the browser.
-  deployService
-    .deploy(deploy)
-    .then(() => {
+  storedFaucetService.callStoredFaucet(accountPublicKey)
+    .then((deployHash) => {
       const response = {
-        deployHashBase16: Buffer.from(deploy.getDeployHash_asU8()).toString("hex")
+        deployHashBase16: Buffer.from(deployHash).toString('hex')
       };
       res.send(response);
     })

--- a/explorer/ui/src/components/BlockDAG.tsx
+++ b/explorer/ui/src/components/BlockDAG.tsx
@@ -622,7 +622,7 @@ const consistentColor = (colors: readonly string[]) => {
 function arraysEqual<T>(a: T[] | null, b: T[] | null) {
   if (a === b) return true;
   if (a == null || b == null) return false;
-  if (a.length != b.length) return false;
+  if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; ++i) {
     if (a[i] !== b[i]) return false;
   }

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { observer } from 'mobx-react';
 import DagContainer, { DagStep } from '../containers/DagContainer';
 import {
   IconButton,
   ListInline,
-  RefreshableComponent,
   shortHash
 } from './Utils';
 import DataTable from './DataTable';

--- a/explorer/ui/src/components/DeployDetails.tsx
+++ b/explorer/ui/src/components/DeployDetails.tsx
@@ -5,7 +5,7 @@ import { DeployContainer } from '../containers/DeployContainer';
 import DataTable from './DataTable';
 import { DeployInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
 import Pages from './Pages';
-import { RefreshableComponent, Icon, shortHash, FailIcon, SuccessIcon } from './Utils';
+import { RefreshableComponent, shortHash, FailIcon, SuccessIcon } from './Utils';
 import ObservableValueMap from '../lib/ObservableValueMap';
 import { Balance, FinalityIcon } from './BlockDetails';
 import { decodeBase16, encodeBase16 } from 'casperlabs-sdk';

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -8,7 +8,6 @@ import {
 import { BlockDAG } from './BlockDAG';
 import DataTable from './DataTable';
 import { BlockInfo } from 'casperlabs-grpc/io/casperlabs/casper/consensus/info_pb';
-import $ from 'jquery';
 import { DagStepButtons, Props } from './BlockList';
 import { Link, withRouter } from 'react-router-dom';
 import Pages from './Pages';

--- a/explorer/ui/src/components/Validators.tsx
+++ b/explorer/ui/src/components/Validators.tsx
@@ -16,9 +16,6 @@ interface Props {
 
 @observer
 class Validators extends RefreshableComponent<Props, {}> {
-  constructor(props: Props) {
-    super(props);
-  }
 
   componentWillUnmount(): void {
     this.props.validatorsContainer.toggleableSubscriber.unsubscribeAndFree();

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -1,4 +1,4 @@
-import { action, IObservableArray, observable, reaction, runInAction } from 'mobx';
+import { action, IObservableArray, observable, runInAction } from 'mobx';
 
 import ErrorContainer from './ErrorContainer';
 import { CasperService, encodeBase16 } from 'casperlabs-sdk';

--- a/explorer/ui/src/containers/FaucetContainer.ts
+++ b/explorer/ui/src/containers/FaucetContainer.ts
@@ -82,7 +82,8 @@ export class FaucetContainer {
       this.onFaucetStatusChange();
     }
     if (!anyNeededUpdate) {
-      window.clearTimeout(this.faucetStatusTimerId);
+      window.clearInterval(this.faucetStatusTimerId);
+      this.faucetStatusTimerId = 0;
     }
   }
 

--- a/integration-testing/casperlabs_local_net/docker_clarity.py
+++ b/integration-testing/casperlabs_local_net/docker_clarity.py
@@ -18,6 +18,12 @@ class DockerClarity(LoggingDockerBase):
         return Path(self.host_mount_dir) / "faucet-account"
 
     @property
+    def faucet_account_public_key(self) -> str:
+        public_key_path = self.faucet_account_path / "account-id-hex"
+        with public_key_path.open() as f:
+            return f.readline()
+
+    @property
     def volumes(self) -> dict:
         account_public_key = self.faucet_account_path / "account-public.pem"
         account_private_key = self.faucet_account_path / "account-private.pem"

--- a/integration-testing/features/clarity.feature
+++ b/integration-testing/features/clarity.feature
@@ -8,15 +8,22 @@ Feature: Clarity
       Then: The content of page contains "<title>CasperLabs Clarity - Home</title>"
 
   # Implemented test_clarity.py : test_create_account_key
-  Scenario: User can create/delete account key and request tokens
+  Scenario: User can create/delete account key and request tokens by using stored version faucet
      Given: Single Node Network With Clarity
        And: A running seleniumHQ container
       When: Visiting http://CLARITY-HOST-NAME:8080/#/accounts
        And: Log into the Clarity
        And: Click `Create Account Key`, and input a account name
       Then: A new account with no no token has been created
-      When: Using the created account to request tokens
+      when: Click `Create Account Key` again, and input another account name
+      Then: Another new account with no no token has been created
+      When: Using the first created account to request tokens
        And: The faucet request succeed
       Then: In Accounts Key page, we can see the balance of the account is 10,000,000
+       And: There should be 2 deploys from the faucet account, one for init stored version faucet, the other is for calling faucet method
+      When: Using the second created account to request tokens
+       And: The faucet request succeed
+      Then: In Accounts Key page, we can see the balance of the account is 10,000,000
+       And: There should be 3 deploys from the faucet account, two for previous faucet, and the last one is for calling faucet method
       When: When click the delete button of the account
       Then: The account is deleted

--- a/integration-testing/test/test_clarity_R2.py
+++ b/integration-testing/test/test_clarity_R2.py
@@ -128,6 +128,7 @@ def create_account(driver):
     driver.find_element(By.LINK_TEXT, "Account Keys").click()
     driver.find_element(By.XPATH, "//button[contains(., 'Create Account Key')]").click()
     account_name = random_string(5)
+    # waiting for showing the modal of the form where to create account keys.
     time.sleep(1)
     account_name_input = driver.find_element(By.ID, "id-account-name")
     account_name_input.click()

--- a/integration-testing/test/test_clarity_R2.py
+++ b/integration-testing/test/test_clarity_R2.py
@@ -43,14 +43,14 @@ def test_create_account_key(one_node_network_with_clarity):
     faucet_public_key = one_node_network_with_clarity.clarity_node.faucet_account_public_key
     trs = find_deploys(driver, faucet_public_key)
     assert (
-        len(trs) == 2
+            len(trs) == 2
     )
 
     # There should be 3 deploys, 2 for previous faucet.
     request_token(driver, another_account_name)
     trs = find_deploys(driver, faucet_public_key)
     assert (
-        len(trs) == 3
+            len(trs) == 3
     )
 
     remove_account(driver, account_name)
@@ -98,7 +98,6 @@ def request_token(driver, account_name):
     :param account_name:
     :return:
     """
-    time.sleep(1)
     driver.find_element(By.LINK_TEXT, "Faucet").click()
     select = Select(driver.find_element(By.ID, "id-account-name"))
     select.select_by_visible_text(account_name)
@@ -126,7 +125,6 @@ def create_account(driver):
     :param driver:
     :return: name of the created account
     """
-    time.sleep(1)
     driver.find_element(By.LINK_TEXT, "Account Keys").click()
     driver.find_element(By.XPATH, "//button[contains(., 'Create Account Key')]").click()
     account_name = random_string(5)

--- a/integration-testing/test/test_clarity_R2.py
+++ b/integration-testing/test/test_clarity_R2.py
@@ -133,6 +133,8 @@ def create_account(driver):
     account_name_input.click()
     account_name_input.send_keys(account_name)
     driver.find_element(By.XPATH, "//button[contains(., 'Save')]").click()
+    # waiting for downloading the keypairs
+    time.sleep(1)
     assert (
         len(driver.find_elements(By.XPATH, f"//td[contains(., '{account_name}')]")) == 1
     )

--- a/integration-testing/test/test_clarity_R2.py
+++ b/integration-testing/test/test_clarity_R2.py
@@ -33,27 +33,78 @@ def test_create_account_key(one_node_network_with_clarity):
     sign_in_button.click()
 
     # create account key
-    driver.find_element(By.LINK_TEXT, "Account Keys").click()
-    driver.find_element(By.XPATH, "//button[contains(., 'Create Account Key')]").click()
-    time.sleep(2)
-    account_name = random_string(5)
-    account_name_input = driver.find_element(By.ID, "id-account-name")
-    account_name_input.click()
-    account_name_input.send_keys(account_name)
-    driver.find_element(By.XPATH, "//button[contains(., 'Save')]").click()
+    account_name = create_account(driver)
+    another_account_name = create_account(driver)
 
+    request_token(driver, account_name)
+
+    # There should be 2 deploys sent by faucet account, one for init stored version contract
+    # The other is calling stored version faucet to do the real faucet
+    faucet_public_key = one_node_network_with_clarity.clarity_node.faucet_account_public_key
+    trs = find_deploys(driver, faucet_public_key)
     assert (
-        len(driver.find_elements(By.XPATH, f"//td[contains(., '{account_name}')]")) >= 1
+        len(trs) == 2
     )
 
-    time.sleep(10)
+    # There should be 3 deploys, 2 for previous faucet.
+    request_token(driver, another_account_name)
+    trs = find_deploys(driver, faucet_public_key)
+    assert (
+        len(trs) == 3
+    )
 
+    remove_account(driver, account_name)
+    remove_account(driver, another_account_name)
+
+
+def remove_account(driver, account_name):
+    """
+    Remove account by account_name
+    :param driver:
+    :param account_name: the account name to remove
+    :return:
+    """
+    driver.find_element(By.LINK_TEXT, "Account Keys").click()
+    # Remove the created account
+    remove_button = driver.find_element(
+        By.XPATH, f"//td[contains(., '{account_name}')]/ancestor::tr/td/button"
+    )
+    remove_button.click()
+    driver.switch_to.alert.accept()
+    # Verify we have deleted the account
+    assert (
+            len(driver.find_elements(By.XPATH, f"//td[contains(., '{account_name}')]")) == 0
+    )
+
+
+def find_deploys(driver, public_key):
+    """
+    Get deploys item for public_key
+    :param driver:
+    :param public_key:
+    :return:
+    """
+    driver.find_element(By.LINK_TEXT, "Deploys").click()
+    driver.find_element(By.CSS_SELECTOR, ".controller-button").click()
+    driver.find_element(By.CSS_SELECTOR, "input.form-control").send_keys(public_key)
+    driver.find_element(By.CSS_SELECTOR, ".btn").click()
+    return driver.find_elements(By.CSS_SELECTOR, "tbody>tr")
+
+
+def request_token(driver, account_name):
+    """
+    Request token for the account specified by account_name
+    :param driver:
+    :param account_name:
+    :return:
+    """
+    time.sleep(1)
     driver.find_element(By.LINK_TEXT, "Faucet").click()
     select = Select(driver.find_element(By.ID, "id-account-name"))
     select.select_by_visible_text(account_name)
     driver.find_element(By.XPATH, "//button[contains(., 'Request tokens')]").click()
-
-    WebDriverWait(driver, 60).until_not(
+    time.sleep(2)
+    WebDriverWait(driver, 90).until_not(
         lambda d: d.find_element(By.CSS_SELECTOR, "table tr:first-child td:last-child")
         .get_attribute("title")
         .startswith("Pending")
@@ -68,14 +119,23 @@ def test_create_account_key(one_node_network_with_clarity):
     xpath_correct_balance = f"//td[contains(., '{account_name}')]/ancestor::tr/td[contains(.,'1,000,000,000')]"
     assert len(driver.find_elements(By.XPATH, xpath_correct_balance)) == 1
 
-    # Remove the created account
-    remove_button = driver.find_element(
-        By.XPATH, f"//td[contains(., '{account_name}')]/ancestor::tr/td/button"
-    )
-    remove_button.click()
-    driver.switch_to.alert.accept()
 
-    # Verify we have deleted the account
+def create_account(driver):
+    """
+    helper method to create account
+    :param driver:
+    :return: name of the created account
+    """
+    time.sleep(1)
+    driver.find_element(By.LINK_TEXT, "Account Keys").click()
+    driver.find_element(By.XPATH, "//button[contains(., 'Create Account Key')]").click()
+    account_name = random_string(5)
+    time.sleep(1)
+    account_name_input = driver.find_element(By.ID, "id-account-name")
+    account_name_input.click()
+    account_name_input.send_keys(account_name)
+    driver.find_element(By.XPATH, "//button[contains(., 'Save')]").click()
     assert (
-        len(driver.find_elements(By.XPATH, f"//td[contains(., '{account_name}')]")) == 0
+        len(driver.find_elements(By.XPATH, f"//td[contains(., '{account_name}')]")) == 1
     )
+    return account_name


### PR DESCRIPTION
### Overview
This PR enables Clarity to use stored version Faucet. 
When receiving the first faucet request, the server will check whether CL has initialized the stored version faucet. If not, it will send CL a deploy to init stored version faucet, then it will send another deploy to do the faucet, and this deploy will include the hash of the first deploy as dependencies, so as to make sure the stored version faucet has been initialized before calling faucet by name.
And this PR also adds an integration test for stored version faucet. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-381
https://casperlabs.atlassian.net/browse/TNET-20

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
