### PR TITLE
TNET-38: Thread pool metrics

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/Main.scala
+++ b/node/src/main/scala/io/casperlabs/node/Main.scala
@@ -6,7 +6,6 @@ import io.casperlabs.catscontrib.effect.implicits.syncId
 import io.casperlabs.ipc.ChainSpec
 import io.casperlabs.node.configuration._
 import io.casperlabs.node.configuration.Configuration.Command.Run
-import io.casperlabs.node.effects.SchedulerFactory
 import io.casperlabs.shared._
 import monix.eval.Task
 import monix.execution.Scheduler

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -40,7 +40,6 @@ import io.casperlabs.node.api.{EventStream, VersionInfo}
 import io.casperlabs.node.api.graphql.FinalizedBlocksStream
 import io.casperlabs.node.casper.consensus.Consensus
 import io.casperlabs.node.configuration.Configuration
-import io.casperlabs.node.effects.SchedulerFactory
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.{ExecutionEngineService, GrpcExecutionEngineService}
 import io.casperlabs.storage.SQLiteStorage
@@ -144,6 +143,7 @@ class NodeRuntime private[node] (
       _ <- Resource.liftF(runRdmbsMigrations(conf.server.dataDir))
 
       _ <- effects.periodicStorageSizeMetrics(conf)
+      _ <- effects.periodicThreadPoolMetrics(schedulerFactory)
 
       implicit0(
         storage: SQLiteStorage.CombinedStorage[Task]

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -40,6 +40,7 @@ import io.casperlabs.node.api.{EventStream, VersionInfo}
 import io.casperlabs.node.api.graphql.FinalizedBlocksStream
 import io.casperlabs.node.casper.consensus.Consensus
 import io.casperlabs.node.configuration.Configuration
+import io.casperlabs.node.effects.SchedulerFactory
 import io.casperlabs.shared._
 import io.casperlabs.smartcontracts.{ExecutionEngineService, GrpcExecutionEngineService}
 import io.casperlabs.storage.SQLiteStorage
@@ -65,38 +66,36 @@ class NodeRuntime private[node] (
 )(
     implicit log: Log[Task],
     logId: Log[Id],
-    uncaughtExceptionHandler: UncaughtExceptionHandler
+    schedulerFactory: SchedulerFactory
 ) {
   import NodeRuntime.RelayingProxy
 
   private[this] val loopScheduler =
-    Scheduler.fixedPool("loop", 2, reporter = uncaughtExceptionHandler)
+    schedulerFactory.fixedPool("loop", 2)
 
   // Bounded thread pool for incoming traffic. Limited thread pool size so loads of request cannot exhaust all resources.
   private[this] val ingressScheduler = {
     val cpus  = java.lang.Runtime.getRuntime.availableProcessors()
     val multi = conf.server.parallelismCpuMultiplier.value
-    Scheduler.forkJoin(
+    schedulerFactory.forkJoin(
       parallelism = Math.max((cpus * multi).toInt, conf.server.minParallelism.value),
       maxThreads = conf.server.ingressThreads.value,
-      name = "ingress-io",
-      reporter = uncaughtExceptionHandler
+      name = "ingress-io"
     )
   }
 
   // Unbounded thread pool for outgoing, blocking IO. It is recommended to have unlimited thread pools for waiting on IO.
   private[this] val egressScheduler =
-    Scheduler.cached("egress-io", 2, Int.MaxValue, reporter = uncaughtExceptionHandler)
+    schedulerFactory.cached("egress-io", 2, Int.MaxValue)
 
   private[this] def dbConnScheduler(name: String, connections: Int, threads: Int) =
-    Scheduler.cached(
+    schedulerFactory.cached(
       s"db-conn-$name",
       connections,
-      math.max(connections, threads),
-      reporter = uncaughtExceptionHandler
+      math.max(connections, threads)
     )
   private[this] def dbIOScheduler(name: String, connections: Int) =
-    Scheduler.cached(s"db-io-$name", connections, Int.MaxValue, reporter = uncaughtExceptionHandler)
+    schedulerFactory.cached(s"db-io-$name", connections, Int.MaxValue)
 
   implicit val raiseIOError: RaiseIOError[Task] = IOError.raiseIOErrorThroughSync[Task]
 
@@ -525,9 +524,9 @@ object NodeRuntime {
   )(
       implicit
       scheduler: Scheduler,
+      schedulerFactory: SchedulerFactory,
       log: Log[Task],
-      logId: Log[Id],
-      uncaughtExceptionHandler: UncaughtExceptionHandler
+      logId: Log[Id]
   ): Task[NodeRuntime] =
     for {
       id      <- NodeEnvironment.create(conf)

--- a/node/src/main/scala/io/casperlabs/node/SchedulerFactory.scala
+++ b/node/src/main/scala/io/casperlabs/node/SchedulerFactory.scala
@@ -1,4 +1,4 @@
-package io.casperlabs.node.effects
+package io.casperlabs.node
 
 import java.util.concurrent._
 import monix.execution.Scheduler
@@ -16,6 +16,12 @@ class SchedulerFactory private (
     reporter: UncaughtExceptionReporter
 ) {
   import SchedulerFactory._
+
+  /** Collect statistics for all pools created by this factory. */
+  def getStats: Map[String, PoolStats] =
+    poolMap.toSeq.map {
+      case (name, pool) => name -> pool.getStats
+    }.toMap
 
   def fixedPool(
       name: String,
@@ -58,7 +64,7 @@ class SchedulerFactory private (
     )
 
   private def register(name: String, scheduler: ExecutorScheduler): ExecutorScheduler = {
-    val pool: Pool = scheduler.executor match {
+    val pool = scheduler.executor match {
       case executor: ForkJoinPool =>
         Pool {
           PoolStats(

--- a/node/src/main/scala/io/casperlabs/node/effects/SchedulerFactory.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/SchedulerFactory.scala
@@ -1,0 +1,122 @@
+package io.casperlabs.node.effects
+
+import java.util.concurrent._
+import monix.execution.Scheduler
+import monix.execution.schedulers.{ExecutorScheduler, SchedulerService}
+import monix.execution.{Features, Scheduler, SchedulerCompanion, UncaughtExceptionReporter}
+import monix.execution.{ExecutionModel => ExecModel}
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+
+/** Replicate some of the methods from monix to create Scheduler instances
+  * but make the thread pools available for metrics reporting.
+  */
+class SchedulerFactory private (
+    poolMap: TrieMap[String, SchedulerFactory.Pool],
+    reporter: UncaughtExceptionReporter
+) {
+  import SchedulerFactory._
+
+  def fixedPool(
+      name: String,
+      poolSize: Int
+  ): SchedulerService =
+    register(
+      name,
+      Scheduler.fixedPool(name, poolSize, reporter = reporter).asInstanceOf[ExecutorScheduler]
+    )
+
+  def forkJoin(
+      parallelism: Int,
+      maxThreads: Int,
+      name: String
+  ): SchedulerService =
+    register(
+      name,
+      ExecutorScheduler
+        .forkJoinDynamic(
+          name,
+          parallelism,
+          maxThreads,
+          daemonic = true,
+          reporter = reporter,
+          executionModel = ExecModel.Default
+        )
+    )
+
+  def cached(
+      name: String,
+      minThreads: Int,
+      maxThreads: Int,
+      keepAliveTime: FiniteDuration = 60.seconds
+  ): SchedulerService =
+    register(
+      name,
+      Scheduler
+        .cached(name, minThreads, maxThreads, keepAliveTime, reporter = reporter)
+        .asInstanceOf[ExecutorScheduler]
+    )
+
+  private def register(name: String, scheduler: ExecutorScheduler): ExecutorScheduler = {
+    val pool: Pool = scheduler.executor match {
+      case executor: ForkJoinPool =>
+        Pool {
+          PoolStats(
+            poolSize = executor.getPoolSize(),
+            activeThreadCount = executor.getActiveThreadCount(),
+            taskQueueSize = executor.getQueuedSubmissionCount().toLong + executor
+              .getQueuedTaskCount()
+          )
+        }
+
+      case executor: ScheduledThreadPoolExecutor =>
+        Pool {
+          PoolStats(
+            poolSize = executor.getPoolSize(),
+            activeThreadCount = executor.getActiveCount(),
+            taskQueueSize = executor.getQueue().size().toLong
+          )
+        }
+
+      case executor: ThreadPoolExecutor =>
+        Pool {
+          PoolStats(
+            poolSize = executor.getPoolSize(),
+            activeThreadCount = executor.getActiveCount(),
+            taskQueueSize = executor.getQueue().size().toLong
+          )
+        }
+
+      case other =>
+        throw new IllegalArgumentException(
+          s"Thread pool '$name' has an unknown executor type: ${other.getClass.getSimpleName}"
+        )
+    }
+
+    poolMap.put(name, pool)
+
+    scheduler
+  }
+}
+
+object SchedulerFactory {
+  def apply(
+      reporter: UncaughtExceptionReporter = UncaughtExceptionReporter.default
+  ): SchedulerFactory =
+    new SchedulerFactory(TrieMap.empty[String, Pool], reporter)
+
+  trait Pool {
+    def getStats: PoolStats
+  }
+  object Pool {
+    def apply(thunk: => PoolStats): Pool = new Pool {
+      override def getStats = thunk
+    }
+  }
+
+  case class PoolStats(
+      poolSize: Int,
+      activeThreadCount: Int,
+      taskQueueSize: Long
+  )
+}

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -127,7 +127,7 @@ package object effects {
       config.addDataSourceProperty("busy_timeout", "5000")
       config.addDataSourceProperty("journal_mode", "WAL")
       config.setConnectionTimeout(connectionTimeout.toMillis)
-      config.setPoolName(s"${poolName}-pool")
+      config.setPoolName(poolName)
       config
     }
 


### PR DESCRIPTION
### Overview
Adds thread pool metrics to the node, updated every 15 seconds.

```console
$ make node-0/metrics | grep threads | grep -v TYPE | sort
casperlabs_threads_db_conn_read_active_thread_count 0.0
casperlabs_threads_db_conn_read_pool_size 10.0
casperlabs_threads_db_conn_read_task_queue_size 0.0
casperlabs_threads_db_conn_write_active_thread_count 0.0
casperlabs_threads_db_conn_write_pool_size 1.0
casperlabs_threads_db_conn_write_task_queue_size 0.0
casperlabs_threads_db_io_read_active_thread_count 0.0
casperlabs_threads_db_io_read_pool_size 10.0
casperlabs_threads_db_io_read_task_queue_size 0.0
casperlabs_threads_db_io_write_active_thread_count 0.0
casperlabs_threads_db_io_write_pool_size 1.0
casperlabs_threads_db_io_write_task_queue_size 0.0
casperlabs_threads_egress_io_active_thread_count 0.0
casperlabs_threads_egress_io_pool_size 4.0
casperlabs_threads_egress_io_task_queue_size 0.0
casperlabs_threads_ingress_io_active_thread_count 0.0
casperlabs_threads_ingress_io_pool_size 4.0
casperlabs_threads_ingress_io_task_queue_size 0.0
casperlabs_threads_loop_active_thread_count 0.0
casperlabs_threads_loop_pool_size 2.0
casperlabs_threads_loop_task_queue_size 23.0
casperlabs_threads_node_runner_active_thread_count 1.0
casperlabs_threads_node_runner_pool_size 11.0
casperlabs_threads_node_runner_task_queue_size 0.0
jvm_threads{component="system-metrics",measure="daemon"} 82.0
jvm_threads{component="system-metrics",measure="peak"} 106.0
jvm_threads{component="system-metrics",measure="total"} 105.0
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-38

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Most of the classes monix uses are internal, so there was no way to go deeper to the thread factory level.

Created another story to capture database connect pool metrics: https://casperlabs.atlassian.net/browse/TNET-39
