### PR TITLE
TNET-40: Space out omegas

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/LeaderSequencer.scala
@@ -141,14 +141,11 @@ object LeaderSequencer extends LeaderSequencer {
     * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
     * */
   private def shuffle[T](arr: Array[T], rand: SecureRandom): Array[T] = {
-    val n = arr.size
-    if (n > 1) {
-      for (i <- n - 1 to 1 by -1) {
-        val r = rand.nextInt(n)
-        val t = arr(i)
-        arr(i) = arr(r)
-        arr(r) = t
-      }
+    for (i <- arr.size - 1 to 1 by -1) {
+      val r = rand.nextInt(i + 1)
+      val t = arr(i)
+      arr(i) = arr(r)
+      arr(r) = t
     }
     arr
   }

--- a/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/package.scala
@@ -84,7 +84,11 @@ package object highway {
       WriterT.tell[F, Vector[HighwayEvent]](events.toVector)
   }
 
+  /** Determine the leader of any given round. */
   type LeaderFunction = Ticks => PublicKeyBS
+
+  /** Determine an order in which this validator should produce their omega messages in any given round. */
+  type OmegaFunction = Ticks => Seq[PublicKeyBS]
 
   type ValidatedMessage = Message @@ ValidatedTag
   def Validated(m: Message) = m.asInstanceOf[ValidatedMessage]

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -955,20 +955,43 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
           }
 
           "randomize the omega delay" in {
-            val ticks: List[Long] = List
-              .fill(10) {
-                runtime.handleAgenda(Agenda.StartRound(roundId)).value.collect {
-                  case Agenda.DelayedAction(tick, _: Agenda.CreateOmegaMessage) =>
-                    tick
-                }
+            implicit val clock = TestClock.adjustable[Id](now)
+
+            val runtime = genesisEraRuntime(
+              "Alice".some,
+              leaderSequencer = mockSequencer("Alice"),
+              roundExponent = exponent
+            )
+
+            val omegaDelays: List[Long] = List
+              .range(0L, 10L)
+              .map { i =>
+                val instant = conf.genesisEraStart plus (roundLength * i)
+                val roundId = conf.toTicks(instant)
+
+                // Omega is based on time, not just the round.
+                clock.set(conf.toInstant(roundId))
+
+                val omegaTick =
+                  runtime
+                    .handleAgenda(Agenda.StartRound(roundId))
+                    .value
+                    .collectFirst {
+                      case Agenda.DelayedAction(tick, _: Agenda.CreateOmegaMessage) =>
+                        tick
+                    }
+                    .get
+
+                omegaTick - roundId
               }
-              .flatten
 
-            ticks.toSet.size should be > 1
+            omegaDelays.toSet.size should be > 1
 
-            forAll(ticks) { tick =>
-              tick should be >= (roundId + (nextRoundId - roundId) * conf.omegaMessageTimeStart).toLong
-              tick should be < (roundId + (nextRoundId - roundId) * conf.omegaMessageTimeEnd).toLong
+            val ticksPerRound = Ticks.roundLength(exponent)
+
+            forAll(omegaDelays) { ticks =>
+              ticks shouldBe >=((ticksPerRound * conf.omegaMessageTimeStart).toLong)
+              ticks shouldBe <=((ticksPerRound * conf.omegaMessageTimeEnd).toLong)
             }
           }
         }
@@ -1456,8 +1479,12 @@ object EraRuntimeSpec {
     messages.map(m => m.validatorId -> m.messageHash).toMap
 
   def mockSequencer(validator: String) = new LeaderSequencer {
-    def apply[F[_]: MonadThrowable](era: Era): F[LeaderFunction] =
+    def leaderFunction[F[_]: MonadThrowable](era: Era): F[LeaderFunction] =
       ((_: Ticks) => validatorKey(validator)).pure[F]
+
+    def omegaFunction[F[_]: MonadThrowable](era: Era): F[OmegaFunction] =
+      // It was completely random before, so we can use the real randomizer.
+      LeaderSequencer.omegaFunction[F](era)
   }
 
   def insert[F[_]: Monad, A <: Message](

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -1451,6 +1451,27 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       EraRuntime.isSameRoundAs(a)(d) shouldBe false
     }
   }
+
+  "omegaOffset" should {
+    "go from 0.0 to 1.0" in {
+      val expected = List(
+        "Alice"   -> 0.0,
+        "Bob"     -> 0.33,
+        "Charlie" -> 0.66,
+        "Dave"    -> 1.0
+      )
+      val names = expected.unzip._1
+
+      Inspectors.forAll(expected) {
+        case (name, offset) =>
+          EraRuntime.omegaOffset(names, name) shouldBe offset +- 0.01
+      }
+    }
+
+    "return 0.5 for single item" in {
+      EraRuntime.omegaOffset(List("Alice"), "Alice") shouldBe 0.5
+    }
+  }
 }
 
 object EraRuntimeSpec {


### PR DESCRIPTION
### Overview
Changes omega message ticks to not be any random number between the configured lower and upper limits within the round but be based on a random ordering of the validators within the round, so that the messages are created with equal time between them and have a higher chance of forming a chain.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-40

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
