### PR TITLE
TNET-39: Hikari pool metrics

### DIFF
--- a/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
+++ b/comm/src/test/scala/io/casperlabs/comm/gossiping/GrpcGossipServiceSpec.scala
@@ -542,7 +542,7 @@ class GrpcGossipServiceSpec
                     res.size shouldBe fetchers.size
                     // We may see some overlap between completion and the start of the next
                     // due to the fact that gRPC will do client side buffering too.
-                    parallelMax.get should be <= (maxParallelBlockDownloads * 2)
+                    parallelMax.get should be <= (maxParallelBlockDownloads * 3)
                     parallelMax.get should be >= maxParallelBlockDownloads
                   }
                 }

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -136,7 +136,7 @@ class NodeRuntime private[node] (
                                                                           conf.server.maxMessageSize.value,
                                                                           conf.server.engineParallelism.value
                                                                         )
-      databaseMetrics = diagnostics.HikariMetricsTrackerFactory()
+      databaseMetrics <- Resource.liftF(diagnostics.HikariMetricsTrackerFactory[Task]())
 
       //TODO: We may want to adjust threading model for better performance
       (writeTransactor, readTransactor) <- effects.doobieTransactors(

--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -136,14 +136,18 @@ class NodeRuntime private[node] (
                                                                           conf.server.maxMessageSize.value,
                                                                           conf.server.engineParallelism.value
                                                                         )
+      databaseMetrics = diagnostics.HikariMetricsTrackerFactory()
+
       //TODO: We may want to adjust threading model for better performance
       (writeTransactor, readTransactor) <- effects.doobieTransactors(
                                             conf,
                                             connectEC = dbConnScheduler,
-                                            transactEC = dbIOScheduler
+                                            transactEC = dbIOScheduler,
+                                            metricsTrackerFactory = databaseMetrics
                                           )
       _ <- Resource.liftF(runRdmbsMigrations(conf.server.dataDir))
 
+      _ <- databaseMetrics.periodicPoolMetrics()
       _ <- effects.periodicStorageSizeMetrics(conf)
 
       implicit0(

--- a/node/src/main/scala/io/casperlabs/node/diagnostics/HikariMetricsTrackerFactory.scala
+++ b/node/src/main/scala/io/casperlabs/node/diagnostics/HikariMetricsTrackerFactory.scala
@@ -3,7 +3,7 @@ package io.casperlabs.node.diagnostics
 import cats._
 import cats.implicits._
 import cats.effect.implicits._
-import cats.effect.{Concurrent, Resource, Timer}
+import cats.effect.{Concurrent, Resource, Sync, Timer}
 import com.zaxxer.hikari.metrics.{IMetricsTracker, MetricsTrackerFactory, PoolStats}
 import io.casperlabs.catscontrib.Catscontrib._
 import io.casperlabs.metrics.Metrics
@@ -70,6 +70,6 @@ object HikariMetricsTrackerFactory {
     def getStats: PoolStats
   }
 
-  def apply()(implicit metricsId: Metrics[Id]): HikariMetricsTrackerFactory =
-    new HikariMetricsTrackerFactory(TrieMap.empty)
+  def apply[F[_]: Sync]()(implicit metricsId: Metrics[Id]): F[HikariMetricsTrackerFactory] =
+    Sync[F].delay(new HikariMetricsTrackerFactory(TrieMap.empty))
 }

--- a/node/src/main/scala/io/casperlabs/node/diagnostics/HikariMetricsTrackerFactory.scala
+++ b/node/src/main/scala/io/casperlabs/node/diagnostics/HikariMetricsTrackerFactory.scala
@@ -1,0 +1,75 @@
+package io.casperlabs.node.diagnostics
+
+import cats._
+import cats.implicits._
+import cats.effect.implicits._
+import cats.effect.{Concurrent, Resource, Timer}
+import com.zaxxer.hikari.metrics.{IMetricsTracker, MetricsTrackerFactory, PoolStats}
+import io.casperlabs.catscontrib.Catscontrib._
+import io.casperlabs.metrics.Metrics
+import scala.collection.concurrent.TrieMap
+import scala.concurrent.duration._
+
+class HikariMetricsTrackerFactory private (
+    trackerMap: TrieMap[String, HikariMetricsTrackerFactory.Tracker]
+)(
+    implicit metricsId: Metrics[Id]
+) extends MetricsTrackerFactory {
+  implicit val metricsSource = Metrics.BaseSource / "database"
+
+  override def create(poolName: String, poolStats: PoolStats): IMetricsTracker = {
+    val tracker = new HikariMetricsTrackerFactory.Tracker {
+      override def getStats =
+        poolStats
+
+      override def recordConnectionAcquiredNanos(elapsedAcquiredNanos: Long): Unit =
+        Metrics[Id].record(s"$poolName-conn-acquired-millis", elapsedAcquiredNanos / 1000000)
+
+      override def recordConnectionCreatedMillis(connectionCreatedMillis: Long): Unit =
+        Metrics[Id].record(s"$poolName-conn-created-millis", connectionCreatedMillis)
+
+      override def recordConnectionUsageMillis(elapsedBorrowedMillis: Long): Unit =
+        Metrics[Id].record(s"$poolName-conn-used-millis", elapsedBorrowedMillis)
+
+      override def recordConnectionTimeout(): Unit =
+        Metrics[Id].incrementCounter(s"$poolName-conn-timeout")
+
+      override def close(): Unit =
+        trackerMap.remove(poolName)
+    }
+    Metrics[Id].incrementCounter(s"$poolName-conn-timeout", 0)
+    trackerMap.put(poolName, tracker)
+    tracker
+  }
+
+  def periodicPoolMetrics[F[_]: Concurrent: Timer: Metrics](
+      updatePeriod: FiniteDuration = 15.seconds
+  ): Resource[F, F[Unit]] = {
+    val update = for {
+      _ <- trackerMap.toList.traverse {
+            case (name, tracker) =>
+              val stats = tracker.getStats
+              for {
+                _ <- Metrics[F]
+                      .setGauge(s"$name-total-conn-count", stats.getTotalConnections().toLong)
+                _ <- Metrics[F]
+                      .setGauge(s"$name-active-conn-count", stats.getActiveConnections().toLong)
+                _ <- Metrics[F]
+                      .setGauge(s"$name-pending-thread-count", stats.getPendingThreads().toLong)
+              } yield ()
+          }
+      _ <- Timer[F].sleep(updatePeriod)
+    } yield ()
+
+    update.forever.background
+  }
+}
+
+object HikariMetricsTrackerFactory {
+  trait Tracker extends IMetricsTracker {
+    def getStats: PoolStats
+  }
+
+  def apply()(implicit metricsId: Metrics[Id]): HikariMetricsTrackerFactory =
+    new HikariMetricsTrackerFactory(TrieMap.empty)
+}

--- a/node/src/main/scala/io/casperlabs/node/effects/package.scala
+++ b/node/src/main/scala/io/casperlabs/node/effects/package.scala
@@ -7,6 +7,7 @@ import cats.effect._
 import cats.effect.implicits._
 import cats.implicits._
 import cats.mtl._
+import com.zaxxer.hikari.metrics.MetricsTrackerFactory
 import doobie.hikari.HikariTransactor
 import doobie.implicits._
 import doobie.util.transactor.Transactor
@@ -95,7 +96,8 @@ package object effects {
   def doobieTransactors(
       conf: Configuration,
       connectEC: (String, Int, Int) => ExecutionContext,
-      transactEC: (String, Int) => ExecutionContext
+      transactEC: (String, Int) => ExecutionContext,
+      metricsTrackerFactory: MetricsTrackerFactory
   ): Resource[Task, (Transactor[Task], Transactor[Task])] = {
     val serverDataDir = conf.server.dataDir
     val readThreads   = conf.server.dbReadThreads.value
@@ -128,6 +130,7 @@ package object effects {
       config.addDataSourceProperty("journal_mode", "WAL")
       config.setConnectionTimeout(connectionTimeout.toMillis)
       config.setPoolName(s"${poolName}-pool")
+      config.setMetricsTrackerFactory(metricsTrackerFactory)
       config
     }
 


### PR DESCRIPTION
### Overview
Reports Hikari pool metrics every 15 seconds:
* Timeout counter
* Connection creation/acquiring/usage millisecond histograms
* Active / Total connection gauges
* Pending threads gague

```console
$ make node-0/metrics | grep database
# TYPE casperlabs_database_write_conn_timeout_total counter
casperlabs_database_write_conn_timeout_total 0.0
# TYPE casperlabs_database_read_conn_timeout_total counter
casperlabs_database_read_conn_timeout_total 0.0
# TYPE casperlabs_database_write_pending_thread_count gauge
casperlabs_database_write_pending_thread_count 0.0
# TYPE casperlabs_database_write_active_conn_count gauge
casperlabs_database_write_active_conn_count 0.0
# TYPE casperlabs_database_read_pending_thread_count gauge
casperlabs_database_read_pending_thread_count 0.0
# TYPE casperlabs_database_read_active_conn_count gauge
casperlabs_database_read_active_conn_count 0.0
# TYPE casperlabs_database_read_total_conn_count gauge
casperlabs_database_read_total_conn_count 1.0
# TYPE casperlabs_database_write_total_conn_count gauge
casperlabs_database_write_total_conn_count 1.0
# TYPE casperlabs_database_read_conn_used_millis histogram
casperlabs_database_read_conn_used_millis_bucket{le="10.0"} 73.0
casperlabs_database_read_conn_used_millis_bucket{le="30.0"} 75.0
casperlabs_database_read_conn_used_millis_bucket{le="100.0"} 76.0
casperlabs_database_read_conn_used_millis_bucket{le="300.0"} 77.0
casperlabs_database_read_conn_used_millis_bucket{le="1000.0"} 77.0
casperlabs_database_read_conn_used_millis_bucket{le="3000.0"} 77.0
casperlabs_database_read_conn_used_millis_bucket{le="10000.0"} 77.0
casperlabs_database_read_conn_used_millis_bucket{le="30000.0"} 77.0
casperlabs_database_read_conn_used_millis_bucket{le="100000.0"} 77.0
casperlabs_database_read_conn_used_millis_bucket{le="+Inf"} 77.0
casperlabs_database_read_conn_used_millis_count 77.0
casperlabs_database_read_conn_used_millis_sum 336.0
# TYPE casperlabs_database_write_conn_acquired_millis histogram
casperlabs_database_write_conn_acquired_millis_bucket{le="10.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="30.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="100.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="300.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="1000.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="3000.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="10000.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="30000.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="100000.0"} 27.0
casperlabs_database_write_conn_acquired_millis_bucket{le="+Inf"} 27.0
casperlabs_database_write_conn_acquired_millis_count 27.0
casperlabs_database_write_conn_acquired_millis_sum 3.0
# TYPE casperlabs_database_read_conn_created_millis histogram
casperlabs_database_read_conn_created_millis_bucket{le="10.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="30.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="100.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="300.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="1000.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="3000.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="10000.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="30000.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="100000.0"} 1.0
casperlabs_database_read_conn_created_millis_bucket{le="+Inf"} 1.0
casperlabs_database_read_conn_created_millis_count 1.0
casperlabs_database_read_conn_created_millis_sum 1.0
# TYPE casperlabs_database_read_conn_acquired_millis histogram
casperlabs_database_read_conn_acquired_millis_bucket{le="10.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="30.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="100.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="300.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="1000.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="3000.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="10000.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="30000.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="100000.0"} 77.0
casperlabs_database_read_conn_acquired_millis_bucket{le="+Inf"} 77.0
casperlabs_database_read_conn_acquired_millis_count 77.0
casperlabs_database_read_conn_acquired_millis_sum 9.0
# TYPE casperlabs_database_write_conn_used_millis histogram
casperlabs_database_write_conn_used_millis_bucket{le="10.0"} 22.0
casperlabs_database_write_conn_used_millis_bucket{le="30.0"} 26.0
casperlabs_database_write_conn_used_millis_bucket{le="100.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="300.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="1000.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="3000.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="10000.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="30000.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="100000.0"} 27.0
casperlabs_database_write_conn_used_millis_bucket{le="+Inf"} 27.0
casperlabs_database_write_conn_used_millis_count 27.0
casperlabs_database_write_conn_used_millis_sum 169.0

```
### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-39

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
