### PR TITLE
ECO-468: fix bug of requesting twice when clicking pagination.

### DIFF
--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -25,10 +25,7 @@ export interface Props extends RouteComponentProps<{}> {
 class _BlockList extends React.Component<Props, {}> {
   constructor(props: Props) {
     super(props);
-    let maxRank = parseInt(props.maxRank || '') || 0;
-    let depth = parseInt(props.depth || '') || 10;
-    this.props.dag.updateMaxRankAndDepth(maxRank, depth);
-    this.props.dag.refreshBlockDagAndSetupSubscriber();
+    this.props.dag.refreshWithDepthAndMaxRank(props.maxRank, props.depth);
   }
 
   async refresh() {
@@ -38,6 +35,13 @@ class _BlockList extends React.Component<Props, {}> {
   componentWillUnmount() {
     // release websocket if necessary
     this.props.dag.toggleableSubscriber.unsubscribeAndFree();
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    if (this.props.depth === nextProps.depth && this.props.maxRank === nextProps.maxRank) {
+      return;
+    }
+    this.props.dag.refreshWithDepthAndMaxRank(nextProps.maxRank, nextProps.depth);
   }
 
   render() {

--- a/explorer/ui/src/components/BlockList.tsx
+++ b/explorer/ui/src/components/BlockList.tsx
@@ -37,6 +37,7 @@ class _BlockList extends React.Component<Props, {}> {
     this.props.dag.toggleableSubscriber.unsubscribeAndFree();
   }
 
+  // when receive new props of depth and maxRank, we need parse them and set related state variables.
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.depth === nextProps.depth && this.props.maxRank === nextProps.maxRank) {
       return;

--- a/explorer/ui/src/components/Explorer.tsx
+++ b/explorer/ui/src/components/Explorer.tsx
@@ -16,31 +16,21 @@ import { BondedValidatorsTable } from './BondedValidatorsTable';
 import { ToggleButton } from './ToggleButton';
 import { BlockType, BlockRole, FinalityIcon } from './BlockDetails';
 
-const DEFAULT_DEPTH = 100;
 
 /** Show the tips of the DAG. */
 @observer
 class _Explorer extends React.Component<Props, {}> {
   constructor(props: Props) {
     super(props);
-    this.refreshWithDepthAndMaxRank(props.maxRank, props.depth);
+    this.props.dag.refreshWithDepthAndMaxRank(props.maxRank, props.depth);
   }
 
-  refreshWithDepthAndMaxRank(
-    maxRankStr: string | null,
-    depthStr: string | null
-  ) {
-    let maxRank = parseInt(maxRankStr || '') || 0;
-    let depth = parseInt(depthStr || '') || DEFAULT_DEPTH;
-    this.props.dag.updateMaxRankAndDepth(maxRank, depth);
-    this.props.dag.refreshBlockDagAndSetupSubscriber();
-  }
 
   componentWillReceiveProps(nextProps: Props) {
     if (this.props.depth === nextProps.depth && this.props.maxRank === nextProps.maxRank) {
       return;
     }
-    this.refreshWithDepthAndMaxRank(nextProps.maxRank, nextProps.depth);
+    this.props.dag.refreshWithDepthAndMaxRank(nextProps.maxRank, nextProps.depth);
   }
 
   async refresh() {

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -80,10 +80,11 @@ export class DagContainer {
       () => this.refreshBlockDag()
     );
 
+    // react to the change of maxRank and depth, so that outer components only need to set DAG's props
+    // DAG manage the refresh by itself.
     reaction(() => {
       return [this.maxRank, this.depth]
     }, () => {
-      console.log("run");
       this.refreshBlockDagAndSetupSubscriber();
     })
   }

--- a/explorer/ui/src/containers/DagContainer.ts
+++ b/explorer/ui/src/containers/DagContainer.ts
@@ -1,4 +1,4 @@
-import { action, IObservableArray, observable, runInAction } from 'mobx';
+import { action, autorun, IObservableArray, observable, reaction, runInAction } from 'mobx';
 
 import ErrorContainer from './ErrorContainer';
 import { CasperService, encodeBase16 } from 'casperlabs-sdk';
@@ -6,13 +6,14 @@ import { BlockInfo, Event } from 'casperlabs-grpc/io/casperlabs/casper/consensus
 import { ToggleStore } from '../components/ToggleButton';
 import { ToggleableSubscriber } from './ToggleableSubscriber';
 
+const DEFAULT_DEPTH = 100;
+
 export class DagStep {
   constructor(private container: DagContainer) {
   }
 
   private step = (f: () => number) => () => {
     this.maxRank = f();
-    this.container.refreshBlockDagAndSetupSubscriber();
     this.container.selectedBlock = undefined;
   };
 
@@ -78,6 +79,22 @@ export class DagContainer {
       () => this.isLatestDag,
       () => this.refreshBlockDag()
     );
+
+    reaction(() => {
+      return [this.maxRank, this.depth]
+    }, () => {
+      console.log("run");
+      this.refreshBlockDagAndSetupSubscriber();
+    })
+  }
+
+  refreshWithDepthAndMaxRank(
+    maxRankStr: string | null,
+    depthStr: string | null
+  ) {
+    let maxRank = parseInt(maxRankStr || '') || 0;
+    let depth = parseInt(depthStr || '') || DEFAULT_DEPTH;
+    this.updateMaxRankAndDepth(maxRank, depth);
   }
 
   @action


### PR DESCRIPTION
### Overview
This PR address the bug of clicking pagination will request twice in the Clarity Explorer page.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-468

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
