### PR TITLE
TNET-32: Not logging download scheduling errors

### DIFF
--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/BlockDownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/BlockDownloadManager.scala
@@ -86,7 +86,7 @@ object BlockDownloadManagerImpl extends DownloadManagerCompanion {
     }
 
   override def dependencies(summary: BlockSummary) =
-    summary.parentHashes ++ summary.justifications.map(_.latestBlockHash)
+    (summary.parentHashes ++ summary.justifications.map(_.latestBlockHash)).distinct
 }
 
 class BlockDownloadManagerImpl[F[_]](

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DeployDownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DeployDownloadManager.scala
@@ -77,7 +77,7 @@ object DeployDownloadManagerImpl extends DownloadManagerCompanion {
     }
 
   override def dependencies(summary: DeploySummary): Seq[ByteString] =
-    summary.getHeader.dependencies
+    summary.getHeader.dependencies.distinct
 }
 
 class DeployDownloadManagerImpl[F[_]](

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -375,9 +375,7 @@ trait DownloadManagerImpl[F[_]] extends DownloadManager[F] { self =>
             } yield downloadFeedback
           )
         // Report any startup errors so the caller knows something's fatally wrong, then carry on.
-        start
-          .attemptAndLog("An error occurred when handling Download signal.")
-          .flatMap(scheduleFeedback.complete) >> run
+        start.attempt.flatMap(scheduleFeedback.complete) >> run
 
       case Signal.DownloadSuccess(id) =>
         val finish = for {


### PR DESCRIPTION
### Overview
The `MissingDependency` error was indeed fixed in https://github.com/CasperLabs/CasperLabs/pull/1975 but the error which got handled was already logged, which was confusing. The PR changes it so that for `scheduleDownload` the logging happens outside; that's what the `scheduleFeedback` is for, after all.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-32

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
