### PR TITLE
HWY-36: Highway schedule

### DIFF
--- a/execution-engine/consensus/highway-core/src/active_validator.rs
+++ b/execution-engine/consensus/highway-core/src/active_validator.rs
@@ -97,8 +97,8 @@ impl<C: Context> ActiveValidator<C> {
     pub fn on_new_vote(&self, vhash: &C::Hash, instant: u64, state: &State<C>) -> Vec<Effect<C>> {
         if self.should_send_confirmation(vhash, instant, state) {
             let panorama = self.confirmation_panorama(vhash, state);
-            let witness_vote = self.new_vote(panorama, instant, None, state);
-            vec![Effect::NewVertex(Vertex::Vote(witness_vote))]
+            let confirmation_vote = self.new_vote(panorama, instant, None, state);
+            vec![Effect::NewVertex(Vertex::Vote(confirmation_vote))]
         } else {
             vec![]
         }
@@ -113,8 +113,8 @@ impl<C: Context> ActiveValidator<C> {
     ) -> Vec<Effect<C>> {
         let panorama = state.panorama().clone();
         let instant = block_context.instant();
-        let witness_vote = self.new_vote(panorama, instant, Some(values), state);
-        vec![Effect::NewVertex(Vertex::Vote(witness_vote))]
+        let proposal_vote = self.new_vote(panorama, instant, Some(values), state);
+        vec![Effect::NewVertex(Vertex::Vote(proposal_vote))]
     }
 
     /// Returns whether the incoming message is a proposal that we need to send a confirmation for.

--- a/execution-engine/consensus/highway-core/src/active_validator.rs
+++ b/execution-engine/consensus/highway-core/src/active_validator.rs
@@ -1,61 +1,286 @@
-use crate::{state::State, traits::Context, validators::ValidatorIndex, vertex::Vertex};
+use crate::{
+    state::State,
+    traits::Context,
+    validators::ValidatorIndex,
+    vertex::{Vertex, WireVote},
+    vote::{Observation, Panorama},
+};
 
 /// An action taken by a validator.
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Effect<C: Context> {
     /// Newly vertex that should be gossiped to peers and added to the protocol state.
     NewVertex(Vertex<C>),
-    /// `step` needs to be called at the specified instant.
+    /// `handle_timer` needs to be called at the specified instant.
     ScheduleTimer(u64),
     /// `propose` needs to be called with a value for a new block with the specified instant.
     // TODO: Add more information required by the deploy buffer.
-    RequestNewBlock(u64),
+    RequestNewBlock(BlockContext),
+}
+
+/// Information about the context in which a new block is created.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct BlockContext {
+    instant: u64,
+}
+
+impl BlockContext {
+    /// The block's timestamp.
+    pub fn instant(&self) -> u64 {
+        self.instant
+    }
 }
 
 /// A validator that actively participates in consensus by creating new vertices.
+///
+/// It implements the Highway schedule. The protocol proceeds in rounds, and in each round one
+/// validator is the _leader_.
+/// * In the beginning of the round, the leader sends a _proposal_ vote, containing consensus values
+///   (i.e. a block).
+/// * Upon receiving the proposal, all the other validators send a _confirmation_ vote, citing only
+///   the proposal, their own previous message, and resulting transitive justifications.
+/// * At a fixed point in time later in the round, everyone unconditionally sends a _witness_ vote,
+///   citing every vote they have received so far.
+///
+/// If the rounds are long enough (i.e. message delivery is fast enough) and there are enough
+/// honest validators, there will be a lot of confirmations for the proposal, and enough witness
+/// votes citing all those confirmations, to create a summit and finalize the proposal.
 pub struct ActiveValidator<C: Context> {
     /// Our own validator index.
     vidx: ValidatorIndex,
     /// The validator's secret signing key.
-    secret: C::ValidatorSecret,
+    // TODO: Sign votes.
+    _secret: C::ValidatorSecret,
     /// The round exponent: Our subjective rounds are `1 << round_exp` milliseconds long.
     round_exp: u8,
+    /// The latest timer we scheduled.
+    next_timer: u64,
 }
 
 impl<C: Context> ActiveValidator<C> {
+    /// Creates a new `ActiveValidator` and the timer effect for the first call.
+    pub fn new(
+        vidx: ValidatorIndex,
+        secret: C::ValidatorSecret,
+        round_exp: u8,
+        instant: u64,
+        state: &State<C>,
+    ) -> (Self, Vec<Effect<C>>) {
+        let mut av = ActiveValidator {
+            vidx,
+            _secret: secret,
+            round_exp,
+            next_timer: 0,
+        };
+        let effects = av.schedule_timer(instant, state);
+        (av, effects)
+    }
+
     /// Returns actions a validator needs to take at the specified `instant`, with the given
     /// protocol `state`.
-    pub fn step(&self, state: &State<C>, instant: u64) -> Vec<Effect<C>> {
-        let round_len = 1u64 << self.round_exp;
-        let round_offset = instant % round_len;
+    pub fn handle_timer(&mut self, instant: u64, state: &State<C>) -> Vec<Effect<C>> {
+        let round_offset = instant % self.round_len();
         let round_id = instant - round_offset;
+        let mut effects = self.schedule_timer(instant, state);
         if round_offset == 0 && state.leader(round_id) == self.vidx {
-            vec![Effect::RequestNewBlock(instant)]
-        // TODO: We need HWY-55 first, to be able to create votes with correct hash.
-        // } else if round_offset * 3 == round_len * 2 {
-        //     let panorama = state.panorama().clone();
-        //     let prev_hash = panorama.get(self.vidx).correct().unwrap();
-        //     let seq_number = state.vote(prev_hash).seq_number + 1;
-        //     let witness_vote = WireVote {
-        //         hash: todo!(),
-        //         panorama,
-        //         sender: self.vidx,
-        //         values: None,
-        //         seq_number,
-        //         instant,
-        //     };
-        //     vec![Effect::NewVertex(Vertex::Vote(witness_vote))]
+            let bctx = BlockContext { instant };
+            effects.push(Effect::RequestNewBlock(bctx));
+        } else if round_offset == self.witness_offset() {
+            let panorama = state.panorama().clone();
+            let witness_vote = self.new_vote(panorama, instant, None, state);
+            effects.push(Effect::NewVertex(Vertex::Vote(witness_vote)))
+        }
+        effects
+    }
+
+    /// Returns actions a validator needs to take upon receiving a new vote.
+    pub fn on_new_vote(&self, vhash: &C::Hash, instant: u64, state: &State<C>) -> Vec<Effect<C>> {
+        if self.should_send_confirmation(vhash, instant, state) {
+            let panorama = self.confirmation_panorama(vhash, state);
+            let witness_vote = self.new_vote(panorama, instant, None, state);
+            vec![Effect::NewVertex(Vertex::Vote(witness_vote))]
         } else {
             vec![]
         }
     }
 
-    pub fn on_new_vote(&self, vhash: &C::Hash, state: &State<C>, instant: u64) -> Vec<Effect<C>> {
-        todo!("{:?}, {:?}, {:?}", vhash, state, instant)
+    /// Proposes a new block with the given consensus value.
+    pub fn propose(
+        &self,
+        values: Vec<C::ConsensusValue>,
+        block_context: BlockContext,
+        state: &State<C>,
+    ) -> Vec<Effect<C>> {
+        let panorama = state.panorama().clone();
+        let instant = block_context.instant();
+        let witness_vote = self.new_vote(panorama, instant, Some(values), state);
+        vec![Effect::NewVertex(Vertex::Vote(witness_vote))]
     }
 
-    /// Propose a new block with the given parent and consensus value.
-    pub fn propose(&self, state: &State<C>, values: Vec<C::ConsensusValue>) -> Vec<Effect<C>> {
-        todo!("{:?}, {:?}, {:?}", state, values, self.secret)
-        // vec![Effect::NewVertex(Vertex::Vote(vote))]
+    /// Returns whether the incoming message is a proposal that we need to send a confirmation for.
+    fn should_send_confirmation(&self, vhash: &C::Hash, instant: u64, state: &State<C>) -> bool {
+        let vote = state.vote(vhash);
+        instant / self.round_len() == vote.instant / self.round_len() // Current round.
+            && state.leader(vote.instant) == vote.sender // The sender is the round's leader.
+            && vote.sender != self.vidx // We didn't send it ourselves.
+            && !state.has_evidence(vote.sender) // The sender is not faulty.
+            && state
+                .panorama()
+                .get(self.vidx)
+                .correct()
+                .map_or(true, |own_vh| {
+                    !state.sees_correct(&state.vote(own_vh).panorama, vhash)
+                }) // We haven't confirmed it already.
+    }
+
+    /// Returns the panorama of the confirmation for the leader vote `vhash`.
+    fn confirmation_panorama(&self, vhash: &C::Hash, state: &State<C>) -> Panorama<C> {
+        let vote = state.vote(vhash);
+        let mut panorama;
+        if let Some(prev_hash) = state.panorama().get(self.vidx).correct().cloned() {
+            let own_vote = state.vote(&prev_hash);
+            panorama = state.merge_panoramas(&vote.panorama, &own_vote.panorama);
+            panorama.update(self.vidx, Observation::Correct(prev_hash));
+        } else {
+            panorama = vote.panorama.clone();
+        }
+        panorama.update(vote.sender, Observation::Correct(vhash.clone()));
+        for faulty_v in state.faulty_validators() {
+            panorama.update(faulty_v, Observation::Faulty);
+        }
+        panorama
+    }
+
+    /// Returns a new vote with the given data, and the correct sequence number.
+    fn new_vote(
+        &self,
+        panorama: Panorama<C>,
+        instant: u64,
+        values: Option<Vec<C::ConsensusValue>>,
+        state: &State<C>,
+    ) -> WireVote<C> {
+        let add1 = |vh: &C::Hash| state.vote(vh).seq_number + 1;
+        let seq_number = panorama.get(self.vidx).correct().map_or(0, add1);
+        WireVote {
+            panorama,
+            sender: self.vidx,
+            values,
+            seq_number,
+            instant,
+        }
+    }
+
+    /// Returns a `ScheduleTimer` effect for the next time we need to be called.
+    fn schedule_timer(&mut self, instant: u64, state: &State<C>) -> Vec<Effect<C>> {
+        if self.next_timer > instant {
+            return Vec::new(); // We already scheduled the next call; nothing to do.
+        }
+        let round_offset = instant % self.round_len();
+        let round_id = instant - round_offset;
+        self.next_timer = if round_offset < self.witness_offset() {
+            round_id + self.witness_offset()
+        } else if state.leader(round_id + self.round_len()) == self.vidx {
+            round_id + self.round_len()
+        } else {
+            round_id + self.round_len() + self.witness_offset()
+        };
+        vec![Effect::ScheduleTimer(self.next_timer)]
+    }
+
+    /// Returns the number of ticks after the beginning of a round when the witness votes are sent.
+    fn witness_offset(&self) -> u64 {
+        self.round_len() * 2 / 3
+    }
+
+    /// The length of a round, in ticks.
+    fn round_len(&self) -> u64 {
+        1u64 << self.round_exp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Debug;
+
+    use super::*;
+    use crate::{
+        finality_detector::{FinalityDetector, FinalityResult},
+        state::{tests::*, AddVoteError, Weight},
+        vertex::Vertex,
+    };
+
+    type Eff = Effect<TestContext>;
+
+    impl Eff {
+        fn unwrap_vote(self) -> WireVote<TestContext> {
+            if let Eff::NewVertex(Vertex::Vote(wvote)) = self {
+                wvote
+            } else {
+                panic!("Unexpected effect: {:?}", self);
+            }
+        }
+    }
+
+    fn unwrap_single<T: Debug>(vec: Vec<T>) -> T {
+        let mut iter = vec.into_iter();
+        match (iter.next(), iter.next()) {
+            (None, _) => panic!("Unexpected empty vec"),
+            (Some(t), None) => t,
+            (Some(t0), Some(t1)) => panic!("Expected only one element: {:?}, {:?}", t0, t1),
+        }
+    }
+
+    #[test]
+    #[allow(clippy::unreadable_literal)] // 0xC0FFEE is more readable than 0x00C0_FFEE.
+    fn active_validator() -> Result<(), AddVoteError<TestContext>> {
+        let mut state = State::<TestContext>::new(&[Weight(3), Weight(4)], 0);
+        let mut fd = FinalityDetector::new(Weight(2));
+
+        // We start at time 410, with round length 16, so the first leader tick is 416, and the
+        // first witness tick 426.
+        assert_eq!(ALICE, state.leader(416)); // Alice will be the first leader.
+        assert_eq!(BOB, state.leader(432)); // Bob will be the second leader.
+        let (mut alice_av, effects) = ActiveValidator::new(ALICE, TestSecret(0), 4, 410, &state);
+        assert_eq!([Eff::ScheduleTimer(416)], *effects);
+        let (mut bob_av, effects) = ActiveValidator::new(BOB, TestSecret(1), 4, 410, &state);
+        assert_eq!([Eff::ScheduleTimer(426)], *effects);
+
+        assert!(alice_av.handle_timer(415, &state).is_empty()); // Too early: No new effects.
+
+        // Alice wants to propose a block, and also make her witness vote at 426.
+        let bctx = match &*alice_av.handle_timer(416, &state) {
+            [Eff::ScheduleTimer(426), Eff::RequestNewBlock(bctx)] => bctx.clone(),
+            effects => panic!("unexpected effects {:?}", effects),
+        };
+        assert_eq!(416, bctx.instant());
+
+        // She has a pending deploy from Colin who wants to pay for a hot beverage.
+        let effects = alice_av.propose(vec![0xC0FFEE], bctx, &state);
+        let proposal_wvote = unwrap_single(effects).unwrap_vote();
+        let prop_hash = proposal_wvote.hash();
+        state.add_vote(proposal_wvote)?;
+        assert!(alice_av.on_new_vote(&prop_hash, 417, &state).is_empty());
+
+        // Bob creates a confirmation vote for Alice's proposal.
+        let effects = bob_av.on_new_vote(&prop_hash, 419, &state);
+        state.add_vote(unwrap_single(effects).unwrap_vote())?;
+
+        // Bob creates his witness message 2/3 through the round.
+        let mut effects = bob_av.handle_timer(426, &state).into_iter();
+        assert_eq!(Some(Eff::ScheduleTimer(432)), effects.next()); // Bob is the next leader.
+        state.add_vote(effects.next().unwrap().unwrap_vote())?;
+        assert_eq!(None, effects.next());
+
+        assert_eq!(FinalityResult::None, fd.run(&state)); // Alice has not witnessed Bob's vote yet.
+
+        // Alice also sends her own witness message, completing the summit for her proposal.
+        let mut effects = alice_av.handle_timer(426, &state).into_iter();
+        assert_eq!(Some(Eff::ScheduleTimer(442)), effects.next()); // Timer for witness vote.
+        state.add_vote(effects.next().unwrap().unwrap_vote())?;
+        assert_eq!(None, effects.next());
+
+        // Payment finalized! "One Pumpkin Spice Mochaccino for Corbyn!"
+        assert_eq!(FinalityResult::Finalized(vec![0xC0FFEE]), fd.run(&state));
+        Ok(())
     }
 }


### PR DESCRIPTION
### Overview
Initial implementation of `ActiveValidator`, which contains the logic for when to create proposal, confirmation and witness messages in Highway. For now, this still uses a fixed round length, and creates witness _ballots_ at 2/3 through the round.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/HWY-36

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
