### PR TITLE
EE-1010 Converting from PublicKey to AccountHash

### DIFF
--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -22,7 +22,7 @@ mod tests {
     use casperlabs_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
     use casperlabs_types::{account::PublicKey, U512};
 
-    const MY_ACCOUNT: PublicKey = PublicKey::ed25519_from([7u8; 32]);
+    const MY_ACCOUNT: PublicKey = PublicKey::new([7u8; 32]);
     // define KEY constant to match that in the contract
     const KEY: &str = "special_value";
     const VALUE: &str = "hello world";

--- a/execution-engine/cargo-casperlabs/src/tests_package.rs
+++ b/execution-engine/cargo-casperlabs/src/tests_package.rs
@@ -20,9 +20,9 @@ const STANDARD_PAYMENT_INSTALL: &str = "standard_payment_install.wasm";
 const INTEGRATION_TESTS_RS_CONTENTS: &str = r#"#[cfg(test)]
 mod tests {
     use casperlabs_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
-    use casperlabs_types::{account::PublicKey, U512};
+    use casperlabs_types::{account::AccountHash, U512};
 
-    const MY_ACCOUNT: PublicKey = PublicKey::new([7u8; 32]);
+    const MY_ACCOUNT: AccountHash = AccountHash::new([7u8; 32]);
     // define KEY constant to match that in the contract
     const KEY: &str = "special_value";
     const VALUE: &str = "hello world";

--- a/execution-engine/contract-as/assembly/account.ts
+++ b/execution-engine/contract-as/assembly/account.ts
@@ -2,7 +2,7 @@ import * as externals from "./externals";
 import {arrayToTyped} from "./utils";
 import {UREF_SERIALIZED_LENGTH} from "./constants";
 import {URef} from "./uref";
-import {PublicKey, PUBLIC_KEY_ED25519_ID} from "./key";
+import {AccountHash} from "./key";
 
 /**
  * Enum representing the possible results of adding an associated key to an account.
@@ -114,14 +114,14 @@ export enum ActionType {
  * Adds an associated key to the account. Associated keys are the keys allowed to sign actions performed
  * in the context of the account.
  *
- * @param publicKey The public key to be added as the associated key.
+ * @param AccountHash The public key to be added as the associated key.
  * @param weight The weight that will be assigned to the new associated key. See [[setActionThreshold]]
  *    for more info about weights.
  * @returns An instance of [[AddKeyFailure]] representing the result.
  */
-export function addAssociatedKey(publicKey: PublicKey, weight: i32): AddKeyFailure {
-    const publicKeyBytes = publicKey.toBytes();
-    const ret = externals.add_associated_key(publicKeyBytes.dataStart, publicKeyBytes.length, weight);
+export function addAssociatedKey(accountHash: AccountHash, weight: i32): AddKeyFailure {
+    const accountHashBytes = accountHash.toBytes();
+    const ret = externals.add_associated_key(accountHashBytes.dataStart, accountHashBytes.length, weight);
     return <AddKeyFailure>ret;
 }
 
@@ -144,13 +144,13 @@ export function setActionThreshold(actionType: ActionType, thresholdValue: u8): 
  * Changes the weight of an existing associated key. See [[addAssociatedKey]] and [[setActionThreshold]]
  * for info about associated keys and their weights.
  *
- * @param publicKey The associated key to be updated.
+ * @param accountHash The associated key to be updated.
  * @param weight The new desired weight of the associated key.
  * @returns An instance of [[UpdateKeyFailure]] representing the result.
  */
-export function updateAssociatedKey(publicKey: PublicKey, weight: i32): UpdateKeyFailure {
-    const publicKeyBytes = publicKey.toBytes();
-    const ret = externals.update_associated_key(publicKeyBytes.dataStart, publicKeyBytes.length, weight);
+export function updateAssociatedKey(accountHash: AccountHash, weight: i32): UpdateKeyFailure {
+    const accountHashBytes = accountHash.toBytes();
+    const ret = externals.update_associated_key(accountHashBytes.dataStart, accountHashBytes.length, weight);
     return <UpdateKeyFailure>ret;
 }
 
@@ -158,12 +158,12 @@ export function updateAssociatedKey(publicKey: PublicKey, weight: i32): UpdateKe
  * Removes the associated key from the account. See [[addAssociatedKey]] for more info about associated
  * keys.
  *
- * @param publicKey The associated key to be removed.
+ * @param accountHash The associated key to be removed.
  * @returns An instance of [[RemoveKeyFailure]] representing the result.
  */
-export function removeAssociatedKey(publicKey: PublicKey): RemoveKeyFailure {
-    const publicKeyBytes = publicKey.toBytes();
-    const ret = externals.remove_associated_key(publicKeyBytes.dataStart, publicKeyBytes.length);
+export function removeAssociatedKey(accountHash: AccountHash): RemoveKeyFailure {
+    const accountHashBytes = accountHash.toBytes();
+    const ret = externals.remove_associated_key(accountHashBytes.dataStart, accountHashBytes.length);
     return <RemoveKeyFailure>ret;
 }
 

--- a/execution-engine/contract-as/assembly/error.ts
+++ b/execution-engine/contract-as/assembly/error.ts
@@ -66,7 +66,7 @@ export const enum ErrorCode {
     PermissionDenied = 23,
     /** The given public key is not associated with the given account. */
     MissingKey = 24,
-    /** Removing/updating the given associated public key would cause the total weight of all remaining `PublicKey`s to fall below one of the action thresholds for the given account. */
+    /** Removing/updating the given associated public key would cause the total weight of all remaining `AccountHash`s to fall below one of the action thresholds for the given account. */
     ThresholdViolation = 25,
     /** Setting the key-management threshold to a value lower than the deployment threshold is disallowed. */
     KeyManagementThreshold = 26,

--- a/execution-engine/contract-as/assembly/externals.ts
+++ b/execution-engine/contract-as/assembly/externals.ts
@@ -66,13 +66,13 @@ export declare function revert(err_code: i32): void;
 export declare function is_valid_uref(target_ptr: usize, target_size: u32): i32;
 /** @hidden */
 @external("env", "add_associated_key")
-export declare function add_associated_key(public_key_ptr: usize, public_key_size: usize, weight: i32): i32;
+export declare function add_associated_key(account_hash_ptr: usize, account_hash_size: usize, weight: i32): i32;
 /** @hidden */
 @external("env", "remove_associated_key")
-export declare function remove_associated_key(public_key_ptr: usize, public_key_size: usize): i32;
+export declare function remove_associated_key(account_hash_ptr: usize, account_hash_size: usize): i32;
 /** @hidden */
 @external("env", "update_associated_key")
-export declare function update_associated_key(public_key_ptr: usize, public_key_size: usize, weight: i32): i32;
+export declare function update_associated_key(account_hash_ptr: usize, account_hash_size: usize, weight: i32): i32;
 /** @hidden */
 @external("env", "set_action_threshold")
 export declare function set_action_threshold(permission_level: u32, threshold: i32): i32;

--- a/execution-engine/contract-as/assembly/index.ts
+++ b/execution-engine/contract-as/assembly/index.ts
@@ -2,7 +2,7 @@ import * as externals from "./externals";
 import {URef, AccessRights} from "./uref";
 import {Error, ErrorCode} from "./error";
 import {CLValue} from "./clvalue";
-import {Key, PublicKey} from "./key";
+import {Key, AccountHash} from "./key";
 import {toBytesString,
         toBytesVecT,
         fromBytesMap,
@@ -303,24 +303,24 @@ export function getBlockTime(): u64 {
 }
 
 /**
- * Returns the caller of the current context, i.e. the [[PublicKey]] of the
+ * Returns the caller of the current context, i.e. the [[AccountHash]] of the
  * account which made the deploy request.
  */
-export function getCaller(): PublicKey {
+export function getCaller(): AccountHash {
   let outputSize = new Uint32Array(1);
   let ret = externals.get_caller(outputSize.dataStart);
   const error = Error.fromResult(ret);
   if (error !== null) {
     error.revert();
-    return <PublicKey>unreachable();
+    return <AccountHash>unreachable();
   }
-  const publicKeyBytes = readHostBuffer(outputSize[0]);
-  const publicKeyResult = PublicKey.fromBytes(publicKeyBytes);
-  if (publicKeyResult.hasError()) {
+  const accountHashBytes = readHostBuffer(outputSize[0]);
+  const accountHashResult = AccountHash.fromBytes(accountHashBytes);
+  if (accountHashResult.hasError()) {
     Error.fromErrorCode(ErrorCode.Deserialize).revert();
-    return <PublicKey>unreachable();
+    return <AccountHash>unreachable();
   }
-  return publicKeyResult.value;
+  return accountHashResult.value;
 }
 
 /**

--- a/execution-engine/contract-as/tests/assembly/bytesrepr.spec.as.ts
+++ b/execution-engine/contract-as/tests/assembly/bytesrepr.spec.as.ts
@@ -8,7 +8,7 @@ import { fromBytesU64, toBytesU64,
          toBytesVecT,
          Error } from "../../assembly/bytesrepr";
 import { CLValue } from "../../assembly/clvalue";
-import { Key, KeyVariant, PublicKey, PUBLIC_KEY_ED25519_ID } from "../../assembly/key";
+import { Key, KeyVariant, AccountHash } from "../../assembly/key";
 import { URef, AccessRights } from "../../assembly/uref";
 import { Option } from "../../assembly/option";
 import { hex2bin } from "../utils/helpers";
@@ -314,8 +314,8 @@ export function testDeserMapOfNamedKeys(): bool {
     let accountBytes = new Array<u8>(32);
     accountBytes.fill(1);
 
-    assert(checkTypedArrayEqual((<PublicKey>deser[0].second.account).bytes, arrayToTyped(accountBytes)));
-    assert(checkTypedArrayEqual((<PublicKey>deser[0].second.account).bytes, arrayToTyped(accountBytes)));
+    assert(checkTypedArrayEqual((<AccountHash>deser[0].second.account).bytes, arrayToTyped(accountBytes)));
+    assert(checkTypedArrayEqual((<AccountHash>deser[0].second.account).bytes, arrayToTyped(accountBytes)));
 
     //
 
@@ -343,7 +343,7 @@ export function testDeserMapOfNamedKeys(): bool {
     // Compares to truth
 
     let truthObj = new Array<Pair<String, Key>>();
-    let keyA = Key.fromAccount(new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(accountBytes)));
+    let keyA = Key.fromAccount(new AccountHash(arrayToTyped(accountBytes)));
     truthObj.push(new Pair<String, Key>("A", keyA));
 
     let urefB = new URef(arrayToTyped(urefBytes), AccessRights.READ_ADD_WRITE);

--- a/execution-engine/contract/src/contract_api/account.rs
+++ b/execution-engine/contract/src/contract_api/account.rs
@@ -5,7 +5,7 @@ use core::convert::TryFrom;
 
 use casperlabs_types::{
     account::{
-        ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure,
+        AccountHash, ActionType, AddKeyFailure, RemoveKeyFailure, SetThresholdFailure,
         UpdateKeyFailure, Weight,
     },
     bytesrepr, URef, UREF_SERIALIZED_LENGTH,
@@ -44,11 +44,11 @@ pub fn set_action_threshold(
 }
 
 /// Adds the given [`PublicKey`] with associated [`Weight`] to the account's associated keys.
-pub fn add_associated_key(public_key: PublicKey, weight: Weight) -> Result<(), AddKeyFailure> {
-    let (public_key_ptr, public_key_size, _bytes) = to_ptr(public_key);
+pub fn add_associated_key(account_hash: AccountHash, weight: Weight) -> Result<(), AddKeyFailure> {
+    let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
     // Cast of u8 (weight) into i32 is assumed to be always safe
     let result = unsafe {
-        ext_ffi::add_associated_key(public_key_ptr, public_key_size, weight.value().into())
+        ext_ffi::add_associated_key(account_hash_ptr, account_hash_size, weight.value().into())
     };
     if result == 0 {
         Ok(())
@@ -58,9 +58,9 @@ pub fn add_associated_key(public_key: PublicKey, weight: Weight) -> Result<(), A
 }
 
 /// Removes the given [`PublicKey`] from the account's associated keys.
-pub fn remove_associated_key(public_key: PublicKey) -> Result<(), RemoveKeyFailure> {
-    let (public_key_ptr, public_key_size, _bytes) = to_ptr(public_key);
-    let result = unsafe { ext_ffi::remove_associated_key(public_key_ptr, public_key_size) };
+pub fn remove_associated_key(account_hash: AccountHash) -> Result<(), RemoveKeyFailure> {
+    let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
+    let result = unsafe { ext_ffi::remove_associated_key(account_hash_ptr, account_hash_size) };
     if result == 0 {
         Ok(())
     } else {
@@ -70,13 +70,13 @@ pub fn remove_associated_key(public_key: PublicKey) -> Result<(), RemoveKeyFailu
 
 /// Updates the [`Weight`] of the given [`PublicKey`] in the account's associated keys.
 pub fn update_associated_key(
-    public_key: PublicKey,
+    account_hash: AccountHash,
     weight: Weight,
 ) -> Result<(), UpdateKeyFailure> {
-    let (public_key_ptr, public_key_size, _bytes) = to_ptr(public_key);
+    let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
     // Cast of u8 (weight) into i32 is assumed to be always safe
     let result = unsafe {
-        ext_ffi::update_associated_key(public_key_ptr, public_key_size, weight.value().into())
+        ext_ffi::update_associated_key(account_hash_ptr, account_hash_size, weight.value().into())
     };
     if result == 0 {
         Ok(())

--- a/execution-engine/contract/src/contract_api/account.rs
+++ b/execution-engine/contract/src/contract_api/account.rs
@@ -43,7 +43,7 @@ pub fn set_action_threshold(
     }
 }
 
-/// Adds the given [`PublicKey`] with associated [`Weight`] to the account's associated keys.
+/// Adds the given [`AccountHash`] with associated [`Weight`] to the account's associated keys.
 pub fn add_associated_key(account_hash: AccountHash, weight: Weight) -> Result<(), AddKeyFailure> {
     let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
     // Cast of u8 (weight) into i32 is assumed to be always safe
@@ -57,7 +57,7 @@ pub fn add_associated_key(account_hash: AccountHash, weight: Weight) -> Result<(
     }
 }
 
-/// Removes the given [`PublicKey`] from the account's associated keys.
+/// Removes the given [`AccountHash`] from the account's associated keys.
 pub fn remove_associated_key(account_hash: AccountHash) -> Result<(), RemoveKeyFailure> {
     let (account_hash_ptr, account_hash_size, _bytes) = to_ptr(account_hash);
     let result = unsafe { ext_ffi::remove_associated_key(account_hash_ptr, account_hash_size) };
@@ -68,7 +68,7 @@ pub fn remove_associated_key(account_hash: AccountHash) -> Result<(), RemoveKeyF
     }
 }
 
-/// Updates the [`Weight`] of the given [`PublicKey`] in the account's associated keys.
+/// Updates the [`Weight`] of the given [`AccountHash`] in the account's associated keys.
 pub fn update_associated_key(
     account_hash: AccountHash,
     weight: Weight,

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -7,7 +7,7 @@ use alloc::{collections::BTreeMap, string::String, vec::Vec};
 use core::mem::MaybeUninit;
 
 use casperlabs_types::{
-    account::PublicKey,
+    account::AccountHash,
     api_error,
     bytesrepr::{self, FromBytes},
     ApiError, BlockTime, CLTyped, CLValue, ContractRef, Key, Phase, URef,
@@ -136,7 +136,7 @@ pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
 
 /// Returns the caller of the current context, i.e. the [`PublicKey`] of the account which made the
 /// deploy request.
-pub fn get_caller() -> PublicKey {
+pub fn get_caller() -> AccountHash {
     let output_size = {
         let mut output_size = MaybeUninit::uninit();
         let ret = unsafe { ext_ffi::get_caller(output_size.as_mut_ptr()) };

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -134,8 +134,8 @@ pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
     Some(bytesrepr::deserialize(arg_bytes))
 }
 
-/// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made the
-/// deploy request.
+/// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made
+/// the deploy request.
 pub fn get_caller() -> AccountHash {
     let output_size = {
         let mut output_size = MaybeUninit::uninit();

--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -134,7 +134,7 @@ pub fn get_arg<T: FromBytes>(i: u32) -> Option<Result<T, bytesrepr::Error>> {
     Some(bytesrepr::deserialize(arg_bytes))
 }
 
-/// Returns the caller of the current context, i.e. the [`PublicKey`] of the account which made the
+/// Returns the caller of the current context, i.e. the [`AccountHash`] of the account which made the
 /// deploy request.
 pub fn get_caller() -> AccountHash {
     let output_size = {

--- a/execution-engine/contract/src/contract_api/system.rs
+++ b/execution-engine/contract/src/contract_api/system.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
 use casperlabs_types::{
-    account::PublicKey, api_error, bytesrepr, ApiError, ContractRef, SystemContractType,
+    account::AccountHash, api_error, bytesrepr, ApiError, ContractRef, SystemContractType,
     TransferResult, TransferredTo, URef, U512, UREF_SERIALIZED_LENGTH,
 };
 
@@ -103,7 +103,7 @@ pub fn get_balance(purse: URef) -> Option<U512> {
 
 /// Transfers `amount` of motes from the default purse of the account to `target`
 /// account.  If `target` does not exist it will be created.
-pub fn transfer_to_account(target: PublicKey, amount: U512) -> TransferResult {
+pub fn transfer_to_account(target: AccountHash, amount: U512) -> TransferResult {
     let (target_ptr, target_size, _bytes1) = contract_api::to_ptr(target);
     let (amount_ptr, amount_size, _bytes2) = contract_api::to_ptr(amount);
     let return_code =
@@ -115,7 +115,7 @@ pub fn transfer_to_account(target: PublicKey, amount: U512) -> TransferResult {
 /// it will be created.
 pub fn transfer_from_purse_to_account(
     source: URef,
-    target: PublicKey,
+    target: AccountHash,
     amount: U512,
 ) -> TransferResult {
     let (source_ptr, source_size, _bytes1) = contract_api::to_ptr(source);

--- a/execution-engine/contract/src/ext_ffi.rs
+++ b/execution-engine/contract/src/ext_ffi.rs
@@ -53,14 +53,14 @@ extern "C" {
     pub fn revert(status: u32) -> !;
     pub fn is_valid_uref(uref_ptr: *const u8, uref_size: usize) -> i32;
     pub fn add_associated_key(
-        public_key_ptr: *const u8,
-        public_key_size: usize,
+        account_hash_ptr: *const u8,
+        account_hash_size: usize,
         weight: i32,
     ) -> i32;
-    pub fn remove_associated_key(public_key_ptr: *const u8, public_key_size: usize) -> i32;
+    pub fn remove_associated_key(account_hash_ptr: *const u8, account_hash_size: usize) -> i32;
     pub fn update_associated_key(
-        public_key_ptr: *const u8,
-        public_key_size: usize,
+        account_hash_ptr: *const u8,
+        account_hash_size: usize,
         weight: i32,
     ) -> i32;
     pub fn set_action_threshold(permission_level: u32, threshold: i32) -> i32;

--- a/execution-engine/contracts-as/test/add-update-associated-key/assembly/index.ts
+++ b/execution-engine/contracts-as/test/add-update-associated-key/assembly/index.ts
@@ -3,33 +3,33 @@ import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
 import {addAssociatedKey, AddKeyFailure, updateAssociatedKey, UpdateKeyFailure} from "../../../../contract-as/assembly/account";
 import {typedToArray} from "../../../../contract-as/assembly/utils";
-import {PublicKey} from "../../../../contract-as/assembly/key";
+import {AccountHash} from "../../../../contract-as/assembly/key";
 
 
 const INIT_WEIGHT: u8 = 1;
 const MOD_WEIGHT: u8 = 2;
 
 export function call(): void {
-  let publicKeyBytes = CL.getArg(0);
-  if (publicKeyBytes === null) {
+  let accountHashBytes = CL.getArg(0);
+  if (accountHashBytes === null) {
     Error.fromErrorCode(ErrorCode.MissingArgument).revert();
     return;
   }
 
-  const publicKeyResult = PublicKey.fromBytes(publicKeyBytes);
-  if (publicKeyResult.hasError()) {
-    Error.fromUserError(<u16>4464 + <u16>publicKeyResult.error).revert();
+  const accountHashResult = AccountHash.fromBytes(accountHashBytes);
+  if (accountHashResult.hasError()) {
+    Error.fromUserError(<u16>4464 + <u16>accountHashResult.error).revert();
     // Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
-  const publicKey = publicKeyResult.value;
+  const accountHash = accountHashResult.value;
   
-  if (addAssociatedKey(publicKey, INIT_WEIGHT) != AddKeyFailure.Ok) {
+  if (addAssociatedKey(accountHash, INIT_WEIGHT) != AddKeyFailure.Ok) {
     Error.fromUserError(<u16>4464).revert();
     return;
   }
 
-  if (updateAssociatedKey(publicKey, MOD_WEIGHT) != UpdateKeyFailure.Ok) {
+  if (updateAssociatedKey(accountHash, MOD_WEIGHT) != UpdateKeyFailure.Ok) {
     Error.fromUserError(<u16>4464 + 1).revert();
     return;
   }

--- a/execution-engine/contracts-as/test/authorized-keys/assembly/index.ts
+++ b/execution-engine/contracts-as/test/authorized-keys/assembly/index.ts
@@ -2,15 +2,15 @@ import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
 import {fromBytesString, fromBytesI32} from "../../../../contract-as/assembly/bytesrepr";
 import {arrayToTyped} from "../../../../contract-as/assembly/utils";
-import {Key, PublicKey, PUBLIC_KEY_ED25519_ID} from "../../../../contract-as/assembly/key"
+import {Key, AccountHash} from "../../../../contract-as/assembly/key"
 import {addAssociatedKey, AddKeyFailure, ActionType, setActionThreshold, SetThresholdFailure} from "../../../../contract-as/assembly/account";
 
 export function call(): void {
   let publicKeyBytes = new Array<u8>(32);
   publicKeyBytes.fill(123);
-  let publicKey = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(publicKeyBytes));
+  let accountHash = new AccountHash(arrayToTyped(publicKeyBytes));
 
-  const addResult = addAssociatedKey(publicKey, 100);
+  const addResult = addAssociatedKey(accountHash, 100);
   switch (addResult) {
     case AddKeyFailure.DuplicateKey:
       break;

--- a/execution-engine/contracts-as/test/get-caller/assembly/index.ts
+++ b/execution-engine/contracts-as/test/get-caller/assembly/index.ts
@@ -1,21 +1,21 @@
 import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
 import {typedToArray, checkArraysEqual} from "../../../../contract-as/assembly/utils";
-import {PublicKey} from "../../../../contract-as/assembly/key";
+import {AccountHash} from "../../../../contract-as/assembly/key";
 
 export function call(): void {
-  const knownPublicKeyBytes = CL.getArg(0);
-  if (knownPublicKeyBytes === null) {
+  const knownAssemblyHashBytes = CL.getArg(0);
+  if (knownAssemblyHashBytes === null) {
     Error.fromErrorCode(ErrorCode.MissingArgument).revert();
     return;
   }
-  let knownPublicKeyResult = PublicKey.fromBytes(knownPublicKeyBytes);
-  if (knownPublicKeyResult.hasError()) {
+  let knownAccountHashResult = AccountHash.fromBytes(knownAssemblyHashBytes);
+  if (knownAccountHashResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;
   }
-  const knownPublicKey = knownPublicKeyResult.value;
+  const knownAccountHash = knownAccountHashResult.value;
   const caller = CL.getCaller();
 
-  assert(caller == knownPublicKey);
+  assert(caller == knownAccountHash);
 }

--- a/execution-engine/contracts-as/test/key-management-thresholds/assembly/index.ts
+++ b/execution-engine/contracts-as/test/key-management-thresholds/assembly/index.ts
@@ -2,7 +2,7 @@ import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
 import {fromBytesString} from "../../../../contract-as/assembly/bytesrepr";
 import {arrayToTyped} from "../../../../contract-as/assembly/utils";
-import {PublicKey, PUBLIC_KEY_ED25519_ID} from "../../../../contract-as/assembly/key";
+import {AccountHash} from "../../../../contract-as/assembly/key";
 import {addAssociatedKey, AddKeyFailure,
         setActionThreshold, ActionType, SetThresholdFailure,
         updateAssociatedKey, UpdateKeyFailure,
@@ -24,15 +24,15 @@ export function call(): void {
 
   let key42sBytes = new Array<u8>(32);
   key42sBytes.fill(42);
-  let key42s = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(key42sBytes));
+  let key42s = new AccountHash(arrayToTyped(key42sBytes));
 
   let key43sBytes = new Array<u8>(32);
   key43sBytes.fill(43);
-  let key43s = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(key43sBytes));
+  let key43s = new AccountHash(arrayToTyped(key43sBytes));
 
   let key1sBytes = new Array<u8>(32);
   key1sBytes.fill(1);
-  let key1s = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(key1sBytes));
+  let key1s = new AccountHash(arrayToTyped(key1sBytes));
 
   if (stage == "init") {
     if (addAssociatedKey(key42s, 100) != AddKeyFailure.Ok) {
@@ -56,7 +56,7 @@ export function call(): void {
   else if (stage == "test-permission-denied") {
     let key44sBytes = new Array<u8>(32);
     key44sBytes.fill(44);
-    let key44s = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(key44sBytes));
+    let key44s = new AccountHash(arrayToTyped(key44sBytes));
     switch (addAssociatedKey(key44s, 1)) {
       case AddKeyFailure.Ok:
         Error.fromUserError(200).revert();
@@ -70,7 +70,7 @@ export function call(): void {
 
     let key43sBytes = new Array<u8>(32);
     key43sBytes.fill(43);
-    let key43s = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(key43sBytes));
+    let key43s = new AccountHash(arrayToTyped(key43sBytes));
 
     switch (updateAssociatedKey(key43s, 2)) {
       case UpdateKeyFailure.Ok:
@@ -108,7 +108,7 @@ export function call(): void {
   else if (stage == "test-key-mgmnt-succeed") {
     let key44sBytes = new Array<u8>(32);
     key44sBytes.fill(44);
-    let key44s = new PublicKey(PUBLIC_KEY_ED25519_ID, arrayToTyped(key44sBytes));
+    let key44s = new AccountHash(arrayToTyped(key44sBytes));
 
     // Has to be executed with keys of total weight >= 254
     if (addAssociatedKey(key44s, 1) != AddKeyFailure.Ok) {

--- a/execution-engine/contracts-as/test/remove-associated-key/assembly/index.ts
+++ b/execution-engine/contracts-as/test/remove-associated-key/assembly/index.ts
@@ -3,7 +3,7 @@ import * as CL from "../../../../contract-as/assembly";
 import {Error, ErrorCode} from "../../../../contract-as/assembly/error";
 import {removeAssociatedKey, RemoveKeyFailure} from "../../../../contract-as/assembly/account";
 import {typedToArray} from "../../../../contract-as/assembly/utils";
-import {PublicKey} from "../../../../contract-as/assembly/key";
+import {AccountHash} from "../../../../contract-as/assembly/key";
 
 export function call(): void {
   let accountBytes = CL.getArg(0);
@@ -12,7 +12,7 @@ export function call(): void {
     return;
   }
 
-  const accountResult = PublicKey.fromBytes(accountBytes);
+  const accountResult = AccountHash.fromBytes(accountBytes);
   if (accountResult.hasError()) {
     Error.fromErrorCode(ErrorCode.InvalidArgument).revert();
     return;

--- a/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
@@ -4,7 +4,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, TransferredTo, U512};
+use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 #[repr(u16)]
 enum Error {
@@ -19,7 +19,7 @@ impl Into<ApiError> for Error {
     }
 }
 
-fn parse_public_key(hex: &[u8]) -> PublicKey {
+fn parse_account_hash(hex: &[u8]) -> AccountHash {
     let mut buffer = [0u8; 32];
     let bytes_written = base16::decode_slice(hex, &mut buffer)
         .ok()
@@ -27,14 +27,14 @@ fn parse_public_key(hex: &[u8]) -> PublicKey {
     if bytes_written != buffer.len() {
         runtime::revert(Error::FailedToParsePublicKey)
     }
-    PublicKey::ed25519_from(buffer)
+    AccountHash::new(buffer)
 }
 
 pub fn create_account(account_addr: &[u8; 64], initial_amount: u64) {
-    let public_key = parse_public_key(account_addr);
+    let account_hash = parse_account_hash(account_addr);
     let amount: U512 = U512::from(initial_amount);
 
-    match system::transfer_to_account(public_key, amount)
+    match system::transfer_to_account(account_hash, amount)
         .unwrap_or_revert_with(Error::TransferFailed)
     {
         TransferredTo::NewAccount => (),

--- a/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
+++ b/execution-engine/contracts/SRE/create-test-node-shared/src/lib.rs
@@ -10,7 +10,7 @@ use types::{account::AccountHash, ApiError, TransferredTo, U512};
 enum Error {
     AccountAlreadyExists = 10,
     TransferFailed = 11,
-    FailedToParsePublicKey = 12,
+    FailedToParseAccountHash = 12,
 }
 
 impl Into<ApiError> for Error {
@@ -23,9 +23,9 @@ fn parse_account_hash(hex: &[u8]) -> AccountHash {
     let mut buffer = [0u8; 32];
     let bytes_written = base16::decode_slice(hex, &mut buffer)
         .ok()
-        .unwrap_or_revert_with(Error::FailedToParsePublicKey);
+        .unwrap_or_revert_with(Error::FailedToParseAccountHash);
     if bytes_written != buffer.len() {
-        runtime::revert(Error::FailedToParsePublicKey)
+        runtime::revert(Error::FailedToParseAccountHash)
     }
     AccountHash::new(buffer)
 }

--- a/execution-engine/contracts/bench/create-accounts/src/main.rs
+++ b/execution-engine/contracts/bench/create-accounts/src/main.rs
@@ -4,6 +4,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use contract::{
     contract_api::{runtime, system},

--- a/execution-engine/contracts/bench/create-accounts/src/main.rs
+++ b/execution-engine/contracts/bench/create-accounts/src/main.rs
@@ -9,23 +9,23 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let accounts: Vec<PublicKey> = {
+    let accounts: Vec<AccountHash> = {
         let data: Vec<Vec<u8>> = runtime::get_arg(0)
             .unwrap_or_revert_with(ApiError::MissingArgument)
             .unwrap_or_revert_with(ApiError::InvalidArgument);
         data.into_iter()
-            .map(|bytes| PublicKey::ed25519_try_from(bytes.as_slice()).unwrap_or_revert())
+            .map(|bytes| AccountHash::try_from(bytes.as_slice()).unwrap_or_revert())
             .collect()
     };
     let seed_amount: U512 = runtime::get_arg(1)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    for public_key in accounts {
-        system::transfer_to_account(public_key, seed_amount)
+    for account_hash in accounts {
+        system::transfer_to_account(account_hash, seed_amount)
             .unwrap_or_revert_with(ApiError::Transfer);
     }
 }

--- a/execution-engine/contracts/bench/transfer-to-existing-account/src/main.rs
+++ b/execution-engine/contracts/bench/transfer-to-existing-account/src/main.rs
@@ -8,7 +8,7 @@ use contract::{
 use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 enum Arg {
-    PublicKey = 0,
+    AccountHash = 0,
     Amount = 1,
 }
 
@@ -19,7 +19,7 @@ enum Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key: AccountHash = runtime::get_arg(Arg::PublicKey as u32)
+    let public_key: AccountHash = runtime::get_arg(Arg::AccountHash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Amount as u32)

--- a/execution-engine/contracts/bench/transfer-to-existing-account/src/main.rs
+++ b/execution-engine/contracts/bench/transfer-to-existing-account/src/main.rs
@@ -19,13 +19,13 @@ enum Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key: AccountHash = runtime::get_arg(Arg::AccountHash as u32)
+    let account_hash: AccountHash = runtime::get_arg(Arg::AccountHash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Amount as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let result = system::transfer_to_account(public_key, amount).unwrap_or_revert();
+    let result = system::transfer_to_account(account_hash, amount).unwrap_or_revert();
     match result {
         TransferredTo::ExistingAccount => {
             // This is the expected result, as all accounts have to be initialized beforehand

--- a/execution-engine/contracts/bench/transfer-to-existing-account/src/main.rs
+++ b/execution-engine/contracts/bench/transfer-to-existing-account/src/main.rs
@@ -5,7 +5,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, TransferredTo, U512};
+use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 enum Arg {
     PublicKey = 0,
@@ -19,7 +19,7 @@ enum Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key: PublicKey = runtime::get_arg(Arg::PublicKey as u32)
+    let public_key: AccountHash = runtime::get_arg(Arg::PublicKey as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Amount as u32)

--- a/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
@@ -25,8 +25,12 @@ enum CustomError {
 #[no_mangle]
 pub fn delegate() {
     let account_hash: AccountHash = runtime::get_arg(Args::AccountHash as u32)
-        .unwrap_or_revert_with(ApiError::User(CustomError::MissingAccountAccountHash as u16))
-        .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAccountAccountHash as u16));
+        .unwrap_or_revert_with(ApiError::User(
+            CustomError::MissingAccountAccountHash as u16,
+        ))
+        .unwrap_or_revert_with(ApiError::User(
+            CustomError::InvalidAccountAccountHash as u16,
+        ));
     let transfer_amount: U512 = runtime::get_arg(Args::Amount as u32)
         .unwrap_or_revert_with(ApiError::User(CustomError::MissingAmount as u16))
         .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAmount as u16));

--- a/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
@@ -20,7 +20,7 @@ enum CustomError {
     InvalidAmount = 4,
 }
 
-/// Executes mote transfer to supplied public key.
+/// Executes mote transfer to supplied account hash.
 /// Transfers the requested amount.
 #[no_mangle]
 pub fn delegate() {

--- a/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
@@ -8,14 +8,14 @@ use types::{account::AccountHash, ApiError, U512};
 
 #[repr(u16)]
 enum Args {
-    AccountPublicKey = 0,
+    AccountHash = 0,
     Amount = 1,
 }
 
 #[repr(u32)]
 enum CustomError {
-    MissingAccountPublicKey = 1,
-    InvalidAccountPublicKey = 2,
+    MissingAccountAccountHash = 1,
+    InvalidAccountAccountHash = 2,
     MissingAmount = 3,
     InvalidAmount = 4,
 }
@@ -24,9 +24,9 @@ enum CustomError {
 /// Transfers the requested amount.
 #[no_mangle]
 pub fn delegate() {
-    let account_hash: AccountHash = runtime::get_arg(Args::AccountPublicKey as u32)
-        .unwrap_or_revert_with(ApiError::User(CustomError::MissingAccountPublicKey as u16))
-        .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAccountPublicKey as u16));
+    let account_hash: AccountHash = runtime::get_arg(Args::AccountHash as u32)
+        .unwrap_or_revert_with(ApiError::User(CustomError::MissingAccountAccountHash as u16))
+        .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAccountAccountHash as u16));
     let transfer_amount: U512 = runtime::get_arg(Args::Amount as u32)
         .unwrap_or_revert_with(ApiError::User(CustomError::MissingAmount as u16))
         .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAmount as u16));

--- a/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account-u512/src/lib.rs
@@ -4,7 +4,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 #[repr(u16)]
 enum Args {
@@ -24,11 +24,11 @@ enum CustomError {
 /// Transfers the requested amount.
 #[no_mangle]
 pub fn delegate() {
-    let public_key: PublicKey = runtime::get_arg(Args::AccountPublicKey as u32)
+    let account_hash: AccountHash = runtime::get_arg(Args::AccountPublicKey as u32)
         .unwrap_or_revert_with(ApiError::User(CustomError::MissingAccountPublicKey as u16))
         .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAccountPublicKey as u16));
     let transfer_amount: U512 = runtime::get_arg(Args::Amount as u32)
         .unwrap_or_revert_with(ApiError::User(CustomError::MissingAmount as u16))
         .unwrap_or_revert_with(ApiError::User(CustomError::InvalidAmount as u16));
-    system::transfer_to_account(public_key, transfer_amount).unwrap_or_revert();
+    system::transfer_to_account(account_hash, transfer_amount).unwrap_or_revert();
 }

--- a/execution-engine/contracts/client/transfer-to-account/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account/src/lib.rs
@@ -4,7 +4,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 enum Args {
     PublicKey = 0,
@@ -14,12 +14,12 @@ enum Args {
 /// Executes mote transfer to supplied public key.
 /// Transfers the requested amount.
 pub fn delegate() {
-    let public_key: PublicKey = runtime::get_arg(Args::PublicKey as u32)
+    let account_hash: AccountHash = runtime::get_arg(Args::PublicKey as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let transfer_amount: u64 = runtime::get_arg(Args::Amount as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let u512_motes = U512::from(transfer_amount);
-    system::transfer_to_account(public_key, u512_motes).unwrap_or_revert();
+    system::transfer_to_account(account_hash, u512_motes).unwrap_or_revert();
 }

--- a/execution-engine/contracts/client/transfer-to-account/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account/src/lib.rs
@@ -11,7 +11,7 @@ enum Args {
     Amount = 1,
 }
 
-/// Executes mote transfer to supplied public key.
+/// Executes mote transfer to supplied account hash.
 /// Transfers the requested amount.
 pub fn delegate() {
     let account_hash: AccountHash = runtime::get_arg(Args::AccountHash as u32)

--- a/execution-engine/contracts/client/transfer-to-account/src/lib.rs
+++ b/execution-engine/contracts/client/transfer-to-account/src/lib.rs
@@ -7,14 +7,14 @@ use contract::{
 use types::{account::AccountHash, ApiError, U512};
 
 enum Args {
-    PublicKey = 0,
+    AccountHash = 0,
     Amount = 1,
 }
 
 /// Executes mote transfer to supplied public key.
 /// Transfers the requested amount.
 pub fn delegate() {
-    let account_hash: AccountHash = runtime::get_arg(Args::PublicKey as u32)
+    let account_hash: AccountHash = runtime::get_arg(Args::AccountHash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let transfer_amount: u64 = runtime::get_arg(Args::Amount as u32)

--- a/execution-engine/contracts/examples/erc20-smart-contract/src/api.rs
+++ b/execution-engine/contracts/examples/erc20-smart-contract/src/api.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 
 use contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
-use types::{account::PublicKey, bytesrepr::FromBytes, CLTyped, ContractRef, URef, U512};
+use types::{account::AccountHash, bytesrepr::FromBytes, CLTyped, ContractRef, URef, U512};
 
 use crate::error::Error;
 
@@ -24,15 +24,15 @@ pub const SELL: &str = "sell";
 pub enum Api {
     Deploy(String, U512),
     InitErc20(U512),
-    BalanceOf(PublicKey),
+    BalanceOf(AccountHash),
     TotalSupply,
-    Transfer(PublicKey, U512),
-    TransferFrom(PublicKey, PublicKey, U512),
-    Approve(PublicKey, U512),
-    Allowance(PublicKey, PublicKey),
-    AssertBalance(PublicKey, U512),
+    Transfer(AccountHash, U512),
+    TransferFrom(AccountHash, AccountHash, U512),
+    Approve(AccountHash, U512),
+    Allowance(AccountHash, AccountHash),
+    AssertBalance(AccountHash, U512),
     AssertTotalSupply(U512),
-    AssertAllowance(PublicKey, PublicKey, U512),
+    AssertAllowance(AccountHash, AccountHash, U512),
     BuyProxy(U512),
     Buy(URef),
     SellProxy(U512),
@@ -67,8 +67,8 @@ impl Api {
                 Api::InitErc20(amount)
             }
             BALANCE_OF => {
-                let public_key: PublicKey = get_arg(arg_shift + 1);
-                Api::BalanceOf(public_key)
+                let account_hash: AccountHash = get_arg(arg_shift + 1);
+                Api::BalanceOf(account_hash)
             }
             TOTAL_SUPPLY => Api::TotalSupply,
             TRANSFER => {

--- a/execution-engine/contracts/examples/erc20-smart-contract/src/erc20.rs
+++ b/execution-engine/contracts/examples/erc20-smart-contract/src/erc20.rs
@@ -4,7 +4,7 @@ use contract::{
     contract_api::{runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, CLValue, URef, U512};
+use types::{account::AccountHash, CLValue, URef, U512};
 
 use crate::{api::Api, error::Error};
 use erc20_logic::{ERC20BurnError, ERC20Trait, ERC20TransferError, ERC20TransferFromError};
@@ -16,13 +16,13 @@ pub const PURSE_NAME: &str = "erc20_main_purse";
 
 struct ERC20Token;
 
-impl ERC20Trait<U512, PublicKey> for ERC20Token {
-    fn read_balance(&mut self, address: &PublicKey) -> Option<U512> {
+impl ERC20Trait<U512, AccountHash> for ERC20Token {
+    fn read_balance(&mut self, address: &AccountHash) -> Option<U512> {
         let key = balance_key(address);
         storage::read_local(&key).unwrap_or_revert()
     }
 
-    fn save_balance(&mut self, address: &PublicKey, balance: U512) {
+    fn save_balance(&mut self, address: &AccountHash, balance: U512) {
         let key = balance_key(address);
         storage::write_local(key, balance);
     }
@@ -35,12 +35,12 @@ impl ERC20Trait<U512, PublicKey> for ERC20Token {
         storage::write_local(TOTAL_SUPPLY_KEY, total_supply);
     }
 
-    fn read_allowance(&mut self, owner: &PublicKey, spender: &PublicKey) -> Option<U512> {
+    fn read_allowance(&mut self, owner: &AccountHash, spender: &AccountHash) -> Option<U512> {
         let key = allowance_key(owner, spender);
         storage::read_local(&key).unwrap_or_revert()
     }
 
-    fn save_allowance(&mut self, owner: &PublicKey, spender: &PublicKey, amount: U512) {
+    fn save_allowance(&mut self, owner: &AccountHash, spender: &AccountHash, amount: U512) {
         let key = allowance_key(owner, spender);
         storage::write_local(key, amount);
     }
@@ -111,15 +111,15 @@ fn mark_as_initialized() {
     storage::write_local(INIT_FLAG_KEY, 1);
 }
 
-fn balance_key(public_key: &PublicKey) -> Vec<u8> {
-    let len = public_key.as_bytes().len() + 1;
+fn balance_key(account_hash: &AccountHash) -> Vec<u8> {
+    let len = account_hash.as_bytes().len() + 1;
     let mut result: Vec<u8> = Vec::with_capacity(len);
     result.extend(&[BALANCE_BYTE]);
-    result.extend(public_key.as_bytes());
+    result.extend(account_hash.as_bytes());
     result
 }
 
-fn allowance_key(owner: &PublicKey, spender: &PublicKey) -> Vec<u8> {
+fn allowance_key(owner: &AccountHash, spender: &AccountHash) -> Vec<u8> {
     let len = owner.as_bytes().len() + spender.as_bytes().len();
     let mut result: Vec<u8> = Vec::with_capacity(len);
     result.extend(owner.as_bytes());

--- a/execution-engine/contracts/examples/keys-manager/src/api.rs
+++ b/execution-engine/contracts/examples/keys-manager/src/api.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 use contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
 use types::{
-    account::{PublicKey, Weight},
+    account::{AccountHash, Weight},
     bytesrepr::FromBytes,
     CLTyped,
 };
@@ -13,7 +13,7 @@ pub const SET_DEPLOYMENT_THRESHOLD: &str = "set_deployment_threshold";
 pub const SET_KEY_MANAGEMENT_THRESHOLD: &str = "set_key_management_threshold";
 
 pub enum Api {
-    SetKeyWeight(PublicKey, Weight),
+    SetKeyWeight(AccountHash, Weight),
     SetDeploymentThreshold(Weight),
     SetKeyManagementThreshold(Weight),
 }

--- a/execution-engine/contracts/examples/keys-manager/src/keys_manager.rs
+++ b/execution-engine/contracts/examples/keys-manager/src/keys_manager.rs
@@ -1,13 +1,13 @@
 use contract::{contract_api::account, unwrap_or_revert::UnwrapOrRevert};
 
 use types::account::{
-    ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure,
-    Weight,
+    AccountHash, ActionType, AddKeyFailure, RemoveKeyFailure, SetThresholdFailure,
+    UpdateKeyFailure, Weight,
 };
 
 use crate::{api::Api, error::Error};
 
-fn add_or_update_key(key: PublicKey, weight: Weight) -> Result<(), Error> {
+fn add_or_update_key(key: AccountHash, weight: Weight) -> Result<(), Error> {
     match account::update_associated_key(key, weight) {
         Ok(()) => Ok(()),
         Err(UpdateKeyFailure::MissingKey) => add_key(key, weight),
@@ -16,7 +16,7 @@ fn add_or_update_key(key: PublicKey, weight: Weight) -> Result<(), Error> {
     }
 }
 
-fn add_key(key: PublicKey, weight: Weight) -> Result<(), Error> {
+fn add_key(key: AccountHash, weight: Weight) -> Result<(), Error> {
     match account::add_associated_key(key, weight) {
         Ok(()) => Ok(()),
         Err(AddKeyFailure::MaxKeysLimit) => Err(Error::MaxKeysLimit),
@@ -25,7 +25,7 @@ fn add_key(key: PublicKey, weight: Weight) -> Result<(), Error> {
     }
 }
 
-fn remove_key_if_exists(key: PublicKey) -> Result<(), Error> {
+fn remove_key_if_exists(key: AccountHash) -> Result<(), Error> {
     match account::remove_associated_key(key) {
         Ok(()) | Err(RemoveKeyFailure::MissingKey) => Ok(()),
         Err(RemoveKeyFailure::PermissionDenied) => Err(Error::PermissionDenied),

--- a/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/api.rs
+++ b/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/api.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 
 use contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
-use types::{account::PublicKey, bytesrepr::FromBytes, CLTyped, ContractRef};
+use types::{account::AccountHash, bytesrepr::FromBytes, CLTyped, ContractRef};
 
 use crate::error::Error;
 
@@ -10,7 +10,7 @@ pub const MOVE: &str = "move";
 pub const CONCEDE: &str = "concede";
 
 pub enum Api {
-    Start(PublicKey, PublicKey),
+    Start(AccountHash, AccountHash),
     Move(u32, u32),
     Concede,
 }

--- a/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/game_state.rs
+++ b/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/game_state.rs
@@ -12,26 +12,26 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use tic_tac_toe_logic::game_state::{CellState, GameState, N_CELLS};
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 use crate::{error::Error, state_key::StateKey};
 
 const GAME_STATE_BYTES_SIZE: usize = N_CELLS + 1;
 
-pub fn read_local(x_player: PublicKey, o_player: PublicKey) -> Option<GameState> {
+pub fn read_local(x_player: AccountHash, o_player: AccountHash) -> Option<GameState> {
     let state_key = StateKey::new(x_player, o_player);
     let value: Option<Vec<u8>> =
         storage::read_local(&state_key).unwrap_or_revert_with(Error::GameStateDeserialization);
     value.and_then(from_value)
 }
 
-pub fn write_local(x_player: PublicKey, o_player: PublicKey, state: &GameState) {
+pub fn write_local(x_player: AccountHash, o_player: AccountHash, state: &GameState) {
     let state_key = StateKey::new(x_player, o_player);
     let value = to_value(state).unwrap_or_revert();
     storage::write_local(state_key, value);
 }
 
-pub fn game_status_key(a: &PublicKey, b: &PublicKey) -> String {
+pub fn game_status_key(a: &AccountHash, b: &AccountHash) -> String {
     if a > b {
         format!("Game {} vs {}", a, b)
     } else {
@@ -39,7 +39,7 @@ pub fn game_status_key(a: &PublicKey, b: &PublicKey) -> String {
     }
 }
 
-pub fn update_game_status(state: &GameState, x_player: PublicKey, o_player: PublicKey) {
+pub fn update_game_status(state: &GameState, x_player: AccountHash, o_player: AccountHash) {
     let name = game_status_key(&x_player, &o_player);
     let key = runtime::get_key(&name).unwrap_or_revert();
     let uref = key.try_into().unwrap_or_revert();

--- a/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/main.rs
+++ b/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/main.rs
@@ -9,7 +9,7 @@ use contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, Key};
+use types::{account::AccountHash, Key};
 
 use tic_tac_toe_logic::{
     game_move::{Move, MoveOutcome},
@@ -30,7 +30,7 @@ use player_data::PlayerData;
 const GAME_CONTRACT_NAME: &str = "tic_tac_toe";
 const GAME_PROXY_CONTRACT_NAME: &str = "tic_tac_toe_proxy";
 
-fn start_game(x_player: PublicKey, o_player: PublicKey) -> Result<(), Error> {
+fn start_game(x_player: AccountHash, o_player: AccountHash) -> Result<(), Error> {
     if PlayerData::read_local(x_player).is_some() {
         return Err(Error::AlreadyPlaying);
     }
@@ -55,7 +55,11 @@ fn start_game(x_player: PublicKey, o_player: PublicKey) -> Result<(), Error> {
     Ok(())
 }
 
-fn take_turn(player: PublicKey, row_position: usize, column_position: usize) -> Result<(), Error> {
+fn take_turn(
+    player: AccountHash,
+    row_position: usize,
+    column_position: usize,
+) -> Result<(), Error> {
     let player_data = PlayerData::read_local(player).ok_or(Error::NoGameFoundForPlayer)?;
 
     let (x_player, o_player) = if player_data.piece() == Player::X {
@@ -91,7 +95,7 @@ fn take_turn(player: PublicKey, row_position: usize, column_position: usize) -> 
     }
 }
 
-fn complete_game(x_player: PublicKey, o_player: PublicKey, winner: Option<Player>) {
+fn complete_game(x_player: AccountHash, o_player: AccountHash, winner: Option<Player>) {
     let x_player_data = PlayerData::read_local(x_player).unwrap_or_revert();
     let o_player_data = PlayerData::read_local(o_player).unwrap_or_revert();
 
@@ -117,7 +121,7 @@ fn complete_game(x_player: PublicKey, o_player: PublicKey, winner: Option<Player
     storage::write_local(o_player, ());
 }
 
-fn concede(player: PublicKey) -> Result<(), Error> {
+fn concede(player: AccountHash) -> Result<(), Error> {
     let player_data = PlayerData::read_local(player).ok_or(Error::NoGameFoundForPlayer)?;
     let (x_player, o_player) = if player_data.piece() == Player::X {
         (player, player_data.opponent())

--- a/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/state_key.rs
+++ b/execution-engine/contracts/examples/tic-tac-toe-smart-contract/src/state_key.rs
@@ -1,14 +1,14 @@
 use alloc::vec::Vec;
 
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{self, ToBytes},
 };
 
 pub struct StateKey([u8; 64]);
 
 impl StateKey {
-    pub fn new(x_player: PublicKey, o_player: PublicKey) -> StateKey {
+    pub fn new(x_player: AccountHash, o_player: AccountHash) -> StateKey {
         let mut result = [0u8; 64];
         for (i, j) in x_player
             .as_bytes()

--- a/execution-engine/contracts/examples/transfer-to-account-batch/src/main.rs
+++ b/execution-engine/contracts/examples/transfer-to-account-batch/src/main.rs
@@ -21,8 +21,8 @@ pub extern "C" fn transfer_batch() {
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
-    for (public_key, amount) in transfers {
-        system::transfer_to_account(public_key, amount).unwrap_or_revert();
+    for (account_hash, amount) in transfers {
+        system::transfer_to_account(account_hash, amount).unwrap_or_revert();
     }
 }
 

--- a/execution-engine/contracts/examples/transfer-to-account-batch/src/main.rs
+++ b/execution-engine/contracts/examples/transfer-to-account-batch/src/main.rs
@@ -8,7 +8,7 @@ use contract::{
     contract_api::{runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, Key, U512};
+use types::{account::AccountHash, ApiError, Key, U512};
 
 const FN_NAME: &str = "transfer_batch";
 
@@ -17,7 +17,7 @@ const FN_NAME: &str = "transfer_batch";
 /// sending the specified amount to the specified key.
 #[no_mangle]
 pub extern "C" fn transfer_batch() {
-    let transfers: Vec<(PublicKey, U512)> = runtime::get_arg(0)
+    let transfers: Vec<(AccountHash, U512)> = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 

--- a/execution-engine/contracts/examples/transfer-to-account-batch/src/main.rs
+++ b/execution-engine/contracts/examples/transfer-to-account-batch/src/main.rs
@@ -12,7 +12,7 @@ use types::{account::AccountHash, ApiError, Key, U512};
 
 const FN_NAME: &str = "transfer_batch";
 
-/// Assumes 0-th argument is a Vec<(PublicKey, U512)>.
+/// Assumes 0-th argument is a Vec<(AccountHash, U512)>.
 /// Performs a transfer for each element of the vector,
 /// sending the specified amount to the specified key.
 #[no_mangle]

--- a/execution-engine/contracts/examples/vesting-smart-contract/src/api.rs
+++ b/execution-engine/contracts/examples/vesting-smart-contract/src/api.rs
@@ -1,7 +1,7 @@
 use alloc::string::String;
 
 use contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
-use types::{account::PublicKey, bytesrepr::FromBytes, CLTyped, ContractRef, URef, U512};
+use types::{account::AccountHash, bytesrepr::FromBytes, CLTyped, ContractRef, URef, U512};
 
 use crate::error::Error;
 
@@ -25,8 +25,8 @@ pub struct VestingConfig {
 
 #[allow(clippy::large_enum_variant)]
 pub enum Api {
-    Deploy(String, PublicKey, PublicKey, VestingConfig),
-    Init(PublicKey, PublicKey, VestingConfig),
+    Deploy(String, AccountHash, AccountHash, VestingConfig),
+    Init(AccountHash, AccountHash, VestingConfig),
     Pause,
     Unpause,
     WithdrawProxy(U512),

--- a/execution-engine/contracts/examples/vesting-smart-contract/src/deployer.rs
+++ b/execution-engine/contracts/examples/vesting-smart-contract/src/deployer.rs
@@ -8,7 +8,7 @@ use contract::{
     contract_api::{account, runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ContractRef, Key, URef};
+use types::{account::AccountHash, ContractRef, Key, URef};
 
 use crate::vesting::PURSE_NAME;
 
@@ -27,8 +27,8 @@ pub fn deploy() {
 
 fn deploy_vesting_contract(
     name: &str,
-    admin: PublicKey,
-    recipient: PublicKey,
+    admin: AccountHash,
+    recipient: AccountHash,
     vesting_config: VestingConfig,
 ) {
     // Create a smart contract purse.

--- a/execution-engine/contracts/examples/vesting-smart-contract/src/vesting.rs
+++ b/execution-engine/contracts/examples/vesting-smart-contract/src/vesting.rs
@@ -5,7 +5,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     CLTyped, URef, U512,
 };
@@ -120,19 +120,19 @@ fn mark_as_initialized() {
     set_key(INIT_FLAG_KEY, 1);
 }
 
-fn set_admin_account(admin: PublicKey) {
+fn set_admin_account(admin: AccountHash) {
     set_key(ADMIN_KEY, admin);
 }
 
-fn admin_account() -> PublicKey {
+fn admin_account() -> AccountHash {
     key(ADMIN_KEY)
 }
 
-fn set_recipient_account(recipient: PublicKey) {
+fn set_recipient_account(recipient: AccountHash) {
     set_key(RECIPIENT_KEY, recipient);
 }
 
-fn recipient_account() -> PublicKey {
+fn recipient_account() -> AccountHash {
     key(RECIPIENT_KEY)
 }
 

--- a/execution-engine/contracts/explorer/faucet/src/lib.rs
+++ b/execution-engine/contracts/explorer/faucet/src/lib.rs
@@ -11,12 +11,12 @@ enum CustomError {
     AlreadyFunded = 1,
 }
 
-/// Executes token transfer to supplied public key.
+/// Executes token transfer to supplied account hash.
 /// Revert status codes:
-/// 1 - requested transfer to already funded public key.
+/// 1 - requested transfer to already funded account hash.
 #[no_mangle]
 pub fn delegate() {
-    let public_key: AccountHash = runtime::get_arg(0)
+    let account_hash: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
@@ -25,15 +25,15 @@ pub fn delegate() {
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
     // Maybe we will decide to allow multiple funds up until some maximum value.
-    let already_funded = storage::read_local::<AccountHash, U512>(&public_key)
+    let already_funded = storage::read_local::<AccountHash, U512>(&account_hash)
         .unwrap_or_default()
         .is_some();
 
     if already_funded {
         runtime::revert(ApiError::User(CustomError::AlreadyFunded as u16));
     } else {
-        system::transfer_to_account(public_key, amount).unwrap_or_revert();
+        system::transfer_to_account(account_hash, amount).unwrap_or_revert();
         // Transfer successful; Store the fact of funding in the local state.
-        storage::write_local(public_key, amount);
+        storage::write_local(account_hash, amount);
     }
 }

--- a/execution-engine/contracts/explorer/faucet/src/lib.rs
+++ b/execution-engine/contracts/explorer/faucet/src/lib.rs
@@ -4,7 +4,7 @@ use contract::{
     contract_api::{runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 #[repr(u32)]
 enum CustomError {
@@ -16,7 +16,7 @@ enum CustomError {
 /// 1 - requested transfer to already funded public key.
 #[no_mangle]
 pub fn delegate() {
-    let public_key: PublicKey = runtime::get_arg(0)
+    let public_key: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
@@ -25,7 +25,7 @@ pub fn delegate() {
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
     // Maybe we will decide to allow multiple funds up until some maximum value.
-    let already_funded = storage::read_local::<PublicKey, U512>(&public_key)
+    let already_funded = storage::read_local::<AccountHash, U512>(&public_key)
         .unwrap_or_default()
         .is_some();
 

--- a/execution-engine/contracts/integration/add-associated-key/src/main.rs
+++ b/execution-engine/contracts/integration/add-associated-key/src/main.rs
@@ -6,7 +6,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{PublicKey, Weight},
+    account::{AccountHash, Weight},
     ApiError,
 };
 
@@ -28,7 +28,7 @@ impl Into<ApiError> for Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let account: PublicKey = runtime::get_arg(Arg::Account as u32)
+    let account: AccountHash = runtime::get_arg(Arg::Account as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let weight_val: u32 = runtime::get_arg(Arg::Weight as u32)

--- a/execution-engine/contracts/integration/get-caller-define/src/main.rs
+++ b/execution-engine/contracts/integration/get-caller-define/src/main.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 use alloc::collections::BTreeMap;
 
 use contract::contract_api::{runtime, storage};
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 const GET_CALLER_EXT: &str = "get_caller_ext";
 const GET_CALLER_KEY: &str = "get_caller";
@@ -16,7 +16,7 @@ fn test_get_caller() {
     // public key == 'ae7cd84d61ff556806691be61e6ab217791905677adbbe085b8c540d916e8393'
     // Will fail if we ever change that.
     let caller = runtime::get_caller();
-    let expected_caller = PublicKey::ed25519_from([
+    let expected_caller = AccountHash::new([
         174, 124, 216, 77, 97, 255, 85, 104, 6, 105, 27, 230, 30, 106, 178, 23, 121, 25, 5, 103,
         122, 219, 190, 8, 91, 140, 84, 13, 145, 110, 131, 147,
     ]);

--- a/execution-engine/contracts/integration/get-caller-define/src/main.rs
+++ b/execution-engine/contracts/integration/get-caller-define/src/main.rs
@@ -13,7 +13,7 @@ const GET_CALLER_KEY: &str = "get_caller";
 
 fn test_get_caller() {
     // Assumes that will be called using test framework genesis account with
-    // public key == 'ae7cd84d61ff556806691be61e6ab217791905677adbbe085b8c540d916e8393'
+    // account hash == 'ae7cd84d61ff556806691be61e6ab217791905677adbbe085b8c540d916e8393'
     // Will fail if we ever change that.
     let caller = runtime::get_caller();
     let expected_caller = AccountHash::new([

--- a/execution-engine/contracts/integration/update-associated-key/src/main.rs
+++ b/execution-engine/contracts/integration/update-associated-key/src/main.rs
@@ -6,7 +6,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{PublicKey, Weight},
+    account::{AccountHash, Weight},
     ApiError,
 };
 
@@ -28,7 +28,7 @@ impl Into<ApiError> for Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let account: PublicKey = runtime::get_arg(Arg::Account as u32)
+    let account: AccountHash = runtime::get_arg(Arg::Account as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let weight_val: u32 = runtime::get_arg(Arg::Weight as u32)

--- a/execution-engine/contracts/profiling/host-function-metrics/src/lib.rs
+++ b/execution-engine/contracts/profiling/host-function-metrics/src/lib.rs
@@ -12,7 +12,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{ActionType, PublicKey, Weight},
+    account::{AccountHash, ActionType, Weight},
     ApiError, BlockTime, CLValue, Key, Phase, U512,
 };
 
@@ -141,7 +141,7 @@ pub extern "C" fn call() {
     let seed: u64 = runtime::get_arg(Arg::Seed as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let (random_bytes, source_account, destination_account): (Vec<u8>, PublicKey, PublicKey) =
+    let (random_bytes, source_account, destination_account): (Vec<u8>, AccountHash, AccountHash) =
         runtime::get_arg(Arg::Others as u32)
             .unwrap_or_revert_with(ApiError::MissingArgument)
             .unwrap_or_revert_with(ApiError::InvalidArgument);

--- a/execution-engine/contracts/profiling/simple-transfer/src/main.rs
+++ b/execution-engine/contracts/profiling/simple-transfer/src/main.rs
@@ -8,7 +8,7 @@ use contract::{
 use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 enum Arg {
-    PublicKey = 0,
+    AccountHash = 0,
     Amount = 1,
 }
 
@@ -19,7 +19,7 @@ enum Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key: AccountHash = runtime::get_arg(Arg::PublicKey as u32)
+    let public_key: AccountHash = runtime::get_arg(Arg::AccountHash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Amount as u32)

--- a/execution-engine/contracts/profiling/simple-transfer/src/main.rs
+++ b/execution-engine/contracts/profiling/simple-transfer/src/main.rs
@@ -5,7 +5,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, TransferredTo, U512};
+use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 enum Arg {
     PublicKey = 0,
@@ -19,7 +19,7 @@ enum Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key: PublicKey = runtime::get_arg(Arg::PublicKey as u32)
+    let public_key: AccountHash = runtime::get_arg(Arg::PublicKey as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Amount as u32)

--- a/execution-engine/contracts/profiling/simple-transfer/src/main.rs
+++ b/execution-engine/contracts/profiling/simple-transfer/src/main.rs
@@ -19,13 +19,13 @@ enum Error {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key: AccountHash = runtime::get_arg(Arg::AccountHash as u32)
+    let account_hash: AccountHash = runtime::get_arg(Arg::AccountHash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Amount as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    match system::transfer_to_account(public_key, amount).unwrap_or_revert() {
+    match system::transfer_to_account(account_hash, amount).unwrap_or_revert() {
         TransferredTo::NewAccount => {
             runtime::revert(ApiError::User(Error::NonExistentAccount as u16))
         }

--- a/execution-engine/contracts/profiling/state-initializer/src/main.rs
+++ b/execution-engine/contracts/profiling/state-initializer/src/main.rs
@@ -10,9 +10,9 @@ use contract::{
 use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 enum Arg {
-    Account1PublicKey = 0,
+    Account1Hash = 0,
     Account1Amount = 1,
-    Account2PublicKey = 2,
+    Account2Hash = 2,
 }
 
 #[repr(u16)]
@@ -32,7 +32,7 @@ fn create_account_with_amount(account: AccountHash, amount: U512) {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key1: AccountHash = runtime::get_arg(Arg::Account1PublicKey as u32)
+    let public_key1: AccountHash = runtime::get_arg(Arg::Account1Hash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Account1Amount as u32)
@@ -40,7 +40,7 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     create_account_with_amount(public_key1, amount);
 
-    let public_key2: AccountHash = runtime::get_arg(Arg::Account2PublicKey as u32)
+    let public_key2: AccountHash = runtime::get_arg(Arg::Account2Hash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     create_account_with_amount(public_key2, U512::zero());

--- a/execution-engine/contracts/profiling/state-initializer/src/main.rs
+++ b/execution-engine/contracts/profiling/state-initializer/src/main.rs
@@ -7,7 +7,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, TransferredTo, U512};
+use types::{account::AccountHash, ApiError, TransferredTo, U512};
 
 enum Arg {
     Account1PublicKey = 0,
@@ -20,7 +20,7 @@ enum Error {
     AccountAlreadyExists = 0,
 }
 
-fn create_account_with_amount(account: PublicKey, amount: U512) {
+fn create_account_with_amount(account: AccountHash, amount: U512) {
     match system::transfer_to_account(account, amount) {
         Ok(TransferredTo::NewAccount) => (),
         Ok(TransferredTo::ExistingAccount) => {
@@ -32,7 +32,7 @@ fn create_account_with_amount(account: PublicKey, amount: U512) {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key1: PublicKey = runtime::get_arg(Arg::Account1PublicKey as u32)
+    let public_key1: AccountHash = runtime::get_arg(Arg::Account1PublicKey as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Account1Amount as u32)
@@ -40,7 +40,7 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     create_account_with_amount(public_key1, amount);
 
-    let public_key2: PublicKey = runtime::get_arg(Arg::Account2PublicKey as u32)
+    let public_key2: AccountHash = runtime::get_arg(Arg::Account2PublicKey as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     create_account_with_amount(public_key2, U512::zero());

--- a/execution-engine/contracts/profiling/state-initializer/src/main.rs
+++ b/execution-engine/contracts/profiling/state-initializer/src/main.rs
@@ -32,16 +32,16 @@ fn create_account_with_amount(account: AccountHash, amount: U512) {
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let public_key1: AccountHash = runtime::get_arg(Arg::Account1Hash as u32)
+    let account_hash1: AccountHash = runtime::get_arg(Arg::Account1Hash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(Arg::Account1Amount as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    create_account_with_amount(public_key1, amount);
+    create_account_with_amount(account_hash1, amount);
 
-    let public_key2: AccountHash = runtime::get_arg(Arg::Account2Hash as u32)
+    let account_hash2: AccountHash = runtime::get_arg(Arg::Account2Hash as u32)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    create_account_with_amount(public_key2, U512::zero());
+    create_account_with_amount(account_hash2, U512::zero());
 }

--- a/execution-engine/contracts/system/mint-token/src/lib.rs
+++ b/execution-engine/contracts/system/mint-token/src/lib.rs
@@ -10,7 +10,7 @@ use contract::{
 };
 use mint::{Mint, RuntimeProvider, StorageProvider};
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::mint::Error,
     ApiError, CLTyped, CLValue, Key, URef, U512,
@@ -24,7 +24,7 @@ const METHOD_TRANSFER: &str = "transfer";
 pub struct MintContract;
 
 impl RuntimeProvider for MintContract {
-    fn get_caller(&self) -> PublicKey {
+    fn get_caller(&self) -> AccountHash {
         runtime::get_caller()
     }
 

--- a/execution-engine/contracts/system/pos-install/src/main.rs
+++ b/execution-engine/contracts/system/pos-install/src/main.rs
@@ -11,8 +11,8 @@ use contract::{
 };
 use proof_of_stake::Stakes;
 use types::{
-    account::PublicKey, system_contract_errors::mint, AccessRights, ApiError, CLValue, ContractRef,
-    Key, URef, U512,
+    account::AccountHash, system_contract_errors::mint, AccessRights, ApiError, CLValue,
+    ContractRef, Key, URef, U512,
 };
 
 const PLACEHOLDER_KEY: Key = Key::Hash([0u8; 32]);
@@ -39,7 +39,7 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let mint = ContractRef::URef(URef::new(mint_uref.addr(), AccessRights::READ));
 
-    let genesis_validators: BTreeMap<PublicKey, U512> =
+    let genesis_validators: BTreeMap<AccountHash, U512> =
         runtime::get_arg(Args::GenesisValidators as u32)
             .unwrap_or_revert_with(ApiError::MissingArgument)
             .unwrap_or_revert_with(ApiError::InvalidArgument);

--- a/execution-engine/contracts/system/pos/src/lib.rs
+++ b/execution-engine/contracts/system/pos/src/lib.rs
@@ -15,7 +15,7 @@ use proof_of_stake::{
     MintProvider, ProofOfStake, Queue, QueueProvider, RuntimeProvider, Stakes, StakesProvider,
 };
 use types::{
-    account::PublicKey, system_contract_errors::pos::Error, ApiError, BlockTime, CLValue, Key,
+    account::AccountHash, system_contract_errors::pos::Error, ApiError, BlockTime, CLValue, Key,
     Phase, TransferResult, URef, U512,
 };
 
@@ -35,7 +35,7 @@ impl MintProvider for ProofOfStakeContract {
     fn transfer_purse_to_account(
         &mut self,
         source: URef,
-        target: PublicKey,
+        target: AccountHash,
         amount: U512,
     ) -> TransferResult {
         system::transfer_from_purse_to_account(source, target, amount)
@@ -102,7 +102,7 @@ impl RuntimeProvider for ProofOfStakeContract {
         runtime::get_blocktime()
     }
 
-    fn get_caller(&self) -> PublicKey {
+    fn get_caller(&self) -> AccountHash {
         runtime::get_caller()
     }
 }
@@ -126,7 +126,7 @@ impl StakesProvider for ProofOfStakeContract {
             let _bytes_written = base16::decode_slice(hex_key, &mut key_bytes)
                 .map_err(|_| Error::StakesKeyDeserializationFailed)?;
             debug_assert!(_bytes_written == key_bytes.len());
-            let pub_key = PublicKey::ed25519_from(key_bytes);
+            let pub_key = AccountHash::new(key_bytes);
             let balance = split_name
                 .next()
                 .and_then(|b| U512::from_dec_str(b).ok())
@@ -225,7 +225,7 @@ pub fn delegate() {
             let amount_spent: U512 = runtime::get_arg(1)
                 .unwrap_or_revert_with(ApiError::MissingArgument)
                 .unwrap_or_revert_with(ApiError::InvalidArgument);
-            let account: PublicKey = runtime::get_arg(2)
+            let account: AccountHash = runtime::get_arg(2)
                 .unwrap_or_revert_with(ApiError::MissingArgument)
                 .unwrap_or_revert_with(ApiError::InvalidArgument);
             pos_contract

--- a/execution-engine/contracts/test/add-update-associated-key/src/main.rs
+++ b/execution-engine/contracts/test/add-update-associated-key/src/main.rs
@@ -6,7 +6,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{PublicKey, Weight},
+    account::{AccountHash, Weight},
     ApiError,
 };
 
@@ -15,7 +15,7 @@ const MOD_WEIGHT: u8 = 2;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let account: PublicKey = runtime::get_arg(0)
+    let account: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 

--- a/execution-engine/contracts/test/authorized-keys/src/main.rs
+++ b/execution-engine/contracts/test/authorized-keys/src/main.rs
@@ -6,13 +6,13 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{ActionType, AddKeyFailure, PublicKey, Weight},
+    account::{AccountHash, ActionType, AddKeyFailure, Weight},
     ApiError,
 };
 
 #[no_mangle]
 pub extern "C" fn call() {
-    match account::add_associated_key(PublicKey::ed25519_from([123; 32]), Weight::new(100)) {
+    match account::add_associated_key(AccountHash::new([123; 32]), Weight::new(100)) {
         Err(AddKeyFailure::DuplicateKey) => {}
         Err(_) => runtime::revert(ApiError::User(50)),
         Ok(_) => {}

--- a/execution-engine/contracts/test/ee-460-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-460-regression/src/main.rs
@@ -13,7 +13,7 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
-    let public_key = AccountHash::new([42; 32]);
-    let result = system::transfer_to_account(public_key, amount);
+    let account_hash = AccountHash::new([42; 32]);
+    let result = system::transfer_to_account(account_hash, amount);
     assert_eq!(result, Err(ApiError::Transfer))
 }

--- a/execution-engine/contracts/test/ee-460-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-460-regression/src/main.rs
@@ -5,7 +5,7 @@ use contract::{
     contract_api::{runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 #[no_mangle]
 pub extern "C" fn call() {
@@ -13,7 +13,7 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 
-    let public_key = PublicKey::ed25519_from([42; 32]);
+    let public_key = AccountHash::new([42; 32]);
     let result = system::transfer_to_account(public_key, amount);
     assert_eq!(result, Err(ApiError::Transfer))
 }

--- a/execution-engine/contracts/test/ee-536-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-536-regression/src/main.rs
@@ -7,7 +7,7 @@ use contract::{
 };
 use types::{
     account::{
-        ActionType, PublicKey, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight,
+        AccountHash, ActionType, RemoveKeyFailure, SetThresholdFailure, UpdateKeyFailure, Weight,
     },
     ApiError,
 };
@@ -15,8 +15,8 @@ use types::{
 #[no_mangle]
 pub extern "C" fn call() {
     // Starts with deployment=1, key_management=1
-    let key_1 = PublicKey::ed25519_from([42; 32]);
-    let key_2 = PublicKey::ed25519_from([43; 32]);
+    let key_1 = AccountHash::new([42; 32]);
+    let key_2 = AccountHash::new([43; 32]);
 
     // Total keys weight = 11 (identity + new key's weight)
     account::add_associated_key(key_1, Weight::new(10)).unwrap_or_revert();

--- a/execution-engine/contracts/test/ee-539-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-539-regression/src/main.rs
@@ -6,14 +6,13 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{ActionType, PublicKey, Weight},
+    account::{AccountHash, ActionType, Weight},
     ApiError,
 };
 
 #[no_mangle]
 pub extern "C" fn call() {
-    account::add_associated_key(PublicKey::ed25519_from([123; 32]), Weight::new(254))
-        .unwrap_or_revert();
+    account::add_associated_key(AccountHash::new([123; 32]), Weight::new(254)).unwrap_or_revert();
     let key_management_threshold: Weight = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);

--- a/execution-engine/contracts/test/ee-550-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-550-regression/src/main.rs
@@ -10,7 +10,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    account::{ActionType, PublicKey, Weight},
+    account::{AccountHash, ActionType, Weight},
     ApiError,
 };
 
@@ -44,9 +44,9 @@ pub extern "C" fn call() {
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     match pass.as_str() {
         "init_remove" => {
-            account::add_associated_key(PublicKey::ed25519_from(KEY_1_ADDR), Weight::new(2))
+            account::add_associated_key(AccountHash::new(KEY_1_ADDR), Weight::new(2))
                 .unwrap_or_revert_with(Error::AddKey1);
-            account::add_associated_key(PublicKey::ed25519_from(KEY_2_ADDR), Weight::new(255))
+            account::add_associated_key(AccountHash::new(KEY_2_ADDR), Weight::new(255))
                 .unwrap_or_revert_with(Error::AddKey2);
             account::set_action_threshold(ActionType::KeyManagement, Weight::new(254))
                 .unwrap_or_revert_with(Error::SetActionThreshold);
@@ -54,14 +54,14 @@ pub extern "C" fn call() {
         "test_remove" => {
             // Deployed with two keys of weights 2 and 255 (total saturates at 255) to satisfy new
             // threshold
-            account::remove_associated_key(PublicKey::ed25519_from(KEY_1_ADDR))
+            account::remove_associated_key(AccountHash::new(KEY_1_ADDR))
                 .unwrap_or_revert_with(Error::RemoveKey);
         }
 
         "init_update" => {
-            account::add_associated_key(PublicKey::ed25519_from(KEY_1_ADDR), Weight::new(3))
+            account::add_associated_key(AccountHash::new(KEY_1_ADDR), Weight::new(3))
                 .unwrap_or_revert_with(Error::AddKey1);
-            account::add_associated_key(PublicKey::ed25519_from(KEY_2_ADDR), Weight::new(255))
+            account::add_associated_key(AccountHash::new(KEY_2_ADDR), Weight::new(255))
                 .unwrap_or_revert_with(Error::AddKey2);
             account::set_action_threshold(ActionType::KeyManagement, Weight::new(254))
                 .unwrap_or_revert_with(Error::SetActionThreshold);
@@ -69,7 +69,7 @@ pub extern "C" fn call() {
         "test_update" => {
             // Deployed with two keys of weights 3 and 255 (total saturates at 255) to satisfy new
             // threshold
-            account::update_associated_key(PublicKey::ed25519_from(KEY_1_ADDR), Weight::new(1))
+            account::update_associated_key(AccountHash::new(KEY_1_ADDR), Weight::new(1))
                 .unwrap_or_revert_with(Error::UpdateKey);
         }
         _ => {

--- a/execution-engine/contracts/test/ee-599-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-599-regression/src/main.rs
@@ -9,7 +9,7 @@ use contract::{
     contract_api::{account, runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, Key, URef, U512};
+use types::{account::AccountHash, ApiError, Key, URef, U512};
 
 const DONATION_AMOUNT: u64 = 1;
 // Different name just to make sure any routine that deals with named keys coming from different
@@ -48,7 +48,7 @@ impl Into<ApiError> for ContractError {
     }
 }
 
-fn get_maintainer_public_key() -> Result<PublicKey, ApiError> {
+fn get_maintainer_public_key() -> Result<AccountHash, ApiError> {
     // Obtain maintainer address from the contract's named keys
     let maintainer_key = runtime::get_key(MAINTAINER).ok_or(ApiError::GetKey)?;
     maintainer_key

--- a/execution-engine/contracts/test/ee-599-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-599-regression/src/main.rs
@@ -48,7 +48,7 @@ impl Into<ApiError> for ContractError {
     }
 }
 
-fn get_maintainer_public_key() -> Result<AccountHash, ApiError> {
+fn get_maintainer_account_hash() -> Result<AccountHash, ApiError> {
     // Obtain maintainer address from the contract's named keys
     let maintainer_key = runtime::get_key(MAINTAINER).ok_or(ApiError::GetKey)?;
     maintainer_key
@@ -72,7 +72,7 @@ fn transfer_funds() -> Result<(), ApiError> {
     // Donation box is the purse funds will be transferred into
     let donation_purse = get_donation_purse()?;
     // This is the address of account which installed the contract
-    let maintainer_public_key = get_maintainer_public_key()?;
+    let maintainer_account_hash = get_maintainer_account_hash()?;
 
     match method.as_str() {
         TRANSFER_FROM_PURSE_TO_PURSE => {
@@ -89,12 +89,12 @@ fn transfer_funds() -> Result<(), ApiError> {
 
             system::transfer_from_purse_to_account(
                 main_purse,
-                maintainer_public_key,
+                maintainer_account_hash,
                 U512::from(DONATION_AMOUNT),
             )?;
         }
         TRANSFER_TO_ACCOUNT => {
-            system::transfer_to_account(maintainer_public_key, U512::from(DONATION_AMOUNT))?;
+            system::transfer_to_account(maintainer_account_hash, U512::from(DONATION_AMOUNT))?;
         }
         GET_MAIN_PURSE => {
             let _main_purse = account::get_main_purse();

--- a/execution-engine/contracts/test/get-caller-subcall/src/main.rs
+++ b/execution-engine/contracts/test/get-caller-subcall/src/main.rs
@@ -9,28 +9,28 @@ use contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, CLValue};
+use types::{account::AccountHash, ApiError, CLValue};
 
 #[no_mangle]
 pub extern "C" fn check_caller_ext() {
-    let caller_public_key: PublicKey = runtime::get_caller();
+    let caller_public_key: AccountHash = runtime::get_caller();
     let return_value = CLValue::from_t(caller_public_key).unwrap_or_revert();
     runtime::ret(return_value)
 }
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let known_public_key: PublicKey = runtime::get_arg(0)
+    let known_public_key: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let caller_public_key: PublicKey = runtime::get_caller();
+    let caller_public_key: AccountHash = runtime::get_caller();
     assert_eq!(
         caller_public_key, known_public_key,
         "caller public key was not known public key"
     );
 
     let pointer = storage::store_function_at_hash("check_caller_ext", BTreeMap::new());
-    let subcall_public_key: PublicKey = runtime::call_contract(pointer, ());
+    let subcall_public_key: AccountHash = runtime::call_contract(pointer, ());
     assert_eq!(
         subcall_public_key, known_public_key,
         "subcall public key was not known public key"

--- a/execution-engine/contracts/test/get-caller-subcall/src/main.rs
+++ b/execution-engine/contracts/test/get-caller-subcall/src/main.rs
@@ -13,26 +13,26 @@ use types::{account::AccountHash, ApiError, CLValue};
 
 #[no_mangle]
 pub extern "C" fn check_caller_ext() {
-    let caller_public_key: AccountHash = runtime::get_caller();
-    let return_value = CLValue::from_t(caller_public_key).unwrap_or_revert();
+    let caller_account_hash: AccountHash = runtime::get_caller();
+    let return_value = CLValue::from_t(caller_account_hash).unwrap_or_revert();
     runtime::ret(return_value)
 }
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let known_public_key: AccountHash = runtime::get_arg(0)
+    let known_account_hash: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let caller_public_key: AccountHash = runtime::get_caller();
+    let caller_account_hash: AccountHash = runtime::get_caller();
     assert_eq!(
-        caller_public_key, known_public_key,
-        "caller public key was not known public key"
+        caller_account_hash, known_account_hash,
+        "caller account hash was not known account hash"
     );
 
     let pointer = storage::store_function_at_hash("check_caller_ext", BTreeMap::new());
-    let subcall_public_key: AccountHash = runtime::call_contract(pointer, ());
+    let subcall_account_hash: AccountHash = runtime::call_contract(pointer, ());
     assert_eq!(
-        subcall_public_key, known_public_key,
-        "subcall public key was not known public key"
+        subcall_account_hash, known_account_hash,
+        "subcall account hash was not known account hash"
     );
 }

--- a/execution-engine/contracts/test/get-caller/src/main.rs
+++ b/execution-engine/contracts/test/get-caller/src/main.rs
@@ -6,12 +6,12 @@ use types::{account::AccountHash, ApiError};
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let known_public_key: AccountHash = runtime::get_arg(0)
+    let known_account_hash: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let caller_public_key: AccountHash = runtime::get_caller();
+    let caller_account_hash: AccountHash = runtime::get_caller();
     assert_eq!(
-        caller_public_key, known_public_key,
-        "caller public key was not known public key"
+        caller_account_hash, known_account_hash,
+        "caller account hash was not known account hash"
     );
 }

--- a/execution-engine/contracts/test/get-caller/src/main.rs
+++ b/execution-engine/contracts/test/get-caller/src/main.rs
@@ -2,14 +2,14 @@
 #![no_main]
 
 use contract::{contract_api::runtime, unwrap_or_revert::UnwrapOrRevert};
-use types::{account::PublicKey, ApiError};
+use types::{account::AccountHash, ApiError};
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let known_public_key: PublicKey = runtime::get_arg(0)
+    let known_public_key: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let caller_public_key: PublicKey = runtime::get_caller();
+    let caller_public_key: AccountHash = runtime::get_caller();
     assert_eq!(
         caller_public_key, known_public_key,
         "caller public key was not known public key"

--- a/execution-engine/contracts/test/key-management-thresholds/src/main.rs
+++ b/execution-engine/contracts/test/key-management-thresholds/src/main.rs
@@ -11,7 +11,7 @@ use contract::{
 };
 use types::{
     account::{
-        ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure,
+        AccountHash, ActionType, AddKeyFailure, RemoveKeyFailure, SetThresholdFailure,
         UpdateKeyFailure, Weight,
     },
     ApiError,
@@ -25,30 +25,28 @@ pub extern "C" fn call() {
 
     if stage == "init" {
         // executed with weight >= 1
-        account::add_associated_key(PublicKey::ed25519_from([42; 32]), Weight::new(100))
+        account::add_associated_key(AccountHash::new([42; 32]), Weight::new(100))
             .unwrap_or_revert();
         // this key will be used to test permission denied when removing keys with low
         // total weight
-        account::add_associated_key(PublicKey::ed25519_from([43; 32]), Weight::new(1))
-            .unwrap_or_revert();
-        account::add_associated_key(PublicKey::ed25519_from([1; 32]), Weight::new(1))
-            .unwrap_or_revert();
+        account::add_associated_key(AccountHash::new([43; 32]), Weight::new(1)).unwrap_or_revert();
+        account::add_associated_key(AccountHash::new([1; 32]), Weight::new(1)).unwrap_or_revert();
         account::set_action_threshold(ActionType::KeyManagement, Weight::new(101))
             .unwrap_or_revert();
     } else if stage == "test-permission-denied" {
         // Has to be executed with keys of total weight < 255
-        match account::add_associated_key(PublicKey::ed25519_from([44; 32]), Weight::new(1)) {
+        match account::add_associated_key(AccountHash::new([44; 32]), Weight::new(1)) {
             Ok(_) => runtime::revert(ApiError::User(200)),
             Err(AddKeyFailure::PermissionDenied) => {}
             Err(_) => runtime::revert(ApiError::User(201)),
         }
 
-        match account::update_associated_key(PublicKey::ed25519_from([43; 32]), Weight::new(2)) {
+        match account::update_associated_key(AccountHash::new([43; 32]), Weight::new(2)) {
             Ok(_) => runtime::revert(ApiError::User(300)),
             Err(UpdateKeyFailure::PermissionDenied) => {}
             Err(_) => runtime::revert(ApiError::User(301)),
         }
-        match account::remove_associated_key(PublicKey::ed25519_from([43; 32])) {
+        match account::remove_associated_key(AccountHash::new([43; 32])) {
             Ok(_) => runtime::revert(ApiError::User(400)),
             Err(RemoveKeyFailure::PermissionDenied) => {}
             Err(_) => runtime::revert(ApiError::User(401)),
@@ -61,13 +59,12 @@ pub extern "C" fn call() {
         }
     } else if stage == "test-key-mgmnt-succeed" {
         // Has to be executed with keys of total weight >= 254
-        account::add_associated_key(PublicKey::ed25519_from([44; 32]), Weight::new(1))
-            .unwrap_or_revert();
+        account::add_associated_key(AccountHash::new([44; 32]), Weight::new(1)).unwrap_or_revert();
         // Updates [43;32] key weight created in init stage
-        account::update_associated_key(PublicKey::ed25519_from([44; 32]), Weight::new(2))
+        account::update_associated_key(AccountHash::new([44; 32]), Weight::new(2))
             .unwrap_or_revert();
         // Removes [43;32] key created in init stage
-        account::remove_associated_key(PublicKey::ed25519_from([44; 32])).unwrap_or_revert();
+        account::remove_associated_key(AccountHash::new([44; 32])).unwrap_or_revert();
         // Sets action threshodl
         account::set_action_threshold(ActionType::KeyManagement, Weight::new(100))
             .unwrap_or_revert();

--- a/execution-engine/contracts/test/pos-bonding/src/main.rs
+++ b/execution-engine/contracts/test/pos-bonding/src/main.rs
@@ -9,7 +9,7 @@ use contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, ContractRef, URef, U512};
+use types::{account::AccountHash, ApiError, ContractRef, URef, U512};
 
 #[repr(u16)]
 enum Error {
@@ -59,7 +59,7 @@ pub extern "C" fn call() {
 
         bond(&pos_pointer, &amount, account::get_main_purse());
     } else if command == TEST_SEED_NEW_ACCOUNT {
-        let account: PublicKey = runtime::get_arg(1)
+        let account: AccountHash = runtime::get_arg(1)
             .unwrap_or_revert_with(ApiError::MissingArgument)
             .unwrap_or_revert_with(ApiError::InvalidArgument);
         let amount: U512 = runtime::get_arg(2)

--- a/execution-engine/contracts/test/pos-finalize-payment/src/main.rs
+++ b/execution-engine/contracts/test/pos-finalize-payment/src/main.rs
@@ -5,7 +5,7 @@ use contract::{
     contract_api::{account, runtime, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, ContractRef, Key, URef, U512};
+use types::{account::AccountHash, ApiError, ContractRef, Key, URef, U512};
 
 fn set_refund_purse(pos: &ContractRef, p: &URef) {
     runtime::call_contract(pos.clone(), ("set_refund_purse", *p))
@@ -21,7 +21,7 @@ fn submit_payment(pos: &ContractRef, amount: U512) {
     system::transfer_from_purse_to_purse(main_purse, payment_purse, amount).unwrap_or_revert()
 }
 
-fn finalize_payment(pos: &ContractRef, amount_spent: U512, account: PublicKey) {
+fn finalize_payment(pos: &ContractRef, amount_spent: U512, account: AccountHash) {
     runtime::call_contract(pos.clone(), ("finalize_payment", amount_spent, account))
 }
 
@@ -38,7 +38,7 @@ pub extern "C" fn call() {
     let maybe_amount_spent: Option<U512> = runtime::get_arg(2)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
-    let maybe_account: Option<PublicKey> = runtime::get_arg(3)
+    let maybe_account: Option<AccountHash> = runtime::get_arg(3)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
 

--- a/execution-engine/contracts/test/remove-associated-key/src/main.rs
+++ b/execution-engine/contracts/test/remove-associated-key/src/main.rs
@@ -5,11 +5,11 @@ use contract::{
     contract_api::{account, runtime},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError};
+use types::{account::AccountHash, ApiError};
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let account: PublicKey = runtime::get_arg(0)
+    let account: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     account::remove_associated_key(account).unwrap_or_revert_with(ApiError::User(0))

--- a/execution-engine/contracts/test/system-contracts-access/src/main.rs
+++ b/execution-engine/contracts/test/system-contracts-access/src/main.rs
@@ -2,7 +2,7 @@
 #![no_main]
 
 use contract::contract_api::{runtime, system};
-use types::{account::PublicKey, AccessRights, ApiError};
+use types::{account::AccountHash, AccessRights, ApiError};
 
 #[repr(u16)]
 enum Error {
@@ -34,7 +34,7 @@ fn delegate() {
     // Step 2 - Mint and PoS should be URefs and they should have valid access rights
     let mint_contract = system::get_mint();
 
-    let expected_access_rights = if runtime::get_caller() == PublicKey::ed25519_from(SYSTEM_ADDR) {
+    let expected_access_rights = if runtime::get_caller() == AccountHash::new(SYSTEM_ADDR) {
         // System account receives read/add/write access
         AccessRights::READ_ADD_WRITE
     } else {

--- a/execution-engine/contracts/test/transfer-purse-to-account-stored/src/main.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account-stored/src/main.rs
@@ -9,7 +9,7 @@ use contract::{
     contract_api::{account, runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, Key, URef, U512};
+use types::{account::AccountHash, ApiError, Key, URef, U512};
 
 const TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME: &str = "transfer_purse_to_account";
 const TRANSFER_FUNCTION_NAME: &str = "transfer";
@@ -19,7 +19,7 @@ const MAIN_PURSE_FINAL_BALANCE_UREF_NAME: &str = "final_balance";
 #[no_mangle]
 pub extern "C" fn transfer() {
     let source: URef = account::get_main_purse();
-    let destination: PublicKey = runtime::get_arg(0)
+    let destination: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(1)

--- a/execution-engine/contracts/test/transfer-purse-to-account/src/main.rs
+++ b/execution-engine/contracts/test/transfer-purse-to-account/src/main.rs
@@ -9,7 +9,7 @@ use contract::{
     contract_api::{account, runtime, storage, system},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{account::PublicKey, ApiError, Key, URef, U512};
+use types::{account::AccountHash, ApiError, Key, URef, U512};
 
 const TRANSFER_RESULT_UREF_NAME: &str = "transfer_result";
 const MAIN_PURSE_FINAL_BALANCE_UREF_NAME: &str = "final_balance";
@@ -17,7 +17,7 @@ const MAIN_PURSE_FINAL_BALANCE_UREF_NAME: &str = "final_balance";
 #[no_mangle]
 pub extern "C" fn call() {
     let source: URef = account::get_main_purse();
-    let destination: PublicKey = runtime::get_arg(0)
+    let destination: AccountHash = runtime::get_arg(0)
         .unwrap_or_revert_with(ApiError::MissingArgument)
         .unwrap_or_revert_with(ApiError::InvalidArgument);
     let amount: U512 = runtime::get_arg(1)

--- a/execution-engine/engine-core/src/engine_state/deploy_item.rs
+++ b/execution-engine/engine-core/src/engine_state/deploy_item.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 use crate::{engine_state::executable_deploy_item::ExecutableDeployItem, DeployHash};
 
@@ -9,22 +9,22 @@ type GasPrice = u64;
 /// Represents a deploy to be executed.  Corresponds to the similarly-named ipc protobuf message.
 #[derive(Clone, PartialEq, Eq)]
 pub struct DeployItem {
-    pub address: PublicKey,
+    pub address: AccountHash,
     pub session: ExecutableDeployItem,
     pub payment: ExecutableDeployItem,
     pub gas_price: GasPrice,
-    pub authorization_keys: BTreeSet<PublicKey>,
+    pub authorization_keys: BTreeSet<AccountHash>,
     pub deploy_hash: DeployHash,
 }
 
 impl DeployItem {
     /// Creates a [`DeployItem`].
     pub fn new(
-        address: PublicKey,
+        address: AccountHash,
         session: ExecutableDeployItem,
         payment: ExecutableDeployItem,
         gas_price: GasPrice,
-        authorization_keys: BTreeSet<PublicKey>,
+        authorization_keys: BTreeSet<AccountHash>,
         deploy_hash: DeployHash,
     ) -> Self {
         DeployItem {

--- a/execution-engine/engine-core/src/engine_state/error.rs
+++ b/execution-engine/engine-core/src/engine_state/error.rs
@@ -10,8 +10,11 @@ use types::ProtocolVersion;
 pub enum Error {
     #[fail(display = "Invalid hash length: expected {}, actual {}", _0, _1)]
     InvalidHashLength { expected: usize, actual: usize },
-    #[fail(display = "Invalid public key length: expected {}, actual {}", _0, _1)]
-    InvalidPublicKeyLength { expected: usize, actual: usize },
+    #[fail(
+        display = "Invalid account hash length: expected {}, actual {}",
+        _0, _1
+    )]
+    InvalidAccountHashLength { expected: usize, actual: usize },
     #[fail(display = "Invalid protocol version: {}", _0)]
     InvalidProtocolVersion(ProtocolVersion),
     #[fail(display = "Invalid upgrade config")]

--- a/execution-engine/engine-core/src/engine_state/utils.rs
+++ b/execution-engine/engine-core/src/engine_state/utils.rs
@@ -37,32 +37,32 @@ mod tests {
 
     #[test]
     fn should_parse_string_to_validator_tuple() {
-        let public_key = AccountHash::new([1u8; 32]);
+        let account_hash = AccountHash::new([1u8; 32]);
         let stake = U512::from(100);
-        let named_key_name = format!("v_{}_{}", HexFmt(&public_key.as_bytes()), stake);
+        let named_key_name = format!("v_{}_{}", HexFmt(&account_hash.as_bytes()), stake);
 
         let parsed = pos_validator_key_name_to_tuple(&named_key_name);
         assert!(parsed.is_some());
-        let (parsed_public_key, parsed_stake) = parsed.unwrap();
-        assert_eq!(parsed_public_key, public_key);
+        let (parsed_account_hash, parsed_stake) = parsed.unwrap();
+        assert_eq!(parsed_account_hash, account_hash);
         assert_eq!(parsed_stake, stake);
     }
 
     #[test]
     fn should_not_parse_string_to_validator_tuple() {
-        let public_key = AccountHash::new([1u8; 32]);
+        let account_hash = AccountHash::new([1u8; 32]);
         let stake = U512::from(100);
 
-        let bad_prefix = format!("a_{}_{}", HexFmt(&public_key.as_bytes()), stake);
+        let bad_prefix = format!("a_{}_{}", HexFmt(&account_hash.as_bytes()), stake);
         assert!(pos_validator_key_name_to_tuple(&bad_prefix).is_none());
 
-        let no_prefix = format!("_{}_{}", HexFmt(&public_key.as_bytes()), stake);
+        let no_prefix = format!("_{}_{}", HexFmt(&account_hash.as_bytes()), stake);
         assert!(pos_validator_key_name_to_tuple(&no_prefix).is_none());
 
         let short_key = format!("v_{}_{}", HexFmt(&[1u8; 31]), stake);
         assert!(pos_validator_key_name_to_tuple(&short_key).is_none());
 
-        let long_key = format!("v_{}00_{}", HexFmt(&public_key.as_bytes()), stake);
+        let long_key = format!("v_{}00_{}", HexFmt(&account_hash.as_bytes()), stake);
         assert!(pos_validator_key_name_to_tuple(&long_key).is_none());
 
         let bad_key = format!("v_{}0g_{}", HexFmt(&[1u8; 31]), stake);
@@ -74,13 +74,13 @@ mod tests {
         let no_key = format!("v_{}", stake);
         assert!(pos_validator_key_name_to_tuple(&no_key).is_none());
 
-        let bad_stake = format!("v_{}_a", HexFmt(&public_key.as_bytes()));
+        let bad_stake = format!("v_{}_a", HexFmt(&account_hash.as_bytes()));
         assert!(pos_validator_key_name_to_tuple(&bad_stake).is_none());
 
-        let no_stake = format!("v_{}_", HexFmt(&public_key.as_bytes()));
+        let no_stake = format!("v_{}_", HexFmt(&account_hash.as_bytes()));
         assert!(pos_validator_key_name_to_tuple(&no_stake).is_none());
 
-        let no_stake = format!("v_{}", HexFmt(&public_key.as_bytes()));
+        let no_stake = format!("v_{}", HexFmt(&account_hash.as_bytes()));
         assert!(pos_validator_key_name_to_tuple(&no_stake).is_none());
     }
 }

--- a/execution-engine/engine-core/src/engine_state/utils.rs
+++ b/execution-engine/engine-core/src/engine_state/utils.rs
@@ -1,8 +1,8 @@
 use types::{account::AccountHash, U512};
 
 /// In PoS, the validators are stored under named keys with names formatted as
-/// "v_<hex-formatted-PublicKey>_<bond-amount>".  This function attempts to parse such a string back
-/// into the `PublicKey` and bond amount.
+/// "v_<hex-formatted-AccountHash>_<bond-amount>".  This function attempts to parse such a string
+/// back into the `AccountHash` and bond amount.
 pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(AccountHash, U512)> {
     let mut split_bond = pos_key_name.split('_'); // expected format is "v_{account_hash}_{bond}".
     if Some("v") != split_bond.next() {

--- a/execution-engine/engine-core/src/engine_state/utils.rs
+++ b/execution-engine/engine-core/src/engine_state/utils.rs
@@ -1,10 +1,10 @@
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 /// In PoS, the validators are stored under named keys with names formatted as
 /// "v_<hex-formatted-PublicKey>_<bond-amount>".  This function attempts to parse such a string back
 /// into the `PublicKey` and bond amount.
-pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(PublicKey, U512)> {
-    let mut split_bond = pos_key_name.split('_'); // expected format is "v_{public_key}_{bond}".
+pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(AccountHash, U512)> {
+    let mut split_bond = pos_key_name.split('_'); // expected format is "v_{account_hash}_{bond}".
     if Some("v") != split_bond.next() {
         None
     } else {
@@ -15,7 +15,7 @@ pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(PublicKey,
         let mut key_bytes = [0u8; 32];
         let _bytes_written = base16::decode_slice(hex_key, &mut key_bytes).ok()?;
         debug_assert!(_bytes_written == key_bytes.len());
-        let pub_key = PublicKey::ed25519_from(key_bytes);
+        let pub_key = AccountHash::new(key_bytes);
         let balance = split_bond.next().and_then(|b| {
             if b.is_empty() {
                 None
@@ -31,13 +31,13 @@ pub fn pos_validator_key_name_to_tuple(pos_key_name: &str) -> Option<(PublicKey,
 mod tests {
     use hex_fmt::HexFmt;
 
-    use types::{account::PublicKey, U512};
+    use types::{account::AccountHash, U512};
 
     use super::pos_validator_key_name_to_tuple;
 
     #[test]
     fn should_parse_string_to_validator_tuple() {
-        let public_key = PublicKey::ed25519_from([1u8; 32]);
+        let public_key = AccountHash::new([1u8; 32]);
         let stake = U512::from(100);
         let named_key_name = format!("v_{}_{}", HexFmt(&public_key.as_bytes()), stake);
 
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn should_not_parse_string_to_validator_tuple() {
-        let public_key = PublicKey::ed25519_from([1u8; 32]);
+        let public_key = AccountHash::new([1u8; 32]);
         let stake = U512::from(100);
 
         let bad_prefix = format!("a_{}_{}", HexFmt(&public_key.as_bytes()), stake);

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -12,7 +12,7 @@ use engine_shared::{
 };
 use engine_storage::{global_state::StateReader, protocol_data::ProtocolData};
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{self, FromBytes},
     BlockTime, CLTyped, CLValue, Key, Phase, ProtocolVersion,
 };
@@ -88,7 +88,7 @@ impl Executor {
         args: Vec<u8>,
         base_key: Key,
         account: &Account,
-        authorized_keys: BTreeSet<PublicKey>,
+        authorized_keys: BTreeSet<AccountHash>,
         blocktime: BlockTime,
         deploy_hash: [u8; 32],
         gas_limit: Gas,
@@ -226,7 +226,7 @@ impl Executor {
         named_keys: &mut BTreeMap<String, Key>,
         base_key: Key,
         account: &Account,
-        authorization_keys: BTreeSet<PublicKey>,
+        authorization_keys: BTreeSet<AccountHash>,
         blocktime: BlockTime,
         deploy_hash: [u8; 32],
         gas_limit: Gas,
@@ -376,7 +376,7 @@ impl Executor {
         keys: &'a mut BTreeMap<String, Key>,
         base_key: Key,
         account: &'a Account,
-        authorization_keys: BTreeSet<PublicKey>,
+        authorization_keys: BTreeSet<AccountHash>,
         blocktime: BlockTime,
         deploy_hash: [u8; 32],
         gas_limit: Gas,
@@ -449,7 +449,7 @@ impl Executor {
         keys: &mut BTreeMap<String, Key>,
         base_key: Key,
         account: &Account,
-        authorization_keys: BTreeSet<PublicKey>,
+        authorization_keys: BTreeSet<AccountHash>,
         blocktime: BlockTime,
         deploy_hash: [u8; 32],
         gas_limit: Gas,

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -3,7 +3,7 @@ use std::convert::TryFrom;
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     api_error,
     bytesrepr::{self, ToBytes},
     Key, TransferredTo, U512,
@@ -315,11 +315,11 @@ where
                 // args(0) = pointer to array of bytes of a public key
                 // args(1) = size of a public key
                 // args(2) = weight of the key
-                let (public_key_ptr, public_key_size, weight_value): (u32, u32, u8) =
+                let (account_hash_ptr, account_hash_size, weight_value): (u32, u32, u8) =
                     Args::parse(args)?;
                 let value = self.add_associated_key(
-                    public_key_ptr,
-                    public_key_size as usize,
+                    account_hash_ptr,
+                    account_hash_size as usize,
                     weight_value,
                 )?;
                 Ok(Some(RuntimeValue::I32(value)))
@@ -328,8 +328,9 @@ where
             FunctionIndex::RemoveAssociatedKeyFuncIndex => {
                 // args(0) = pointer to array of bytes of a public key
                 // args(1) = size of a public key
-                let (public_key_ptr, public_key_size): (_, u32) = Args::parse(args)?;
-                let value = self.remove_associated_key(public_key_ptr, public_key_size as usize)?;
+                let (account_hash_ptr, account_hash_size): (_, u32) = Args::parse(args)?;
+                let value =
+                    self.remove_associated_key(account_hash_ptr, account_hash_size as usize)?;
                 Ok(Some(RuntimeValue::I32(value)))
             }
 
@@ -337,11 +338,11 @@ where
                 // args(0) = pointer to array of bytes of a public key
                 // args(1) = size of a public key
                 // args(2) = weight of the key
-                let (public_key_ptr, public_key_size, weight_value): (u32, u32, u8) =
+                let (account_hash_ptr, account_hash_size, weight_value): (u32, u32, u8) =
                     Args::parse(args)?;
                 let value = self.update_associated_key(
-                    public_key_ptr,
-                    public_key_size as usize,
+                    account_hash_ptr,
+                    account_hash_size as usize,
                     weight_value,
                 )?;
                 Ok(Some(RuntimeValue::I32(value)))
@@ -375,7 +376,7 @@ where
                 // args(3) = length of array of bytes of an amount
                 let (key_ptr, key_size, amount_ptr, amount_size): (u32, u32, u32, u32) =
                     Args::parse(args)?;
-                let public_key: PublicKey = {
+                let public_key: AccountHash = {
                     let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
@@ -407,7 +408,7 @@ where
                     let bytes = self.bytes_from_mem(source_ptr, source_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
-                let public_key: PublicKey = {
+                let public_key: AccountHash = {
                     let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -312,8 +312,8 @@ where
             }
 
             FunctionIndex::AddAssociatedKeyFuncIndex => {
-                // args(0) = pointer to array of bytes of a public key
-                // args(1) = size of a public key
+                // args(0) = pointer to array of bytes of an account hash
+                // args(1) = size of an account hash
                 // args(2) = weight of the key
                 let (account_hash_ptr, account_hash_size, weight_value): (u32, u32, u8) =
                     Args::parse(args)?;
@@ -326,8 +326,8 @@ where
             }
 
             FunctionIndex::RemoveAssociatedKeyFuncIndex => {
-                // args(0) = pointer to array of bytes of a public key
-                // args(1) = size of a public key
+                // args(0) = pointer to array of bytes of an account hash
+                // args(1) = size of an account hash
                 let (account_hash_ptr, account_hash_size): (_, u32) = Args::parse(args)?;
                 let value =
                     self.remove_associated_key(account_hash_ptr, account_hash_size as usize)?;
@@ -335,8 +335,8 @@ where
             }
 
             FunctionIndex::UpdateAssociatedKeyFuncIndex => {
-                // args(0) = pointer to array of bytes of a public key
-                // args(1) = size of a public key
+                // args(0) = pointer to array of bytes of an account hash
+                // args(1) = size of an account hash
                 // args(2) = weight of the key
                 let (account_hash_ptr, account_hash_size, weight_value): (u32, u32, u8) =
                     Args::parse(args)?;
@@ -370,13 +370,13 @@ where
             }
 
             FunctionIndex::TransferToAccountIndex => {
-                // args(0) = pointer to array of bytes of a public key
-                // args(1) = length of array of bytes of a public key
+                // args(0) = pointer to array of bytes of an account hash
+                // args(1) = length of array of bytes of an account hash
                 // args(2) = pointer to array of bytes of an amount
                 // args(3) = length of array of bytes of an amount
                 let (key_ptr, key_size, amount_ptr, amount_size): (u32, u32, u32, u32) =
                     Args::parse(args)?;
-                let public_key: AccountHash = {
+                let account_hash: AccountHash = {
                     let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
@@ -384,15 +384,15 @@ where
                     let bytes = self.bytes_from_mem(amount_ptr, amount_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
-                let ret = self.transfer_to_account(public_key, amount)?;
+                let ret = self.transfer_to_account(account_hash, amount)?;
                 Ok(Some(RuntimeValue::I32(TransferredTo::i32_from(ret))))
             }
 
             FunctionIndex::TransferFromPurseToAccountIndex => {
                 // args(0) = pointer to array of bytes in Wasm memory of a source purse
                 // args(1) = length of array of bytes in Wasm memory of a source purse
-                // args(2) = pointer to array of bytes in Wasm memory of a public key
-                // args(3) = length of array of bytes in Wasm memory of a public key
+                // args(2) = pointer to array of bytes in Wasm memory of an account hash
+                // args(3) = length of array of bytes in Wasm memory of an account hash
                 // args(4) = pointer to array of bytes in Wasm memory of an amount
                 // args(5) = length of array of bytes in Wasm memory of an amount
                 let (source_ptr, source_size, key_ptr, key_size, amount_ptr, amount_size): (
@@ -408,7 +408,7 @@ where
                     let bytes = self.bytes_from_mem(source_ptr, source_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
-                let public_key: AccountHash = {
+                let account_hash: AccountHash = {
                     let bytes = self.bytes_from_mem(key_ptr, key_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
@@ -416,7 +416,8 @@ where
                     let bytes = self.bytes_from_mem(amount_ptr, amount_size as usize)?;
                     bytesrepr::deserialize(bytes).map_err(Error::BytesRepr)?
                 };
-                let ret = self.transfer_from_purse_to_account(source_purse, public_key, amount)?;
+                let ret =
+                    self.transfer_from_purse_to_account(source_purse, account_hash, amount)?;
                 Ok(Some(RuntimeValue::I32(TransferredTo::i32_from(ret))))
             }
 

--- a/execution-engine/engine-core/src/runtime/mint_internal.rs
+++ b/execution-engine/engine-core/src/runtime/mint_internal.rs
@@ -2,7 +2,7 @@ use engine_shared::stored_value::StoredValue;
 use engine_storage::global_state::StateReader;
 use mint::{Mint, RuntimeProvider, StorageProvider};
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     system_contract_errors::mint::Error,
     CLTyped, CLValue, Key, URef,
@@ -15,7 +15,7 @@ where
     R: StateReader<Key, StoredValue>,
     R::Error: Into<execution::Error>,
 {
-    fn get_caller(&self) -> PublicKey {
+    fn get_caller(&self) -> AccountHash {
         self.get_caller()
     }
 

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -2332,21 +2332,21 @@ where
 
     fn add_associated_key(
         &mut self,
-        public_key_ptr: u32,
+        account_hash_ptr: u32,
         account_hash_size: usize,
         weight_value: u8,
     ) -> Result<i32, Trap> {
-        let public_key = {
-            // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, account_hash_size)?;
-            // Public key deserialized
+        let account_hash = {
+            // Account hash as serialized bytes
+            let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
+            // Account hash deserialized
             let source: AccountHash =
                 bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
         let weight = Weight::new(weight_value);
 
-        match self.context.add_associated_key(public_key, weight) {
+        match self.context.add_associated_key(account_hash, weight) {
             Ok(_) => Ok(0),
             // This relies on the fact that `AddKeyFailure` is represented as
             // i32 and first variant start with number `1`, so all other variants
@@ -2363,15 +2363,15 @@ where
         account_hash_ptr: u32,
         account_hash_size: usize,
     ) -> Result<i32, Trap> {
-        let public_key = {
-            // Public key as serialized bytes
+        let account_hash = {
+            // Account hash as serialized bytes
             let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
-            // Public key deserialized
+            // Account hash deserialized
             let source: AccountHash =
                 bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
-        match self.context.remove_associated_key(public_key) {
+        match self.context.remove_associated_key(account_hash) {
             Ok(_) => Ok(0),
             Err(Error::RemoveKeyFailure(e)) => Ok(e as i32),
             Err(e) => Err(e.into()),
@@ -2384,17 +2384,17 @@ where
         account_hash_size: usize,
         weight_value: u8,
     ) -> Result<i32, Trap> {
-        let public_key = {
-            // Public key as serialized bytes
+        let account_hash = {
+            // Account hash as serialized bytes
             let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
-            // Public key deserialized
+            // Account hash deserialized
             let source: AccountHash =
                 bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
         let weight = Weight::new(weight_value);
 
-        match self.context.update_associated_key(public_key, weight) {
+        match self.context.update_associated_key(account_hash, weight) {
             Ok(_) => Ok(0),
             // This relies on the fact that `UpdateKeyFailure` is represented as
             // i32 and first variant start with number `1`, so all other variants

--- a/execution-engine/engine-core/src/runtime/mod.rs
+++ b/execution-engine/engine-core/src/runtime/mod.rs
@@ -23,7 +23,7 @@ use engine_storage::{global_state::StateReader, protocol_data::ProtocolData};
 use proof_of_stake::ProofOfStake;
 use standard_payment::StandardPayment;
 use types::{
-    account::{ActionType, PublicKey, Weight},
+    account::{AccountHash, ActionType, Weight},
     bytesrepr::{self, FromBytes, ToBytes},
     system_contract_errors,
     system_contract_errors::mint,
@@ -1860,7 +1860,7 @@ where
                     return Err(err);
                 }
 
-                let validator: PublicKey = runtime.context.get_caller();
+                let validator: AccountHash = runtime.context.get_caller();
                 let amount: U512 = Self::get_argument(&args, 1)?;
                 let source_uref: URef = Self::get_argument(&args, 2)?;
                 runtime
@@ -1874,7 +1874,7 @@ where
                     return Err(err);
                 }
 
-                let validator: PublicKey = runtime.context.get_caller();
+                let validator: AccountHash = runtime.context.get_caller();
                 let maybe_amount: Option<U512> = Self::get_argument(&args, 1)?;
                 runtime
                     .unbond(validator, maybe_amount)
@@ -1897,7 +1897,7 @@ where
             }
             METHOD_FINALIZE_PAYMENT => {
                 let amount_spent: U512 = Self::get_argument(&args, 1)?;
-                let account: PublicKey = Self::get_argument(&args, 2)?;
+                let account: AccountHash = Self::get_argument(&args, 2)?;
                 runtime
                     .finalize_payment(amount_spent, account)
                     .map_err(Self::reverter)?;
@@ -2333,14 +2333,14 @@ where
     fn add_associated_key(
         &mut self,
         public_key_ptr: u32,
-        public_key_size: usize,
+        account_hash_size: usize,
         weight_value: u8,
     ) -> Result<i32, Trap> {
         let public_key = {
             // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, public_key_size)?;
+            let source_serialized = self.bytes_from_mem(public_key_ptr, account_hash_size)?;
             // Public key deserialized
-            let source: PublicKey =
+            let source: AccountHash =
                 bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
@@ -2360,14 +2360,14 @@ where
 
     fn remove_associated_key(
         &mut self,
-        public_key_ptr: u32,
-        public_key_size: usize,
+        account_hash_ptr: u32,
+        account_hash_size: usize,
     ) -> Result<i32, Trap> {
         let public_key = {
             // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, public_key_size)?;
+            let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
             // Public key deserialized
-            let source: PublicKey =
+            let source: AccountHash =
                 bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
@@ -2380,15 +2380,15 @@ where
 
     fn update_associated_key(
         &mut self,
-        public_key_ptr: u32,
-        public_key_size: usize,
+        account_hash_ptr: u32,
+        account_hash_size: usize,
         weight_value: u8,
     ) -> Result<i32, Trap> {
         let public_key = {
             // Public key as serialized bytes
-            let source_serialized = self.bytes_from_mem(public_key_ptr, public_key_size)?;
+            let source_serialized = self.bytes_from_mem(account_hash_ptr, account_hash_size)?;
             // Public key deserialized
-            let source: PublicKey =
+            let source: AccountHash =
                 bytesrepr::deserialize(source_serialized).map_err(Error::BytesRepr)?;
             source
         };
@@ -2491,7 +2491,7 @@ where
     fn transfer_to_new_account(
         &mut self,
         source: URef,
-        target: PublicKey,
+        target: AccountHash,
         amount: U512,
     ) -> Result<TransferResult, Error> {
         let mint_contract_key = self.get_mint_contract_uref().into();
@@ -2565,7 +2565,7 @@ where
     /// `target` account. If that account does not exist, creates one.
     fn transfer_to_account(
         &mut self,
-        target: PublicKey,
+        target: AccountHash,
         amount: U512,
     ) -> Result<TransferResult, Error> {
         let source = self.context.get_main_purse()?;
@@ -2577,7 +2577,7 @@ where
     fn transfer_from_purse_to_account(
         &mut self,
         source: URef,
-        target: PublicKey,
+        target: AccountHash,
         amount: U512,
     ) -> Result<TransferResult, Error> {
         let target_key = Key::Account(target);

--- a/execution-engine/engine-core/src/runtime/proof_of_stake_internal.rs
+++ b/execution-engine/engine-core/src/runtime/proof_of_stake_internal.rs
@@ -9,7 +9,7 @@ use proof_of_stake::{
     MintProvider, ProofOfStake, Queue, QueueProvider, RuntimeProvider, Stakes, StakesProvider,
 };
 use types::{
-    account::PublicKey, bytesrepr::ToBytes, system_contract_errors::pos::Error, ApiError,
+    account::AccountHash, bytesrepr::ToBytes, system_contract_errors::pos::Error, ApiError,
     BlockTime, CLValue, Key, Phase, TransferredTo, URef, U512,
 };
 
@@ -27,7 +27,7 @@ where
     fn transfer_purse_to_account(
         &mut self,
         source: URef,
-        target: PublicKey,
+        target: AccountHash,
         amount: U512,
     ) -> Result<TransferredTo, ApiError> {
         self.transfer_from_purse_to_account(source, target, amount)
@@ -123,7 +123,7 @@ where
         self.context.get_blocktime()
     }
 
-    fn get_caller(&self) -> PublicKey {
+    fn get_caller(&self) -> AccountHash {
         self.context.get_caller()
     }
 }
@@ -150,7 +150,7 @@ where
             let _bytes_written = base16::decode_slice(hex_key, &mut key_bytes)
                 .map_err(|_| Error::StakesKeyDeserializationFailed)?;
             debug_assert!(_bytes_written == key_bytes.len());
-            let pub_key = PublicKey::ed25519_from(key_bytes);
+            let pub_key = AccountHash::new(key_bytes);
             let balance = split_name
                 .next()
                 .and_then(|b| U512::from_dec_str(b).ok())

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -714,7 +714,7 @@ fn manage_associated_keys() {
         };
         account
             .get_associated_key_weight(account_hash)
-            .expect("Public key wasn't added to associated keys");
+            .expect("Account hash wasn't added to associated keys");
 
         let new_weight = Weight::new(100);
         runtime_context
@@ -729,7 +729,7 @@ fn manage_associated_keys() {
         };
         let value = account
             .get_associated_key_weight(account_hash)
-            .expect("Public key wasn't added to associated keys");
+            .expect("Account hash wasn't added to associated keys");
 
         assert_eq!(value, &new_weight, "value was not updated");
 

--- a/execution-engine/engine-core/src/tracking_copy/ext.rs
+++ b/execution-engine/engine-core/src/tracking_copy/ext.rs
@@ -5,7 +5,7 @@ use engine_shared::{
     stored_value::StoredValue, TypeMismatch,
 };
 use engine_storage::global_state::StateReader;
-use types::{account::PublicKey, bytesrepr::ToBytes, CLValue, Key, URef, U512};
+use types::{account::AccountHash, bytesrepr::ToBytes, CLValue, Key, URef, U512};
 
 use crate::{execution, tracking_copy::TrackingCopy};
 
@@ -16,7 +16,7 @@ pub trait TrackingCopyExt<R> {
     fn get_account(
         &mut self,
         correlation_id: CorrelationId,
-        public_key: PublicKey,
+        account_hash: AccountHash,
     ) -> Result<Account, Self::Error>;
 
     /// Gets the purse balance key for a given purse id
@@ -52,9 +52,9 @@ where
     fn get_account(
         &mut self,
         correlation_id: CorrelationId,
-        public_key: PublicKey,
+        account_hash: AccountHash,
     ) -> Result<Account, Self::Error> {
-        let account_key = Key::Account(public_key);
+        let account_key = Key::Account(account_hash);
         match self.get(correlation_id, &account_key).map_err(Into::into)? {
             Some(StoredValue::Account(account)) => Ok(account),
             Some(other) => Err(execution::Error::TypeMismatch(TypeMismatch::new(

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -347,8 +347,8 @@ proptest! {
         v in stored_value_arb(), // value in account state
         name in "\\PC*", // human-readable name for state
         missing_name in "\\PC*",
-        pk in account_hash_arb(), // account public key
-        address in account_hash_arb(), // address for account key
+        pk in account_hash_arb(), // account hash
+        address in account_hash_arb(), // address for account hash
     ) {
         let correlation_id = CorrelationId::new();
         let named_keys = iter::once((name.clone(), k)).collect();

--- a/execution-engine/engine-core/src/tracking_copy/tests.rs
+++ b/execution-engine/engine-core/src/tracking_copy/tests.rs
@@ -12,7 +12,7 @@ use engine_shared::{
 };
 use engine_storage::global_state::{in_memory::InMemoryGlobalState, StateProvider, StateReader};
 use types::{
-    account::{PublicKey, Weight, ED25519_LENGTH},
+    account::{AccountHash, Weight, ACCOUNT_HASH_LENGTH},
     gens::*,
     AccessRights, CLValue, Key, ProtocolVersion, URef,
 };
@@ -175,12 +175,12 @@ fn tracking_copy_add_i32() {
 
 #[test]
 fn tracking_copy_add_named_key() {
-    let zero_public_key = PublicKey::ed25519_from([0u8; ED25519_LENGTH]);
+    let zero_account_hash = AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]);
     let correlation_id = CorrelationId::new();
     // DB now holds an `Account` so that we can test adding a `NamedKey`
-    let associated_keys = AssociatedKeys::new(zero_public_key, Weight::new(1));
+    let associated_keys = AssociatedKeys::new(zero_account_hash, Weight::new(1));
     let account = Account::new(
-        zero_public_key,
+        zero_account_hash,
         BTreeMap::new(),
         URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
         associated_keys,
@@ -347,8 +347,8 @@ proptest! {
         v in stored_value_arb(), // value in account state
         name in "\\PC*", // human-readable name for state
         missing_name in "\\PC*",
-        pk in public_key_arb(), // account public key
-        address in public_key_arb(), // address for account key
+        pk in account_hash_arb(), // account public key
+        address in account_hash_arb(), // address for account key
     ) {
         let correlation_id = CorrelationId::new();
         let named_keys = iter::once((name.clone(), k)).collect();
@@ -388,8 +388,8 @@ proptest! {
         v in stored_value_arb(), // value in contract state
         state_name in "\\PC*", // human-readable name for state
         contract_name in "\\PC*", // human-readable name for contract
-        pk in public_key_arb(), // account public key
-        address in public_key_arb(), // address for account key
+        pk in account_hash_arb(), // account hash
+        address in account_hash_arb(), // address for account hash
         body in vec(any::<u8>(), 1..1000), //contract body
         hash in u8_slice_32(), // hash for contract key
     ) {

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/bond.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/bond.rs
@@ -1,31 +1,31 @@
 use std::convert::{TryFrom, TryInto};
 
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 use crate::engine_server::{ipc::Bond, mappings::MappingError};
 
-impl From<(PublicKey, U512)> for Bond {
-    fn from((key, amount): (PublicKey, U512)) -> Self {
+impl From<(AccountHash, U512)> for Bond {
+    fn from((account_hash, amount): (AccountHash, U512)) -> Self {
         let mut pb_bond = Bond::new();
-        pb_bond.set_validator_public_key(key.as_bytes().to_vec());
+        pb_bond.validator_account_hash = account_hash.as_bytes().to_vec();
         pb_bond.set_stake(amount.into());
         pb_bond
     }
 }
 
-impl TryFrom<Bond> for (PublicKey, U512) {
+impl TryFrom<Bond> for (AccountHash, U512) {
     type Error = MappingError;
 
     fn try_from(mut pb_bond: Bond) -> Result<Self, Self::Error> {
         // TODO: our TryFromSliceForPublicKeyError should convey length info
-        let public_key =
-            PublicKey::ed25519_try_from(pb_bond.get_validator_public_key()).map_err(|_| {
-                MappingError::invalid_public_key_length(pb_bond.validator_public_key.len())
+        let account_hash =
+            AccountHash::try_from(pb_bond.get_validator_account_hash()).map_err(|_| {
+                MappingError::invalid_account_hash_length(pb_bond.validator_account_hash.len())
             })?;
 
         let stake = pb_bond.take_stake().try_into()?;
 
-        Ok((public_key, stake))
+        Ok((account_hash, stake))
     }
 }
 
@@ -40,8 +40,8 @@ mod tests {
 
     proptest! {
         #[test]
-        fn round_trip(public_key in gens::public_key_arb(), u512 in gens::u512_arb()) {
-            test_utils::protobuf_round_trip::<(PublicKey, U512), Bond>((public_key, u512));
+        fn round_trip(account_hash in gens::account_hash_arb(), u512 in gens::u512_arb()) {
+            test_utils::protobuf_round_trip::<(AccountHash, U512), Bond>((account_hash, u512));
         }
     }
 }

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/bond.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/bond.rs
@@ -17,7 +17,7 @@ impl TryFrom<Bond> for (AccountHash, U512) {
     type Error = MappingError;
 
     fn try_from(mut pb_bond: Bond) -> Result<Self, Self::Error> {
-        // TODO: our TryFromSliceForPublicKeyError should convey length info
+        // TODO: our TryFromSliceForAccountHashError should convey length info
         let account_hash =
             AccountHash::try_from(pb_bond.get_validator_account_hash()).map_err(|_| {
                 MappingError::invalid_account_hash_length(pb_bond.validator_account_hash.len())

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/deploy_item.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/deploy_item.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use engine_core::engine_state::deploy_item::DeployItem;
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 use crate::engine_server::{ipc, mappings::MappingError};
 
@@ -12,8 +12,8 @@ impl TryFrom<ipc::DeployItem> for DeployItem {
     type Error = MappingError;
 
     fn try_from(mut pb_deploy_item: ipc::DeployItem) -> Result<Self, Self::Error> {
-        let address = PublicKey::ed25519_try_from(pb_deploy_item.get_address())
-            .map_err(|_| MappingError::invalid_public_key_length(pb_deploy_item.address.len()))?;
+        let address = AccountHash::try_from(pb_deploy_item.get_address())
+            .map_err(|_| MappingError::invalid_account_hash_length(pb_deploy_item.address.len()))?;
 
         let session = pb_deploy_item
             .take_session()
@@ -33,10 +33,10 @@ impl TryFrom<ipc::DeployItem> for DeployItem {
             .get_authorization_keys()
             .iter()
             .map(|raw: &Vec<u8>| {
-                PublicKey::ed25519_try_from(raw.as_slice())
-                    .map_err(|_| MappingError::invalid_public_key_length(raw.len()))
+                AccountHash::try_from(raw.as_slice())
+                    .map_err(|_| MappingError::invalid_account_hash_length(raw.len()))
             })
-            .collect::<Result<BTreeSet<PublicKey>, Self::Error>>()?;
+            .collect::<Result<BTreeSet<AccountHash>, Self::Error>>()?;
 
         let deploy_hash = pb_deploy_item.get_deploy_hash().try_into().map_err(|_| {
             MappingError::invalid_deploy_hash_length(pb_deploy_item.deploy_hash.len())

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/deploy_result.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/deploy_result.rs
@@ -29,7 +29,7 @@ impl From<(EngineStateError, ExecutionEffect, Gas)> for DeployResult {
             // We don't have separate IPC messages for storage errors so for the time being they are
             // all reported as "wasm errors".
             error @ EngineStateError::InvalidHashLength { .. }
-            | error @ EngineStateError::InvalidPublicKeyLength { .. }
+            | error @ EngineStateError::InvalidAccountHashLength { .. }
             | error @ EngineStateError::InvalidProtocolVersion { .. }
             | error @ EngineStateError::InvalidUpgradeConfig
             | error @ EngineStateError::WasmPreprocessing(_)

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/genesis_account.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/genesis_account.rs
@@ -27,8 +27,8 @@ impl TryFrom<ChainSpec_GenesisConfig_ExecConfig_GenesisAccount> for GenesisAccou
         mut pb_genesis_account: ChainSpec_GenesisConfig_ExecConfig_GenesisAccount,
     ) -> Result<Self, Self::Error> {
         // TODO: our TryFromSliceForAccountHashError should convey length info
-        let account_hash = AccountHash::try_from(pb_genesis_account.get_public_key_hash())
-            .map_err(|_| {
+        let account_hash =
+            AccountHash::try_from(&pb_genesis_account.public_key_hash).map_err(|_| {
                 MappingError::invalid_account_hash_length(pb_genesis_account.public_key_hash.len())
             })?;
         let balance = pb_genesis_account

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/genesis_account.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/genesis_account.rs
@@ -27,8 +27,8 @@ impl TryFrom<ChainSpec_GenesisConfig_ExecConfig_GenesisAccount> for GenesisAccou
         mut pb_genesis_account: ChainSpec_GenesisConfig_ExecConfig_GenesisAccount,
     ) -> Result<Self, Self::Error> {
         // TODO: our TryFromSliceForAccountHashError should convey length info
-        let account_hash =
-            AccountHash::try_from(&pb_genesis_account.public_key_hash).map_err(|_| {
+        let account_hash = AccountHash::try_from(&pb_genesis_account.public_key_hash as &[u8])
+            .map_err(|_| {
                 MappingError::invalid_account_hash_length(pb_genesis_account.public_key_hash.len())
             })?;
         let balance = pb_genesis_account

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/genesis_account.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/ipc/genesis_account.rs
@@ -26,7 +26,7 @@ impl TryFrom<ChainSpec_GenesisConfig_ExecConfig_GenesisAccount> for GenesisAccou
     fn try_from(
         mut pb_genesis_account: ChainSpec_GenesisConfig_ExecConfig_GenesisAccount,
     ) -> Result<Self, Self::Error> {
-        // TODO: our TryFromSliceForPublicKeyError should convey length info
+        // TODO: our TryFromSliceForAccountHashError should convey length info
         let account_hash = AccountHash::try_from(pb_genesis_account.get_public_key_hash())
             .map_err(|_| {
                 MappingError::invalid_account_hash_length(pb_genesis_account.public_key_hash.len())

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/mod.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use engine_core::{engine_state, DEPLOY_HASH_LENGTH};
-use types::account::ED25519_LENGTH;
+use types::account::ACCOUNT_HASH_LENGTH;
 
 pub use transforms::TransformMap;
 
@@ -36,7 +36,7 @@ pub(crate) fn vec_to_array64(input: Vec<u8>, input_name: &str) -> Result<[u8; 64
 #[derive(Debug)]
 pub enum MappingError {
     InvalidStateHashLength { expected: usize, actual: usize },
-    InvalidPublicKeyLength { expected: usize, actual: usize },
+    InvalidAccountHashLength { expected: usize, actual: usize },
     InvalidDeployHashLength { expected: usize, actual: usize },
     Parsing(ParsingError),
     InvalidStateHash(String),
@@ -45,9 +45,9 @@ pub enum MappingError {
 }
 
 impl MappingError {
-    pub fn invalid_public_key_length(actual: usize) -> Self {
-        let expected = ED25519_LENGTH;
-        MappingError::InvalidPublicKeyLength { expected, actual }
+    pub fn invalid_account_hash_length(actual: usize) -> Self {
+        let expected = ACCOUNT_HASH_LENGTH;
+        MappingError::InvalidAccountHashLength { expected, actual }
     }
 
     pub fn invalid_deploy_hash_length(actual: usize) -> Self {
@@ -82,7 +82,7 @@ impl Display for MappingError {
                 "Invalid hash length: expected {}, actual {}",
                 expected, actual
             ),
-            MappingError::InvalidPublicKeyLength { expected, actual } => write!(
+            MappingError::InvalidAccountHashLength { expected, actual } => write!(
                 f,
                 "Invalid public key length: expected {}, actual {}",
                 expected, actual

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/account.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/account.rs
@@ -46,7 +46,7 @@ impl TryFrom<state::Account> for Account {
 
     fn try_from(pb_account: state::Account) -> Result<Self, Self::Error> {
         let account_hash =
-            mappings::vec_to_array(pb_account.public_key, "Protobuf Account::PublicKey")?;
+            mappings::vec_to_array(pb_account.public_key, "Protobuf Account::AccountHash")?;
 
         let named_keys: NamedKeyMap = pb_account.named_keys.into_vec().try_into()?;
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/account.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/account.rs
@@ -17,7 +17,7 @@ impl From<Account> for state::Account {
     fn from(mut account: Account) -> Self {
         let mut pb_account = state::Account::new();
 
-        pb_account.set_public_key(account.account_hash().as_bytes().to_vec());
+        pb_account.public_key = account.account_hash().as_bytes().to_vec();
 
         let named_keys = mem::replace(account.named_keys_mut(), BTreeMap::new());
         let pb_named_keys: Vec<NamedKey> = NamedKeyMap::new(named_keys).into();
@@ -103,9 +103,9 @@ impl TryFrom<state::Account> for Account {
 }
 
 impl From<(&AccountHash, &Weight)> for Account_AssociatedKey {
-    fn from((public_key, weight): (&AccountHash, &Weight)) -> Self {
+    fn from((account_hash, weight): (&AccountHash, &Weight)) -> Self {
         let mut pb_associated_key = Account_AssociatedKey::new();
-        pb_associated_key.set_public_key(public_key.as_bytes().to_vec());
+        pb_associated_key.public_key = account_hash.as_bytes().to_vec();
         pb_associated_key.set_weight(weight.value().into());
         pb_associated_key
     }
@@ -115,14 +115,14 @@ impl TryFrom<Account_AssociatedKey> for (AccountHash, Weight) {
     type Error = ParsingError;
 
     fn try_from(pb_associated_key: Account_AssociatedKey) -> Result<Self, Self::Error> {
-        let public_key = AccountHash::new(mappings::vec_to_array(
+        let account_hash = AccountHash::new(mappings::vec_to_array(
             pb_associated_key.public_key,
             "Protobuf Account::AssociatedKey",
         )?);
 
         let weight = weight_from(pb_associated_key.weight, "Protobuf AssociatedKey::Weight")?;
 
-        Ok((public_key, weight))
+        Ok((account_hash, weight))
     }
 }
 

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/key.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/key.rs
@@ -1,7 +1,7 @@
 use std::convert::{TryFrom, TryInto};
 
 use types::{
-    account::PublicKey, Key, BLAKE2B_DIGEST_LENGTH, KEY_LOCAL_LENGTH, KEY_LOCAL_SEED_LENGTH,
+    account::AccountHash, Key, BLAKE2B_DIGEST_LENGTH, KEY_LOCAL_LENGTH, KEY_LOCAL_SEED_LENGTH,
 };
 
 use crate::engine_server::{
@@ -50,7 +50,7 @@ impl TryFrom<state::Key> for Key {
         let key = match pb_key {
             Key_oneof_value::address(pb_account) => {
                 let account = mappings::vec_to_array(pb_account.account, "Protobuf Key::Account")?;
-                Key::Account(PublicKey::ed25519_from(account))
+                Key::Account(AccountHash::new(account))
             }
             Key_oneof_value::hash(pb_hash) => {
                 let hash = mappings::vec_to_array(pb_hash.hash, "Protobuf Key::Hash")?;

--- a/execution-engine/engine-shared/src/account/associated_keys.rs
+++ b/execution-engine/engine-shared/src/account/associated_keys.rs
@@ -99,8 +99,8 @@ impl AssociatedKeys {
     }
 
     /// Calculates total weight of all authorization keys excluding a given key
-    pub fn total_keys_weight_excluding(&self, public_key: AccountHash) -> Weight {
-        self.calculate_any_keys_weight(self.0.keys().filter(|&&element| element != public_key))
+    pub fn total_keys_weight_excluding(&self, account_hash: AccountHash) -> Weight {
+        self.calculate_any_keys_weight(self.0.keys().filter(|&&element| element != account_hash))
     }
 }
 

--- a/execution-engine/engine-shared/src/account/associated_keys.rs
+++ b/execution-engine/engine-shared/src/account/associated_keys.rs
@@ -2,17 +2,17 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use types::{
     account::{
-        AddKeyFailure, PublicKey, RemoveKeyFailure, UpdateKeyFailure, Weight, MAX_ASSOCIATED_KEYS,
+        AccountHash, AddKeyFailure, RemoveKeyFailure, UpdateKeyFailure, Weight, MAX_ASSOCIATED_KEYS,
     },
     bytesrepr::{Error, FromBytes, ToBytes},
 };
 
 #[derive(Default, PartialOrd, Ord, PartialEq, Eq, Clone, Debug)]
-pub struct AssociatedKeys(BTreeMap<PublicKey, Weight>);
+pub struct AssociatedKeys(BTreeMap<AccountHash, Weight>);
 
 impl AssociatedKeys {
-    pub fn new(key: PublicKey, weight: Weight) -> AssociatedKeys {
-        let mut bt: BTreeMap<PublicKey, Weight> = BTreeMap::new();
+    pub fn new(key: AccountHash, weight: Weight) -> AssociatedKeys {
+        let mut bt: BTreeMap<AccountHash, Weight> = BTreeMap::new();
         bt.insert(key, weight);
         AssociatedKeys(bt)
     }
@@ -20,7 +20,7 @@ impl AssociatedKeys {
     /// Adds new AssociatedKey to the set.
     /// Returns true if added successfully, false otherwise.
     #[allow(clippy::map_entry)]
-    pub fn add_key(&mut self, key: PublicKey, weight: Weight) -> Result<(), AddKeyFailure> {
+    pub fn add_key(&mut self, key: AccountHash, weight: Weight) -> Result<(), AddKeyFailure> {
         if self.0.len() == MAX_ASSOCIATED_KEYS {
             Err(AddKeyFailure::MaxKeysLimit)
         } else if self.0.contains_key(&key) {
@@ -34,7 +34,7 @@ impl AssociatedKeys {
     /// Removes key from the associated keys set.
     /// Returns true if value was found in the set prior to the removal, false
     /// otherwise.
-    pub fn remove_key(&mut self, key: &PublicKey) -> Result<(), RemoveKeyFailure> {
+    pub fn remove_key(&mut self, key: &AccountHash) -> Result<(), RemoveKeyFailure> {
         self.0
             .remove(key)
             .map(|_| ())
@@ -44,7 +44,7 @@ impl AssociatedKeys {
     /// Adds new AssociatedKey to the set.
     /// Returns true if added successfully, false otherwise.
     #[allow(clippy::map_entry)]
-    pub fn update_key(&mut self, key: PublicKey, weight: Weight) -> Result<(), UpdateKeyFailure> {
+    pub fn update_key(&mut self, key: AccountHash, weight: Weight) -> Result<(), UpdateKeyFailure> {
         if !self.0.contains_key(&key) {
             return Err(UpdateKeyFailure::MissingKey);
         }
@@ -53,15 +53,15 @@ impl AssociatedKeys {
         Ok(())
     }
 
-    pub fn get(&self, key: &PublicKey) -> Option<&Weight> {
+    pub fn get(&self, key: &AccountHash) -> Option<&Weight> {
         self.0.get(key)
     }
 
-    pub fn contains_key(&self, key: &PublicKey) -> bool {
+    pub fn contains_key(&self, key: &AccountHash) -> bool {
         self.0.contains_key(key)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&PublicKey, &Weight)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&AccountHash, &Weight)> {
         self.0.iter()
     }
 
@@ -80,7 +80,7 @@ impl AssociatedKeys {
     /// Uniqueness is determined based on the input collection properties,
     /// which is either BTreeSet (in [`AssociatedKeys::calculate_keys_weight`])
     /// or BTreeMap (in [`AssociatedKeys::total_keys_weight`]).
-    fn calculate_any_keys_weight<'a>(&self, keys: impl Iterator<Item = &'a PublicKey>) -> Weight {
+    fn calculate_any_keys_weight<'a>(&self, keys: impl Iterator<Item = &'a AccountHash>) -> Weight {
         let total = keys
             .filter_map(|key| self.0.get(key))
             .fold(0u8, |acc, w| acc.saturating_add(w.value()));
@@ -89,7 +89,7 @@ impl AssociatedKeys {
     }
 
     /// Calculates total weight of authorization keys provided by an argument
-    pub fn calculate_keys_weight(&self, authorization_keys: &BTreeSet<PublicKey>) -> Weight {
+    pub fn calculate_keys_weight(&self, authorization_keys: &BTreeSet<AccountHash>) -> Weight {
         self.calculate_any_keys_weight(authorization_keys.iter())
     }
 
@@ -99,7 +99,7 @@ impl AssociatedKeys {
     }
 
     /// Calculates total weight of all authorization keys excluding a given key
-    pub fn total_keys_weight_excluding(&self, public_key: PublicKey) -> Weight {
+    pub fn total_keys_weight_excluding(&self, public_key: AccountHash) -> Weight {
         self.calculate_any_keys_weight(self.0.keys().filter(|&&element| element != public_key))
     }
 }
@@ -116,7 +116,7 @@ impl ToBytes for AssociatedKeys {
 
 impl FromBytes for AssociatedKeys {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (keys_map, rem) = BTreeMap::<PublicKey, Weight>::from_bytes(bytes)?;
+        let (keys_map, rem) = BTreeMap::<AccountHash, Weight>::from_bytes(bytes)?;
         let mut keys = AssociatedKeys::default();
         keys_map.into_iter().for_each(|(k, v)| {
             // NOTE: we're ignoring potential errors (duplicate key, maximum number of
@@ -131,12 +131,12 @@ impl FromBytes for AssociatedKeys {
 pub mod gens {
     use proptest::prelude::*;
 
-    use types::gens::{public_key_arb, weight_arb};
+    use types::gens::{account_hash_arb, weight_arb};
 
     use super::AssociatedKeys;
 
     pub fn associated_keys_arb(size: usize) -> impl Strategy<Value = AssociatedKeys> {
-        proptest::collection::btree_map(public_key_arb(), weight_arb(), size).prop_map(|keys| {
+        proptest::collection::btree_map(account_hash_arb(), weight_arb(), size).prop_map(|keys| {
             let mut associated_keys = AssociatedKeys::default();
             keys.into_iter().for_each(|(k, v)| {
                 associated_keys.add_key(k, v).unwrap();
@@ -151,7 +151,7 @@ mod tests {
     use std::{collections::BTreeSet, iter::FromIterator};
 
     use types::{
-        account::{AddKeyFailure, PublicKey, Weight, ED25519_LENGTH, MAX_ASSOCIATED_KEYS},
+        account::{AccountHash, AddKeyFailure, Weight, ACCOUNT_HASH_LENGTH, MAX_ASSOCIATED_KEYS},
         bytesrepr,
     };
 
@@ -159,11 +159,9 @@ mod tests {
 
     #[test]
     fn associated_keys_add() {
-        let mut keys = AssociatedKeys::new(
-            PublicKey::ed25519_from([0u8; ED25519_LENGTH]),
-            Weight::new(1),
-        );
-        let new_pk = PublicKey::ed25519_from([1u8; ED25519_LENGTH]);
+        let mut keys =
+            AssociatedKeys::new(AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]), Weight::new(1));
+        let new_pk = AccountHash::new([1u8; ACCOUNT_HASH_LENGTH]);
         let new_pk_weight = Weight::new(2);
         assert!(keys.add_key(new_pk, new_pk_weight).is_ok());
         assert_eq!(keys.get(&new_pk), Some(&new_pk_weight))
@@ -173,7 +171,7 @@ mod tests {
     fn associated_keys_add_full() {
         let map = (0..MAX_ASSOCIATED_KEYS).map(|k| {
             (
-                PublicKey::ed25519_from([k as u8; ED25519_LENGTH]),
+                AccountHash::new([k as u8; ACCOUNT_HASH_LENGTH]),
                 Weight::new(k as u8),
             )
         });
@@ -185,7 +183,7 @@ mod tests {
         };
         assert_eq!(
             keys.add_key(
-                PublicKey::ed25519_from([100u8; ED25519_LENGTH]),
+                AccountHash::new([100u8; ACCOUNT_HASH_LENGTH]),
                 Weight::new(100)
             ),
             Err(AddKeyFailure::MaxKeysLimit)
@@ -194,7 +192,7 @@ mod tests {
 
     #[test]
     fn associated_keys_add_duplicate() {
-        let pk = PublicKey::ed25519_from([0u8; ED25519_LENGTH]);
+        let pk = AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]);
         let weight = Weight::new(1);
         let mut keys = AssociatedKeys::new(pk, weight);
         assert_eq!(
@@ -206,20 +204,20 @@ mod tests {
 
     #[test]
     fn associated_keys_remove() {
-        let pk = PublicKey::ed25519_from([0u8; ED25519_LENGTH]);
+        let pk = AccountHash::new([0u8; ACCOUNT_HASH_LENGTH]);
         let weight = Weight::new(1);
         let mut keys = AssociatedKeys::new(pk, weight);
         assert!(keys.remove_key(&pk).is_ok());
         assert!(keys
-            .remove_key(&PublicKey::ed25519_from([1u8; ED25519_LENGTH]))
+            .remove_key(&AccountHash::new([1u8; ACCOUNT_HASH_LENGTH]))
             .is_err());
     }
 
     #[test]
     fn associated_keys_calculate_keys_once() {
-        let key_1 = PublicKey::ed25519_from([0; 32]);
-        let key_2 = PublicKey::ed25519_from([1; 32]);
-        let key_3 = PublicKey::ed25519_from([2; 32]);
+        let key_1 = AccountHash::new([0; 32]);
+        let key_2 = AccountHash::new([1; 32]);
+        let key_3 = AccountHash::new([2; 32]);
         let mut keys = AssociatedKeys::default();
 
         keys.add_key(key_2, Weight::new(2))
@@ -240,12 +238,12 @@ mod tests {
     #[test]
     fn associated_keys_total_weight() {
         let associated_keys = {
-            let mut res = AssociatedKeys::new(PublicKey::ed25519_from([1u8; 32]), Weight::new(1));
-            res.add_key(PublicKey::ed25519_from([2u8; 32]), Weight::new(11))
+            let mut res = AssociatedKeys::new(AccountHash::new([1u8; 32]), Weight::new(1));
+            res.add_key(AccountHash::new([2u8; 32]), Weight::new(11))
                 .expect("should add key 1");
-            res.add_key(PublicKey::ed25519_from([3u8; 32]), Weight::new(12))
+            res.add_key(AccountHash::new([3u8; 32]), Weight::new(12))
                 .expect("should add key 2");
-            res.add_key(PublicKey::ed25519_from([4u8; 32]), Weight::new(13))
+            res.add_key(AccountHash::new([4u8; 32]), Weight::new(13))
                 .expect("should add key 3");
             res
         };
@@ -257,16 +255,16 @@ mod tests {
 
     #[test]
     fn associated_keys_total_weight_excluding() {
-        let identity_key = PublicKey::ed25519_from([1u8; 32]);
+        let identity_key = AccountHash::new([1u8; 32]);
         let identity_key_weight = Weight::new(1);
 
-        let key_1 = PublicKey::ed25519_from([2u8; 32]);
+        let key_1 = AccountHash::new([2u8; 32]);
         let key_1_weight = Weight::new(11);
 
-        let key_2 = PublicKey::ed25519_from([3u8; 32]);
+        let key_2 = AccountHash::new([3u8; 32]);
         let key_2_weight = Weight::new(12);
 
-        let key_3 = PublicKey::ed25519_from([4u8; 32]);
+        let key_3 = AccountHash::new([4u8; 32]);
         let key_3_weight = Weight::new(13);
 
         let associated_keys = {
@@ -284,10 +282,10 @@ mod tests {
 
     #[test]
     fn overflowing_keys_weight() {
-        let identity_key = PublicKey::ed25519_from([1u8; 32]);
-        let key_1 = PublicKey::ed25519_from([2u8; 32]);
-        let key_2 = PublicKey::ed25519_from([3u8; 32]);
-        let key_3 = PublicKey::ed25519_from([4u8; 32]);
+        let identity_key = AccountHash::new([1u8; 32]);
+        let key_1 = AccountHash::new([2u8; 32]);
+        let key_2 = AccountHash::new([3u8; 32]);
+        let key_3 = AccountHash::new([4u8; 32]);
 
         let identity_key_weight = Weight::new(250);
         let weight_1 = Weight::new(1);
@@ -319,11 +317,11 @@ mod tests {
     #[test]
     fn serialization_roundtrip() {
         let mut keys = AssociatedKeys::default();
-        keys.add_key(PublicKey::ed25519_from([1; 32]), Weight::new(1))
+        keys.add_key(AccountHash::new([1; 32]), Weight::new(1))
             .unwrap();
-        keys.add_key(PublicKey::ed25519_from([2; 32]), Weight::new(2))
+        keys.add_key(AccountHash::new([2; 32]), Weight::new(2))
             .unwrap();
-        keys.add_key(PublicKey::ed25519_from([3; 32]), Weight::new(3))
+        keys.add_key(AccountHash::new([3; 32]), Weight::new(3))
             .unwrap();
         bytesrepr::test_serialization_roundtrip(&keys);
     }

--- a/execution-engine/engine-shared/src/test_utils.rs
+++ b/execution-engine/engine-shared/src/test_utils.rs
@@ -7,10 +7,10 @@ use types::{account::AccountHash, AccessRights, Key, URef};
 use crate::{account::Account, stored_value::StoredValue};
 
 /// Returns an account value paired with its key
-pub fn mocked_account(public_key: AccountHash) -> Vec<(Key, StoredValue)> {
+pub fn mocked_account(account_hash: AccountHash) -> Vec<(Key, StoredValue)> {
     let purse = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
-    let account = Account::create(public_key, BTreeMap::new(), purse);
-    vec![(Key::Account(public_key), StoredValue::Account(account))]
+    let account = Account::create(account_hash, BTreeMap::new(), purse);
+    vec![(Key::Account(account_hash), StoredValue::Account(account))]
 }
 
 pub fn wasm_costs_mock() -> WasmCosts {

--- a/execution-engine/engine-shared/src/test_utils.rs
+++ b/execution-engine/engine-shared/src/test_utils.rs
@@ -2,12 +2,12 @@
 use std::collections::BTreeMap;
 
 use engine_wasm_prep::wasm_costs::WasmCosts;
-use types::{account::PublicKey, AccessRights, Key, URef};
+use types::{account::AccountHash, AccessRights, Key, URef};
 
 use crate::{account::Account, stored_value::StoredValue};
 
 /// Returns an account value paired with its key
-pub fn mocked_account(public_key: PublicKey) -> Vec<(Key, StoredValue)> {
+pub fn mocked_account(public_key: AccountHash) -> Vec<(Key, StoredValue)> {
     let purse = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
     let account = Account::create(public_key, BTreeMap::new(), purse);
     vec![(Key::Account(public_key), StoredValue::Account(account))]

--- a/execution-engine/engine-shared/src/transform.rs
+++ b/execution-engine/engine-shared/src/transform.rs
@@ -299,7 +299,7 @@ pub mod gens {
 mod tests {
     use num::{Bounded, Num};
 
-    use types::{account::PublicKey, AccessRights, ProtocolVersion, URef, U128, U256, U512};
+    use types::{account::AccountHash, AccessRights, ProtocolVersion, URef, U128, U256, U512};
 
     use super::*;
     use crate::{
@@ -308,7 +308,7 @@ mod tests {
     };
 
     const ZERO_ARRAY: [u8; 32] = [0; 32];
-    const ZERO_PUBLIC_KEY: PublicKey = PublicKey::ed25519_from(ZERO_ARRAY);
+    const ZERO_PUBLIC_KEY: AccountHash = AccountHash::new(ZERO_ARRAY);
     const TEST_STR: &str = "a";
     const TEST_BOOL: bool = true;
 

--- a/execution-engine/engine-storage/benches/trie_bench.rs
+++ b/execution-engine/engine-storage/benches/trie_bench.rs
@@ -7,7 +7,7 @@ use test::{black_box, Bencher};
 use casperlabs_engine_storage::trie::{Pointer, PointerBlock, Trie};
 use engine_shared::{newtypes::Blake2bHash, stored_value::StoredValue};
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{FromBytes, ToBytes},
     CLValue, Key,
 };
@@ -15,7 +15,7 @@ use types::{
 #[bench]
 fn serialize_trie_leaf(b: &mut Bencher) {
     let leaf = Trie::Leaf {
-        key: Key::Account(PublicKey::ed25519_from([0; 32])),
+        key: Key::Account(AccountHash::new([0; 32])),
         value: StoredValue::CLValue(CLValue::from_t(42_i32).unwrap()),
     };
     b.iter(|| ToBytes::to_bytes(black_box(&leaf)));
@@ -24,7 +24,7 @@ fn serialize_trie_leaf(b: &mut Bencher) {
 #[bench]
 fn deserialize_trie_leaf(b: &mut Bencher) {
     let leaf = Trie::Leaf {
-        key: Key::Account(PublicKey::ed25519_from([0; 32])),
+        key: Key::Account(AccountHash::new([0; 32])),
         value: StoredValue::CLValue(CLValue::from_t(42_i32).unwrap()),
     };
     let leaf_bytes = leaf.to_bytes().unwrap();

--- a/execution-engine/engine-storage/src/global_state/in_memory.rs
+++ b/execution-engine/engine-storage/src/global_state/in_memory.rs
@@ -201,7 +201,7 @@ impl StateProvider for InMemoryGlobalState {
 
 #[cfg(test)]
 mod tests {
-    use types::{account::PublicKey, CLValue};
+    use types::{account::AccountHash, CLValue};
 
     use super::*;
 
@@ -214,11 +214,11 @@ mod tests {
     fn create_test_pairs() -> [TestPair; 2] {
         [
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([1_u8; 32])),
+                key: Key::Account(AccountHash::new([1_u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t(1_i32).unwrap()),
             },
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([2_u8; 32])),
+                key: Key::Account(AccountHash::new([2_u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t(2_i32).unwrap()),
             },
         ]
@@ -227,15 +227,15 @@ mod tests {
     fn create_test_pairs_updated() -> [TestPair; 3] {
         [
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([1u8; 32])),
+                key: Key::Account(AccountHash::new([1u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t("one".to_string()).unwrap()),
             },
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([2u8; 32])),
+                key: Key::Account(AccountHash::new([2u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t("two".to_string()).unwrap()),
             },
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([3u8; 32])),
+                key: Key::Account(AccountHash::new([3u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t(3_i32).unwrap()),
             },
         ]

--- a/execution-engine/engine-storage/src/global_state/lmdb.rs
+++ b/execution-engine/engine-storage/src/global_state/lmdb.rs
@@ -164,7 +164,7 @@ mod tests {
     use lmdb::DatabaseFlags;
     use tempfile::tempdir;
 
-    use types::{account::PublicKey, CLValue};
+    use types::{account::AccountHash, CLValue};
 
     use crate::{
         trie_store::operations::{write, WriteResult},
@@ -182,11 +182,11 @@ mod tests {
     fn create_test_pairs() -> [TestPair; 2] {
         [
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([1_u8; 32])),
+                key: Key::Account(AccountHash::new([1_u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t(1_i32).unwrap()),
             },
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([2_u8; 32])),
+                key: Key::Account(AccountHash::new([2_u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t(2_i32).unwrap()),
             },
         ]
@@ -195,15 +195,15 @@ mod tests {
     fn create_test_pairs_updated() -> [TestPair; 3] {
         [
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([1u8; 32])),
+                key: Key::Account(AccountHash::new([1u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t("one".to_string()).unwrap()),
             },
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([2u8; 32])),
+                key: Key::Account(AccountHash::new([2u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t("two".to_string()).unwrap()),
             },
             TestPair {
-                key: Key::Account(PublicKey::ed25519_from([3u8; 32])),
+                key: Key::Account(AccountHash::new([3u8; 32])),
                 value: StoredValue::CLValue(CLValue::from_t(3_i32).unwrap()),
             },
         ]

--- a/execution-engine/engine-storage/src/global_state/mod.rs
+++ b/execution-engine/engine-storage/src/global_state/mod.rs
@@ -11,7 +11,7 @@ use engine_shared::{
     transform::{self, Transform},
     TypeMismatch,
 };
-use types::{account::PublicKey, bytesrepr, Key, ProtocolVersion, U512};
+use types::{account::AccountHash, bytesrepr, Key, ProtocolVersion, U512};
 
 use crate::{
     protocol_data::ProtocolData,
@@ -45,7 +45,7 @@ pub enum CommitResult {
     RootNotFound,
     Success {
         state_root: Blake2bHash,
-        bonded_validators: HashMap<PublicKey, U512>,
+        bonded_validators: HashMap<AccountHash, U512>,
     },
     KeyNotFound(Key),
     TypeMismatch(TypeMismatch),

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
@@ -1,3 +1,4 @@
+// TODO: With AccountHash replacing Keys, does this need to stay?
 use proptest::{arbitrary, array, collection, prop_oneof, strategy::Strategy};
 
 use engine_shared::{make_array_newtype, newtypes::Blake2bHash};

--- a/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
+++ b/execution-engine/engine-storage/src/trie_store/operations/tests/ee_699.rs
@@ -135,7 +135,7 @@ impl FromBytes for PublicKey {
     }
 }
 
-fn public_key_arb() -> impl Strategy<Value = PublicKey> {
+fn account_hash_arb() -> impl Strategy<Value = PublicKey> {
     prop_oneof![
         basic_arb().prop_map(PublicKey::Basic),
         similar_arb().prop_map(PublicKey::Similar),
@@ -164,9 +164,9 @@ impl ToBytes for TestKey {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         let mut ret = Vec::with_capacity(self.serialized_length());
         match self {
-            TestKey::Account(public_key) => {
+            TestKey::Account(account_hash) => {
                 ret.push(KEY_ACCOUNT_ID);
-                ret.extend(&public_key.to_bytes()?)
+                ret.extend(&account_hash.to_bytes()?)
             }
             TestKey::Hash(hash) => {
                 ret.push(KEY_HASH_ID);
@@ -187,7 +187,7 @@ impl ToBytes for TestKey {
     fn serialized_length(&self) -> usize {
         U8_SERIALIZED_LENGTH
             + match self {
-                TestKey::Account(public_key) => public_key.serialized_length(),
+                TestKey::Account(account_hash) => account_hash.serialized_length(),
                 TestKey::Hash(hash) => hash.serialized_length(),
                 TestKey::URef(uref) => uref.serialized_length(),
                 TestKey::Local(local) => local.serialized_length(),
@@ -222,7 +222,7 @@ impl FromBytes for TestKey {
 
 fn test_key_arb() -> impl Strategy<Value = TestKey> {
     prop_oneof![
-        public_key_arb().prop_map(TestKey::Account),
+        account_hash_arb().prop_map(TestKey::Account),
         gens::u8_slice_32().prop_map(TestKey::Hash),
         gens::uref_arb().prop_map(TestKey::URef),
         (gens::u8_slice_32(), gens::u8_slice_32())

--- a/execution-engine/engine-test-support/src/internal/deploy_item_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/deploy_item_builder.rs
@@ -5,17 +5,17 @@ use engine_core::{
     engine_state::{deploy_item::DeployItem, executable_deploy_item::ExecutableDeployItem},
     DeployHash,
 };
-use types::{account::PublicKey, bytesrepr::ToBytes, URef};
+use types::{account::AccountHash, bytesrepr::ToBytes, URef};
 
 use crate::internal::utils;
 
 #[derive(Default)]
 struct DeployItemData {
-    pub address: Option<PublicKey>,
+    pub address: Option<AccountHash>,
     pub payment_code: Option<ExecutableDeployItem>,
     pub session_code: Option<ExecutableDeployItem>,
     pub gas_price: u64,
-    pub authorization_keys: BTreeSet<PublicKey>,
+    pub authorization_keys: BTreeSet<AccountHash>,
     pub deploy_hash: DeployHash,
 }
 
@@ -28,7 +28,7 @@ impl DeployItemBuilder {
         Default::default()
     }
 
-    pub fn with_address(mut self, address: PublicKey) -> Self {
+    pub fn with_address(mut self, address: AccountHash) -> Self {
         self.deploy_item.address = Some(address);
         self
     }
@@ -137,7 +137,7 @@ impl DeployItemBuilder {
         self
     }
 
-    pub fn with_authorization_keys<T: Clone + Into<PublicKey>>(
+    pub fn with_authorization_keys<T: Clone + Into<AccountHash>>(
         mut self,
         authorization_keys: &[T],
     ) -> Self {
@@ -164,7 +164,7 @@ impl DeployItemBuilder {
             address: self
                 .deploy_item
                 .address
-                .unwrap_or_else(|| PublicKey::ed25519_from([0u8; 32])),
+                .unwrap_or_else(|| AccountHash::new([0u8; 32])),
             session: self.deploy_item.session_code.unwrap(),
             payment: self.deploy_item.payment_code.unwrap(),
             gas_price: self.deploy_item.gas_price,

--- a/execution-engine/engine-test-support/src/internal/exec_with_return.rs
+++ b/execution-engine/engine-test-support/src/internal/exec_with_return.rs
@@ -15,7 +15,7 @@ use engine_shared::{gas::Gas, newtypes::CorrelationId};
 use engine_storage::{global_state::StateProvider, protocol_data::ProtocolData};
 use engine_wasm_prep::Preprocessor;
 use types::{
-    account::PublicKey, bytesrepr::FromBytes, BlockTime, CLTyped, CLValue, Key, Phase,
+    account::AccountHash, bytesrepr::FromBytes, BlockTime, CLTyped, CLValue, Key, Phase,
     ProtocolVersion, URef, U512,
 };
 
@@ -31,7 +31,7 @@ const INIT_FN_STORE_ID: u32 = 0;
 pub fn exec<S, T>(
     config: EngineConfig,
     builder: &mut WasmTestBuilder<S>,
-    address: PublicKey,
+    address: AccountHash,
     wasm_file: &str,
     block_time: u64,
     deploy_hash: [u8; 32],

--- a/execution-engine/engine-test-support/src/internal/execute_request_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/execute_request_builder.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 
 use contract::args_parser::ArgsParser;
 use engine_core::engine_state::{deploy_item::DeployItem, execute_request::ExecuteRequest};
-use types::{account::PublicKey, ProtocolVersion};
+use types::{account::AccountHash, ProtocolVersion};
 
 use crate::internal::{DeployItemBuilder, DEFAULT_BLOCK_TIME, DEFAULT_PAYMENT};
 
@@ -46,7 +46,7 @@ impl ExecuteRequestBuilder {
     }
 
     pub fn standard(
-        public_key: PublicKey,
+        account_hash: AccountHash,
         session_file: &str,
         session_args: impl ArgsParser,
     ) -> Self {
@@ -54,10 +54,10 @@ impl ExecuteRequestBuilder {
         let deploy_hash: [u8; 32] = rng.gen();
 
         let deploy = DeployItemBuilder::new()
-            .with_address(public_key)
+            .with_address(account_hash)
             .with_session_code(session_file, session_args)
             .with_empty_payment_bytes((*DEFAULT_PAYMENT,))
-            .with_authorization_keys(&[public_key])
+            .with_authorization_keys(&[account_hash])
             .with_deploy_hash(deploy_hash)
             .build();
 
@@ -65,7 +65,7 @@ impl ExecuteRequestBuilder {
     }
 
     pub fn contract_call_by_hash(
-        sender: PublicKey,
+        sender: AccountHash,
         contract_hash: [u8; 32],
         args: impl ArgsParser,
     ) -> Self {

--- a/execution-engine/engine-test-support/src/internal/mod.rs
+++ b/execution-engine/engine-test-support/src/internal/mod.rs
@@ -15,7 +15,7 @@ use engine_core::engine_state::{
 };
 use engine_shared::{motes::Motes, newtypes::Blake2bHash, test_utils};
 use engine_wasm_prep::wasm_costs::WasmCosts;
-use types::{account::PublicKey, ProtocolVersion, U512};
+use types::{account::AccountHash, ProtocolVersion, U512};
 
 use super::{DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE};
 pub use additive_map_diff::AdditiveMapDiff;
@@ -34,9 +34,9 @@ pub const STANDARD_PAYMENT_CONTRACT: &str = "standard_payment.wasm";
 pub const DEFAULT_CHAIN_NAME: &str = "gerald";
 pub const DEFAULT_GENESIS_TIMESTAMP: u64 = 0;
 pub const DEFAULT_BLOCK_TIME: u64 = 0;
-pub const MOCKED_ACCOUNT_ADDRESS: PublicKey = PublicKey::ed25519_from([48u8; 32]);
+pub const MOCKED_ACCOUNT_ADDRESS: AccountHash = AccountHash::new([48u8; 32]);
 
-pub const DEFAULT_ACCOUNT_KEY: PublicKey = DEFAULT_ACCOUNT_ADDR;
+pub const DEFAULT_ACCOUNT_KEY: AccountHash = DEFAULT_ACCOUNT_ADDR;
 
 lazy_static! {
     pub static ref DEFAULT_GENESIS_CONFIG_HASH: Blake2bHash = [42; 32].into();

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -46,7 +46,7 @@ use engine_storage::{
     trie_store::lmdb::LmdbTrieStore,
 };
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{self, ToBytes},
     CLValue, Key, URef, U512,
 };
@@ -77,7 +77,7 @@ pub struct WasmTestBuilder<S> {
     /// Cached transform maps after subsequent successful runs i.e. `transforms[0]` is for first
     /// exec call etc.
     transforms: Vec<AdditiveMap<Key, Transform>>,
-    bonded_validators: Vec<HashMap<PublicKey, U512>>,
+    bonded_validators: Vec<HashMap<AccountHash, U512>>,
     /// Cached genesis transforms
     genesis_account: Option<Account>,
     /// Genesis transforms
@@ -457,7 +457,7 @@ where
             .take_bonded_validators()
             .into_iter()
             .map(TryInto::try_into)
-            .collect::<Result<HashMap<PublicKey, U512>, MappingError>>()
+            .collect::<Result<HashMap<AccountHash, U512>, MappingError>>()
             .unwrap();
         self.bonded_validators.push(bonded_validators);
         self
@@ -524,7 +524,7 @@ where
         self.transforms.clone()
     }
 
-    pub fn get_bonded_validators(&self) -> Vec<HashMap<PublicKey, U512>> {
+    pub fn get_bonded_validators(&self) -> Vec<HashMap<AccountHash, U512>> {
         self.bonded_validators.clone()
     }
 
@@ -621,7 +621,7 @@ where
             .expect("should parse balance into a U512")
     }
 
-    pub fn get_account(&self, public_key: PublicKey) -> Option<Account> {
+    pub fn get_account(&self, public_key: AccountHash) -> Option<Account> {
         let account_value = self
             .query(None, Key::Account(public_key), &[])
             .expect("should query account");

--- a/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
+++ b/execution-engine/engine-test-support/src/internal/wasm_test_builder.rs
@@ -621,9 +621,9 @@ where
             .expect("should parse balance into a U512")
     }
 
-    pub fn get_account(&self, public_key: AccountHash) -> Option<Account> {
+    pub fn get_account(&self, account_hash: AccountHash) -> Option<Account> {
         let account_value = self
-            .query(None, Key::Account(public_key), &[])
+            .query(None, Key::Account(account_hash), &[])
             .expect("should query account");
 
         if let StoredValue::Account(account) = account_value {

--- a/execution-engine/engine-test-support/src/lib.rs
+++ b/execution-engine/engine-test-support/src/lib.rs
@@ -26,9 +26,9 @@
 //! ```no_run
 //! # use types as casperlabs_types;
 //! use casperlabs_engine_test_support::{Code, Error, SessionBuilder, TestContextBuilder, Value};
-//! use casperlabs_types::{account::PublicKey, U512};
+//! use casperlabs_types::{account::AccountHash, U512};
 //!
-//! const MY_ACCOUNT: PublicKey = PublicKey::ed25519_from([7u8; 32]);
+//! const MY_ACCOUNT: AccountHash = AccountHash::new([7u8; 32]);
 //! const KEY: &str = "special_value";
 //! const VALUE: &str = "hello world";
 //!
@@ -75,7 +75,7 @@ pub use code::Code;
 pub use error::{Error, Result};
 pub use session::{Session, SessionBuilder};
 pub use test_context::{TestContext, TestContextBuilder};
-pub use types::account::PublicKey;
+pub use types::account::AccountHash;
 pub use value::Value;
 
 /// The address of a [`URef`](types::URef) (unforgeable reference) on the network.
@@ -85,7 +85,7 @@ pub type URefAddr = [u8; 32];
 pub type Hash = [u8; 32];
 
 /// Default test account address.
-pub const DEFAULT_ACCOUNT_ADDR: PublicKey = PublicKey::ed25519_from([6u8; 32]);
+pub const DEFAULT_ACCOUNT_ADDR: AccountHash = AccountHash::new([6u8; 32]);
 
 /// Default initial balance of a test account in motes.
 pub const DEFAULT_ACCOUNT_INITIAL_BALANCE: u64 = 100_000_000_000;

--- a/execution-engine/engine-test-support/src/session.rs
+++ b/execution-engine/engine-test-support/src/session.rs
@@ -6,7 +6,7 @@ use types::ProtocolVersion;
 
 use crate::{
     internal::{DeployItemBuilder, ExecuteRequestBuilder, DEFAULT_PAYMENT},
-    Code, PublicKey,
+    AccountHash, Code,
 };
 
 /// A single session, i.e. a single request to execute a single deploy within the test context.
@@ -41,7 +41,7 @@ impl SessionBuilder {
     }
 
     /// Returns `self` with the provided account address set.
-    pub fn with_address(mut self, address: PublicKey) -> Self {
+    pub fn with_address(mut self, address: AccountHash) -> Self {
         self.di_builder = self.di_builder.with_address(address);
         self
     }
@@ -68,7 +68,7 @@ impl SessionBuilder {
     }
 
     /// Returns `self` with the provided authorization keys set.
-    pub fn with_authorization_keys(mut self, keys: &[PublicKey]) -> Self {
+    pub fn with_authorization_keys(mut self, keys: &[AccountHash]) -> Self {
         self.di_builder = self.di_builder.with_authorization_keys(keys);
         self
     }

--- a/execution-engine/engine-test-support/src/test_context.rs
+++ b/execution-engine/engine-test-support/src/test_context.rs
@@ -9,7 +9,7 @@ use types::{AccessRights, Key, URef, U512};
 
 use crate::{
     internal::{InMemoryWasmTestBuilder, DEFAULT_GENESIS_CONFIG, DEFAULT_GENESIS_CONFIG_HASH},
-    Error, PublicKey, Result, Session, URefAddr, Value,
+    AccountHash, Error, Result, Session, URefAddr, Value,
 };
 
 /// Context in which to run a test of a Wasm smart contract.
@@ -32,7 +32,7 @@ impl TestContext {
     /// Queries for a [`Value`] stored under the given `key` and `path`.
     ///
     /// Returns an [`Error`] if not found.
-    pub fn query<T: AsRef<str>>(&self, key: PublicKey, path: &[T]) -> Result<Value> {
+    pub fn query<T: AsRef<str>>(&self, key: AccountHash, path: &[T]) -> Result<Value> {
         let path = path.iter().map(AsRef::as_ref).collect::<Vec<_>>();
         self.inner
             .query(None, Key::Account(key), &path)
@@ -69,7 +69,7 @@ impl TestContextBuilder {
     /// the Genesis block.
     ///
     /// Note: `initial_balance` represents the number of motes.
-    pub fn with_account(mut self, address: PublicKey, initial_balance: U512) -> Self {
+    pub fn with_account(mut self, address: AccountHash, initial_balance: U512) -> Self {
         let new_account = GenesisAccount::new(address, Motes::new(initial_balance), Motes::zero());
         self.genesis_config
             .ee_config_mut()

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -13,7 +13,7 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key, URef, U512};
+use types::{account::AccountHash, Key, URef, U512};
 
 const CONTRACT_CREATE_ACCOUNTS: &str = "create_accounts.wasm";
 const CONTRACT_CREATE_PURSES: &str = "create_purses.wasm";
@@ -23,7 +23,7 @@ const CONTRACT_TRANSFER_TO_PURSE: &str = "transfer_to_purse.wasm";
 /// Size of batch used in multiple execs benchmark, and multiple deploys per exec cases.
 const TRANSFER_BATCH_SIZE: u64 = 3;
 const PER_RUN_FUNDING: u64 = 10_000_000;
-const TARGET_ADDR: PublicKey = PublicKey::ed25519_from([127; 32]);
+const TARGET_ADDR: AccountHash = AccountHash::new([127; 32]);
 
 /// Converts an integer into an array of type [u8; 32] by converting integer
 /// into its big endian representation and embedding it at the end of the
@@ -34,7 +34,7 @@ fn make_deploy_hash(i: u64) -> [u8; 32] {
     result
 }
 
-fn bootstrap(data_dir: &Path, accounts: &[PublicKey], amount: U512) -> LmdbWasmTestBuilder {
+fn bootstrap(data_dir: &Path, accounts: &[AccountHash], amount: U512) -> LmdbWasmTestBuilder {
     let accounts_bytes: Vec<Vec<u8>> = accounts
         .iter()
         .map(|public_key| public_key.as_bytes().to_vec())
@@ -64,7 +64,7 @@ fn bootstrap(data_dir: &Path, accounts: &[PublicKey], amount: U512) -> LmdbWasmT
 
 fn create_purses(
     builder: &mut LmdbWasmTestBuilder,
-    source: PublicKey,
+    source: AccountHash,
     total_purses: u64,
     purse_amount: U512,
 ) -> Vec<URef> {
@@ -102,7 +102,7 @@ fn create_purses(
 /// batch determined by value of TRANSFER_BATCH_SIZE.
 fn transfer_to_account_multiple_execs(
     builder: &mut LmdbWasmTestBuilder,
-    account: PublicKey,
+    account: AccountHash,
     should_commit: bool,
 ) {
     let amount = U512::one();
@@ -125,7 +125,7 @@ fn transfer_to_account_multiple_execs(
 /// Executes multiple deploys per single exec with based on TRANSFER_BATCH_SIZE.
 fn transfer_to_account_multiple_deploys(
     builder: &mut LmdbWasmTestBuilder,
-    account: PublicKey,
+    account: AccountHash,
     should_commit: bool,
 ) {
     let mut exec_builder = ExecuteRequestBuilder::new();

--- a/execution-engine/engine-tests/benches/transfer_bench.rs
+++ b/execution-engine/engine-tests/benches/transfer_bench.rs
@@ -37,7 +37,7 @@ fn make_deploy_hash(i: u64) -> [u8; 32] {
 fn bootstrap(data_dir: &Path, accounts: &[AccountHash], amount: U512) -> LmdbWasmTestBuilder {
     let accounts_bytes: Vec<Vec<u8>> = accounts
         .iter()
-        .map(|public_key| public_key.as_bytes().to_vec())
+        .map(|account_hash| account_hash.as_bytes().to_vec())
         .collect();
 
     let exec_request = ExecuteRequestBuilder::standard(

--- a/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
+++ b/execution-engine/engine-tests/src/profiling/concurrent_executor.rs
@@ -319,12 +319,12 @@ impl Drop for ClientPool {
 
 fn new_execute_request(args: &Args) -> ExecuteRequest {
     let amount = U512::one();
-    let account_1_public_key = profiling::account_1_public_key();
-    let account_2_public_key = profiling::account_2_public_key();
+    let account_1_account_hash = profiling::account_1_account_hash();
+    let account_2_account_hash = profiling::account_2_account_hash();
     ExecuteRequestBuilder::standard(
-        account_1_public_key,
+        account_1_account_hash,
         CONTRACT_NAME,
-        (account_2_public_key, amount),
+        (account_2_account_hash, amount),
     )
     .with_pre_state_hash(&args.pre_state_hash)
     .build()

--- a/execution-engine/engine-tests/src/profiling/host_function_metrics.rs
+++ b/execution-engine/engine-tests/src/profiling/host_function_metrics.rs
@@ -136,8 +136,8 @@ fn run_test(root_hash: Vec<u8>, repetitions: usize, data_dir: &Path) {
     let log_settings = Settings::new(LevelFilter::Warn).with_metrics_enabled(true);
     let _ = logging::initialize(log_settings);
 
-    let account_1_public_key = profiling::account_1_public_key();
-    let account_2_public_key = profiling::account_2_public_key();
+    let account_1_account_hash = profiling::account_1_account_hash();
+    let account_2_account_hash = profiling::account_2_account_hash();
 
     let engine_config = EngineConfig::new()
         .with_use_system_contracts(cfg!(feature = "use-system-contracts"))
@@ -154,17 +154,17 @@ fn run_test(root_hash: Vec<u8>, repetitions: usize, data_dir: &Path) {
         rng.fill(random_bytes.as_mut_slice());
 
         let deploy = DeployItemBuilder::new()
-            .with_address(account_1_public_key)
+            .with_address(account_1_account_hash)
             .with_deploy_hash(rng.gen())
             .with_session_code(
                 HOST_FUNCTION_METRICS_CONTRACT,
                 (
                     seed,
-                    (random_bytes, account_1_public_key, account_2_public_key),
+                    (random_bytes, account_1_account_hash, account_2_account_hash),
                 ),
             )
             .with_empty_payment_bytes((U512::from(PAYMENT_AMOUNT),))
-            .with_authorization_keys(&[account_1_public_key])
+            .with_authorization_keys(&[account_1_account_hash])
             .build();
         let exec_request = ExecuteRequestBuilder::new()
             .push_deploy(deploy.clone())

--- a/execution-engine/engine-tests/src/profiling/mod.rs
+++ b/execution-engine/engine-tests/src/profiling/mod.rs
@@ -3,7 +3,7 @@ use std::{env, path::PathBuf, str::FromStr};
 use clap::{Arg, ArgMatches};
 
 use engine_test_support::DEFAULT_ACCOUNT_INITIAL_BALANCE;
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const DATA_DIR_ARG_NAME: &str = "data-dir";
 const DATA_DIR_ARG_SHORT: &str = "d";
@@ -12,9 +12,9 @@ const DATA_DIR_ARG_VALUE_NAME: &str = "PATH";
 const DATA_DIR_ARG_HELP: &str = "Directory in which persistent data is stored [default: current \
                                  working directory]";
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 pub const ACCOUNT_1_INITIAL_AMOUNT: u64 = DEFAULT_ACCOUNT_INITIAL_BALANCE - 1_000_000_000;
-const ACCOUNT_2_ADDR: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([2u8; 32]);
 
 pub fn exe_name() -> String {
     env::current_exe()
@@ -52,7 +52,7 @@ pub fn parse_count(count_as_str: &str) -> usize {
     count
 }
 
-pub fn account_1_public_key() -> PublicKey {
+pub fn account_1_account_hash() -> AccountHash {
     ACCOUNT_1_ADDR
 }
 
@@ -60,6 +60,6 @@ pub fn account_1_initial_amount() -> U512 {
     ACCOUNT_1_INITIAL_AMOUNT.into()
 }
 
-pub fn account_2_public_key() -> PublicKey {
+pub fn account_2_account_hash() -> AccountHash {
     ACCOUNT_2_ADDR
 }

--- a/execution-engine/engine-tests/src/profiling/simple_transfer.rs
+++ b/execution-engine/engine-tests/src/profiling/simple_transfer.rs
@@ -92,19 +92,19 @@ fn main() {
         profiling::parse_hash(input.trim_end())
     });
 
-    let account_1_public_key = profiling::account_1_public_key();
-    let account_2_public_key = profiling::account_2_public_key();
+    let account_1_account_hash = profiling::account_1_account_hash();
+    let account_2_account_hash = profiling::account_2_account_hash();
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()
-            .with_address(account_1_public_key)
+            .with_address(account_1_account_hash)
             .with_deploy_hash([1; 32])
             .with_session_code(
                 "simple_transfer.wasm",
-                (account_2_public_key, U512::from(TRANSFER_AMOUNT)),
+                (account_2_account_hash, U512::from(TRANSFER_AMOUNT)),
             )
             .with_payment_code(STANDARD_PAYMENT_WASM, (*DEFAULT_PAYMENT,))
-            .with_authorization_keys(&[account_1_public_key])
+            .with_authorization_keys(&[account_1_account_hash])
             .build();
 
         ExecuteRequestBuilder::new().push_deploy(deploy).build()

--- a/execution-engine/engine-tests/src/profiling/state_initializer.rs
+++ b/execution-engine/engine-tests/src/profiling/state_initializer.rs
@@ -39,10 +39,10 @@ fn data_dir() -> PathBuf {
 fn main() {
     let data_dir = data_dir();
 
-    let genesis_public_key = DEFAULT_ACCOUNT_ADDR;
-    let account_1_public_key = profiling::account_1_public_key();
+    let genesis_account_hash = DEFAULT_ACCOUNT_ADDR;
+    let account_1_account_hash = profiling::account_1_account_hash();
     let account_1_initial_amount = profiling::account_1_initial_amount();
-    let account_2_public_key = profiling::account_2_public_key();
+    let account_2_account_hash = profiling::account_2_account_hash();
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()
@@ -51,13 +51,13 @@ fn main() {
             .with_session_code(
                 STATE_INITIALIZER_CONTRACT,
                 (
-                    account_1_public_key,
+                    account_1_account_hash,
                     account_1_initial_amount,
-                    account_2_public_key,
+                    account_2_account_hash,
                 ),
             )
             .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,))
-            .with_authorization_keys(&[genesis_public_key])
+            .with_authorization_keys(&[genesis_account_hash])
             .build();
 
         ExecuteRequestBuilder::new().push_deploy(deploy).build()

--- a/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/associated_keys.rs
@@ -8,14 +8,14 @@ use engine_test_support::{
     DEFAULT_ACCOUNT_ADDR,
 };
 use types::{
-    account::{PublicKey, Weight},
+    account::{AccountHash, Weight},
     U512,
 };
 
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
 const CONTRACT_REMOVE_ASSOCIATED_KEY: &str = "remove_associated_key.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 lazy_static! {
     static ref ACCOUNT_1_INITIAL_FUND: U512 = *DEFAULT_PAYMENT * 10;

--- a/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/authorized_keys.rs
@@ -6,7 +6,7 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::account::{PublicKey, Weight};
+use types::account::{AccountHash, Weight};
 
 const CONTRACT_ADD_UPDATE_ASSOCIATED_KEY: &str = "add_update_associated_key.wasm";
 const CONTRACT_AUTHORIZED_KEYS: &str = "authorized_keys.wasm";
@@ -33,7 +33,7 @@ fn should_deploy_with_authorized_identity_key() {
 fn should_raise_auth_failure_with_invalid_key() {
     // tests that authorized keys that does not belong to account raises
     // Error::Authorization
-    let key_1 = PublicKey::ed25519_from([254; 32]);
+    let key_1 = AccountHash::new([254; 32]);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_1);
 
     let exec_request = {
@@ -76,9 +76,9 @@ fn should_raise_auth_failure_with_invalid_key() {
 fn should_raise_auth_failure_with_invalid_keys() {
     // tests that authorized keys that does not belong to account raises
     // Error::Authorization
-    let key_1 = PublicKey::ed25519_from([254; 32]);
-    let key_2 = PublicKey::ed25519_from([253; 32]);
-    let key_3 = PublicKey::ed25519_from([252; 32]);
+    let key_1 = AccountHash::new([254; 32]);
+    let key_2 = AccountHash::new([253; 32]);
+    let key_3 = AccountHash::new([252; 32]);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_1);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_2);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_3);
@@ -118,9 +118,9 @@ fn should_raise_auth_failure_with_invalid_keys() {
 #[test]
 fn should_raise_deploy_authorization_failure() {
     // tests that authorized keys needs sufficient cumulative weight
-    let key_1 = PublicKey::ed25519_from([254; 32]);
-    let key_2 = PublicKey::ed25519_from([253; 32]);
-    let key_3 = PublicKey::ed25519_from([252; 32]);
+    let key_1 = AccountHash::new([254; 32]);
+    let key_2 = AccountHash::new([253; 32]);
+    let key_3 = AccountHash::new([252; 32]);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_1);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_2);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_3);
@@ -281,8 +281,8 @@ fn should_authorize_deploy_with_multiple_keys() {
     // tests that authorized keys needs sufficient cumulative weight
     // and each of the associated keys is greater than threshold
 
-    let key_1 = PublicKey::ed25519_from([254; 32]);
-    let key_2 = PublicKey::ed25519_from([253; 32]);
+    let key_1 = AccountHash::new([254; 32]);
+    let key_2 = AccountHash::new([253; 32]);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_1);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_2);
 
@@ -329,7 +329,7 @@ fn should_authorize_deploy_with_multiple_keys() {
 fn should_not_authorize_deploy_with_duplicated_keys() {
     // tests that authorized keys needs sufficient cumulative weight
     // and each of the associated keys is greater than threshold
-    let key_1 = PublicKey::ed25519_from([254; 32]);
+    let key_1 = AccountHash::new([254; 32]);
     assert_ne!(DEFAULT_ACCOUNT_ADDR, key_1);
 
     let exec_request_1 = ExecuteRequestBuilder::standard(

--- a/execution-engine/engine-tests/src/test/contract_api/account/key_management_thresholds.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/account/key_management_thresholds.rs
@@ -5,7 +5,7 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 const CONTRACT_KEY_MANAGEMENT_THRESHOLDS: &str = "key_management_thresholds.wasm";
 
@@ -56,7 +56,7 @@ fn should_verify_key_management_permission_with_sufficient_weight() {
             .with_authorization_keys(&[
                 DEFAULT_ACCOUNT_ADDR,
                 // Key [42; 32] is created in init stage
-                PublicKey::ed25519_from([42; 32]),
+                AccountHash::new([42; 32]),
             ])
             .build();
         ExecuteRequestBuilder::from_deploy_item(deploy).build()

--- a/execution-engine/engine-tests/src/test/contract_api/create_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/create_purse.rs
@@ -7,10 +7,10 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key, U512};
+use types::{account::AccountHash, Key, U512};
 const CONTRACT_CREATE_PURSE_01: &str = "create_purse_01.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 const TEST_PURSE_NAME: &str = "test_purse";
 
 lazy_static! {

--- a/execution-engine/engine-tests/src/test/contract_api/get_caller.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/get_caller.rs
@@ -5,12 +5,12 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 const CONTRACT_GET_CALLER: &str = "get_caller.wasm";
 const CONTRACT_GET_CALLER_SUBCALL: &str = "get_caller_subcall.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
@@ -32,10 +32,10 @@ fn should_list_named_keys() {
     };
 
     let new_named_keys = {
-        let public_key = AccountHash::new([1; 32]);
+        let account_hash = AccountHash::new([1; 32]);
         let mut named_keys = BTreeMap::new();
         assert!(named_keys
-            .insert(NEW_NAME_ACCOUNT.to_string(), Key::Account(public_key))
+            .insert(NEW_NAME_ACCOUNT.to_string(), Key::Account(account_hash))
             .is_none());
         assert!(named_keys
             .insert(NEW_NAME_HASH.to_string(), Key::Hash([2; 32]))

--- a/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
@@ -5,7 +5,7 @@ use engine_test_support::{
     internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key};
+use types::{account::AccountHash, Key};
 
 const CONTRACT_LIST_NAMED_KEYS: &str = "list_named_keys.wasm";
 const NEW_NAME_ACCOUNT: &str = "Account";
@@ -32,7 +32,7 @@ fn should_list_named_keys() {
     };
 
     let new_named_keys = {
-        let public_key = PublicKey::ed25519_from([1; 32]);
+        let public_key = AccountHash::new([1; 32]);
         let mut named_keys = BTreeMap::new();
         assert!(named_keys
             .insert(NEW_NAME_ACCOUNT.to_string(), Key::Account(public_key))

--- a/execution-engine/engine-tests/src/test/contract_api/main_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/main_purse.rs
@@ -6,11 +6,11 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key};
+use types::{account::AccountHash, Key};
 
 const CONTRACT_MAIN_PURSE: &str = "main_purse.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/contract_api/mint_purse.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/mint_purse.rs
@@ -2,11 +2,11 @@ use engine_test_support::{
     internal::{ExecuteRequestBuilder, WasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_MINT_PURSE: &str = "mint_purse.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
-const SYSTEM_ADDR: PublicKey = PublicKey::ed25519_from([0u8; 32]);
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const TRANSFER_AMOUNT: u64 = 250_000_000 + 1000;
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/contract_api/transfer.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer.rs
@@ -9,7 +9,7 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
@@ -22,8 +22,8 @@ lazy_static! {
     static ref ACCOUNT_1_INITIAL_BALANCE: U512 = *DEFAULT_PAYMENT;
 }
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
-const ACCOUNT_2_ADDR: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
+const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([2u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
@@ -10,10 +10,10 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, ApiError, CLValue, Key, TransferResult, TransferredTo, U512};
+use types::{account::AccountHash, ApiError, CLValue, Key, TransferResult, TransferredTo, U512};
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([42u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 lazy_static! {
     static ref ACCOUNT_1_INITIAL_FUND: U512 = *DEFAULT_PAYMENT + 42;
 }

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_purse_to_account.rs
@@ -21,18 +21,18 @@ lazy_static! {
 #[ignore]
 #[test]
 fn should_run_purse_to_account_transfer() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
-    let genesis_public_key = DEFAULT_ACCOUNT_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
+    let genesis_account_hash = DEFAULT_ACCOUNT_ADDR;
     let exec_request_1 = ExecuteRequestBuilder::standard(
         DEFAULT_ACCOUNT_ADDR,
         CONTRACT_TRANSFER_PURSE_TO_ACCOUNT,
-        (account_1_public_key, *ACCOUNT_1_INITIAL_FUND),
+        (account_1_account_hash, *ACCOUNT_1_INITIAL_FUND),
     )
     .build();
     let exec_request_2 = ExecuteRequestBuilder::standard(
-        account_1_public_key,
+        account_1_account_hash,
         CONTRACT_TRANSFER_PURSE_TO_ACCOUNT,
-        (genesis_public_key, U512::from(1)),
+        (genesis_account_hash, U512::from(1)),
     )
     .build();
     let mut builder = InMemoryWasmTestBuilder::default();

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_stored.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_stored.rs
@@ -7,12 +7,12 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_TRANSFER_TO_ACCOUNT_NAME: &str = "transfer_to_account";
 const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";
 const STORE_AT_HASH: &str = "hash";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/contract_api/transfer_u512_stored.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/transfer_u512_stored.rs
@@ -7,13 +7,13 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_KEY_NAME: &str = "transfer_to_account";
 const CONTRACT_TRANSFER_TO_ACCOUNT_NAME: &str = "transfer_to_account_u512";
 const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";
 const STORE_AT_HASH: &str = "hash";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 const TRANSFER_AMOUNT: u64 = 1;
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/deploy/non_standard_payment.rs
+++ b/execution-engine/engine-tests/src/test/deploy/non_standard_payment.rs
@@ -9,9 +9,9 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, bytesrepr::ToBytes, CLValue, Key, U512};
+use types::{account::AccountHash, bytesrepr::ToBytes, CLValue, Key, U512};
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([42u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 const DO_NOTHING_WASM: &str = "do_nothing.wasm";
 const TRANSFER_PURSE_TO_ACCOUNT_WASM: &str = "transfer_purse_to_account.wasm";
 const TRANSFER_MAIN_PURSE_TO_NEW_PURSE_WASM: &str = "transfer_main_purse_to_new_purse.wasm";
@@ -24,7 +24,7 @@ fn should_charge_non_main_purse() {
     // instead of account_1 main purse
     const TEST_PURSE_NAME: &str = "test-purse";
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = U512::from(10_000_000);
     let account_1_funding_amount = U512::from(100_000_000);
     let account_1_purse_funding_amount = U512::from(50_000_000);
@@ -36,7 +36,7 @@ fn should_charge_non_main_purse() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM, // creates account_1
-                (account_1_public_key, account_1_funding_amount),
+                (account_1_account_hash, account_1_funding_amount),
             )
             .with_empty_payment_bytes((payment_purse_amount,))
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
@@ -54,7 +54,7 @@ fn should_charge_non_main_purse() {
                 (TEST_PURSE_NAME, account_1_purse_funding_amount),
             )
             .with_empty_payment_bytes((payment_purse_amount,))
-            .with_authorization_keys(&[account_1_public_key])
+            .with_authorization_keys(&[account_1_account_hash])
             .with_deploy_hash([2; 32])
             .build();
 
@@ -117,7 +117,7 @@ fn should_charge_non_main_purse() {
                 NAMED_PURSE_PAYMENT_WASM,
                 (TEST_PURSE_NAME, payment_purse_amount),
             )
-            .with_authorization_keys(&[account_1_public_key])
+            .with_authorization_keys(&[account_1_account_hash])
             .with_deploy_hash([3; 32])
             .build();
 

--- a/execution-engine/engine-tests/src/test/deploy/preconditions.rs
+++ b/execution-engine/engine-tests/src/test/deploy/preconditions.rs
@@ -8,15 +8,15 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([42u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 
 #[ignore]
 #[test]
 fn should_raise_precondition_authorization_failure_invalid_account() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
-    let nonexistent_account_addr = PublicKey::ed25519_from([99u8; 32]);
+    let account_1_account_hash = ACCOUNT_1_ADDR;
+    let nonexistent_account_addr = AccountHash::new([99u8; 32]);
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 
@@ -26,7 +26,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
             .with_deploy_hash([1; 32])
             .with_session_code(
                 "transfer_purse_to_account.wasm",
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_address(nonexistent_account_addr)
             .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
@@ -53,7 +53,7 @@ fn should_raise_precondition_authorization_failure_invalid_account() {
 #[ignore]
 #[test]
 fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
-    let empty_keys: [PublicKey; 0] = [];
+    let empty_keys: [AccountHash; 0] = [];
     let exec_request = {
         let deploy = DeployItemBuilder::new()
             .with_address(DEFAULT_ACCOUNT_ADDR)
@@ -85,7 +85,7 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
 #[test]
 fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
     let account_1_public_key = ACCOUNT_1_ADDR;
-    let nonexistent_account_addr = PublicKey::ed25519_from([99u8; 32]);
+    let nonexistent_account_addr = AccountHash::new([99u8; 32]);
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 

--- a/execution-engine/engine-tests/src/test/deploy/preconditions.rs
+++ b/execution-engine/engine-tests/src/test/deploy/preconditions.rs
@@ -84,7 +84,7 @@ fn should_raise_precondition_authorization_failure_empty_authorized_keys() {
 #[ignore]
 #[test]
 fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let nonexistent_account_addr = AccountHash::new([99u8; 32]);
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
@@ -95,7 +95,7 @@ fn should_raise_precondition_authorization_failure_invalid_authorized_keys() {
             .with_deploy_hash([1; 32])
             .with_session_code(
                 "transfer_purse_to_account.wasm",
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_payment_code("standard_payment.wasm", (U512::from(payment_purse_amount),))
             // invalid authorization key to force error

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -52,7 +52,7 @@ fn should_exec_non_stored_code() {
     // using the new execute logic, passing code for both payment and session
     // should work exactly as it did with the original exec logic
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 
@@ -61,7 +61,7 @@ fn should_exec_non_stored_code() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
                 &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
@@ -146,7 +146,7 @@ fn should_exec_stored_code_by_hash() {
 
     let modified_balance_alpha: U512 = builder.get_purse_balance(default_account.main_purse());
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let transferred_amount = 1;
 
     // next make another deploy that USES stored payment logic
@@ -155,7 +155,7 @@ fn should_exec_stored_code_by_hash() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
                 &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_stored_payment_hash(
                 stored_payment_contract_hash.to_vec(),
@@ -237,7 +237,7 @@ fn should_exec_stored_code_by_named_hash() {
         .expect("should get genesis account");
     let modified_balance_alpha: U512 = builder.get_purse_balance(default_account.main_purse());
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let transferred_amount = 1;
 
     // next make another deploy that USES stored payment logic
@@ -246,7 +246,7 @@ fn should_exec_stored_code_by_named_hash() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
                 &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_stored_payment_named_key(
                 STANDARD_PAYMENT_CONTRACT_NAME,
@@ -343,7 +343,7 @@ fn should_exec_stored_code_by_named_uref() {
         .expect("should get genesis account");
     let modified_balance_alpha: U512 = builder.get_purse_balance(default_account.main_purse());
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let transferred_amount = 1;
 
     // next make another deploy that USES stored session logic
@@ -352,7 +352,7 @@ fn should_exec_stored_code_by_named_uref() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_stored_session_named_key(
                 TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
@@ -461,7 +461,7 @@ fn should_exec_payment_and_session_stored_code() {
     let gas = result.cost();
     let motes_bravo = Motes::from_gas(gas, CONV_RATE).expect("should have motes");
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let transferred_amount = 1;
 
     // next make another deploy that USES stored payment logic & stored transfer
@@ -471,7 +471,7 @@ fn should_exec_payment_and_session_stored_code() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_stored_session_named_key(
                 TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_stored_payment_named_key(
                 STANDARD_PAYMENT_CONTRACT_NAME,
@@ -520,7 +520,7 @@ fn should_exec_payment_and_session_stored_code() {
 fn should_produce_same_transforms_by_uref_or_named_uref() {
     // get transforms for direct uref and named uref and compare them
 
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 100_000_000;
     let transferred_amount = 1;
 
@@ -565,7 +565,7 @@ fn should_produce_same_transforms_by_uref_or_named_uref() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_stored_session_uref(
                 stored_payment_contract_uref,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
@@ -610,7 +610,7 @@ fn should_produce_same_transforms_by_uref_or_named_uref() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_stored_session_named_key(
                 TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_payment_code(
                 &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),
@@ -635,7 +635,7 @@ fn should_produce_same_transforms_by_uref_or_named_uref() {
 #[ignore]
 #[test]
 fn should_have_equivalent_transforms_with_stored_contract_pointers() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 100_000_000;
     let transferred_amount = 1;
 
@@ -707,7 +707,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 .with_address(DEFAULT_ACCOUNT_ADDR)
                 .with_stored_session_named_key(
                     TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME,
-                    (account_1_public_key, U512::from(transferred_amount)),
+                    (account_1_account_hash, U512::from(transferred_amount)),
                 )
                 .with_stored_payment_hash(
                     stored_payment_contract_hash.to_vec(),
@@ -749,7 +749,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 .with_address(DEFAULT_ACCOUNT_ADDR)
                 .with_session_code(
                     &format!("{}.wasm", TRANSFER_PURSE_TO_ACCOUNT_CONTRACT_NAME),
-                    (account_1_public_key, U512::from(transferred_amount)),
+                    (account_1_account_hash, U512::from(transferred_amount)),
                 )
                 .with_payment_code(
                     &format!("{}.wasm", STANDARD_PAYMENT_CONTRACT_NAME),

--- a/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
+++ b/execution-engine/engine-tests/src/test/deploy/stored_contracts.rs
@@ -10,9 +10,9 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, Key, ProtocolVersion, U512};
+use types::{account::AccountHash, Key, ProtocolVersion, U512};
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([42u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 const DEFAULT_ACTIVATION_POINT: ActivationPoint = 1;
 const DO_NOTHING_NAME: &str = "do_nothing";
 const DO_NOTHING_STORED_CONTRACT_NAME: &str = "do_nothing_stored";
@@ -799,7 +799,7 @@ fn should_have_equivalent_transforms_with_stored_contract_pointers() {
                 Transform::Write(StoredValue::Account(la)),
                 Transform::Write(StoredValue::Account(ra)),
             ) => {
-                assert_eq!(la.public_key(), ra.public_key());
+                assert_eq!(la.account_hash(), ra.account_hash());
                 assert_eq!(la.main_purse(), ra.main_purse());
                 assert_eq!(la.action_thresholds(), ra.action_thresholds());
 

--- a/execution-engine/engine-tests/src/test/examples/erc20/erc20_test.rs
+++ b/execution-engine/engine-tests/src/test/examples/erc20/erc20_test.rs
@@ -6,7 +6,7 @@ use engine_test_support::internal::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder as TestBuilder,
     DEFAULT_RUN_GENESIS_REQUEST,
 };
-use types::{account::PublicKey, bytesrepr::ToBytes, ApiError, CLValue, Key, U512};
+use types::{account::AccountHash, bytesrepr::ToBytes, ApiError, CLValue, Key, U512};
 
 const ERC_20_CONTRACT_WASM: &str = "erc20_smart_contract.wasm";
 const TRANFER_TO_ACCOUNT_WASM: &str = "transfer_to_account_u512.wasm";
@@ -30,7 +30,7 @@ pub struct ERC20Test {
 }
 
 impl ERC20Test {
-    pub fn new(sender: PublicKey, init_balance: U512) -> ERC20Test {
+    pub fn new(sender: AccountHash, init_balance: U512) -> ERC20Test {
         let mut builder = TestBuilder::default();
         builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST).commit();
         let test = ERC20Test {
@@ -43,7 +43,7 @@ impl ERC20Test {
             .with_contract(sender, TOKEN_NAME)
     }
 
-    pub fn query_contract_hash(&self, account: PublicKey, name: &str) -> [u8; 32] {
+    pub fn query_contract_hash(&self, account: AccountHash, name: &str) -> [u8; 32] {
         let account_key = Key::Account(account);
         let value: CLValue = self
             .builder
@@ -54,7 +54,7 @@ impl ERC20Test {
         key.into_hash().unwrap()
     }
 
-    pub fn deploy_erc20_contract(mut self, sender: PublicKey, init_balance: U512) -> Self {
+    pub fn deploy_erc20_contract(mut self, sender: AccountHash, init_balance: U512) -> Self {
         let request = ExecuteRequestBuilder::standard(
             sender,
             ERC_20_CONTRACT_WASM,
@@ -67,8 +67,8 @@ impl ERC20Test {
 
     pub fn call_erc20_transfer(
         mut self,
-        sender: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        recipient: AccountHash,
         amount: U512,
     ) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -83,7 +83,7 @@ impl ERC20Test {
 
     pub fn call_erc20_balance_assertion(
         mut self,
-        sender: PublicKey,
+        sender: AccountHash,
         expected_amount: U512,
     ) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -103,8 +103,8 @@ impl ERC20Test {
 
     pub fn call_erc20_allowance_assertion(
         mut self,
-        owner: PublicKey,
-        spender: PublicKey,
+        owner: AccountHash,
+        spender: AccountHash,
         expected_amount: U512,
     ) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -125,7 +125,7 @@ impl ERC20Test {
 
     pub fn call_erc20_total_supply_assertion(
         mut self,
-        sender: PublicKey,
+        sender: AccountHash,
         expected_amount: U512,
     ) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -144,8 +144,8 @@ impl ERC20Test {
 
     pub fn call_erc20_approve(
         mut self,
-        sender: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        recipient: AccountHash,
         amount: U512,
     ) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -160,9 +160,9 @@ impl ERC20Test {
 
     pub fn call_erc20_transfer_from(
         mut self,
-        sender: PublicKey,
-        owner: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        owner: AccountHash,
+        recipient: AccountHash,
         amount: U512,
     ) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -181,7 +181,7 @@ impl ERC20Test {
         self
     }
 
-    pub fn call_erc20_buy(mut self, sender: PublicKey, amount: U512) -> Self {
+    pub fn call_erc20_buy(mut self, sender: AccountHash, amount: U512) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
             sender,
             self.get_proxy_hash(),
@@ -192,7 +192,7 @@ impl ERC20Test {
         self
     }
 
-    pub fn call_erc20_sell(mut self, sender: PublicKey, amount: U512) -> Self {
+    pub fn call_erc20_sell(mut self, sender: AccountHash, amount: U512) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
             sender,
             self.get_proxy_hash(),
@@ -205,8 +205,8 @@ impl ERC20Test {
 
     pub fn call_clx_transfer_with_success(
         mut self,
-        sender: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        recipient: AccountHash,
         amount: U512,
     ) -> Self {
         let request =
@@ -232,7 +232,7 @@ impl ERC20Test {
         self
     }
 
-    pub fn assert_clx_account_balance_no_gas(self, account: PublicKey, expected: U512) -> Self {
+    pub fn assert_clx_account_balance_no_gas(self, account: AccountHash, expected: U512) -> Self {
         let account_purse = self.builder.get_account(account).unwrap().main_purse();
         let mut account_balance = self.builder.get_purse_balance(account_purse);
         let last_deploy_index = self.builder.get_exec_responses_count();
@@ -267,7 +267,7 @@ impl ERC20Test {
     /// Balances are stored in the local storage and are represented as 33 bytes arrays where:
     /// - the first byte is "1";
     /// - the rest is 32 bytes of the account's public key.
-    pub fn assert_erc20_balance(self, address: PublicKey, expected: U512) -> Self {
+    pub fn assert_erc20_balance(self, address: AccountHash, expected: U512) -> Self {
         let mut balance_bytes: Vec<u8> = Vec::with_capacity(33);
         balance_bytes.extend(&[1]);
         balance_bytes.extend(address.as_bytes());
@@ -304,8 +304,8 @@ impl ERC20Test {
     /// - the second 32 bytes are token spender's public key.
     pub fn assert_erc20_allowance(
         self,
-        owner: PublicKey,
-        spender: PublicKey,
+        owner: AccountHash,
+        spender: AccountHash,
         expected: U512,
     ) -> Self {
         let allowance_bytes: Vec<u8> = owner
@@ -339,7 +339,7 @@ impl ERC20Test {
             .unwrap_or_else(|| panic!("Field proxy_hash not set."))
     }
 
-    pub fn with_contract(mut self, sender: PublicKey, token_name: &str) -> Self {
+    pub fn with_contract(mut self, sender: AccountHash, token_name: &str) -> Self {
         self.token_hash = Some(self.query_contract_hash(sender, token_name));
         self.proxy_hash = Some(self.query_contract_hash(sender, UREF_NAME_ERC20_PROXY));
         self

--- a/execution-engine/engine-tests/src/test/examples/erc20/mod.rs
+++ b/execution-engine/engine-tests/src/test/examples/erc20/mod.rs
@@ -1,13 +1,13 @@
 mod erc20_test;
 
 use engine_test_support::{DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE};
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 use erc20_test::ERC20Test;
 
-const ACCOUNT_1: PublicKey = DEFAULT_ACCOUNT_ADDR;
-const ACCOUNT_2: PublicKey = PublicKey::ed25519_from([2u8; 32]);
-const ACCOUNT_3: PublicKey = PublicKey::ed25519_from([3u8; 32]);
+const ACCOUNT_1: AccountHash = DEFAULT_ACCOUNT_ADDR;
+const ACCOUNT_2: AccountHash = AccountHash::new([2u8; 32]);
+const ACCOUNT_3: AccountHash = AccountHash::new([3u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/examples/keys_manager.rs
+++ b/execution-engine/engine-tests/src/test/examples/keys_manager.rs
@@ -4,23 +4,23 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::account::{PublicKey, Weight};
+use types::account::{AccountHash, Weight};
 
 const CONTRACT_WASM: &str = "keys_manager.wasm";
 const METHOD_SET_KEY_WEIGHT: &str = "set_key_weight";
 const METHOD_SET_DEPLOYMENT_THRESHOLD: &str = "set_deployment_threshold";
 const METHOD_SET_KEY_MANAGEMENT_THRESHOLD: &str = "set_key_management_threshold";
 
-const ALICE: PublicKey = DEFAULT_ACCOUNT_ADDR;
-const BOB: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const ALICE: AccountHash = DEFAULT_ACCOUNT_ADDR;
+const BOB: AccountHash = AccountHash::new([2u8; 32]);
 
 struct KeysManagerTest {
     pub builder: TestBuilder,
-    pub sender: PublicKey,
+    pub sender: AccountHash,
 }
 
 impl KeysManagerTest {
-    pub fn new(sender: PublicKey) -> KeysManagerTest {
+    pub fn new(sender: AccountHash) -> KeysManagerTest {
         let mut builder = TestBuilder::default();
         builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST).commit();
         KeysManagerTest { builder, sender }
@@ -31,7 +31,7 @@ impl KeysManagerTest {
         self
     }
 
-    pub fn set_key_weight(mut self, key: PublicKey, weight: Weight) -> Self {
+    pub fn set_key_weight(mut self, key: AccountHash, weight: Weight) -> Self {
         let request = ExecuteRequestBuilder::standard(
             self.sender,
             CONTRACT_WASM,
@@ -58,11 +58,12 @@ impl KeysManagerTest {
         self.update_threshold(METHOD_SET_KEY_MANAGEMENT_THRESHOLD, threshold)
     }
 
-    pub fn assert_keys(self, mut expected: Vec<(PublicKey, Weight)>) -> Self {
+    pub fn assert_keys(self, mut expected: Vec<(AccountHash, Weight)>) -> Self {
         // Get and sort existing keys.
         let account = self.builder.get_account(self.sender).unwrap();
         let keys_iter = account.get_associated_keys();
-        let mut keys: Vec<(PublicKey, Weight)> = keys_iter.map(|pair| (*pair.0, *pair.1)).collect();
+        let mut keys: Vec<(AccountHash, Weight)> =
+            keys_iter.map(|pair| (*pair.0, *pair.1)).collect();
         keys.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
 
         // Sort and parse expected keys.

--- a/execution-engine/engine-tests/src/test/examples/tic_tac_toe.rs
+++ b/execution-engine/engine-tests/src/test/examples/tic_tac_toe.rs
@@ -1,6 +1,8 @@
 extern crate alloc;
 
-use engine_test_support::{Code, Hash, PublicKey, SessionBuilder, TestContext, TestContextBuilder};
+use engine_test_support::{
+    AccountHash, Code, Hash, SessionBuilder, TestContext, TestContextBuilder,
+};
 
 use types::{Key, U512};
 
@@ -14,8 +16,8 @@ mod method {
     pub const CONCEDE: &str = "concede";
 }
 
-const PLAYER_X: PublicKey = PublicKey::ed25519_from([1u8; 32]);
-const PLAYER_O: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const PLAYER_X: AccountHash = AccountHash::new([1u8; 32]);
+const PLAYER_O: AccountHash = AccountHash::new([2u8; 32]);
 
 pub struct GameTest {
     pub context: TestContext,
@@ -52,7 +54,7 @@ impl GameTest {
         self
     }
 
-    pub fn concede(mut self, player: PublicKey) -> Self {
+    pub fn concede(mut self, player: AccountHash) -> Self {
         let proxy = Code::Hash(self.proxy_contract_hash());
         let args = (self.game_contract_hash(), method::CONCEDE);
         let session = SessionBuilder::new(proxy, args)
@@ -63,7 +65,7 @@ impl GameTest {
         self
     }
 
-    pub fn make_move(mut self, player: PublicKey, move_x: u32, move_y: u32) -> Self {
+    pub fn make_move(mut self, player: AccountHash, move_x: u32, move_y: u32) -> Self {
         let proxy = Code::Hash(self.proxy_contract_hash());
         let args = (self.game_contract_hash(), method::MOVE, move_x, move_y);
         let session = SessionBuilder::new(proxy, args)
@@ -93,7 +95,7 @@ impl GameTest {
         self.contract_hash(GAME_PROXY_CONTRACT_NAME)
     }
 
-    pub fn player_status(&self, player: PublicKey) -> String {
+    pub fn player_status(&self, player: AccountHash) -> String {
         let key: String = format!("{}", player);
         self.context
             .query(PLAYER_X, &[GAME_CONTRACT_NAME, key.as_str()])
@@ -105,8 +107,8 @@ impl GameTest {
     pub fn assert_player_in_game(
         self,
         playing_as: &str,
-        player: PublicKey,
-        opponent: PublicKey,
+        player: AccountHash,
+        opponent: AccountHash,
     ) -> Self {
         let val = self.player_status(player);
         let expected = format!("playing as {} against {}", playing_as, opponent);
@@ -114,28 +116,28 @@ impl GameTest {
         self
     }
 
-    pub fn assert_player_won(self, player: PublicKey, opponent: PublicKey) -> Self {
+    pub fn assert_player_won(self, player: AccountHash, opponent: AccountHash) -> Self {
         let val = self.player_status(player);
         let expected = format!("victorious against {}", opponent);
         assert_eq!(val, expected);
         self
     }
 
-    pub fn assert_player_lost(self, player: PublicKey, opponent: PublicKey) -> Self {
+    pub fn assert_player_lost(self, player: AccountHash, opponent: AccountHash) -> Self {
         let val = self.player_status(player);
         let expected = format!("defeated by {}", opponent);
         assert_eq!(val, expected);
         self
     }
 
-    pub fn assert_player_draw(self, player: PublicKey, opponent: PublicKey) -> Self {
+    pub fn assert_player_draw(self, player: AccountHash, opponent: AccountHash) -> Self {
         let val = self.player_status(player);
         let expected = format!("draw against {}", opponent);
         assert_eq!(val, expected);
         self
     }
 
-    pub fn assert_board_status(self, pk1: PublicKey, pk2: PublicKey, expected: &str) -> Self {
+    pub fn assert_board_status(self, pk1: AccountHash, pk2: AccountHash, expected: &str) -> Self {
         let key: String = if pk1 > pk2 {
             format!("Game {} vs {}", pk1, pk2)
         } else {

--- a/execution-engine/engine-tests/src/test/examples/vesting/mod.rs
+++ b/execution-engine/engine-tests/src/test/examples/vesting/mod.rs
@@ -1,13 +1,13 @@
 mod vesting_test;
 
 use engine_test_support::{DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE};
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 use vesting_test::{VestingConfig, VestingTest};
 
-const FAUCET: PublicKey = DEFAULT_ACCOUNT_ADDR;
-const RECIPIENT: PublicKey = PublicKey::ed25519_from([2u8; 32]);
-const ADMIN: PublicKey = PublicKey::ed25519_from([3u8; 32]);
+const FAUCET: AccountHash = DEFAULT_ACCOUNT_ADDR;
+const RECIPIENT: AccountHash = AccountHash::new([2u8; 32]);
+const ADMIN: AccountHash = AccountHash::new([3u8; 32]);
 
 const NOT_ADMIN_ERROR_CODE: u32 = 65544;
 const NOT_RECIPIENT_ERROR_CODE: u32 = 65545;

--- a/execution-engine/engine-tests/src/test/examples/vesting/vesting_test.rs
+++ b/execution-engine/engine-tests/src/test/examples/vesting/vesting_test.rs
@@ -6,7 +6,7 @@ use engine_test_support::internal::{
     utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder as TestBuilder,
     DEFAULT_RUN_GENESIS_REQUEST,
 };
-use types::{account::PublicKey, bytesrepr::FromBytes, ApiError, CLTyped, CLValue, Key, U512};
+use types::{account::AccountHash, bytesrepr::FromBytes, ApiError, CLTyped, CLValue, Key, U512};
 
 const TRANFER_TO_ACCOUNT_WASM: &str = "transfer_to_account_u512.wasm";
 const VESTING_CONTRACT_WASM: &str = "vesting_smart_contract.wasm";
@@ -66,9 +66,9 @@ pub struct VestingTest {
 
 impl VestingTest {
     pub fn new(
-        sender: PublicKey,
-        admin: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        admin: AccountHash,
+        recipient: AccountHash,
         vesting_config: &VestingConfig,
     ) -> VestingTest {
         let mut builder = TestBuilder::default();
@@ -100,7 +100,7 @@ impl VestingTest {
         self
     }
 
-    pub fn with_contract(mut self, sender: PublicKey, vesting_contract_name: &str) -> Self {
+    pub fn with_contract(mut self, sender: AccountHash, vesting_contract_name: &str) -> Self {
         self.vesting_hash = Some(self.query_contract_hash(sender, vesting_contract_name));
         self.proxy_hash = Some(self.query_contract_hash(sender, VESTING_PROXY_CONTRACT_NAME));
         self
@@ -121,7 +121,7 @@ impl VestingTest {
             .unwrap_or_else(|| panic!("Field proxy_hash not set."))
     }
 
-    pub fn query_contract_hash(&self, account: PublicKey, name: &str) -> [u8; 32] {
+    pub fn query_contract_hash(&self, account: AccountHash, name: &str) -> [u8; 32] {
         let account_key = Key::Account(account);
         let value: CLValue = self
             .builder
@@ -134,9 +134,9 @@ impl VestingTest {
 
     pub fn deploy_vesting_contract(
         mut self,
-        sender: PublicKey,
-        admin: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        admin: AccountHash,
+        recipient: AccountHash,
         vesting_config: &VestingConfig,
     ) -> Self {
         let request = ExecuteRequestBuilder::standard(
@@ -161,7 +161,7 @@ impl VestingTest {
         self
     }
 
-    pub fn call_vesting_pause(mut self, sender: PublicKey) -> Self {
+    pub fn call_vesting_pause(mut self, sender: AccountHash) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
             sender,
             self.get_proxy_hash(),
@@ -173,7 +173,7 @@ impl VestingTest {
         self
     }
 
-    pub fn call_vesting_unpause(mut self, sender: PublicKey) -> Self {
+    pub fn call_vesting_unpause(mut self, sender: AccountHash) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
             sender,
             self.get_proxy_hash(),
@@ -185,7 +185,7 @@ impl VestingTest {
         self
     }
 
-    pub fn call_withdraw(mut self, sender: PublicKey, amount: U512) -> Self {
+    pub fn call_withdraw(mut self, sender: AccountHash, amount: U512) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
             sender,
             self.get_proxy_hash(),
@@ -197,7 +197,7 @@ impl VestingTest {
         self
     }
 
-    pub fn call_admin_release(mut self, sender: PublicKey) -> Self {
+    pub fn call_admin_release(mut self, sender: AccountHash) -> Self {
         let request = ExecuteRequestBuilder::contract_call_by_hash(
             sender,
             self.get_proxy_hash(),
@@ -211,8 +211,8 @@ impl VestingTest {
 
     pub fn call_clx_transfer_with_success(
         mut self,
-        sender: PublicKey,
-        recipient: PublicKey,
+        sender: AccountHash,
+        recipient: AccountHash,
         amount: U512,
     ) -> Self {
         let request =
@@ -242,7 +242,7 @@ impl VestingTest {
         self
     }
 
-    pub fn assert_clx_account_balance_no_gas(self, account: PublicKey, expected: U512) -> Self {
+    pub fn assert_clx_account_balance_no_gas(self, account: AccountHash, expected: U512) -> Self {
         let account_purse = self.builder.get_account(account).unwrap().main_purse();
         let mut account_balance = self.builder.get_purse_balance(account_purse);
         let last_deploy_index = self.builder.get_exec_responses_count();

--- a/execution-engine/engine-tests/src/test/explorer/faucet.rs
+++ b/execution-engine/engine-tests/src/test/explorer/faucet.rs
@@ -2,10 +2,10 @@ use engine_test_support::{
     internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 const FAUCET_CONTRACT: &str = "faucet.wasm";
-const NEW_ACCOUNT_ADDR: PublicKey = PublicKey::ed25519_from([99u8; 32]);
+const NEW_ACCOUNT_ADDR: AccountHash = AccountHash::new([99u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/explorer/faucet_stored.rs
+++ b/execution-engine/engine-tests/src/test/explorer/faucet_stored.rs
@@ -5,12 +5,12 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 const FAUCET: &str = "faucet";
 const STANDARD_PAYMENT_CONTRACT_NAME: &str = "standard_payment";
 const STORE_AT_HASH: &str = "hash";
-const NEW_ACCOUNT_ADDR: PublicKey = PublicKey::ed25519_from([99u8; 32]);
+const NEW_ACCOUNT_ADDR: AccountHash = AccountHash::new([99u8; 32]);
 
 fn get_builder() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();

--- a/execution-engine/engine-tests/src/test/regression/ee_532.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_532.rs
@@ -2,10 +2,10 @@ use engine_core::engine_state::Error;
 use engine_test_support::internal::{
     ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST,
 };
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 const CONTRACT_EE_532_REGRESSION: &str = "ee_532_regression.wasm";
-const UNKNOWN_ADDR: PublicKey = PublicKey::ed25519_from([42u8; 32]);
+const UNKNOWN_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/regression/ee_550.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_550.rs
@@ -5,7 +5,7 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::account::PublicKey;
+use types::account::AccountHash;
 
 const PASS_INIT_REMOVE: &str = "init_remove";
 const PASS_TEST_REMOVE: &str = "test_remove";
@@ -34,7 +34,7 @@ fn should_run_ee_550_remove_with_saturated_threshold_regression() {
                 (String::from(PASS_TEST_REMOVE),),
             )
             .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,))
-            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR, PublicKey::ed25519_from(KEY_2_ADDR)])
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR, AccountHash::new(KEY_2_ADDR)])
             .with_deploy_hash(DEPLOY_HASH)
             .build();
 
@@ -71,7 +71,7 @@ fn should_run_ee_550_update_with_saturated_threshold_regression() {
                 (String::from(PASS_TEST_UPDATE),),
             )
             .with_payment_code(STANDARD_PAYMENT_CONTRACT, (*DEFAULT_PAYMENT,))
-            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR, PublicKey::ed25519_from(KEY_2_ADDR)])
+            .with_authorization_keys(&[DEFAULT_ACCOUNT_ADDR, AccountHash::new(KEY_2_ADDR)])
             .with_deploy_hash(DEPLOY_HASH)
             .build();
 

--- a/execution-engine/engine-tests/src/test/regression/ee_572.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_572.rs
@@ -6,15 +6,15 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key, U512};
+use types::{account::AccountHash, Key, U512};
 
 const CONTRACT_CREATE: &str = "ee_572_regression_create.wasm";
 const CONTRACT_ESCALATE: &str = "ee_572_regression_escalate.wasm";
 const CONTRACT_TRANSFER: &str = "transfer_purse_to_account.wasm";
 const CREATE: &str = "create";
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
-const ACCOUNT_2_ADDR: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
+const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([2u8; 32]);
 
 #[ignore]
 #[test]

--- a/execution-engine/engine-tests/src/test/regression/ee_598.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_598.rs
@@ -9,10 +9,10 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, ApiError, U512};
+use types::{account::AccountHash, ApiError, U512};
 
 const CONTRACT_POS_BONDING: &str = "pos_bonding.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([7u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([7u8; 32]);
 
 const GENESIS_VALIDATOR_STAKE: u64 = 50_000;
 lazy_static! {
@@ -27,7 +27,7 @@ fn should_fail_unboding_more_than_it_was_staked_ee_598_regression() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::new(
-            PublicKey::ed25519_from([42; 32]),
+            AccountHash::new([42; 32]),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );

--- a/execution-engine/engine-tests/src/test/regression/ee_599.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_599.rs
@@ -9,14 +9,14 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_EE_599_REGRESSION: &str = "ee_599_regression.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
 const DONATION_PURSE_COPY_KEY: &str = "donation_purse_copy";
 const EXPECTED_ERROR: &str = "InvalidContext";
 const TRANSFER_FUNDS_KEY: &str = "transfer_funds";
-const VICTIM_ADDR: PublicKey = PublicKey::ed25519_from([42; 32]);
+const VICTIM_ADDR: AccountHash = AccountHash::new([42; 32]);
 
 lazy_static! {
     static ref VICTIM_INITIAL_FUNDS: U512 = *DEFAULT_PAYMENT * 10;

--- a/execution-engine/engine-tests/src/test/regression/ee_601.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_601.rs
@@ -11,7 +11,7 @@ use types::{CLValue, Key};
 #[ignore]
 #[test]
 fn should_run_ee_601_pay_session_new_uref_collision() {
-    let genesis_public_key = DEFAULT_ACCOUNT_ADDR;
+    let genesis_account_hash = DEFAULT_ACCOUNT_ADDR;
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()
@@ -19,7 +19,7 @@ fn should_run_ee_601_pay_session_new_uref_collision() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_payment_code("ee_601_regression.wasm", (*DEFAULT_PAYMENT,))
             .with_session_code("ee_601_regression.wasm", ())
-            .with_authorization_keys(&[genesis_public_key])
+            .with_authorization_keys(&[genesis_account_hash])
             .build();
 
         ExecuteRequestBuilder::new().push_deploy(deploy).build()

--- a/execution-engine/engine-tests/src/test/regression/ee_803.rs
+++ b/execution-engine/engine-tests/src/test/regression/ee_803.rs
@@ -10,14 +10,14 @@ use engine_test_support::{
     internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key, URef, U512};
+use types::{account::AccountHash, Key, URef, U512};
 
 const CONTRACT_DO_NOTHING: &str = "do_nothing.wasm";
 const CONTRACT_TRANSFER: &str = "transfer_purse_to_account.wasm";
 const CONTRACT_EE_803_REGRESSION: &str = "ee_803_regression.wasm";
 const COMMAND_BOND: &str = "bond";
 const COMMAND_UNBOND: &str = "unbond";
-const ACCOUNT_ADDR_1: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_ADDR_1: AccountHash = AccountHash::new([1u8; 32]);
 const GENESIS_VALIDATOR_STAKE: u64 = 50_000;
 
 fn get_pos_purse_by_name(builder: &InMemoryWasmTestBuilder, purse_name: &str) -> Option<URef> {
@@ -53,7 +53,7 @@ fn should_not_be_able_to_unbond_reward() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::new(
-            PublicKey::ed25519_from([42; 32]),
+            AccountHash::new([42; 32]),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -8,14 +8,14 @@ use engine_test_support::internal::{
     utils, InMemoryWasmTestBuilder, DEFAULT_WASM_COSTS, MINT_INSTALL_CONTRACT,
     POS_INSTALL_CONTRACT, STANDARD_PAYMENT_INSTALL_CONTRACT,
 };
-use types::{account::PublicKey, Key, ProtocolVersion, U512};
+use types::{account::AccountHash, Key, ProtocolVersion, U512};
 
 #[cfg(feature = "use-system-contracts")]
 const BAD_INSTALL: &str = "standard_payment.wasm";
 
 const GENESIS_CONFIG_HASH: [u8; 32] = [127; 32];
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
-const ACCOUNT_2_ADDR: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
+const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([2u8; 32]);
 const ACCOUNT_1_BONDED_AMOUNT: u64 = 1_000_000;
 const ACCOUNT_2_BONDED_AMOUNT: u64 = 2_000_000;
 const ACCOUNT_1_BALANCE: u64 = 1_000_000_000;

--- a/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/genesis.rs
@@ -26,10 +26,10 @@ const ACCOUNT_2_BALANCE: u64 = 2_000_000_000;
 fn should_run_genesis() {
     let account_1_balance = Motes::new(ACCOUNT_1_BALANCE.into());
     let account_1 = {
-        let account_1_public_key = ACCOUNT_1_ADDR;
+        let account_1_account_hash = ACCOUNT_1_ADDR;
         let account_1_bonded_amount = Motes::new(ACCOUNT_1_BONDED_AMOUNT.into());
         GenesisAccount::new(
-            account_1_public_key,
+            account_1_account_hash,
             account_1_balance,
             account_1_bonded_amount,
         )
@@ -37,10 +37,10 @@ fn should_run_genesis() {
 
     let account_2_balance = Motes::new(ACCOUNT_2_BALANCE.into());
     let account_2 = {
-        let account_2_public_key = ACCOUNT_2_ADDR;
+        let account_2_account_hash = ACCOUNT_2_ADDR;
         let account_2_bonded_amount = Motes::new(ACCOUNT_2_BONDED_AMOUNT.into());
         GenesisAccount::new(
-            account_2_public_key,
+            account_2_account_hash,
             account_2_balance,
             account_2_bonded_amount,
         )
@@ -111,21 +111,21 @@ fn should_run_genesis() {
 fn should_fail_if_bad_mint_install_contract_is_provided() {
     let run_genesis_request = {
         let account_1 = {
-            let account_1_public_key = ACCOUNT_1_ADDR;
+            let account_1_account_hash = ACCOUNT_1_ADDR;
             let account_1_balance = Motes::new(ACCOUNT_1_BALANCE.into());
             let account_1_bonded_amount = Motes::new(ACCOUNT_1_BONDED_AMOUNT.into());
             GenesisAccount::new(
-                account_1_public_key,
+                account_1_account_hash,
                 account_1_balance,
                 account_1_bonded_amount,
             )
         };
         let account_2 = {
-            let account_2_public_key = ACCOUNT_2_ADDR;
+            let account_2_account_hash = ACCOUNT_2_ADDR;
             let account_2_balance = Motes::new(ACCOUNT_2_BALANCE.into());
             let account_2_bonded_amount = Motes::new(ACCOUNT_2_BONDED_AMOUNT.into());
             GenesisAccount::new(
-                account_2_public_key,
+                account_2_account_hash,
                 account_2_balance,
                 account_2_bonded_amount,
             )
@@ -160,21 +160,21 @@ fn should_fail_if_bad_mint_install_contract_is_provided() {
 fn should_fail_if_bad_pos_install_contract_is_provided() {
     let run_genesis_request = {
         let account_1 = {
-            let account_1_public_key = ACCOUNT_1_ADDR;
+            let account_1_account_hash = ACCOUNT_1_ADDR;
             let account_1_balance = Motes::new(ACCOUNT_1_BALANCE.into());
             let account_1_bonded_amount = Motes::new(ACCOUNT_1_BONDED_AMOUNT.into());
             GenesisAccount::new(
-                account_1_public_key,
+                account_1_account_hash,
                 account_1_balance,
                 account_1_bonded_amount,
             )
         };
         let account_2 = {
-            let account_2_public_key = ACCOUNT_2_ADDR;
+            let account_2_account_hash = ACCOUNT_2_ADDR;
             let account_2_balance = Motes::new(ACCOUNT_2_BALANCE.into());
             let account_2_bonded_amount = Motes::new(ACCOUNT_2_BONDED_AMOUNT.into());
             GenesisAccount::new(
-                account_2_public_key,
+                account_2_account_hash,
                 account_2_balance,
                 account_2_bonded_amount,
             )

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -8,11 +8,11 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, AccessRights, Key, URef, U512};
+use types::{account::AccountHash, AccessRights, Key, URef, U512};
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
 const TRANSFER_AMOUNT: u64 = 250_000_000 + 1000;
-const SYSTEM_ADDR: PublicKey = PublicKey::ed25519_from([0u8; 32]);
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
 const DEPLOY_HASH_2: [u8; 32] = [2u8; 32];
 const N_VALIDATORS: u8 = 5;
 
@@ -44,8 +44,8 @@ fn should_run_pos_install_contract() {
         .expect_success();
 
     let mint_uref = URef::new(builder.get_mint_contract_uref().addr(), AccessRights::READ);
-    let genesis_validators: BTreeMap<PublicKey, U512> = (1u8..=N_VALIDATORS)
-        .map(|i| (PublicKey::ed25519_from([i; 32]), U512::from(i)))
+    let genesis_validators: BTreeMap<AccountHash, U512> = (1u8..=N_VALIDATORS)
+        .map(|i| (AccountHash::new([i; 32]), U512::from(i)))
         .collect();
 
     let total_bond = genesis_validators.values().fold(U512::zero(), |x, y| x + y);

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/bonding.rs
@@ -9,10 +9,10 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, ApiError, Key, URef, U512};
+use types::{account::AccountHash, ApiError, Key, URef, U512};
 
 const CONTRACT_POS_BONDING: &str = "pos_bonding.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 const ACCOUNT_1_SEED_AMOUNT: u64 = 100_000_000 * 2;
 const ACCOUNT_1_STAKE: u64 = 42_000;
 const ACCOUNT_1_UNBOND_1: u64 = 22_000;
@@ -50,7 +50,7 @@ fn should_run_successful_bond_and_unbond() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::new(
-            PublicKey::ed25519_from([42; 32]),
+            AccountHash::new([42; 32]),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );
@@ -424,7 +424,7 @@ fn should_fail_bonding_with_insufficient_funds() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::new(
-            PublicKey::ed25519_from([42; 32]),
+            AccountHash::new([42; 32]),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );
@@ -484,7 +484,7 @@ fn should_fail_unbonding_validator_without_bonding_first() {
     let accounts = {
         let mut tmp: Vec<GenesisAccount> = DEFAULT_ACCOUNTS.clone();
         let account = GenesisAccount::new(
-            PublicKey::ed25519_from([42; 32]),
+            AccountHash::new([42; 32]),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()) * Motes::new(2.into()),
             Motes::new(GENESIS_VALIDATOR_STAKE.into()),
         );

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/commit_validators.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/commit_validators.rs
@@ -7,14 +7,14 @@ use engine_test_support::{
     internal::{utils, ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_ACCOUNTS},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_LOCAL_STATE: &str = "local_state.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 const ACCOUNT_1_BALANCE: u64 = 2000;
 const ACCOUNT_1_BOND: u64 = 1000;
 
-const ACCOUNT_2_ADDR: PublicKey = PublicKey::ed25519_from([2u8; 32]);
+const ACCOUNT_2_ADDR: AccountHash = AccountHash::new([2u8; 32]);
 const ACCOUNT_2_BALANCE: u64 = 2000;
 const ACCOUNT_2_BOND: u64 = 200;
 
@@ -50,14 +50,14 @@ fn should_return_bonded_validators() {
         .get_bonded_validators()[0]
         .clone();
 
-    let expected: HashMap<PublicKey, U512> = {
+    let expected: HashMap<AccountHash, U512> = {
         let zero = Motes::zero();
         accounts
             .iter()
             .filter_map(move |genesis_account| {
                 if genesis_account.bonded_amount() > zero {
                     Some((
-                        genesis_account.public_key(),
+                        genesis_account.account_hash(),
                         genesis_account.bonded_amount().value(),
                     ))
                 } else {

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
@@ -106,14 +106,14 @@ fn finalize_payment_should_refund_to_specified_purse() {
     );
 
     let exec_request = {
-        let genesis_public_key = DEFAULT_ACCOUNT_ADDR;
+        let genesis_account_hash = DEFAULT_ACCOUNT_ADDR;
 
         let deploy = DeployItemBuilder::new()
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_deploy_hash([1; 32])
             .with_session_code("do_nothing.wasm", ())
             .with_payment_code(FINALIZE_PAYMENT, args)
-            .with_authorization_keys(&[genesis_public_key])
+            .with_authorization_keys(&[genesis_account_hash])
             .build();
 
         ExecuteRequestBuilder::new().push_deploy(deploy).build()

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/finalize_payment.rs
@@ -12,7 +12,7 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, Key, URef, U512};
+use types::{account::AccountHash, Key, URef, U512};
 
 const CONTRACT_FINALIZE_PAYMENT: &str = "pos_finalize_payment.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
@@ -20,8 +20,8 @@ const FINALIZE_PAYMENT: &str = "pos_finalize_payment.wasm";
 const LOCAL_REFUND_PURSE: &str = "local_refund_purse";
 const POS_REFUND_PURSE_NAME: &str = "pos_refund_purse";
 
-const SYSTEM_ADDR: PublicKey = PublicKey::ed25519_from([0u8; 32]);
-const ACCOUNT_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+const ACCOUNT_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 fn initialize() -> InMemoryWasmTestBuilder {
     let mut builder = InMemoryWasmTestBuilder::default();
@@ -85,7 +85,7 @@ fn finalize_payment_should_refund_to_specified_purse() {
     let refund_purse_flag: u8 = 1;
     // Don't need to run finalize_payment manually, it happens during
     // the deploy because payment code is enabled.
-    let args: (U512, u8, Option<U512>, Option<PublicKey>) =
+    let args: (U512, u8, Option<U512>, Option<AccountHash>) =
         (payment_amount, refund_purse_flag, None, None);
 
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
@@ -193,7 +193,7 @@ fn get_pos_purse_by_name(builder: &InMemoryWasmTestBuilder, purse_name: &str) ->
 
 fn get_named_account_balance(
     builder: &InMemoryWasmTestBuilder,
-    account_address: PublicKey,
+    account_address: AccountHash,
     name: &str,
 ) -> Option<U512> {
     let account_key = Key::Account(account_address);

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/get_payment_purse.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/get_payment_purse.rs
@@ -5,11 +5,11 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_POS_GET_PAYMENT_PURSE: &str = "pos_get_payment_purse.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 const ACCOUNT_1_INITIAL_BALANCE: u64 = 100_000_000 + 100;
 
 #[ignore]

--- a/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/refund_purse.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/proof_of_stake/refund_purse.rs
@@ -5,10 +5,10 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 #[ignore]
 #[test]
@@ -33,12 +33,12 @@ fn initialize() -> InMemoryWasmTestBuilder {
     builder
 }
 
-fn transfer(builder: &mut InMemoryWasmTestBuilder, public_key: PublicKey, amount: U512) {
+fn transfer(builder: &mut InMemoryWasmTestBuilder, account_hash: AccountHash, amount: U512) {
     let exec_request = {
         ExecuteRequestBuilder::standard(
             DEFAULT_ACCOUNT_ADDR,
             CONTRACT_TRANSFER_PURSE_TO_ACCOUNT,
-            (public_key, amount),
+            (account_hash, amount),
         )
         .build()
     };
@@ -46,14 +46,14 @@ fn transfer(builder: &mut InMemoryWasmTestBuilder, public_key: PublicKey, amount
     builder.exec(exec_request).expect_success().commit();
 }
 
-fn refund_tests(builder: &mut InMemoryWasmTestBuilder, public_key: PublicKey) {
+fn refund_tests(builder: &mut InMemoryWasmTestBuilder, account_hash: AccountHash) {
     let exec_request = {
         let deploy = DeployItemBuilder::new()
-            .with_address(public_key)
+            .with_address(account_hash)
             .with_deploy_hash([2; 32])
             .with_session_code("do_nothing.wasm", ())
             .with_payment_code("pos_refund_purse.wasm", (*DEFAULT_PAYMENT,))
-            .with_authorization_keys(&[public_key])
+            .with_authorization_keys(&[account_hash])
             .build();
 
         ExecuteRequestBuilder::new().push_deploy(deploy).build()

--- a/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
@@ -12,9 +12,9 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR, DEFAULT_ACCOUNT_INITIAL_BALANCE,
 };
-use types::{account::PublicKey, ApiError, Key, URef, U512};
+use types::{account::AccountHash, ApiError, Key, URef, U512};
 
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([42u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([42u8; 32]);
 const DO_NOTHING_WASM: &str = "do_nothing.wasm";
 const TRANSFER_PURSE_TO_ACCOUNT_WASM: &str = "transfer_purse_to_account.wasm";
 const REVERT_WASM: &str = "revert.wasm";
@@ -23,12 +23,12 @@ const ENDLESS_LOOP_WASM: &str = "endless_loop.wasm";
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
 
     let exec_request = ExecuteRequestBuilder::standard(
         DEFAULT_ACCOUNT_ADDR,
         TRANSFER_PURSE_TO_ACCOUNT_WASM,
-        (account_1_public_key, U512::from(MAX_PAYMENT - 1)),
+        (account_1_account_hash, U512::from(MAX_PAYMENT - 1)),
     )
     .build();
 
@@ -75,7 +75,7 @@ fn should_raise_insufficient_payment_when_caller_lacks_minimum_balance() {
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
 
     let exec_request = {
         let deploy = DeployItemBuilder::new()
@@ -83,7 +83,7 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
             .with_deploy_hash([1; 32])
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, U512::from(1)),
+                (account_1_account_hash, U512::from(1)),
             )
             .with_empty_payment_bytes((U512::from(1),))
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
@@ -147,7 +147,7 @@ fn should_raise_insufficient_payment_when_payment_code_does_not_pay_enough() {
 #[ignore]
 #[test]
 fn should_raise_insufficient_payment_error_when_out_of_gas() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount: U512 = U512::from(1);
     let transferred_amount = U512::from(1);
 
@@ -158,7 +158,7 @@ fn should_raise_insufficient_payment_error_when_out_of_gas() {
             .with_empty_payment_bytes((payment_purse_amount,))
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, transferred_amount),
+                (account_1_account_hash, transferred_amount),
             )
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
             .build();
@@ -221,7 +221,7 @@ fn should_raise_insufficient_payment_error_when_out_of_gas() {
 #[ignore]
 #[test]
 fn should_forward_payment_execution_runtime_error() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let transferred_amount = U512::from(1);
 
     let exec_request = {
@@ -231,7 +231,7 @@ fn should_forward_payment_execution_runtime_error() {
             .with_payment_code(REVERT_WASM, ())
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, transferred_amount),
+                (account_1_account_hash, transferred_amount),
             )
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
             .build();
@@ -290,7 +290,7 @@ fn should_forward_payment_execution_runtime_error() {
 #[ignore]
 #[test]
 fn should_forward_payment_execution_gas_limit_error() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let transferred_amount = U512::from(1);
 
     let exec_request = {
@@ -300,7 +300,7 @@ fn should_forward_payment_execution_gas_limit_error() {
             .with_payment_code(ENDLESS_LOOP_WASM, ())
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, transferred_amount),
+                (account_1_account_hash, transferred_amount),
             )
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
             .build();
@@ -356,7 +356,7 @@ fn should_forward_payment_execution_gas_limit_error() {
 #[ignore]
 #[test]
 fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 
@@ -367,7 +367,7 @@ fn should_run_out_of_gas_when_session_code_exceeds_gas_limit() {
             .with_empty_payment_bytes((U512::from(payment_purse_amount),))
             .with_session_code(
                 ENDLESS_LOOP_WASM,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
             .build();
@@ -452,7 +452,7 @@ fn should_correctly_charge_when_session_code_runs_out_of_gas() {
 #[ignore]
 #[test]
 fn should_correctly_charge_when_session_code_fails() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 
@@ -463,7 +463,7 @@ fn should_correctly_charge_when_session_code_fails() {
             .with_empty_payment_bytes((U512::from(payment_purse_amount),))
             .with_session_code(
                 REVERT_WASM,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
             .build();

--- a/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/standard_payment.rs
@@ -509,7 +509,7 @@ fn should_correctly_charge_when_session_code_fails() {
 #[ignore]
 #[test]
 fn should_correctly_charge_when_session_code_succeeds() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 
@@ -519,7 +519,7 @@ fn should_correctly_charge_when_session_code_succeeds() {
             .with_deploy_hash([1; 32])
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_empty_payment_bytes((U512::from(payment_purse_amount),))
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
@@ -588,7 +588,7 @@ fn get_pos_rewards_purse_balance(builder: &InMemoryWasmTestBuilder) -> U512 {
 #[ignore]
 #[test]
 fn should_finalize_to_rewards_purse() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 10_000_000;
     let transferred_amount = 1;
 
@@ -597,7 +597,7 @@ fn should_finalize_to_rewards_purse() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, U512::from(transferred_amount)),
+                (account_1_account_hash, U512::from(transferred_amount)),
             )
             .with_empty_payment_bytes((U512::from(payment_purse_amount),))
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
@@ -623,7 +623,7 @@ fn should_finalize_to_rewards_purse() {
 #[ignore]
 #[test]
 fn independent_standard_payments_should_not_write_the_same_keys() {
-    let account_1_public_key = ACCOUNT_1_ADDR;
+    let account_1_account_hash = ACCOUNT_1_ADDR;
     let payment_purse_amount = 10_000_000;
     let transfer_amount = 10_000_000;
 
@@ -634,7 +634,7 @@ fn independent_standard_payments_should_not_write_the_same_keys() {
             .with_address(DEFAULT_ACCOUNT_ADDR)
             .with_session_code(
                 TRANSFER_PURSE_TO_ACCOUNT_WASM,
-                (account_1_public_key, U512::from(transfer_amount)),
+                (account_1_account_hash, U512::from(transfer_amount)),
             )
             .with_empty_payment_bytes((U512::from(payment_purse_amount),))
             .with_authorization_keys(&[DEFAULT_ACCOUNT_KEY])
@@ -668,7 +668,7 @@ fn independent_standard_payments_should_not_write_the_same_keys() {
             .with_address(ACCOUNT_1_ADDR)
             .with_session_code(DO_NOTHING_WASM, ())
             .with_empty_payment_bytes((U512::from(payment_purse_amount),))
-            .with_authorization_keys(&[account_1_public_key])
+            .with_authorization_keys(&[account_1_account_hash])
             .with_deploy_hash([1; 32])
             .build();
 

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contract_urefs_access_rights.rs
@@ -7,12 +7,12 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, U512};
+use types::{account::AccountHash, U512};
 
 const CONTRACT_CHECK_SYSTEM_CONTRACT_UREFS_ACCESS_RIGHTS: &str =
     "check_system_contract_urefs_access_rights.wasm";
 const CONTRACT_TRANSFER_PURSE_TO_ACCOUNT: &str = "transfer_purse_to_account.wasm";
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 lazy_static! {
     static ref ACCOUNT_1_INITIAL_BALANCE: U512 = *DEFAULT_PAYMENT;

--- a/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/system_contracts_access.rs
@@ -10,21 +10,21 @@ use engine_test_support::{
     },
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, URef, U512};
+use types::{account::AccountHash, URef, U512};
 
 const CONTRACT_SYSTEM_CONTRACTS_ACCESS: &str = "system_contracts_access.wasm";
 const CONTRACT_OVERWRITE_UREF_CONTENT: &str = "overwrite_uref_content.wasm";
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
 
-const SYSTEM_ADDR: PublicKey = PublicKey::ed25519_from([0u8; 32]);
-const ACCOUNT_1_ADDR: PublicKey = PublicKey::ed25519_from([1u8; 32]);
+const SYSTEM_ADDR: AccountHash = AccountHash::new([0u8; 32]);
+const ACCOUNT_1_ADDR: AccountHash = AccountHash::new([1u8; 32]);
 
 lazy_static! {
     static ref ACCOUNT_1_INITIAL_BALANCE: U512 = *DEFAULT_PAYMENT * 10;
     static ref SYSTEM_INITIAL_BALANCE: U512 = *DEFAULT_PAYMENT * 10;
 }
 
-fn run_test_with_address(builder: &mut InMemoryWasmTestBuilder, address: PublicKey) {
+fn run_test_with_address(builder: &mut InMemoryWasmTestBuilder, address: AccountHash) {
     let exec_request =
         ExecuteRequestBuilder::standard(address, CONTRACT_SYSTEM_CONTRACTS_ACCESS, ()).build();
 
@@ -53,7 +53,7 @@ fn should_verify_system_contracts_access_rights_default() {
     run_test_with_address(&mut builder, ACCOUNT_1_ADDR);
 }
 
-fn overwrite_as_account(builder: &mut InMemoryWasmTestBuilder, uref: URef, address: PublicKey) {
+fn overwrite_as_account(builder: &mut InMemoryWasmTestBuilder, uref: URef, address: AccountHash) {
     let exec_request =
         ExecuteRequestBuilder::standard(address, CONTRACT_OVERWRITE_UREF_CONTENT, (uref,)).build();
 

--- a/execution-engine/mint/src/lib.rs
+++ b/execution-engine/mint/src/lib.rs
@@ -5,11 +5,11 @@ mod storage_provider;
 
 use core::convert::TryFrom;
 
-use types::{account::PublicKey, system_contract_errors::mint::Error, Key, URef, U512};
+use types::{account::AccountHash, system_contract_errors::mint::Error, Key, URef, U512};
 
 pub use crate::{runtime_provider::RuntimeProvider, storage_provider::StorageProvider};
 
-const SYSTEM_ACCOUNT: PublicKey = PublicKey::ed25519_from([0; 32]);
+const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0; 32]);
 
 pub trait Mint: RuntimeProvider + StorageProvider {
     fn mint(&mut self, initial_balance: U512) -> Result<URef, Error> {

--- a/execution-engine/mint/src/runtime_provider.rs
+++ b/execution-engine/mint/src/runtime_provider.rs
@@ -1,7 +1,7 @@
-use types::{account::PublicKey, Key};
+use types::{account::AccountHash, Key};
 
 pub trait RuntimeProvider {
-    fn get_caller(&self) -> PublicKey;
+    fn get_caller(&self) -> AccountHash;
 
     fn put_key(&mut self, name: &str, key: Key);
 }

--- a/execution-engine/proof-of-stake/src/lib.rs
+++ b/execution-engine/proof-of-stake/src/lib.rs
@@ -12,7 +12,7 @@ mod stakes_provider;
 use core::marker::Sized;
 
 use types::{
-    account::PublicKey,
+    account::AccountHash,
     system_contract_errors::pos::{Error, Result},
     AccessRights, TransferredTo, URef, U512,
 };
@@ -25,7 +25,7 @@ pub use crate::{
 pub trait ProofOfStake:
     MintProvider + QueueProvider + RuntimeProvider + StakesProvider + Sized
 {
-    fn bond(&mut self, validator: PublicKey, amount: U512, source: URef) -> Result<()> {
+    fn bond(&mut self, validator: AccountHash, amount: U512, source: URef) -> Result<()> {
         if amount.is_zero() {
             return Err(Error::BondTooSmall);
         }
@@ -47,7 +47,7 @@ pub trait ProofOfStake:
         Ok(())
     }
 
-    fn unbond(&mut self, validator: PublicKey, maybe_amount: Option<U512>) -> Result<()> {
+    fn unbond(&mut self, validator: AccountHash, maybe_amount: Option<U512>) -> Result<()> {
         let pos_purse = internal::get_bonding_purse(self)?;
         let timestamp = self.get_block_time();
         internal::unbond(self, maybe_amount, validator, timestamp)?;
@@ -79,7 +79,7 @@ pub trait ProofOfStake:
         Ok(maybe_purse.map(|p| p.remove_access_rights()))
     }
 
-    fn finalize_payment(&mut self, amount_spent: U512, account: PublicKey) -> Result<()> {
+    fn finalize_payment(&mut self, amount_spent: U512, account: AccountHash) -> Result<()> {
         internal::finalize_payment(self, amount_spent, account)
     }
 }
@@ -88,7 +88,7 @@ mod internal {
     use alloc::vec::Vec;
 
     use types::{
-        account::PublicKey,
+        account::AccountHash,
         system_contract_errors::pos::{Error, PurseLookupError, Result},
         BlockTime, Key, Phase, URef, U512,
     };
@@ -99,7 +99,7 @@ mod internal {
     };
 
     /// Account used to run system functions (in particular `finalize_payment`).
-    const SYSTEM_ACCOUNT: PublicKey = PublicKey::ed25519_from([0u8; 32]);
+    const SYSTEM_ACCOUNT: AccountHash = AccountHash::new([0u8; 32]);
 
     /// The uref name where the PoS purse is stored. It contains all staked motes, and all unbonded
     /// motes that are yet to be paid out.
@@ -132,7 +132,7 @@ mod internal {
     pub fn bond<P: QueueProvider + StakesProvider>(
         provider: &mut P,
         amount: U512,
-        validator: PublicKey,
+        validator: AccountHash,
         timestamp: BlockTime,
     ) -> Result<()> {
         let mut queue = provider.read_bonding();
@@ -158,7 +158,7 @@ mod internal {
     pub fn unbond<P: QueueProvider + StakesProvider>(
         provider: &mut P,
         maybe_amount: Option<U512>,
-        validator: PublicKey,
+        validator: AccountHash,
         timestamp: BlockTime,
     ) -> Result<()> {
         let mut queue = provider.read_unbonding();
@@ -261,7 +261,7 @@ mod internal {
     pub fn finalize_payment<P: MintProvider + RuntimeProvider>(
         provider: &mut P,
         amount_spent: U512,
-        account: PublicKey,
+        account: AccountHash,
     ) -> Result<()> {
         let caller = provider.get_caller();
         if caller != SYSTEM_ACCOUNT {
@@ -311,7 +311,7 @@ mod internal {
     pub fn refund_to_account<M: MintProvider>(
         mint_provider: &mut M,
         payment_purse: URef,
-        account: PublicKey,
+        account: AccountHash,
         amount: U512,
     ) -> Result<()> {
         match mint_provider.transfer_purse_to_account(payment_purse, account, amount) {
@@ -326,7 +326,7 @@ mod internal {
 
         use std::{cell::RefCell, iter, thread_local};
 
-        use types::{account::PublicKey, system_contract_errors::pos::Result, BlockTime, U512};
+        use types::{account::AccountHash, system_contract_errors::pos::Result, BlockTime, U512};
 
         use super::{bond, step, unbond, BOND_DELAY, UNBOND_DELAY};
         use crate::{
@@ -341,7 +341,7 @@ mod internal {
             static BONDING: RefCell<Queue> = RefCell::new(Queue(Default::default()));
             static UNBONDING: RefCell<Queue> = RefCell::new(Queue(Default::default()));
             static STAKES: RefCell<Stakes> = RefCell::new(
-                Stakes(iter::once((PublicKey::ed25519_from(KEY1), U512::from(1_000))).collect())
+                Stakes(iter::once((AccountHash::new(KEY1), U512::from(1_000))).collect())
             );
         }
 
@@ -379,7 +379,7 @@ mod internal {
             let expected = Stakes(
                 stakes
                     .iter()
-                    .map(|(key, amount)| (PublicKey::ed25519_from(*key), U512::from(*amount)))
+                    .map(|(key, amount)| (AccountHash::new(*key), U512::from(*amount)))
                     .collect(),
             );
             assert_eq!(Ok(expected), Provider.read());
@@ -391,7 +391,7 @@ mod internal {
             bond(
                 &mut provider,
                 U512::from(500),
-                PublicKey::ed25519_from(KEY2),
+                AccountHash::new(KEY2),
                 BlockTime::new(1),
             )
             .expect("bond validator 2");
@@ -406,7 +406,7 @@ mod internal {
             unbond::<Provider>(
                 &mut provider,
                 Some(U512::from(500)),
-                PublicKey::ed25519_from(KEY1),
+                AccountHash::new(KEY1),
                 BlockTime::new(2),
             )
             .expect("partly unbond validator 1");

--- a/execution-engine/proof-of-stake/src/mint_provider.rs
+++ b/execution-engine/proof-of-stake/src/mint_provider.rs
@@ -1,10 +1,10 @@
-use types::{account::PublicKey, TransferResult, URef, U512};
+use types::{account::AccountHash, TransferResult, URef, U512};
 
 pub trait MintProvider {
     fn transfer_purse_to_account(
         &mut self,
         source: URef,
-        target: PublicKey,
+        target: AccountHash,
         amount: U512,
     ) -> TransferResult;
 

--- a/execution-engine/proof-of-stake/src/runtime_provider.rs
+++ b/execution-engine/proof-of-stake/src/runtime_provider.rs
@@ -1,4 +1,4 @@
-use types::{account::PublicKey, BlockTime, Key, Phase};
+use types::{account::AccountHash, BlockTime, Key, Phase};
 
 pub trait RuntimeProvider {
     fn get_key(&self, name: &str) -> Option<Key>;
@@ -11,5 +11,5 @@ pub trait RuntimeProvider {
 
     fn get_block_time(&self) -> BlockTime;
 
-    fn get_caller(&self) -> PublicKey;
+    fn get_caller(&self) -> AccountHash;
 }

--- a/execution-engine/types/benches/bytesrepr_bench.rs
+++ b/execution-engine/types/benches/bytesrepr_bench.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeMap, iter};
 use test::{black_box, Bencher};
 
 use casperlabs_types::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes},
     AccessRights, CLTyped, CLValue, Key, URef, U128, U256, U512,
 };
@@ -222,14 +222,14 @@ fn deserialize_unit(b: &mut Bencher) {
 
 #[bench]
 fn serialize_key_account(b: &mut Bencher) {
-    let account = Key::Account(PublicKey::ed25519_from([0u8; 32]));
+    let account = Key::Account(AccountHash::new([0u8; 32]));
 
     b.iter(|| ToBytes::to_bytes(black_box(&account)))
 }
 
 #[bench]
 fn deserialize_key_account(b: &mut Bencher) {
-    let account = Key::Account(PublicKey::ed25519_from([0u8; 32]));
+    let account = Key::Account(AccountHash::new([0u8; 32]));
     let account_bytes = account.to_bytes().unwrap();
 
     b.iter(|| Key::from_bytes(black_box(&account_bytes)))
@@ -433,7 +433,7 @@ fn serialize_cl_value_namedkey(b: &mut Bencher) {
     b.iter(|| {
         serialize_cl_value((
             TEST_STR_1.to_string(),
-            Key::Account(PublicKey::ed25519_from([0xffu8; 32])),
+            Key::Account(AccountHash::new([0xffu8; 32])),
         ))
     });
 }
@@ -444,7 +444,7 @@ fn deserialize_cl_value_namedkey(b: &mut Bencher) {
         b,
         (
             TEST_STR_1.to_string(),
-            Key::Account(PublicKey::ed25519_from([0xffu8; 32])),
+            Key::Account(AccountHash::new([0xffu8; 32])),
         ),
     );
 }

--- a/execution-engine/types/src/account.rs
+++ b/execution-engine/types/src/account.rs
@@ -7,7 +7,6 @@ use core::{
 };
 
 use failure::Fail;
-use hex_fmt::HexFmt;
 
 use crate::{
     bytesrepr::{Error, FromBytes, ToBytes, U8_SERIALIZED_LENGTH},
@@ -143,140 +142,77 @@ impl CLTyped for Weight {
         CLType::U8
     }
 }
-/// The length in bytes of a [`PublicKey`].
-pub const ED25519_LENGTH: usize = 32;
 
-/// The number of bytes in a serialized [`Ed25519`].
-pub const ED25519_SERIALIZED_LENGTH: usize = ED25519_LENGTH;
+/// The length in bytes of a [`AccountHash`].
+pub const ACCOUNT_HASH_LENGTH: usize = 32;
 
-/// The upper bound of bytes in a serialized [`PublicKey`].
-pub const PUBLIC_KEY_SERIALIZED_MAX_LENGTH: usize = ED25519_SERIALIZED_LENGTH;
+/// The number of bytes in a serialized [`AccountHash`].
+pub const ACCOUNT_HASH_SERIALIZED_LENGTH: usize = 32;
 
-/// A type alias for the raw bytes of an Ed25519 public key.
-pub type Ed25519Bytes = [u8; ED25519_LENGTH];
+/// A type alias for the raw bytes of an Account Hash.
+pub type AccountHashBytes = [u8; ACCOUNT_HASH_LENGTH];
 
-/// A newtype wrapping a [`Ed25519Bytes`] which is the raw bytes of
-/// the public key of an Ed25519 key pair.
+/// A newtype wrapping a [`AccountHashBytes`] which is the raw bytes of
+/// the AccountHash, a hash of Public Key and Algorithm
 #[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
-pub struct Ed25519(Ed25519Bytes);
+pub struct AccountHash(AccountHashBytes);
 
-impl Ed25519 {
-    /// Constructs a new `Ed25519` instance from the raw bytes of an Ed25519 public key.
-    pub const fn new(value: Ed25519Bytes) -> Ed25519 {
-        Ed25519(value)
+impl AccountHash {
+    /// Constructs a new `AccountHash` instance from the raw bytes of an Public Key Account Hash.
+    pub const fn new(value: AccountHashBytes) -> AccountHash {
+        AccountHash(value)
     }
 
-    /// Returns the raw bytes of the public key as an array.
-    pub fn value(&self) -> Ed25519Bytes {
+    /// Returns the raw bytes of the account hash as an array.
+    pub fn value(&self) -> AccountHashBytes {
         self.0
     }
 
-    /// Returns the raw bytes of the public key as a `slice`.
+    /// Returns the raw bytes of the account hash as a `slice`.
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
-}
 
-impl Display for Ed25519 {
-    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        write!(f, "Ed25519({})", HexFmt(&self.0))
-    }
-}
-
-impl ToBytes for Ed25519 {
-    fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        self.0.to_bytes()
-    }
-
-    fn serialized_length(&self) -> usize {
-        ED25519_SERIALIZED_LENGTH
-    }
-}
-
-impl FromBytes for Ed25519 {
-    fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (bytes, rem) = <[u8; 32]>::from_bytes(bytes)?;
-        Ok((Ed25519::new(bytes), rem))
-    }
-}
-
-/// An enum of supported public key types.
-#[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy)]
-pub enum PublicKey {
-    /// An Ed25519 public key type.
-    Ed25519(Ed25519),
-}
-
-impl Display for PublicKey {
-    fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        let PublicKey::Ed25519(ed25519) = self;
-        write!(f, "PublicKey({})", ed25519)
-    }
-}
-
-impl PublicKey {
-    /// Constructs a new `PublicKey` using Ed25519 bytes.
-    pub const fn ed25519_from(key: Ed25519Bytes) -> PublicKey {
-        let ed25519 = Ed25519::new(key);
-        PublicKey::Ed25519(ed25519)
-    }
-
-    /// Attemps a new `PublicKey` creation using a slice of bytes.
-    pub fn ed25519_try_from(bytes: &[u8]) -> Result<PublicKey, TryFromSliceForPublicKeyError> {
-        Ed25519Bytes::try_from(bytes)
-            .map(PublicKey::ed25519_from)
+    /// Attemps a new `AccountHash` creation using a slice of bytes.
+    pub fn try_from(bytes: &[u8]) -> Result<AccountHash, TryFromSliceForPublicKeyError> {
+        AccountHashBytes::try_from(bytes)
+            .map(AccountHash::new)
             .map_err(|_| TryFromSliceForPublicKeyError(()))
     }
+}
 
-    /// Returns the raw bytes of the public key as an array.
-    #[doc(hidden)]
-    pub fn value(self) -> Ed25519Bytes {
-        let PublicKey::Ed25519(ed25519) = self;
-        ed25519.value()
-    }
-
-    /// Returns the raw bytes of the public key as a `slice`.
-    pub fn as_bytes(&self) -> &[u8] {
-        let PublicKey::Ed25519(ed25519) = self;
-        ed25519.as_bytes()
+impl Display for AccountHash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "AccountHash({})", self)
     }
 }
 
-impl Debug for PublicKey {
+impl Debug for AccountHash {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-impl CLTyped for PublicKey {
+impl CLTyped for AccountHash {
     fn cl_type() -> CLType {
         CLType::FixedList(Box::new(CLType::U8), 32)
     }
 }
 
-impl From<Ed25519> for PublicKey {
-    fn from(ed25519: Ed25519) -> PublicKey {
-        PublicKey::Ed25519(ed25519)
-    }
-}
-
-impl ToBytes for PublicKey {
+impl ToBytes for AccountHash {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
-        let PublicKey::Ed25519(ed25519) = self;
-        let mut bytes = Vec::with_capacity(PUBLIC_KEY_SERIALIZED_MAX_LENGTH);
-        bytes.append(&mut ed25519.to_bytes()?);
-        Ok(bytes)
+        self.0.to_bytes()
     }
 
     fn serialized_length(&self) -> usize {
-        PUBLIC_KEY_SERIALIZED_MAX_LENGTH
+        ACCOUNT_HASH_SERIALIZED_LENGTH
     }
 }
 
-impl FromBytes for PublicKey {
+impl FromBytes for AccountHash {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
-        let (ed25519, rem) = Ed25519::from_bytes(bytes)?;
-        Ok((PublicKey::from(ed25519), rem))
+        let (bytes, rem) = <[u8; 32]>::from_bytes(bytes)?;
+        Ok((AccountHash::new(bytes), rem))
     }
 }
 
@@ -391,21 +327,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ed25519_public_key_from_slice() {
+    fn account_hash_from_slice() {
         let bytes: Vec<u8> = (0..32).collect();
-        let public_key = PublicKey::ed25519_try_from(&bytes[..]).expect("should create public key");
-        assert_eq!(&bytes, &public_key.as_bytes());
+        let account_hash = AccountHash::try_from(&bytes[..]).expect("should create account hash");
+        assert_eq!(&bytes, &account_hash.as_bytes());
     }
     #[test]
-    fn ed25519_public_key_from_slice_too_small() {
-        let _public_key =
-            PublicKey::ed25519_try_from(&[0u8; 31][..]).expect_err("should not create public key");
+    fn account_hash_from_slice_too_small() {
+        let _account_hash =
+            AccountHash::try_from(&[0u8; 31][..]).expect_err("should not create account hash");
     }
 
     #[test]
-    fn ed25519_public_key_from_slice_too_big() {
-        let _public_key =
-            PublicKey::ed25519_try_from(&[0u8; 33][..]).expect_err("should not create public key");
+    fn account_hash_from_slice_too_big() {
+        let _account_hash =
+            AccountHash::try_from(&[0u8; 33][..]).expect_err("should not create account hash");
     }
 
     #[test]

--- a/execution-engine/types/src/account.rs
+++ b/execution-engine/types/src/account.rs
@@ -172,10 +172,23 @@ impl AccountHash {
     pub fn as_bytes(&self) -> &[u8] {
         &self.0
     }
+}
 
-    /// Attemps a new `AccountHash` creation using a slice of bytes.
-    pub fn try_from(bytes: &[u8]) -> Result<AccountHash, TryFromSliceForAccountHashError> {
+impl TryFrom<&[u8]> for AccountHash {
+    type Error = TryFromSliceForAccountHashError;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, TryFromSliceForAccountHashError> {
         AccountHashBytes::try_from(bytes)
+            .map(AccountHash::new)
+            .map_err(|_| TryFromSliceForAccountHashError(()))
+    }
+}
+
+impl TryFrom<&alloc::vec::Vec<u8>> for AccountHash {
+    type Error = TryFromSliceForAccountHashError;
+
+    fn try_from(bytes: &Vec<u8>) -> Result<Self, Self::Error> {
+        AccountHashBytes::try_from(bytes as &[u8])
             .map(AccountHash::new)
             .map_err(|_| TryFromSliceForAccountHashError(()))
     }
@@ -183,13 +196,13 @@ impl AccountHash {
 
 impl Display for AccountHash {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        write!(f, "AccountHash({})", self)
+        write!(f, "{}", base16::encode_lower(&self.0))
     }
 }
 
 impl Debug for AccountHash {
     fn fmt(&self, f: &mut Formatter) -> core::fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "AccountHash({})", base16::encode_lower(&self.0))
     }
 }
 

--- a/execution-engine/types/src/api_error.rs
+++ b/execution-engine/types/src/api_error.rs
@@ -8,7 +8,7 @@ use core::{
 use crate::{
     account::{
         AddKeyFailure, RemoveKeyFailure, SetThresholdFailure, TryFromIntError,
-        TryFromSliceForPublicKeyError, UpdateKeyFailure,
+        TryFromSliceForAccountHashError, UpdateKeyFailure,
     },
     bytesrepr,
     system_contract_errors::{mint, pos},
@@ -364,19 +364,19 @@ pub enum ApiError {
     /// Out of memory error.
     OutOfMemory,
     /// There are already [`MAX_ASSOCIATED_KEYS`](crate::account::MAX_ASSOCIATED_KEYS)
-    /// [`PublicKey`](crate::account::PublicKey)s associated with the given account.
+    /// [`AccountHash`](crate::account::AccountHash)s associated with the given account.
     MaxKeysLimit,
-    /// The given [`PublicKey`](crate::account::PublicKey) is already associated with the given
+    /// The given [`AccountHash`](crate::account::AccountHash) is already associated with the given
     /// account.
     DuplicateKey,
     /// Caller doesn't have sufficient permissions to perform the given action.
     PermissionDenied,
-    /// The given [`PublicKey`](crate::account::PublicKey) is not associated with the given
+    /// The given [`AccountHash`](crate::account::AccountHash) is not associated with the given
     /// account.
     MissingKey,
-    /// Removing/updating the given associated [`PublicKey`](crate::account::PublicKey) would cause
-    /// the total [`Weight`](crate::account::Weight) of all remaining `PublicKey`s to fall below
-    /// one of the action thresholds for the given account.
+    /// Removing/updating the given associated [`AccountHash`](crate::account::AccountHash) would
+    /// cause the total [`Weight`](crate::account::Weight) of all remaining `AccountHash`s to
+    /// fall below one of the action thresholds for the given account.
     ThresholdViolation,
     /// Setting the key-management threshold to a value lower than the deployment threshold is
     /// disallowed.
@@ -478,8 +478,8 @@ impl From<TryFromIntError> for ApiError {
     }
 }
 
-impl From<TryFromSliceForPublicKeyError> for ApiError {
-    fn from(_error: TryFromSliceForPublicKeyError) -> Self {
+impl From<TryFromSliceForAccountHashError> for ApiError {
+    fn from(_error: TryFromSliceForAccountHashError) -> Self {
         ApiError::Deserialize
     }
 }

--- a/execution-engine/types/src/bytesrepr.rs
+++ b/execution-engine/types/src/bytesrepr.rs
@@ -1000,7 +1000,7 @@ mod proptests {
         }
 
         #[test]
-        fn test_public_key(pk in public_key_arb()) {
+        fn test_account_hash(pk in account_hash_arb()) {
             bytesrepr::test_serialization_roundtrip(&pk);
         }
 

--- a/execution-engine/types/src/gens.rs
+++ b/execution-engine/types/src/gens.rs
@@ -13,7 +13,7 @@ use proptest::{
 };
 
 use crate::{
-    account::{PublicKey, Weight},
+    account::{AccountHash, Weight},
     AccessRights, CLType, CLValue, Key, Phase, ProtocolVersion, SemVer, URef, U128, U256, U512,
 };
 
@@ -57,15 +57,15 @@ pub fn uref_arb() -> impl Strategy<Value = URef> {
 
 pub fn key_arb() -> impl Strategy<Value = Key> {
     prop_oneof![
-        public_key_arb().prop_map(Key::Account),
+        account_hash_arb().prop_map(Key::Account),
         u8_slice_32().prop_map(Key::Hash),
         uref_arb().prop_map(Key::URef),
         (u8_slice_32(), u8_slice_32()).prop_map(|(seed, key)| Key::local(seed, &key))
     ]
 }
 
-pub fn public_key_arb() -> impl Strategy<Value = PublicKey> {
-    u8_slice_32().prop_map(PublicKey::ed25519_from)
+pub fn account_hash_arb() -> impl Strategy<Value = AccountHash> {
+    u8_slice_32().prop_map(AccountHash::new)
 }
 
 pub fn weight_arb() -> impl Strategy<Value = Weight> {

--- a/execution-engine/types/src/key.rs
+++ b/execution-engine/types/src/key.rs
@@ -321,7 +321,7 @@ mod tests {
         let account_key = Key::Account(account_hash);
         assert_eq!(
             format!("{}", account_key),
-            format!("Key::Account(Ed25519({}))", expected_hash)
+            format!("Key::Account({})", expected_hash)
         );
         let uref_key = Key::URef(URef::new(addr_array, AccessRights::READ));
         assert_eq!(

--- a/execution-engine/types/src/key.rs
+++ b/execution-engine/types/src/key.rs
@@ -201,9 +201,9 @@ impl ToBytes for Key {
     fn to_bytes(&self) -> Result<Vec<u8>, Error> {
         let mut result = bytesrepr::unchecked_allocate_buffer(self);
         match self {
-            Key::Account(public_key) => {
+            Key::Account(account_hash) => {
                 result.push(ACCOUNT_ID);
-                result.append(&mut public_key.to_bytes()?);
+                result.append(&mut account_hash.to_bytes()?);
             }
             Key::Hash(hash) => {
                 result.push(HASH_ID);
@@ -224,7 +224,9 @@ impl ToBytes for Key {
 
     fn serialized_length(&self) -> usize {
         match self {
-            Key::Account(public_key) => KEY_ID_SERIALIZED_LENGTH + public_key.serialized_length(),
+            Key::Account(account_hash) => {
+                KEY_ID_SERIALIZED_LENGTH + account_hash.serialized_length()
+            }
             Key::Hash(_) => KEY_HASH_SERIALIZED_LENGTH,
             Key::URef(_) => KEY_UREF_SERIALIZED_LENGTH,
             Key::Local { .. } => KEY_LOCAL_SERIALIZED_LENGTH,
@@ -237,8 +239,8 @@ impl FromBytes for Key {
         let (id, remainder) = u8::from_bytes(bytes)?;
         match id {
             ACCOUNT_ID => {
-                let (public_key, rem) = AccountHash::from_bytes(remainder)?;
-                Ok((Key::Account(public_key), rem))
+                let (account_hash, rem) = AccountHash::from_bytes(remainder)?;
+                Ok((Key::Account(account_hash), rem))
             }
             HASH_ID => {
                 let (hash, rem) = <[u8; KEY_HASH_LENGTH]>::from_bytes(remainder)?;

--- a/execution-engine/types/src/key.rs
+++ b/execution-engine/types/src/key.rs
@@ -8,7 +8,7 @@ use blake2::{
 use hex_fmt::HexFmt;
 
 use crate::{
-    account::PublicKey,
+    account::AccountHash,
     bytesrepr::{self, Error, FromBytes, ToBytes},
     ContractRef, URef, UREF_SERIALIZED_LENGTH,
 };
@@ -49,7 +49,7 @@ fn hash(bytes: &[u8]) -> [u8; BLAKE2B_DIGEST_LENGTH] {
 #[derive(PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
 pub enum Key {
     /// A `Key` under which a user account is stored.
-    Account(PublicKey),
+    Account(AccountHash),
     /// A `Key` under which a smart contract is stored and which is the pseudo-hash of the
     /// contract.
     Hash([u8; KEY_HASH_LENGTH]),
@@ -103,9 +103,10 @@ impl Key {
     /// Returns a human-readable version of `self`, with the inner bytes encoded to Base16.
     pub fn as_string(&self) -> String {
         match self {
-            Key::Account(PublicKey::Ed25519(addr)) => {
-                format!("account-ed25519-{}", base16::encode_lower(&addr.value()))
-            }
+            Key::Account(account_hash) => format!(
+                "account-account_hash-{}",
+                base16::encode_lower(&account_hash.value())
+            ),
             Key::Hash(addr) => format!("hash-{}", base16::encode_lower(addr)),
             Key::URef(uref) => uref.as_string(),
             Key::Local { hash, .. } => format!("local-{}", base16::encode_lower(hash)),
@@ -124,7 +125,7 @@ impl Key {
 
     /// Returns the inner bytes of `self` if `self` is of type [`Key::Account`], otherwise returns
     /// `None`.
-    pub fn into_account(self) -> Option<PublicKey> {
+    pub fn into_account(self) -> Option<AccountHash> {
         match self {
             Key::Account(bytes) => Some(bytes),
             _ => None,
@@ -175,7 +176,7 @@ impl Key {
 impl Display for Key {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
-            Key::Account(PublicKey::Ed25519(ed25519)) => write!(f, "Key::Account({})", ed25519),
+            Key::Account(account_hash) => write!(f, "Key::Account({})", account_hash),
             Key::Hash(addr) => write!(f, "Key::Hash({})", HexFmt(addr)),
             Key::URef(uref) => write!(f, "Key::{}", uref), /* Display impl for URef will append */
             // URef(…).
@@ -236,7 +237,7 @@ impl FromBytes for Key {
         let (id, remainder) = u8::from_bytes(bytes)?;
         match id {
             ACCOUNT_ID => {
-                let (public_key, rem) = PublicKey::from_bytes(remainder)?;
+                let (public_key, rem) = AccountHash::from_bytes(remainder)?;
                 Ok((Key::Account(public_key), rem))
             }
             HASH_ID => {
@@ -314,8 +315,8 @@ mod tests {
     fn should_display_key() {
         let expected_hash = core::iter::repeat("0").take(64).collect::<String>();
         let addr_array = [0u8; 32];
-        let public_key = PublicKey::ed25519_from(addr_array);
-        let account_key = Key::Account(public_key);
+        let account_hash = AccountHash::new(addr_array);
+        let account_key = Key::Account(account_hash);
         assert_eq!(
             format!("{}", account_key),
             format!("Key::Account(Ed25519({}))", expected_hash)
@@ -355,9 +356,9 @@ mod tests {
     #[test]
     fn check_key_account_getters() {
         let account = [42; 32];
-        let public_key = PublicKey::ed25519_from(account);
-        let key1 = Key::Account(public_key);
-        assert_eq!(key1.into_account(), Some(public_key));
+        let account_hash = AccountHash::new(account);
+        let key1 = Key::Account(account_hash);
+        assert_eq!(key1.into_account(), Some(account_hash));
         assert!(key1.into_hash().is_none());
         assert!(key1.as_uref().is_none());
         assert!(key1.into_local().is_none());
@@ -398,7 +399,7 @@ mod tests {
 
     #[test]
     fn key_max_serialized_length() {
-        let key_account = Key::Account(PublicKey::ed25519_from([42; 32]));
+        let key_account = Key::Account(AccountHash::new([42; 32]));
         assert!(key_account.serialized_length() < Key::max_serialized_length());
 
         let key_hash = Key::Hash([42; 32]);


### PR DESCRIPTION
Replacing PublicKey with AccountHash in ContractRuntime.

https://casperlabs.atlassian.net/browse/EE-1010

- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
