### PR TITLE
HWY-55: Add Context::hash, so the user can specify a hash function.

### DIFF
--- a/execution-engine/consensus/highway-core/Cargo.toml
+++ b/execution-engine/consensus/highway-core/Cargo.toml
@@ -9,6 +9,8 @@ repository = "https://github.com/CasperLabs/CasperLabs"
 license-file = "../LICENSE"
 
 [dependencies]
+bincode = "1.2.1"
 derive_more = "0.99.7"
 displaydoc = "0.1.6"
+serde = { version = "1.0.111", features = [ "derive" ] }
 thiserror = "1.0.17"

--- a/execution-engine/consensus/highway-core/src/active_validator.rs
+++ b/execution-engine/consensus/highway-core/src/active_validator.rs
@@ -9,7 +9,7 @@ pub enum Effect<C: Context> {
     /// `step` needs to be called at this time.
     ScheduleTimer(Instant),
     /// `propose` needs to be called with a value for a new block with the specified parent.
-    RequestNewBlock(Option<C::VoteHash>),
+    RequestNewBlock(Option<C::Hash>),
 }
 
 /// A validator that actively participates in consensus by creating new vertices.

--- a/execution-engine/consensus/highway-core/src/block.rs
+++ b/execution-engine/consensus/highway-core/src/block.rs
@@ -11,13 +11,13 @@ pub struct Block<C: Context> {
     ///
     /// For every `p = 1 << i` that divides `height`, this contains an `i`-th entry pointing to the
     /// ancestor with `height - p`.
-    pub skip_idx: Vec<C::VoteHash>,
+    pub skip_idx: Vec<C::Hash>,
 }
 
 impl<C: Context> Block<C> {
     /// Creates a new block with the given parent and values. Panics if parent does not exist.
     pub fn new(
-        parent_hash: Option<C::VoteHash>,
+        parent_hash: Option<C::Hash>,
         values: Vec<C::ConsensusValue>,
         state: &State<C>,
     ) -> Block<C> {
@@ -38,7 +38,7 @@ impl<C: Context> Block<C> {
     }
 
     /// Returns the block's parent, or `None` if it has height 0.
-    pub fn parent(&self) -> Option<&C::VoteHash> {
+    pub fn parent(&self) -> Option<&C::Hash> {
         self.skip_idx.first()
     }
 

--- a/execution-engine/consensus/highway-core/src/highway.rs
+++ b/execution-engine/consensus/highway-core/src/highway.rs
@@ -71,7 +71,7 @@ impl<C: Context> Highway<C> {
     pub fn get_dependency(&self, dependency: Dependency<C>) -> Option<Vertex<C>> {
         let state = &self.state;
         match dependency {
-            Dependency::Vote(hash) => state.wire_vote(hash).map(Vertex::Vote),
+            Dependency::Vote(hash) => state.wire_vote(&hash).map(Vertex::Vote),
             Dependency::Evidence(idx) => state.opt_evidence(idx).cloned().map(Vertex::Evidence),
         }
     }

--- a/execution-engine/consensus/highway-core/src/lib.rs
+++ b/execution-engine/consensus/highway-core/src/lib.rs
@@ -27,6 +27,11 @@
 //! or with some other governance system that can add and remove validators, by starting a new
 //! protocol instance whenever the set of validators changes.
 
+// This needs to come before the other modules, so the macros are available everywhere.
+#[cfg(test)]
+#[macro_use]
+mod test_macros;
+
 pub mod active_validator;
 pub mod finality_detector;
 pub mod highway;

--- a/execution-engine/consensus/highway-core/src/test_macros.rs
+++ b/execution-engine/consensus/highway-core/src/test_macros.rs
@@ -1,0 +1,37 @@
+//! Macros for concise test setup.
+
+/// Creates a panorama from a list of either observations or vote hashes. Vote hashes are converted
+/// to `Correct` observations.
+macro_rules! panorama {
+    ($($obs:expr),*) => {crate::vote::Panorama(vec![$($obs.into()),*])};
+}
+
+/// Creates a vote with the given sender, sequence number and panorama.
+macro_rules! vote {
+    ($sender: expr, $seq_num: expr; $($obs:expr),*) => {
+        vote!($sender, $seq_num; $($obs),*; None);
+    };
+    ($sender: expr, $seq_num: expr; $($obs:expr),*; $val: expr) => {
+        crate::vertex::WireVote {
+            panorama: panorama!($($obs),*),
+            sender: $sender,
+            values: $val,
+            seq_number: $seq_num,
+        }
+    };
+}
+
+/// Creates a vote with the given sender, sequence number and panorama, assigns its hash to `$hash`
+/// and adds the vote to `$state`. Returns an error if vote addition fails.
+macro_rules! add_vote {
+    ($state: ident, $hash: ident, $sender: expr, $seq_num: expr; $($obs:expr),*) => {
+        let vote = vote!($sender, $seq_num; $($obs),*; None);
+        let $hash = vote.hash();
+        $state.add_vote(vote)?;
+    };
+    ($state: ident, $hash: ident, $sender: expr, $seq_num: expr; $($obs:expr),*; $val: expr) => {
+        let vote = vote!($sender, $seq_num; $($obs),*; Some(vec![$val]));
+        let $hash = vote.hash();
+        $state.add_vote(vote)?;
+    };
+}

--- a/execution-engine/consensus/highway-core/src/traits.rs
+++ b/execution-engine/consensus/highway-core/src/traits.rs
@@ -1,16 +1,18 @@
 use std::{fmt::Debug, hash::Hash};
 
+use serde::{de::DeserializeOwned, Serialize};
+
 /// A validator identifier.
 pub trait ValidatorIdT: Eq + Ord + Clone + Debug + Hash {}
 impl<VID> ValidatorIdT for VID where VID: Eq + Ord + Clone + Debug + Hash {}
 
 /// The consensus value type, e.g. a list of transactions.
-pub trait ConsensusValueT: Eq + Clone + Debug + Hash {}
-impl<CV> ConsensusValueT for CV where CV: Eq + Clone + Debug + Hash {}
+pub trait ConsensusValueT: Eq + Clone + Debug + Hash + Serialize + DeserializeOwned {}
+impl<CV> ConsensusValueT for CV where CV: Eq + Clone + Debug + Hash + Serialize + DeserializeOwned {}
 
 /// A hash, as an identifier for a block or vote.
-pub trait HashT: Eq + Ord + Clone + Debug + Hash {}
-impl<H> HashT for H where H: Eq + Ord + Clone + Debug + Hash {}
+pub trait HashT: Eq + Ord + Clone + Debug + Hash + Serialize + DeserializeOwned {}
+impl<H> HashT for H where H: Eq + Ord + Clone + Debug + Hash + Serialize + DeserializeOwned {}
 
 /// A validator's secret signing key.
 pub trait ValidatorSecret: Debug {
@@ -30,7 +32,9 @@ pub trait Context: Clone + Debug + PartialEq {
     /// A validator's secret signing key.
     type ValidatorSecret: ValidatorSecret;
     /// Unique identifiers for votes.
-    type VoteHash: HashT;
+    type Hash: HashT;
     /// The ID of a consensus protocol instance.
     type InstanceId: HashT;
+
+    fn hash(data: &[u8]) -> Self::Hash;
 }

--- a/execution-engine/consensus/highway-core/src/validators.rs
+++ b/execution-engine/consensus/highway-core/src/validators.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, hash::Hash, iter::FromIterator};
 
+use serde::{Deserialize, Serialize};
+
 /// The index of a validator, in a list of all validators, ordered by ID.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct ValidatorIndex(pub u32);
 
 impl From<u32> for ValidatorIndex {


### PR DESCRIPTION
### Overview
Vote hashes are now computed by hashing their contents.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-55

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
