### PR TITLE
TNET-31: Base block

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -19,6 +19,7 @@ import io.casperlabs.storage.era.EraStorage
 
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NonFatal
+import io.casperlabs.storage.dag.AncestorsStorage
 
 /** The supervisor loads all the active eras when it starts and does the following things:
   * - acts as a gateway for the rest of the system to execute blocks by passing them to the right era
@@ -295,7 +296,7 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: BlockRela
 
 object EraSupervisor {
 
-  def apply[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: DagStorage: FinalityStorageReader: BlockRelaying: ForkChoiceManager](
+  def apply[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: DagStorage: FinalityStorageReader: BlockRelaying: ForkChoiceManager: AncestorsStorage](
       conf: HighwayConf,
       genesis: BlockSummary,
       maybeMessageProducer: Option[MessageProducer[F]],

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -36,6 +36,7 @@ import io.casperlabs.models.Message.{asMainRank, JRank, MainRank}
 import io.casperlabs.shared.Sorting._
 import scala.concurrent.duration._
 import io.casperlabs.casper.consensus.info.DeployInfo
+import io.casperlabs.shared.ByteStringPrettyPrinter.byteStringShow
 
 /** Produce a signed message, persisted message.
   * The producer should the thread safe, so that when it's

--- a/casper/src/test/scala/io/casperlabs/casper/highway/BaseBlockSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/BaseBlockSpec.scala
@@ -49,6 +49,7 @@ class BaseBlockSpec
             // Set the fork choice to go towards k1.
             fc <- db.lookupUnsafe(b1)
             _  <- forkchoice.set(fc.asInstanceOf[Message.Block])
+            _  <- db.markAsFinalized(k1, Set.empty, orphaned = Set(k2))
 
             _ <- EraRuntime.isOrphanEra[Task](k1) shouldBeF false
             _ <- EraRuntime.isOrphanEra[Task](k2) shouldBeF true

--- a/casper/src/test/scala/io/casperlabs/casper/highway/BaseBlockSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/BaseBlockSpec.scala
@@ -92,7 +92,7 @@ class BaseBlockSpec
         postEraVotingDuration = HighwayConf.VotingDuration.FixedLength(postEraVotingDuration)
       )
 
-      // The hypotheses is that if Alice builds more isolated eras than the the lookback
+      // The hypotheses is that if Alice builds more isolated eras than the lookback
       // of the fork choice then the other validators will join them:
       //
       // e0 - e1 - e2 - e3 - e4

--- a/casper/src/test/scala/io/casperlabs/casper/highway/BaseBlockSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/BaseBlockSpec.scala
@@ -1,0 +1,54 @@
+package io.casperlabs.casper.highway
+
+import cats.implicits._
+import monix.eval.Task
+import org.scalatest._
+import scala.concurrent.duration._
+import io.casperlabs.casper.highway.mocks.MockMessageProducer
+
+class BaseBlockSpec extends FlatSpec with Matchers with Inspectors with HighwayFixture {
+
+  behavior of "EraRuntime"
+
+  it should "not participate in eras that aren't part of the main chain" in testFixture {
+    implicit timer => implicit db =>
+      new Fixture(
+        length = 3 * eraDuration,
+        initRoundExponent = 15 // ~ 8 hours
+      ) {
+        val thisProducer  = messageProducer
+        val otherProducer = new MockMessageProducer[Task]("Bob")
+
+        // 2 weeks for genesis, then 1 week for the descendants.
+        // e0 - e1
+        //    \ e2
+        override def test =
+          for {
+            _  <- insertGenesis()
+            e0 <- addGenesisEra()
+            k1 <- e0.block(thisProducer, e0.keyBlockHash)
+            k2 <- e0.block(otherProducer, e0.keyBlockHash)
+
+            // The LFB goes towards k1, orphaning the other key block k2.
+            _ <- db.markAsFinalized(k1, Set.empty, Set(k2))
+
+            // But the other validator doesn't see this and produces an era e2 on top of k2.
+            // This validator should not produce messages in the era which it knows is not
+            // on the path of the LFB.
+            e1 <- e0.addChildEra(k1)
+            e2 <- e0.addChildEra(k2)
+            r1 <- makeRuntime(e1)
+            r2 <- makeRuntime(e2)
+
+            // This validator should not have scheduled actions for the orphaned era.
+            a1 <- r1.initAgenda
+            _  = a1 should not be empty
+            a2 <- r2.initAgenda
+            _  = a2 shouldBe empty
+
+            // This validator should not react to lambda messages in the orphaned era.
+
+          } yield {}
+      }
+  }
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -670,7 +670,7 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
 
           "only cite the lambda message and validators own latest message" in {
             var forkChoiceFun: MockForkChoice.ForkChoiceFun =
-              (_, _) => sys.error("Fork choice unassigned.")
+              (_, _) => ForkChoice.Result(genesis, Set.empty)
 
             implicit val ds = defaultBlockDagStorage
             implicit val fc = MockForkChoice[Id](genesis, Some(forkChoiceFun(_, _)))

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -28,12 +28,18 @@ class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with High
       //         \ e4 - e5
       override def test =
         for {
+          _  <- insertGenesis()
           e0 <- addGenesisEra()
-          _  <- e0.addChildEra()
-          e2 <- e0.addChildEra()
-          e3 <- e2.addChildEra()
-          e4 <- e2.addChildEra()
-          e5 <- e4.addChildEra()
+          b1 <- e0.block(messageProducer, genesis.blockSummary.blockHash)
+          b2 <- e0.block(messageProducer, genesis.blockSummary.blockHash)
+          _  <- e0.addChildEra(b1)
+          e2 <- e0.addChildEra(b2)
+          b3 <- e2.block(messageProducer, b2)
+          b4 <- e2.block(messageProducer, b2)
+          e3 <- e2.addChildEra(b3)
+          e4 <- e2.addChildEra(b4)
+          b5 <- e4.block(messageProducer, b3)
+          e5 <- e4.addChildEra(b5)
           // Wait until where e3 and e4 are voting.
           // Their parent eras will have their voting over, and
           // their children should be active.

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -110,7 +110,7 @@ class EraSupervisorSpec
 
   it should "relay created messages to other nodes" in testFixtures(
     validators = List("Alice", "Bob", "Charlie")
-  ) { implicit timer => validatorDatabases =>
+  ) { timer => validatorDatabases =>
     new NetworkFixture(validatorDatabases) {
 
       override val start  = genesisEraStart

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -16,7 +16,12 @@ import io.casperlabs.casper.highway.mocks.MockMessageProducer
 import io.casperlabs.crypto.Keys
 import io.casperlabs.shared.Log
 
-class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with HighwayFixture {
+class EraSupervisorSpec
+    extends FlatSpec
+    with Matchers
+    with Inspectors
+    with HighwayFixture
+    with HighwayNetworkFixture {
 
   behavior of "collectActiveEras"
 
@@ -106,83 +111,49 @@ class EraSupervisorSpec extends FlatSpec with Matchers with Inspectors with High
   it should "relay created messages to other nodes" in testFixtures(
     validators = List("Alice", "Bob", "Charlie")
   ) { implicit timer => validatorDatabases =>
-    new FixtureLike {
+    new NetworkFixture(validatorDatabases) {
+
       override val start  = genesisEraStart
       override val length = days(5)
 
-      class RelayFixture(
+      override def makeRelayFixture(
           validator: String,
           db: SQLiteStorage.CombinedStorage[Task],
           supervisorsRef: Ref[Task, Map[String, EraSupervisor[Task]]],
           isSyncedRef: Ref[Task, Boolean]
-      ) extends Fixture(
-            length,
-            validator = validator,
-            initRoundExponent = 15,
-            isSyncedRef = isSyncedRef
-          ) (timer, db) {
+      ) =
+        new RelayFixture(
+          length,
+          validator = validator,
+          initRoundExponent = 15,
+          supervisorsRef,
+          isSyncedRef
+        ) (timer, db) {
 
-        val validatorId: PublicKeyBS              = validator
-        val relayedRef: Ref[Task, Set[BlockHash]] = Ref.unsafe(Set.empty)
+          val validatorId: PublicKeyBS = validator
 
-        override lazy val blockRelaying = new BlockRelaying[Task] {
-          override def relay(hashes: List[BlockHash]): Task[WaitHandle[Task]] =
-            for {
-              _           <- relayedRef.update(_ ++ hashes)
-              blocks      <- hashes.traverse(h => db.getBlockMessage(h)).map(_.flatten)
-              _           = blocks should not be empty
-              supervisors <- supervisorsRef.get
-              // Notify other supervisors.
-              _ <- supervisors
-                    .filterKeys(_ != validator)
-                    .values
-                    .toList
-                    .traverse(s => blocks.traverse(b => s.validateAndAddBlock(b)))
-            } yield ().pure[Task]
-        }
+          override val test = for {
+            _        <- sleepUntil(start plus length)
+            relayed  <- relayedRef.get
+            dag      <- db.getRepresentation
+            messages <- relayed.toList.traverse(dag.lookupUnsafe)
+            parents  <- messages.traverse(m => dag.lookupUnsafe(m.parentBlock))
+          } yield {
+            messages should not be empty
+            atLeast(1, messages) shouldBe a[Message.Ballot]
+            atLeast(1, messages) shouldBe a[Message.Block]
 
-        override val test = for {
-          _        <- sleepUntil(start plus length)
-          relayed  <- relayedRef.get
-          dag      <- db.getRepresentation
-          messages <- relayed.toList.traverse(dag.lookupUnsafe)
-          parents  <- messages.traverse(m => dag.lookupUnsafe(m.parentBlock))
-        } yield {
-          messages should not be empty
-          atLeast(1, messages) shouldBe a[Message.Ballot]
-          atLeast(1, messages) shouldBe a[Message.Block]
-
-          // Validators should only try to relay their own messages.
-          forAll(messages) { m =>
-            m.validatorId shouldBe validatorId
-          }
-          // There should be some responses to other validators' messages.
-          forAtLeast(1, parents) { p =>
-            p.validatorId should not be empty
-            p.validatorId should not be validatorId
+            // Validators should only try to relay their own messages.
+            forAll(messages) { m =>
+              m.validatorId shouldBe validatorId
+            }
+            // There should be some responses to other validators' messages.
+            forAtLeast(1, parents) { p =>
+              p.validatorId should not be empty
+              p.validatorId should not be validatorId
+            }
           }
         }
-      }
-
-      val network =
-        for {
-          // Don't create messages until we add all supervisors to this collection,
-          // otherwise they might miss some messages and there's no synchronizer here.
-          isSyncedRef    <- Resource.liftF(Ref[Task].of(false))
-          supervisorsRef <- Resource.liftF(Ref[Task].of(Map.empty[String, EraSupervisor[Task]]))
-          fixtures = validatorDatabases.map {
-            case (validator, db) =>
-              new RelayFixture(validator, db, supervisorsRef, isSyncedRef)
-          }
-          validators  = validatorDatabases.unzip._1
-          supervisors <- fixtures.traverse(_.makeSupervisor())
-          _ <- Resource.liftF {
-                supervisorsRef.set(validators zip supervisors toMap) *> isSyncedRef.set(true)
-              }
-        } yield fixtures
-
-      override def test: Task[Unit] =
-        network.use(_.traverse(_.test).void)
     }
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -103,7 +103,7 @@ trait HighwayFixture
       val validator: String = "Alice",
       val initRoundExponent: Int = 0,
       val isSyncedRef: Ref[Task, Boolean] = Ref.unsafe(true),
-      printLevel: Log.Level = Log.Level.Error
+      protected val printLevel: Log.Level = Log.Level.Error
   )(
       implicit
       timer: Timer[Task],

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -277,7 +277,12 @@ trait HighwayFixture
       )
 
     def insertGenesis(): Task[Unit] =
-      db.put(BlockMsgWithTransform().withBlockMessage(genesisBlock))
+      db.put(BlockMsgWithTransform().withBlockMessage(genesisBlock)) *>
+        db.markAsFinalized(
+          genesis.messageHash,
+          Set.empty,
+          Set.empty
+        )
 
     def makeSupervisor(): Resource[Task, EraSupervisor[Task]] =
       for {

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayNetworkFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayNetworkFixture.scala
@@ -1,0 +1,84 @@
+package io.casperlabs.casper.highway
+
+import cats.implicits._
+import cats.effect.{Resource, Timer}
+import cats.effect.concurrent.Ref
+import monix.eval.Task
+import org.scalatest._
+import scala.concurrent.duration.FiniteDuration
+import io.casperlabs.crypto.Keys.PublicKeyBS
+import io.casperlabs.comm.gossiping.WaitHandle
+import io.casperlabs.comm.gossiping.relaying.BlockRelaying
+import io.casperlabs.storage.{BlockHash, SQLiteStorage}
+
+trait HighwayNetworkFixture { self: HighwayFixture =>
+
+  abstract class RelayFixture(
+      length: FiniteDuration,
+      validator: String,
+      initRoundExponent: Int,
+      supervisorsRef: Ref[Task, Map[String, EraSupervisor[Task]]],
+      isSyncedRef: Ref[Task, Boolean]
+  )(
+      implicit
+      timer: Timer[Task],
+      db: SQLiteStorage.CombinedStorage[Task]
+  ) extends Fixture(
+        length = length,
+        validator = validator,
+        initRoundExponent = initRoundExponent,
+        isSyncedRef = isSyncedRef
+      ) (timer, db) {
+
+    val relayedRef: Ref[Task, Set[BlockHash]] = Ref.unsafe(Set.empty)
+
+    override lazy val blockRelaying = new BlockRelaying[Task] {
+      override def relay(hashes: List[BlockHash]): Task[WaitHandle[Task]] =
+        for {
+          _           <- relayedRef.update(_ ++ hashes)
+          blocks      <- hashes.traverse(h => db.getBlockMessage(h).map(_.get))
+          supervisors <- supervisorsRef.get
+          // Notify other supervisors.
+          _ <- supervisors
+                .filterKeys(_ != validator)
+                .values
+                .toList
+                .traverse(s => blocks.traverse(b => s.validateAndAddBlock(b)))
+        } yield ().pure[Task]
+    }
+  }
+
+  abstract class NetworkFixture(
+      validatorDatabases: List[(String, SQLiteStorage.CombinedStorage[Task])]
+  ) extends FixtureLike {
+
+    // Test all networked fixtures.
+    override def test: Task[Unit] =
+      network.use(_.traverse(_.test).void)
+
+    def network: Resource[Task, List[RelayFixture]] =
+      for {
+        // Don't create messages until we add all supervisors to this collection,
+        // otherwise they might miss some messages and there's no synchronizer here.
+        isSyncedRef    <- Resource.liftF(Ref[Task].of(false))
+        supervisorsRef <- Resource.liftF(Ref[Task].of(Map.empty[String, EraSupervisor[Task]]))
+        fixtures = validatorDatabases.map {
+          case (validator, db) =>
+            makeRelayFixture(validator, db, supervisorsRef, isSyncedRef)
+        }
+        validators  = validatorDatabases.unzip._1
+        supervisors <- fixtures.traverse(_.makeSupervisor())
+        _ <- Resource.liftF {
+              supervisorsRef.set(validators zip supervisors toMap) *> isSyncedRef.set(true)
+            }
+      } yield fixtures
+
+    def makeRelayFixture(
+        validator: String,
+        db: SQLiteStorage.CombinedStorage[Task],
+        supervisorsRef: Ref[Task, Map[String, EraSupervisor[Task]]],
+        isSyncedRef: Ref[Task, Boolean]
+    ): RelayFixture
+  }
+
+}

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
@@ -16,6 +16,7 @@ import io.casperlabs.storage.dag.DagStorage
 import io.casperlabs.models.Message
 import scala.util.control.NonFatal
 import io.casperlabs.shared.ByteStringPrettyPrinter._
+import io.casperlabs.shared.Log
 
 class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
     val validatorId: PublicKeyBS

--- a/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/mocks/MockMessageProducer.scala
@@ -75,6 +75,12 @@ class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
           .Header()
           .withMessageType(Block.MessageType.BALLOT)
           .withMessageRole(messageRole)
+          .withMainRank(target.mainRank + 1)
+          .withJRank(
+            (target.jRank +: justifications.values.flatten.map(_.jRank).toList)
+              .map(_.asInstanceOf[Long])
+              .max + 1
+          )
           .withValidatorPublicKey(validatorId)
           .withParentHashes(List(target.messageHash))
           .withJustifications(
@@ -111,6 +117,12 @@ class MockMessageProducer[F[_]: Sync: BlockStorageWriter: DagStorage](
           Block
             .Header()
             .withMessageRole(messageRole)
+            .withMainRank(mainParent.mainRank + 1)
+            .withJRank(
+              (mainParent.jRank +: justifications.values.flatten.map(_.jRank).toList)
+                .map(_.asInstanceOf[Long])
+                .max + 1
+            )
             .withValidatorPublicKey(validatorId)
             .withParentHashes(List(mainParent.messageHash))
             .withJustifications(


### PR DESCRIPTION
### Overview
There was supposed to be a "base block" mechanism in Highway to prevent eras that aren't building on the last finalized block to go on for too long. That wasn't added but in the case of an output-only validator there was nothing to contradict their fork choices when they started new eras, which compelled other validators to join them.

~The PR adds a mechanism to the start of eras whereby if the fork choice given the key block of the era being created isn't related to the key block itself then the validator will not produce messages in the era.~

Maybe this isn't enough: if the output-only validator keeps on going, at some point the key block they pick will have nothing to do with anything else the other validators know about:
```
e0 - e1 - e2 - e3 - e4
   \ 
    e1' - e2' - e3' - e4'
```
If the other validators keep accepting messages from the one building lower fork, when they see `e4'` they will start from a key block in `e2'` and see it as the only logical choice.

~So I guess I must actually reject messages that go into orphaned eras, not just not-respond.~

What I ended up with is hopefully a variant of the "base era" feature whereby we would check if the latest finalized key block is an ancestor of the new era. Currently I'm checking if the key block of the new era is related to the LFB, i.e. is it on the main chain: eventually if the eras continue to diverge then there will be a key block unrelated to the main chain and there the validators will stop participating. But it also means they would not reject the situation until `e3'`.


### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-31

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I tried to add a unit test to demonstrate the situation but gave up. It's not clear why it doesn't behave as it should, so I left it there for further investigation.