### PR TITLE
HWY-36: Add leader sequence computation.

### DIFF
--- a/execution-engine/consensus/highway-core/Cargo.toml
+++ b/execution-engine/consensus/highway-core/Cargo.toml
@@ -11,4 +11,6 @@ license-file = "../LICENSE"
 [dependencies]
 derive_more = "0.99.7"
 displaydoc = "0.1.6"
+rand = "0.7.3"
+rand_chacha = "0.2.2"
 thiserror = "1.0.17"

--- a/execution-engine/consensus/highway-core/src/active_validator.rs
+++ b/execution-engine/consensus/highway-core/src/active_validator.rs
@@ -1,33 +1,66 @@
-use std::time::Instant;
-
-use crate::{state::State, traits::Context, vertex::Vertex};
+use crate::{state::State, traits::Context, validators::ValidatorIndex, vertex::Vertex};
 
 /// An action taken by a validator.
 pub enum Effect<C: Context> {
     /// Newly vertex that should be gossiped to peers and added to the protocol state.
     NewVertex(Vertex<C>),
-    /// `step` needs to be called at this time.
-    ScheduleTimer(Instant),
-    /// `propose` needs to be called with a value for a new block with the specified parent.
-    RequestNewBlock(Option<C::VoteHash>),
+    /// `step` needs to be called at the specified instant.
+    ScheduleTimer(u64),
+    /// `propose` needs to be called with a value for a new block with the specified instant.
+    // TODO: Add more information required by the deploy buffer.
+    RequestNewBlock(u64),
 }
 
 /// A validator that actively participates in consensus by creating new vertices.
 pub struct ActiveValidator<C: Context> {
+    /// Our own validator index.
+    vidx: ValidatorIndex,
     /// The validator's secret signing key.
     secret: C::ValidatorSecret,
+    /// The round exponent: Our subjective rounds are `1 << round_exp` milliseconds long.
+    round_exp: u8,
 }
 
 impl<C: Context> ActiveValidator<C> {
-    /// Returns actions a validator needs to take at the specified `time`, with the given protocol
-    /// `state`.
-    pub fn step(&self, _state: &State<C>, _time: Instant) -> Vec<Effect<C>> {
-        todo!("{:?}", self.secret)
+    /// Returns actions a validator needs to take at the specified `instant`, with the given
+    /// protocol `state`.
+    pub fn step(&self, state: &State<C>, instant: u64) -> Vec<Effect<C>> {
+        let round_len = 1u64 << self.round_exp;
+        let round_id = instant % round_len;
+        let round_offset = instant - round_id;
+        if round_offset == 0 && state.leader(round_id) == self.vidx {
+            vec![Effect::RequestNewBlock(instant)]
+        // TODO: We need HWY-55 first, to be able to create votes with correct hash.
+        // } else if round_offset * 3 == round_len * 2 {
+        //     let panorama = state.panorama().clone();
+        //     let prev_hash = panorama.get(self.vidx).correct().unwrap();
+        //     let seq_number = state.vote(prev_hash).seq_number + 1;
+        //     let witness_vote = WireVote {
+        //         hash: todo!(),
+        //         panorama,
+        //         sender: self.vidx,
+        //         values: None,
+        //         seq_number,
+        //         instant,
+        //     };
+        //     vec![Effect::NewVertex(Vertex::Vote(witness_vote))]
+        } else {
+            vec![]
+        }
+    }
+
+    pub fn on_new_vote(
+        &self,
+        vhash: &C::VoteHash,
+        state: &State<C>,
+        instant: u64,
+    ) -> Vec<Effect<C>> {
+        todo!("{:?}, {:?}, {:?}", vhash, state, instant)
     }
 
     /// Propose a new block with the given parent and consensus value.
     pub fn propose(&self, state: &State<C>, values: Vec<C::ConsensusValue>) -> Vec<Effect<C>> {
-        todo!("{:?}, {:?}", state, values)
+        todo!("{:?}, {:?}, {:?}", state, values, self.secret)
         // vec![Effect::NewVertex(Vertex::Vote(vote))]
     }
 }

--- a/execution-engine/consensus/highway-core/src/active_validator.rs
+++ b/execution-engine/consensus/highway-core/src/active_validator.rs
@@ -26,8 +26,8 @@ impl<C: Context> ActiveValidator<C> {
     /// protocol `state`.
     pub fn step(&self, state: &State<C>, instant: u64) -> Vec<Effect<C>> {
         let round_len = 1u64 << self.round_exp;
-        let round_id = instant % round_len;
-        let round_offset = instant - round_id;
+        let round_offset = instant % round_len;
+        let round_id = instant - round_offset;
         if round_offset == 0 && state.leader(round_id) == self.vidx {
             vec![Effect::RequestNewBlock(instant)]
         // TODO: We need HWY-55 first, to be able to create votes with correct hash.

--- a/execution-engine/consensus/highway-core/src/finality_detector.rs
+++ b/execution-engine/consensus/highway-core/src/finality_detector.rs
@@ -227,7 +227,7 @@ mod tests {
 
     #[test]
     fn finality_detector() -> Result<(), AddVoteError<TestContext>> {
-        let mut state = State::new(&[Weight(5), Weight(4), Weight(1)]);
+        let mut state = State::new(&[Weight(5), Weight(4), Weight(1)], 0);
 
         // Create blocks with scores as follows:
         //

--- a/execution-engine/consensus/highway-core/src/highway.rs
+++ b/execution-engine/consensus/highway-core/src/highway.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use crate::{
     evidence::Evidence,
     state::{AddVoteError, State},
@@ -35,8 +33,6 @@ pub struct HighwayParams<C: Context> {
     instance_id: C::InstanceId,
     /// The validator IDs and weight map.
     validators: Validators<C::ValidatorId>,
-    /// The duration of a single tick.
-    tick_length: Duration,
 }
 
 /// A passive instance of the Highway protocol, containing its local state.
@@ -53,7 +49,7 @@ pub struct Highway<C: Context> {
 }
 
 impl<C: Context> Highway<C> {
-    /// Try to add an incoming vertex to the protocol highway.
+    /// Try to add an incoming vertex to the protocol state.
     ///
     /// If the vertex is invalid, or if there are dependencies that need to be added first, returns
     /// `Invalid` resp. `MissingDependency`.

--- a/execution-engine/consensus/highway-core/src/state.rs
+++ b/execution-engine/consensus/highway-core/src/state.rs
@@ -158,7 +158,12 @@ impl<C: Context> State<C> {
     pub fn leader(&self, instant: u64) -> ValidatorIndex {
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed.wrapping_add(instant));
         // TODO: `rand` doesn't seem to document how it generates this. Needs to be portable.
+        // We select a random one out of the `total_weight` weight units, starting numbering at 1.
         let r = Weight(rng.gen_range(1, self.total_weight().0 + 1));
+        // The weight units are subdivided into intervals that belong to some validator.
+        // `cumulative_w[i]` denotes the last weight unit that belongs to validator `i`.
+        // `binary_search` returns the first `i` with `cumulative_w[i] >= r`, i.e. the validator
+        // who owns the randomly selected weight unit.
         let idx = self.cumulative_w.binary_search(&r).unwrap_or_else(identity);
         ValidatorIndex(idx as u32)
     }

--- a/execution-engine/consensus/highway-core/src/tallies.rs
+++ b/execution-engine/consensus/highway-core/src/tallies.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn tallies() -> Result<(), AddVoteError<TestContext>> {
-        let mut state = State::new(WEIGHTS);
+        let mut state = State::new(WEIGHTS, 0);
 
         // Create blocks with scores as follows:
         //

--- a/execution-engine/consensus/highway-core/src/vertex.rs
+++ b/execution-engine/consensus/highway-core/src/vertex.rs
@@ -41,4 +41,5 @@ pub struct WireVote<C: Context> {
     pub sender: ValidatorIndex,
     pub values: Option<Vec<C::ConsensusValue>>,
     pub seq_number: u64,
+    pub instant: u64,
 }

--- a/execution-engine/consensus/highway-core/src/vote.rs
+++ b/execution-engine/consensus/highway-core/src/vote.rs
@@ -87,6 +87,8 @@ pub struct Vote<C: Context> {
     /// For every `p = 1 << i` that divides `seq_number`, this contains an `i`-th entry pointing to
     /// the older vote with `seq_number - p`.
     pub skip_idx: Vec<C::VoteHash>,
+    /// This vote's instant, in milliseconds since the epoch.
+    pub instant: u64,
 }
 
 impl<C: Context> Vote<C> {
@@ -120,6 +122,7 @@ impl<C: Context> Vote<C> {
             sender: wvote.sender,
             block,
             skip_idx,
+            instant: wvote.instant,
         };
         (vote, wvote.values)
     }


### PR DESCRIPTION
### Overview
Add a random seed and a `leader` method to the protocol state, that
assigns to each instant a validator.

Also, measure time in milliseconds since the epoch. A `u64` is
sufficient for that, and `SystemTime` is larger and Rust-specific.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-36

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
