### PR TITLE
NDRS-61: track block dependencies in the deploy buffer

### DIFF
--- a/execution-engine/consensus/consensus-service/src/deploy_buffer/mod.rs
+++ b/execution-engine/consensus/consensus-service/src/deploy_buffer/mod.rs
@@ -30,7 +30,7 @@ impl DeployBuffer {
         // finalized blocks from the set `blocks`
         let deploys_to_return =
             blocks
-                .into_iter()
+                .iter()
                 .fold(self.collected_deploys.clone(), |mut set, block_hash| {
                     let empty = HashSet::new();
                     let included_deploys = self.processed.get(block_hash).unwrap_or(&empty)
@@ -105,7 +105,7 @@ mod tests {
         assert!(buffer.remaining_deploys(&blocks).is_empty());
 
         // try adding the same deploy again
-        buffer.add_deploy(deploy2.clone());
+        buffer.add_deploy(deploy2);
 
         // it shouldn't be returned if we include block 1 in the past blocks
         assert!(buffer.remaining_deploys(&blocks).is_empty());

--- a/execution-engine/consensus/consensus-service/src/deploy_buffer/mod.rs
+++ b/execution-engine/consensus/consensus-service/src/deploy_buffer/mod.rs
@@ -1,12 +1,18 @@
-use std::mem;
+use std::collections::{HashMap, HashSet};
 
 // TODO: temporary type, probably will get replaced with something with more structure
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Deploy(Vec<u8>);
+
+/// TODO: also temporary, will be defined somewhere else
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BlockHash([u8; 32]);
 
 #[derive(Debug, Clone, Default)]
 pub struct DeployBuffer {
-    collected_deploys: Vec<Deploy>,
+    collected_deploys: HashSet<Deploy>,
+    processed: HashMap<BlockHash, HashSet<Deploy>>,
+    finalized: HashMap<BlockHash, HashSet<Deploy>>,
 }
 
 impl DeployBuffer {
@@ -15,32 +21,106 @@ impl DeployBuffer {
     }
 
     pub fn add_deploy(&mut self, deploy: Deploy) {
-        self.collected_deploys.push(deploy);
+        // TBD: do we add deploys that already are in `processed` or `finalized`?
+        self.collected_deploys.insert(deploy);
     }
 
-    pub fn remaining_deploys(&mut self) -> Vec<Deploy> {
-        mem::take(&mut self.collected_deploys)
+    pub fn remaining_deploys(&mut self, blocks: &HashSet<BlockHash>) -> HashSet<Deploy> {
+        // deploys_to_return = all deploys in collected_deploys that aren't in processed or
+        // finalized blocks from the set `blocks`
+        let deploys_to_return =
+            blocks
+                .into_iter()
+                .fold(self.collected_deploys.clone(), |mut set, block_hash| {
+                    let empty = HashSet::new();
+                    let included_deploys = self.processed.get(block_hash).unwrap_or(&empty)
+                        | self.finalized.get(block_hash).unwrap_or(&empty);
+                    set.retain(|deploy| !included_deploys.contains(deploy));
+                    set
+                });
+        self.collected_deploys
+            .retain(|deploy| !deploys_to_return.contains(deploy));
+        deploys_to_return
+    }
+
+    pub fn added_block(&mut self, block: BlockHash, deploys: HashSet<Deploy>) {
+        self.collected_deploys
+            .retain(|deploy| !deploys.contains(deploy));
+        self.processed.insert(block, deploys);
+    }
+
+    pub fn finalized_block(&mut self, block: BlockHash) {
+        if let Some(deploys) = self.processed.remove(&block) {
+            self.finalized.insert(block, deploys);
+        } else {
+            panic!("finalized block that hasn't been processed!");
+        }
+    }
+
+    pub fn orphaned_block(&mut self, block: BlockHash) {
+        if let Some(deploys) = self.processed.remove(&block) {
+            self.collected_deploys.extend(deploys);
+        } else {
+            panic!("orphaned block that hasn't been processed!");
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Deploy, DeployBuffer};
+    use super::{BlockHash, Deploy, DeployBuffer};
+    use std::collections::HashSet;
 
     #[test]
     fn add_and_take_deploys() {
+        let no_blocks = HashSet::new();
         let mut buffer = DeployBuffer::new();
+        let deploy1 = Deploy(vec![1]);
+        let deploy2 = Deploy(vec![2]);
+        let deploy3 = Deploy(vec![3]);
+        let deploy4 = Deploy(vec![4]);
 
-        assert!(buffer.remaining_deploys().is_empty());
+        assert!(buffer.remaining_deploys(&no_blocks).is_empty());
 
-        buffer.add_deploy(Deploy(vec![1]));
-        buffer.add_deploy(Deploy(vec![2]));
+        // add two deploys
+        buffer.add_deploy(deploy1.clone());
+        buffer.add_deploy(deploy2.clone());
 
-        assert_eq!(
-            buffer.remaining_deploys(),
-            vec![Deploy(vec![1]), Deploy(vec![2])]
-        );
+        // take the deploys out
+        let deploys = buffer.remaining_deploys(&no_blocks);
 
-        assert!(buffer.remaining_deploys().is_empty());
+        assert_eq!(deploys.len(), 2);
+        assert!(deploys.contains(&deploy1));
+        assert!(deploys.contains(&deploy2));
+
+        assert!(buffer.remaining_deploys(&no_blocks).is_empty());
+
+        // the two deploys will be included in block 1
+        let block_hash1 = BlockHash([0; 32]);
+        buffer.added_block(block_hash1, deploys);
+
+        let mut blocks = HashSet::new();
+        blocks.insert(block_hash1);
+
+        assert!(buffer.remaining_deploys(&blocks).is_empty());
+
+        // try adding the same deploy again
+        buffer.add_deploy(deploy2.clone());
+
+        // it shouldn't be returned if we include block 1 in the past blocks
+        assert!(buffer.remaining_deploys(&blocks).is_empty());
+
+        // finalize the block
+        buffer.finalized_block(block_hash1);
+
+        // add more deploys
+        buffer.add_deploy(deploy3.clone());
+        buffer.add_deploy(deploy4.clone());
+
+        let deploys = buffer.remaining_deploys(&blocks);
+
+        assert_eq!(deploys.len(), 2);
+        assert!(deploys.contains(&deploy3));
+        assert!(deploys.contains(&deploy4));
     }
 }


### PR DESCRIPTION
### Overview
This adds tracking of the blocks to the deploy buffer. It's required for the deploy buffer to know which deploys have already been added in the past, which is needed for preventing replay attacks.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDRS-61

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
It's unclear whether deploys should be added to the buffer in `add_deploy` if they are already included in a processed or a finalized block.
I'd be in favor of "no" if the deploy is in a finalized block and "yes" for a processed block - because processed blocks aren't anything certain, they can get orphaned, in which case the deploy will be re-added anyway, so there would be no point of preventing it in advance.