### PR TITLE
NDSC-56: Rename to `account_public_key_hash`

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/PrettyPrinter.scala
@@ -138,5 +138,5 @@ object PrettyPrinter extends ByteStringPrettyPrinter {
     s"Deployment threshold ${at.deploymentThreshold}, Key management threshold: ${at.keyManagementThreshold}"
 
   def buildString(d: consensus.Deploy): String =
-    s"Deploy ${buildStringNoLimit(d.deployHash)} (account ${buildStringNoLimit(d.getHeader.accountHash)})"
+    s"Deploy ${buildStringNoLimit(d.deployHash)} (account ${buildStringNoLimit(d.getHeader.accountPublicKeyHash)})"
 }

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -575,7 +575,7 @@ object ProtoUtil {
       .withPayment(Deploy.Code().withWasm(sessionCode))
     val h = Deploy
       .Header()
-      .withAccountHash(ByteString.copyFrom(Ed25519.publicKeyHash(pk)))
+      .withAccountPublicKeyHash(ByteString.copyFrom(Ed25519.publicKeyHash(pk)))
       .withTimestamp(timestamp)
       .withBodyHash(protoHash(b))
       .withTtlMillis(ttl.toMillis.toInt)
@@ -624,7 +624,7 @@ object ProtoUtil {
                   }.sequence
     } yield {
       ipc.DeployItem(
-        address = d.getHeader.accountHash,
+        address = d.getHeader.accountPublicKeyHash,
         session = session,
         payment = payment,
         gasPrice = GAS_PRICE,

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -599,7 +599,7 @@ abstract class HashSetCasperTest
         .withHeader(
           deployDatas(1).getHeader
             .withTimestamp(deployDatas(0).getHeader.timestamp)
-            .withAccountHash(deployDatas(0).getHeader.accountHash)
+            .withAccountPublicKeyHash(deployDatas(0).getHeader.accountPublicKeyHash)
         ) // deployPrim0 has the same (user, millisecond timestamp) with deployDatas(0)
       _            <- nodes(0).deployBuffer.addDeploy(deployDatas(0))
       signedBlock1 <- nodes(0).propose()

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -408,7 +408,7 @@ object DeployRuntime {
         deployConfig.paymentAmount.map(bigIntArg("amount", _)).toList
       )
 
-    val accountHash = Ed25519.publicKeyHash(from)
+    val accountPublicKeyHash = Ed25519.publicKeyHash(from)
 
     consensus
       .Deploy()
@@ -416,7 +416,7 @@ object DeployRuntime {
         consensus.Deploy
           .Header()
           .withTimestamp(System.currentTimeMillis)
-          .withAccountHash(ByteString.copyFrom(accountHash))
+          .withAccountPublicKeyHash(ByteString.copyFrom(accountPublicKeyHash))
           .withGasPrice(deployConfig.gasPrice)
           .withTtlMillis(deployConfig.timeToLive.getOrElse(0))
           .withDependencies(deployConfig.dependencies)

--- a/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
+++ b/models/src/test/scala/io/casperlabs/models/ArbitraryConsensus.scala
@@ -206,7 +206,7 @@ trait ArbitraryConsensus {
       bodyHash = protoHash(body)
       header = Deploy
         .Header()
-        .withAccountHash(accountKeys.publicKeyHash)
+        .withAccountPublicKeyHash(accountKeys.publicKeyHash)
         .withTimestamp(timestamp)
         .withGasPrice(gasPrice)
         .withBodyHash(bodyHash)

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -36,7 +36,7 @@ message Deploy {
         // Removed the nonce.
         reserved 2;
         // Identifying the Account is the key used to sign the Deploy.
-        bytes account_hash = 1;
+        bytes account_public_key_hash = 1;
         // Current time milliseconds.
         uint64 timestamp = 3;
         // Conversion rate between the cost of Wasm opcodes and the motes sent by the `payment_code`.

--- a/protobuf/io/casperlabs/ipc/ipc.proto
+++ b/protobuf/io/casperlabs/ipc/ipc.proto
@@ -45,12 +45,12 @@ message Bond {
 message DeployItem {
     reserved 5; // motes in payment
     reserved 7; // nonce
-    // Public key of the account which is the context of the execution.
+    // Public key hash of the account which is the context of the execution.
     bytes address = 1; // length 32 bytes
     DeployPayload session = 3;
     DeployPayload payment = 4;
     uint64 gas_price = 6; // in units of Mote / Gas
-    // Public keys used to sign this deploy, to be checked against the keys
+    // Hashes of the public keys used to sign this deploy, to be checked against the keys
     // associated with the account.
     repeated bytes authorization_keys = 8;
     bytes deploy_hash = 9;

--- a/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/deploy/SQLiteDeployStorage.scala
@@ -78,7 +78,7 @@ class SQLiteDeployStorage[F[_]: Time: Sync](
           pd =>
             (
               pd.getDeploy.deployHash,
-              pd.getDeploy.getHeader.accountHash,
+              pd.getDeploy.getHeader.accountPublicKeyHash,
               pd.getDeploy.getHeader.timestamp,
               pd.getDeploy.clearBody.toByteString,
               pd.getDeploy.getBody.toByteString
@@ -109,7 +109,7 @@ class SQLiteDeployStorage[F[_]: Time: Sync](
                 block.blockHash,
                 pd.getDeploy.deployHash,
                 deployPosition,
-                pd.getDeploy.getHeader.accountHash,
+                pd.getDeploy.getHeader.accountPublicKeyHash,
                 pd.getDeploy.getHeader.timestamp,
                 block.getHeader.timestamp,
                 pd.cost,
@@ -137,7 +137,7 @@ class SQLiteDeployStorage[F[_]: Time: Sync](
       ).updateMany(deploys.map { d =>
         (
           d.deployHash,
-          d.getHeader.accountHash,
+          d.getHeader.accountPublicKeyHash,
           d.getHeader.timestamp,
           d.clearBody.toByteString,
           d.getBody.toByteString
@@ -151,7 +151,7 @@ class SQLiteDeployStorage[F[_]: Time: Sync](
             (
               d.deployHash,
               status,
-              d.getHeader.accountHash,
+              d.getHeader.accountPublicKeyHash,
               currentTimeEpochMillis,
               currentTimeEpochMillis,
               d.clearBody.toByteString,

--- a/storage/src/test/scala/io/casperlabs/storage/benchmarks/StorageBenchSuite.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/benchmarks/StorageBenchSuite.scala
@@ -66,7 +66,7 @@ object StorageBenchSuite {
   //Take this into account before change it
   def randomDeployData: Deploy =
     Deploy()
-      .withHeader(Deploy.Header().withAccountHash(randomHexString(32)))
+      .withHeader(Deploy.Header().withAccountPublicKeyHash(randomHexString(32)))
       .withBody(
         Deploy
           .Body()

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/DeployStorageSpec.scala
@@ -204,7 +204,7 @@ trait DeployStorageSpec
         val discarded = sample(arbDeploy.arbitrary)
         val wrongAccount =
           processed
-            .withHeader(processed.getHeader.withAccountHash(sample(genHash)))
+            .withHeader(processed.getHeader.withAccountPublicKeyHash(sample(genHash)))
             .withDeployHash(sample(genHash))
         for {
           //given
@@ -213,7 +213,9 @@ trait DeployStorageSpec
           _ <- writer.addAsDiscarded(discarded)
           _ <- writer.addAsFinalized(finalized)
           //when
-          p <- reader.readProcessedByAccount(PublicKeyHash(processed.getHeader.accountHash))
+          p <- reader.readProcessedByAccount(
+                PublicKeyHash(processed.getHeader.accountPublicKeyHash)
+              )
           //should
         } yield {
           p shouldBe List(processed)
@@ -467,7 +469,7 @@ trait DeployStorageSpec
     deploys(Random.nextInt(deploys.size)).deployHash
 
   private def chooseAccount(deploys: List[Deploy]): PublicKeyHashBS =
-    PublicKeyHash(deploys(Random.nextInt(deploys.size)).getHeader.accountHash)
+    PublicKeyHash(deploys(Random.nextInt(deploys.size)).getHeader.accountPublicKeyHash)
 
   private implicit class DeployStorageWriterOps(writer: DeployStorageWriter[Task]) {
     def addAsPending(d: Deploy): Task[Unit]   = writer.addAsPending(List(d))

--- a/storage/src/test/scala/io/casperlabs/storage/deploy/MockDeployStorage.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/deploy/MockDeployStorage.scala
@@ -191,7 +191,7 @@ class MockDeployStorage[F[_]: Sync: Log](
     override def readProcessed: F[List[Deploy]] = readByStatus(ProcessedStatusCode)
 
     override def readProcessedByAccount(account: PublicKeyHashBS): F[List[Deploy]] =
-      readProcessed.map(_.filter(_.getHeader.accountHash == account))
+      readProcessed.map(_.filter(_.getHeader.accountPublicKeyHash == account))
 
     override def readProcessedHashes: F[List[ByteString]] = readProcessed.map(_.map(_.deployHash))
 


### PR DESCRIPTION
### Overview
To be consistent with the verbose but unambigous naming in https://github.com/CasperLabs/CasperLabs/pull/1990 this PR renames `account_hash` to `account_public_key_hash` and also treats the instances of `public_key` in `state.proto` the same way.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDSC-56

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
