### PR TITLE
TNET-29: Streaming without holding DB connections

### DIFF
--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -197,6 +197,9 @@ cache-neighborhood-after = 6
 # How many records to pull from the DB in a chunk of a stream.
 deploy-stream-chunk-size = 10
 
+# How many records or rank ranges to pull from the DB in a chunk of a stream.
+dag-stream-chunk-size = 10
+
 # io.casperlabs.node.configuration.Configuration.GrpcServer
 [grpc]
 

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -195,7 +195,7 @@ cache-neighborhood-before = 5
 cache-neighborhood-after = 6
 
 # How many records to pull from the DB in a chunk of a stream.
-deploy-stream-chunk-size = 20
+deploy-stream-chunk-size = 10
 
 # io.casperlabs.node.configuration.Configuration.GrpcServer
 [grpc]

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -150,6 +150,7 @@ class NodeRuntime private[node] (
         storage: SQLiteStorage.CombinedStorage[Task]
       ) <- Resource.liftF(
             SQLiteStorage.create[Task](
+              dagStorageChunkSize = conf.blockstorage.dagStreamChunkSize,
               deployStorageChunkSize = conf.blockstorage.deployStreamChunkSize,
               tickUnit = TimeUnit.MILLISECONDS,
               readXa = readTransactor,

--- a/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Configuration.scala
@@ -119,7 +119,8 @@ object Configuration extends ParserImplicits {
       cacheMaxSizeBytes: Long,
       cacheNeighborhoodBefore: Int,
       cacheNeighborhoodAfter: Int,
-      deployStreamChunkSize: Int
+      deployStreamChunkSize: Int,
+      dagStreamChunkSize: Int
   ) extends SubConfig
 
   case class Grpc(

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -549,6 +549,11 @@ private[configuration] final case class Options private (
     )
 
     @scallop
+    val blockstorageDagStreamChunkSize = gen[Int](
+      "How many records or rank ranges to pull from the DB in a chunk of a stream."
+    )
+
+    @scallop
     val casperValidatorPublicKey =
       gen[String](
         "base-64 or PEM encoding of the public key to use for signing a proposed blocks. " +

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -107,6 +107,7 @@ cache-max-size-bytes = 1
 cache-neighborhood-before = 1
 cache-neighborhood-after = 1
 deploy-stream-chunk-size = 1
+dag-stream-chunk-size = 1
 
 [metrics]
 prometheus = false

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -158,7 +158,8 @@ class ConfigurationSpec
       cacheMaxSizeBytes = 1,
       cacheNeighborhoodBefore = 1,
       cacheNeighborhoodAfter = 1,
-      deployStreamChunkSize = 1
+      deployStreamChunkSize = 1,
+      dagStreamChunkSize = 1
     )
     val kamonSettings = Configuration.Kamon(
       prometheus = false,

--- a/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/block/CachingBlockStorageTest.scala
@@ -213,8 +213,8 @@ object CachingBlockStorageTest {
   ): Task[BlockStorage[Task]] =
     for {
       underlyingBlockStorage <- SQLiteBlockStorage.create[Task](xa, xa)
-      dagStorage             <- SQLiteDagStorage.create[Task](xa, xa)
-      deployStorage          <- SQLiteDeployStorage.create[Task](100, xa, xa)
+      dagStorage             <- SQLiteDagStorage.create[Task](10, xa, xa)
+      deployStorage          <- SQLiteDeployStorage.create[Task](10, xa, xa)
     } yield new BlockStorage[Task] {
       override def get(
           blockHash: BlockHash

--- a/storage/src/test/scala/io/casperlabs/storage/dag/CachingDagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/CachingDagStorageTest.scala
@@ -45,7 +45,7 @@ class CachingDagStorageTest
   private def prepareTestEnvironment(cacheSize: Long, neighborhoodRange: Int) = {
     implicit val metrics: MockMetrics = new MockMetrics()
     for {
-      dagStorage <- SQLiteDagStorage.create[Task](xa, xa)
+      dagStorage <- SQLiteDagStorage.create[Task](10, xa, xa)
       cache <- CachingDagStorage[Task](
                 dagStorage,
                 cacheSize,

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -444,4 +444,16 @@ class SQLiteDagStorageTest
 
   override def createTestResource: Task[DagStorage[Task] with EraStorage[Task]] =
     SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
+
+  "ranges" should "divide up the start and end to chunks" in {
+    SQLiteDagStorage.ranges(10)(7, 33) shouldBe Seq(
+      7  -> 16,
+      17 -> 26,
+      27 -> 33
+    )
+  }
+
+  it should "return empty list for backwards boundaries" in {
+    SQLiteDagStorage.ranges(10)(67, 0) shouldBe empty
+  }
 }

--- a/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
+++ b/storage/src/test/scala/io/casperlabs/storage/dag/DagStorageTest.scala
@@ -446,7 +446,7 @@ class SQLiteDagStorageTest
     SQLiteStorage.create[Task](readXa = xa, writeXa = xa)
 
   "ranges" should "divide up the start and end to chunks" in {
-    SQLiteDagStorage.ranges(10)(7, 33) shouldBe Seq(
+    SQLiteDagStorage.ranges(10)(7, 33).toList shouldBe List(
       7  -> 16,
       17 -> 26,
       27 -> 33


### PR DESCRIPTION
### Overview
The PR changes the streaming endpoints of the SQL storage to perform explicit batching on input ranges, so that only sub-streams hold the database connection. This may be worse performance wise, need to test.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-29

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
It turns out that in the gossiping interface only the deploys and the periodic synchronization used streaming from the database. 
