### PR TITLE
TNET-41: Ordering for recursive CLTypes so they can be used as map keys.

### DIFF
--- a/models/src/main/scala/io/casperlabs/models/cltype/CLValueInstance.scala
+++ b/models/src/main/scala/io/casperlabs/models/cltype/CLValueInstance.scala
@@ -275,7 +275,7 @@ object CLValueInstance {
     // This error is raised when serializing (as in the `toValue` method) a
     // `Map` with keys that cannot be sorted because no ordering is defined. Keys
     // must be sorted to ensure deterministic serialization.
-    case object UnorderedElements extends Error
+    case class UnorderedElements(message: java.lang.String) extends Error
   }
 
   implicit class OrderingOps[T](x: T)(implicit ev: Ordering[T]) {
@@ -419,7 +419,7 @@ object CLValueInstance {
 
       case CLValueInstance.Map(values, _, _) :: tail =>
         Try(values.toList.sortBy(_._1)) match {
-          case Failure(_) => Left(Error.UnorderedElements)
+          case Failure(ex) => Left(Error.UnorderedElements(ex.getMessage))
 
           case Success(sortedPairs) =>
             val sortedElems = sortedPairs.flatMap { case (k, v) => immutable.List(k, v) }

--- a/models/src/main/scala/io/casperlabs/models/cltype/CLValueInstance.scala
+++ b/models/src/main/scala/io/casperlabs/models/cltype/CLValueInstance.scala
@@ -278,10 +278,10 @@ object CLValueInstance {
     case class UnorderedElements(message: java.lang.String) extends Error
   }
 
-  implicit class OrderingOps[T](x: T)(implicit ev: Ordering[T]) {
+  private implicit class OrderingOps[T](x: T)(implicit ev: Ordering[T]) {
     def <(y: T): Boolean = ev.lt(x, y)
   }
-  implicit class SeqOrderingOps[T](x: Seq[T])(implicit ev: Ordering[T]) {
+  private implicit class SeqOrderingOps[T](x: Seq[T])(implicit ev: Ordering[T]) {
     def <(y: Seq[T]): Boolean = implicitly[Ordering[Iterable[T]]].lt(x.toIterable, y.toIterable)
   }
 


### PR DESCRIPTION
### Overview
Keys of maps in the ABI need deterministic sorting. Recursive types didn't have sorting which resulted in just an error being logged:
```
W 2020-06-08T10:52:47.731              (ExecEngineUtil.scala:239)  …il.handleInvalidDeploys.237 [85:node-runner-85] deploy=92f4fa477d... failed precondition error: error_message=Error parsing deploy arguments: InstanceError(UnorderedElements)
```

The PR defines ordering for `List`, `FixedList`, `Map`, `Option`, `Result` and the `Tuple` variants.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-41

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
