### PR TITLE
NDRS-60: Initial basic deploy buffer

### DIFF
--- a/execution-engine/consensus/consensus-service/src/deploy_buffer/mod.rs
+++ b/execution-engine/consensus/consensus-service/src/deploy_buffer/mod.rs
@@ -1,0 +1,46 @@
+use std::mem;
+
+// TODO: temporary type, probably will get replaced with something with more structure
+#[derive(Debug, Clone, PartialEq)]
+pub struct Deploy(Vec<u8>);
+
+#[derive(Debug, Clone, Default)]
+pub struct DeployBuffer {
+    collected_deploys: Vec<Deploy>,
+}
+
+impl DeployBuffer {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn add_deploy(&mut self, deploy: Deploy) {
+        self.collected_deploys.push(deploy);
+    }
+
+    pub fn remaining_deploys(&mut self) -> Vec<Deploy> {
+        mem::take(&mut self.collected_deploys)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Deploy, DeployBuffer};
+
+    #[test]
+    fn add_and_take_deploys() {
+        let mut buffer = DeployBuffer::new();
+
+        assert!(buffer.remaining_deploys().is_empty());
+
+        buffer.add_deploy(Deploy(vec![1]));
+        buffer.add_deploy(Deploy(vec![2]));
+
+        assert_eq!(
+            buffer.remaining_deploys(),
+            vec![Deploy(vec![1]), Deploy(vec![2])]
+        );
+
+        assert!(buffer.remaining_deploys().is_empty());
+    }
+}

--- a/execution-engine/consensus/consensus-service/src/lib.rs
+++ b/execution-engine/consensus/consensus-service/src/lib.rs
@@ -1,3 +1,4 @@
 #![allow(dead_code)]
 pub mod consensus_service;
+pub mod deploy_buffer;
 pub mod traits;

--- a/execution-engine/consensus/pothole/tests/mock_network/world.rs
+++ b/execution-engine/consensus/pothole/tests/mock_network/world.rs
@@ -150,7 +150,7 @@ mod tests {
 
         assert!(world.fire_timers(node_id).is_empty());
 
-        world.advance_time(one_second);
+        world.advance_time(two_seconds);
 
         assert!(world.fire_timers(node_id).len() == 1);
     }


### PR DESCRIPTION
### Overview
This is just an initial stub of the deploy buffer, providing almost none of the required functionality, only storing and returning deploys. It will be further developed over the course of the next tasks.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDRS-60

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
