### PR TITLE
NDSC-66: Accept Secp256k1 keys for deploys and validators

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -566,16 +566,17 @@ object ProtoUtil {
   def deploy(
       timestamp: Long,
       sessionCode: ByteString = ByteString.EMPTY,
-      ttl: FiniteDuration = 1.minute
+      ttl: FiniteDuration = 1.minute,
+      signatureAlgorithm: SignatureAlgorithm = Ed25519
   ): Deploy = {
-    val (sk, pk) = Ed25519.newKeyPair
+    val (sk, pk) = signatureAlgorithm.newKeyPair
     val b = Deploy
       .Body()
       .withSession(Deploy.Code().withWasm(sessionCode))
       .withPayment(Deploy.Code().withWasm(sessionCode))
     val h = Deploy
       .Header()
-      .withAccountPublicKeyHash(ByteString.copyFrom(Ed25519.publicKeyHash(pk)))
+      .withAccountPublicKeyHash(ByteString.copyFrom(signatureAlgorithm.publicKeyHash(pk)))
       .withTimestamp(timestamp)
       .withBodyHash(protoHash(b))
       .withTtlMillis(ttl.toMillis.toInt)
@@ -583,7 +584,7 @@ object ProtoUtil {
       .withHeader(h)
       .withBody(b)
       .withHashes
-      .sign(sk, pk)
+      .approve(signatureAlgorithm, sk, pk)
 
   }
 

--- a/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/HashSetCasperTest.scala
@@ -1367,10 +1367,11 @@ abstract class HashSetCasperTest
         .withBlockHash(blockHash)
         .withHeader(header)
         .withBody(body)
+    val validatorId = validatorKeys(1)
     ProtoUtil.signBlock(
       blockThatPointsToInvalidBlock,
-      validatorKeys(1).privateKey,
-      Ed25519
+      validatorId.privateKey,
+      validatorId.signatureAlgorithm
     )
   }
 }

--- a/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/api/CreateBlockAPITest.scala
@@ -65,9 +65,11 @@ class CreateBlockAPITest
   implicit val deployRelaying = new NoOpsDeployRelaying[Task]
 
   private val (validatorKeys, validators) = {
-    val (sks, pks) = (1 to 4).map(_ => Ed25519.newKeyPair).unzip
-    val hs         = pks.map(pk => Keys.PublicKeyHash(ByteString.copyFrom(Ed25519.publicKeyHash(pk))))
-    sks -> hs
+    val validatorIds = (1 to 4) map { _ =>
+      val (sk, pk) = Ed25519.newKeyPair
+      ValidatorIdentity(pk, sk, Ed25519)
+    }
+    validatorIds -> validatorIds.map(_.publicKeyHashBS)
   }
   private val bonds                                   = createBonds(validators)
   private val BlockMsgWithTransform(Some(genesis), _) = createGenesis(bonds)

--- a/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
@@ -23,13 +23,13 @@ object DeployOps extends ArbitraryConsensus {
     // Clears previous signatures and adds a new one.
     def signSingle: Deploy = {
       val (sk, pk) = Ed25519.newKeyPair
-      DeployImplicits.DeployOps(deploy.withApprovals(Seq.empty)).sign(sk, pk)
+      DeployImplicits.DeployOps(deploy.withApprovals(Seq.empty)).approve(Ed25519, sk, pk)
     }
 
     // Adds a new signature to already existing ones.
     def addSignature: Deploy = {
       val (sk, pk) = Ed25519.newKeyPair
-      DeployImplicits.DeployOps(deploy).sign(sk, pk)
+      DeployImplicits.DeployOps(deploy).approve(Ed25519, sk, pk)
     }
     def withSessionCode(bytes: ByteString): Deploy =
       rehash(

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -387,7 +387,7 @@ object DeployRuntime {
       publicKey    <- readKey[F, PublicKey](publicKeyFile, "public", Ed25519.tryParsePublicKey _)
       privateKey   <- readKey[F, PrivateKey](privateKeyFile, "private", Ed25519.tryParsePrivateKey _)
       deploy       <- Sync[F].fromTry(Try(Deploy.parseFrom(deployBA)))
-      signedDeploy = deploy.sign(privateKey, publicKey)
+      signedDeploy = deploy.approve(Ed25519, privateKey, publicKey)
       _            <- writeDeploy(signedDeploy, output)
     } yield ()
 
@@ -527,7 +527,7 @@ object DeployRuntime {
     } yield {
       val deploy =
         makeDeploy(accountPublicKey, deployConfig, sessionArgs)
-      (maybePrivateKey, maybePublicKey).mapN(deploy.sign) getOrElse deploy
+      (maybePrivateKey, maybePublicKey).mapN(deploy.approve(Ed25519, _, _)) getOrElse deploy
     }
 
     gracefulExit(

--- a/crypto/src/main/scala/io/casperlabs/crypto/signatures/SignatureAlgorithm.scala
+++ b/crypto/src/main/scala/io/casperlabs/crypto/signatures/SignatureAlgorithm.scala
@@ -61,15 +61,10 @@ sealed trait SignatureAlgorithm {
 
 object SignatureAlgorithm {
 
-  /**
-    * TODO: Temporarily disabled `secp256k1` because of errors,
-    * because some parts of the node complain if validator ID's size
-    * doesn't equal to 32 bytes
-    */
   def unapply(alg: String): Option[SignatureAlgorithm] = alg match {
-    case "ed25519" => Some(Ed25519)
-    //    case "secp256k1" => Some(Secp256k1)
-    case _ => None
+    case "ed25519"   => Some(Ed25519)
+    case "secp256k1" => Some(Secp256k1)
+    case _           => None
   }
 
   /**

--- a/models/src/main/scala/io/casperlabs/models/DeployImplicits.scala
+++ b/models/src/main/scala/io/casperlabs/models/DeployImplicits.scala
@@ -5,7 +5,7 @@ import io.casperlabs.casper.consensus
 import io.casperlabs.casper.consensus.{Deploy, DeploySummary}
 import io.casperlabs.crypto.Keys.{PrivateKey, PublicKey}
 import io.casperlabs.crypto.hash.Blake2b256
-import io.casperlabs.crypto.signatures.SignatureAlgorithm.Ed25519
+import io.casperlabs.crypto.signatures.SignatureAlgorithm
 import io.casperlabs.shared.Sorting.byteStringOrdering
 
 object DeployImplicits {
@@ -19,13 +19,13 @@ object DeployImplicits {
       d.withHeader(h).withDeployHash(hash(h))
     }
 
-    def sign(privateKey: PrivateKey, publicKey: PublicKey): Deploy = {
-      val sig = Ed25519.sign(d.deployHash.toByteArray, privateKey)
+    def approve(alg: SignatureAlgorithm, privateKey: PrivateKey, publicKey: PublicKey): Deploy = {
+      val sig = alg.sign(d.deployHash.toByteArray, privateKey)
       val approval = consensus
         .Approval()
         .withApproverPublicKey(ByteString.copyFrom(publicKey))
         .withSignature(
-          consensus.Signature().withSigAlgorithm(Ed25519.name).withSig(ByteString.copyFrom(sig))
+          consensus.Signature().withSigAlgorithm(alg.name).withSig(ByteString.copyFrom(sig))
         )
       val approvals = d.approvals.toList :+ approval
       d.withApprovals(approvals.distinct.sortBy(_.approverPublicKey))


### PR DESCRIPTION
### Overview
Enables Secp256k1 keys for deploys and block validators.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDSC-66

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
