### PR TITLE
TNET-36: Fix finality detector pruning loop

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
@@ -216,7 +216,7 @@ package object votingmatrix {
       // Which candidate (if any) does each validator vote for and since which level.
       firstLevelZeroVotes: MutableSeq[Option[Vote]],
       candidateBlockHash: BlockHash,
-      // Which validators were (and are still) part of the committee.
+      // Which validators were (and are still) part of the committee that vote for this candidate.
       mask: MutableSeq[Boolean],
       q: Weight,
       weight: MutableSeq[Weight]
@@ -237,12 +237,12 @@ package object votingmatrix {
                 case (witnessedHighestLevel, witnessedIndex) =>
                   // See if the witnessed validator is voting for the same candidate.
                   firstLevelZeroVotes(witnessedIndex) match {
-                    case Some((witnessedBlockHash, witnessedVoteLevel))
-                        if witnessedBlockHash == candidateBlockHash && witnessedVoteLevel <= witnessedHighestLevel =>
+                    case Some((_, witnessedVoteLevel))
+                        if witnessedVoteLevel <= witnessedHighestLevel =>
                       // The validator at `witnessedIndex` puts their weight behind the one at `voterIndex`
                       weight(witnessedIndex)
 
-                    // Voting for a different candidate or the voter hasn't witnessed the vote.
+                    // The voter hasn't witnessed the vote.
                     case _ => Zero
                   }
               }

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
@@ -155,11 +155,6 @@ package object votingmatrix {
       weightMap           <- matrix.get.map(_.weightMap)
       validators          <- matrix.get.map(_.validators)
       firstLevelZeroVotes <- matrix.get.map(_.firstLevelZeroVotes)
-      _ = println(
-        "level-0 votes: " + firstLevelZeroVotes
-          .map(_.map(v => s"${v._1.show} -> ${v._2}"))
-          .mkString("; ")
-      )
       // Get Map[VoteBranch, List[Validator]] directly from firstLevelZeroVotes
       committee <- if (firstLevelZeroVotes.isEmpty) {
                     // No one voted on anything in the current b-game
@@ -226,7 +221,6 @@ package object votingmatrix {
       q: Weight,
       weight: MutableSeq[Weight]
   ): Option[(MutableSeq[Boolean], Weight)] = {
-    println(s"validator views: $validatorsViews")
     // Go through each validator in the matrix rows and see if
     // enough other validators saw them voting for the candidate.
     val (newMask, prunedValidator, maxTotalWeight) = validatorsViews.zipWithIndex

--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/package.scala
@@ -235,7 +235,7 @@ package object votingmatrix {
               .filter { case (_, witnessedIndex) => mask(witnessedIndex) }
               .map {
                 case (witnessedHighestLevel, witnessedIndex) =>
-                  // See if the witnessed validator is voting for the same candidate.
+                  // See if the witnessed level includes the vote for the candidate.
                   firstLevelZeroVotes(witnessedIndex) match {
                     case Some((_, witnessedVoteLevel))
                         if witnessedVoteLevel <= witnessedHighestLevel =>

--- a/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/EraSupervisor.scala
@@ -228,8 +228,10 @@ class EraSupervisor[F[_]: Concurrent: Timer: Log: Metrics: EraStorage: BlockRela
           _ <- addToParent(child)
         } yield ()
 
-      case HighwayEvent.CreatedLambdaMessage(m)  => handleCreatedMessage(m, "lambda-message")
-      case HighwayEvent.CreatedLambdaResponse(m) => handleCreatedMessage(m, "lambda-response")
+      case HighwayEvent.CreatedLambdaMessage(m) =>
+        handleCreatedMessage(m, "lambda-message")
+      case HighwayEvent.CreatedLambdaResponse(m) =>
+        handleCreatedMessage(m, "lambda-response")
       case HighwayEvent.CreatedOmegaMessage(m) =>
         handleCreatedMessage(m, "omega-message")
       case HighwayEvent.HandledLambdaMessage =>

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -119,7 +119,7 @@ class FinalityDetectorByVotingMatrixTest
     } yield ()
   }
 
-  it should "finalize as many blocks as possible in a round (TNET-36) even with omega blocks" in withCombinedStorage() {
+  it should "finalize as many blocks as possible in a round even with omega blocks (TNET-36)" in withCombinedStorage() {
     implicit storage =>
       /* The DAG looks like:
        * A3
@@ -162,14 +162,14 @@ class FinalityDetectorByVotingMatrixTest
             justifications = justifications.mapValues(_.blockHash)
           ) map {
             case (block, detected) =>
+              println(s"created block ${block.blockHash.show}")
               shouldFinalize match {
-                case Some(fin) =>
+                case Some(newLFB) =>
                   detected should not be empty
-                  detected.last.consensusValue shouldBe block.blockHash
+                  detected.last.consensusValue shouldBe newLFB.blockHash
                 case None =>
                   detected shouldBe empty
               }
-              println(s"created block ${block.blockHash.show}")
               block
           }
 

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -134,7 +134,7 @@ class FinalityDetectorByVotingMatrixTest
             messageRole: MessageRole,
             parent: Block,
             justifications: Map[Validator, Block],
-            shouldFinalize: Option[Block]
+            shouldFinalize: Option[(Block, Set[Validator])]
         ) =>
           createBlockAndUpdateFinalityDetector[Task](
             parentsHashList = Seq(parent.blockHash),
@@ -148,9 +148,10 @@ class FinalityDetectorByVotingMatrixTest
           ) map {
             case (block, detected) =>
               shouldFinalize match {
-                case Some(newLFB) =>
+                case Some((newLFB, committee)) =>
                   detected should not be empty
                   detected.last.consensusValue shouldBe newLFB.blockHash
+                  detected.last.validator shouldBe committee
                 case None =>
                   detected shouldBe empty
               }
@@ -212,14 +213,28 @@ class FinalityDetectorByVotingMatrixTest
         c2 <- create(vC, BLOC, WITN, a1, Map(vA -> a1, vB -> b1, vC -> c1), None)
         d2 <- create(vD, BALL, WITN, a1, Map(vA -> a1, vD -> d1), None)
         b2 <- create(vB, BALL, WITN, c2, Map(vA -> a2, vB -> b1, vC -> c2), None)
-        a3 <- create(vA, BLOC, PROP, c2, Map(vA -> a2, vB -> b2, vC -> c2, vD -> d2), Some(a1))
+        a3 <- create(
+               vA,
+               BLOC,
+               PROP,
+               c2,
+               Map(vA  -> a2, vB -> b2, vC -> c2, vD -> d2),
+               Some(a1 -> Set(vA, vB, vC))
+             )
 
         b3 <- create(vB, BALL, CONF, a3, Map(vA -> a3, vB -> b2, vC -> c2, vD -> d2), None)
         c3 <- create(vC, BALL, CONF, a3, Map(vA -> a3, vB -> b2, vC -> c2, vD -> d2), None)
         d3 <- create(vD, BALL, CONF, a3, Map(vA -> a3, vB -> b2, vC -> c2, vD -> d2), None)
         a4 <- create(vA, BALL, WITN, a3, Map(vA -> a3, vB -> b3, vC -> c3, vD -> d3), None)
         b4 <- create(vB, BALL, WITN, a3, Map(vA -> a4, vB -> b3, vC -> c3, vD -> d3), None)
-        c4 <- create(vC, BALL, WITN, a3, Map(vA -> a4, vB -> b4, vC -> c3, vD -> d3), Some(a3))
+        c4 <- create(
+               vC,
+               BALL,
+               WITN,
+               a3,
+               Map(vA  -> a4, vB -> b4, vC -> c3, vD -> d3),
+               Some(a3 -> Set(vA, vB, vC, vD))
+             )
         d4 <- create(vD, BALL, WITN, a3, Map(vA -> a4, vB -> b4, vC -> c4, vD -> d3), None)
         a5 <- create(vA, BLOC, PROP, a3, Map(vA -> a4, vB -> b4, vC -> c4, vD -> d4), None)
 

--- a/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorByVotingMatrixTest.scala
@@ -164,8 +164,6 @@ class FinalityDetectorByVotingMatrixTest
       val PROP = MessageRole.PROPOSAL
       val WITN = MessageRole.WITNESS
 
-      // A level-1 summit with 2/3 quorum is just 2/3 of validators having seen each other vote for the candidate.
-
       /* The DAG looks like:
        *
        * A5 ---------
@@ -233,7 +231,7 @@ class FinalityDetectorByVotingMatrixTest
                WITN,
                a3,
                Map(vA  -> a4, vB -> b4, vC -> c3, vD -> d3),
-               Some(a3 -> Set(vA, vB, vC, vD))
+               Some(a3 -> Set(vA, vB, vC))
              )
         d4 <- create(vD, BALL, WITN, a3, Map(vA -> a4, vB -> b4, vC -> c4, vD -> d3), None)
         a5 <- create(vA, BLOC, PROP, a3, Map(vA -> a4, vB -> b4, vC -> c4, vD -> d4), None)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/BlockGenerator.scala
@@ -73,7 +73,8 @@ trait BlockGenerator {
       postStateHash: ByteString = ByteString.EMPTY,
       chainName: String = "casperlabs",
       preStateHash: ByteString = ByteString.EMPTY,
-      messageType: Block.MessageType = Block.MessageType.BLOCK
+      messageType: Block.MessageType = Block.MessageType.BLOCK,
+      messageRole: Block.MessageRole = Block.MessageRole.UNDEFINED
   ): F[Block] =
     createMessageNew[F](
       parentsHashList,
@@ -85,7 +86,8 @@ trait BlockGenerator {
       postStateHash,
       chainName,
       preStateHash,
-      messageType
+      messageType,
+      messageRole
     )
 
   def createMessageNew[F[_]: MonadThrowable: Time: DagStorage](
@@ -99,6 +101,7 @@ trait BlockGenerator {
       chainName: String = "casperlabs",
       preStateHash: ByteString = ByteString.EMPTY,
       messageType: Block.MessageType = Block.MessageType.BLOCK,
+      messageRole: Block.MessageRole = Block.MessageRole.UNDEFINED,
       maybeValidatorPrevBlockHash: Option[BlockHash] = None,
       maybeValidatorBlockSeqNum: Option[Int] = None
   ): F[Block] = {
@@ -179,6 +182,7 @@ trait BlockGenerator {
           keyBlockHash = keyBlockHash
         )
         .withMessageType(messageType)
+        .withMessageRole(messageRole)
       block = ProtoUtil.unsignedBlockProto(body, header)
     } yield block
   }


### PR DESCRIPTION
### Overview
Tried to replicate the slow LFB problem in a unit test. I was investigating what I thought was early finalization and added comments to try and understand the code and it didn't seem to make sense. I noticed that the elimination of validators from the committee seems to take weights in an inverse relation to what I think is logical. 

This is what the voting matrix looks like at the time `a2` is added in the unit test:
``` 
              level of validator witnessed in the panorama
               A, B, C
panorama of A [3, 2, 0]
panorama of B [1, 2, 0]
panorama of C [1, 0, 2]
```
~So I think to get the support for `A` we need `[0][0] + [1][0] + [2][0]` and the old code was doing `[0][0] + [0][1] + [0][2]`.~

Turns out it was correct, so the the PR just adds comments.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-36

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
The test passed, couldn't reproduce the slow LFB issue. Will try to do so running multiple nodes in docker.
