### PR TITLE
NDSC-68: Update hack docker accounts csv

### DIFF
--- a/hack/docker/Makefile
+++ b/hack/docker/Makefile
@@ -144,8 +144,8 @@ slow:
 	@# Create a `faucet-account` to hold some initial tokens to distribute.
 	mkdir -p keys/faucet-account
 	../key-management/docker-gen-account-keys.sh keys/faucet-account
-	FAUCET_ID="$$(cat keys/faucet-account/account-id-hex)" ; \
-	echo "$$FAUCET_ID,1000000000000000000,0" > .casperlabs/chainspec/genesis/accounts.csv
+	FAUCET_PK="$$(cat keys/faucet-account/account-pk-hex)" ; \
+	echo "$$FAUCET_PK,ed25519,1000000000000000000,0" > .casperlabs/chainspec/genesis/accounts.csv
 
 	@# Create bonded validators with 0 balance.
 	bash -c 'i=0 ; while [[ $$i -lt $(CL_CASPER_NUM_VALIDATORS) ]] ; do \
@@ -155,8 +155,8 @@ slow:
 		../key-management/docker-gen-keys.sh .casperlabs/nodes/node-$$i ; \
 		../key-management/docker-gen-account-keys.sh keys/account-$$i ; \
 		BOND=$$(( $(CL_CASPER_NUM_VALIDATORS)*10+$$i )) ; \
-		VALIDATOR_ID="$$(cat .casperlabs/nodes/node-$$i/validator-id-hex)" ; \
-		echo "$$VALIDATOR_ID,0,$$BOND" >> .casperlabs/chainspec/genesis/accounts.csv ; \
+		VALIDATOR_PK="$$(cat .casperlabs/nodes/node-$$i/validator-pk-hex)" ; \
+		echo "$$VALIDATOR_PK,ed25519,0,$$BOND" >> .casperlabs/chainspec/genesis/accounts.csv ; \
 		((i = i + 1)) ; \
 	done'
 

--- a/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/ChainSpec.scala
@@ -166,7 +166,8 @@ object ChainSpec extends ParserImplicits {
               } yield Account(accountHash, balance, bondedAmount)
 
             case _ =>
-              s"Could not parse line into an Account: $line".asLeft[Account]
+              s"Could not parse line into an Account: $line; expected <pk>,<algo>,<balance>,<bond>"
+                .asLeft[Account]
           }
         }
         .toList


### PR DESCRIPTION
### Overview
Updates the `accounts.csv` generation in `hack/docker` to work with multi-sig expectations.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDSC-68

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
On the feature branch we need to edit the `docker-gen-keys.sh` script to disable pulling `latest`, and run `make docker-build/key-generator` instead to create a version that does what we want.
