### PR TITLE
NO-TICKET: add package-lock.json to files targeted by casperlabs-updater

### DIFF
--- a/ci/casperlabs-updater/src/regex_data.rs
+++ b/ci/casperlabs-updater/src/regex_data.rs
@@ -433,11 +433,18 @@ pub mod contract_as {
 
     lazy_static! {
         pub static ref DEPENDENT_FILES: Vec<DependentFile> = {
-            vec![DependentFile::new(
-                "contract-as/package.json",
-                PACKAGE_JSON_VERSION_REGEX.clone(),
-                replacement,
-            )]
+            vec![
+                DependentFile::new(
+                    "contract-as/package.json",
+                    PACKAGE_JSON_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+                DependentFile::new(
+                    "contract-as/package-lock.json",
+                    PACKAGE_JSON_VERSION_REGEX.clone(),
+                    replacement,
+                ),
+            ]
         };
     }
 }


### PR DESCRIPTION
### Overview
This adds `execution-engine/contracts-as/package-lock.json` to files targeted by casperlabs-updater.

### Which JIRA ticket does this PR relate to?
NO-TICKET

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
