### PR TITLE
TNET-42: Override block gas limit

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/CasperConf.scala
@@ -14,6 +14,9 @@ import io.casperlabs.shared.{Log, LogSource}
 import scala.concurrent.duration.FiniteDuration
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
+import eu.timepit.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric._
 
 final case class CasperConf(
     validatorPublicKey: Option[String],
@@ -30,7 +33,8 @@ final case class CasperConf(
     autoProposeBallotInterval: FiniteDuration,
     autoProposeAccInterval: FiniteDuration,
     autoProposeAccCount: Int,
-    minTtl: FiniteDuration
+    minTtl: FiniteDuration,
+    maxBlockCost: Long Refined NonNegative
 ) extends SubConfig
 
 object CasperConf {

--- a/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/highway/MessageProducer.scala
@@ -78,7 +78,8 @@ object MessageProducer {
       validatorIdentity: ValidatorIdentity,
       chainName: String,
       upgrades: Seq[ipc.ChainSpec.UpgradePoint],
-      onlyTakeOwnLatestFromJustifications: Boolean = false
+      onlyTakeOwnLatestFromJustifications: Boolean = false,
+      maxBlockCost: Long = 0
   ): MessageProducer[F] =
     new MessageProducer[F] {
       override val validatorId =
@@ -163,7 +164,7 @@ object MessageProducer {
                            props.protocolVersion,
                            props.mainRank,
                            props.configuration.deployConfig.maxBlockSizeBytes,
-                           props.configuration.deployConfig.maxBlockCost,
+                           lowerLimit(props.configuration.deployConfig.maxBlockCost, maxBlockCost),
                            upgrades
                          )
 
@@ -347,4 +348,8 @@ object MessageProducer {
                .takeUntil(_.keyBlockHash == keyBlock.eraId)
                .toList
     } yield eras.reverse
+
+  /** Find the lower limit of values where 0 means unlimited. */
+  def lowerLimit(default: Long, limit: Long): Long =
+    List(default, limit).filterNot(_ == 0).minimumOption.getOrElse(default)
 }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/MessageProducerSpec.scala
@@ -367,6 +367,20 @@ class MessageProducerSpec extends FlatSpec with Matchers with Inspectors with Hi
             _ <- erasUntil(eF) shouldBeF List(eC.keyBlockHash, eE.keyBlockHash, eF.keyBlockHash)
           } yield ()
       }
+  }
 
+  behavior of "lowerLimit"
+
+  it should "return the limit if the default is 0" in {
+    MessageProducer.lowerLimit(0, 10) shouldBe 10
+  }
+  it should "return the default if the limit is 0" in {
+    MessageProducer.lowerLimit(10, 0) shouldBe 10
+  }
+  it should "return the default if it's lower" in {
+    MessageProducer.lowerLimit(5, 10) shouldBe 5
+  }
+  it should "return the limit if it's lower" in {
+    MessageProducer.lowerLimit(10, 5) shouldBe 5
   }
 }

--- a/node/src/main/resources/default-configuration.toml
+++ b/node/src/main/resources/default-configuration.toml
@@ -295,6 +295,9 @@ auto-propose-acc-count = 10
 # Minimum TTL value of a deploy
 min-ttl = "1hour"
 
+# Override the value in the chainspec with a lower value; 0 means use whatever is in the chainspec.
+max-block-cost = 0
+
 # Highway parameters that we can freely choose or tweak; the rest is in the Genesis chain spec.
 [highway]
 

--- a/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
+++ b/node/src/main/scala/io/casperlabs/node/casper/consensus.scala
@@ -325,7 +325,8 @@ object Highway {
                        MessageProducer[F](
                          validatorId,
                          chainName = chainSpec.getGenesis.name,
-                         upgrades = chainSpec.upgrades
+                         upgrades = chainSpec.upgrades,
+                         maxBlockCost = conf.casper.maxBlockCost.value
                        )
                      },
                      messageExecutor = new MessageExecutor[F](

--- a/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
+++ b/node/src/main/scala/io/casperlabs/node/configuration/Options.scala
@@ -537,6 +537,11 @@ private[configuration] final case class Options private (
     )
 
     @scallop
+    val casperMaxBlockCost = gen[Long](
+      "Override the value in the chainspec with a lower value; 0 means use whatever is in the chainspec."
+    )
+
+    @scallop
     val blockstorageCacheMaxSizeBytes =
       gen[Long]("Maximum size of each of in-memory block/dag/justifications caches in bytes.")
 

--- a/node/src/test/resources/default-configuration.toml
+++ b/node/src/test/resources/default-configuration.toml
@@ -95,6 +95,7 @@ auto-propose-ballot-interval = "1second"
 auto-propose-acc-interval = "1second"
 auto-propose-acc-count = 1
 min-ttl = "1hour"
+max-block-cost = 0
 
 [highway]
 enabled = false

--- a/node/src/test/scala/io/casperlabs/node/configuration/ArbitraryImplicits.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ArbitraryImplicits.scala
@@ -69,6 +69,18 @@ trait ArbitraryImplicits {
     } yield refineV[NonNegative](n).right.get
   }
 
+  implicit val positiveLongGen: Arbitrary[Refined[Long, Positive]] = Arbitrary {
+    for {
+      n <- Gen.choose(1L, 10L)
+    } yield refineV[Positive](n).right.get
+  }
+
+  implicit val nonNegativeLongGen: Arbitrary[Refined[Long, NonNegative]] = Arbitrary {
+    for {
+      n <- Gen.choose(0L, 10L)
+    } yield refineV[NonNegative](n).right.get
+  }
+
   implicit val gte1DoubleGen: Arbitrary[Refined[Double, GreaterEqual[W.`1.0`.T]]] = Arbitrary {
     for {
       d <- Gen.choose(1.0, 10.0)

--- a/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
+++ b/node/src/test/scala/io/casperlabs/node/configuration/ConfigurationSpec.scala
@@ -140,7 +140,8 @@ class ConfigurationSpec
       autoProposeBallotInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeAccInterval = FiniteDuration(1, TimeUnit.SECONDS),
       autoProposeAccCount = 1,
-      minTtl = FiniteDuration(1, TimeUnit.HOURS)
+      minTtl = FiniteDuration(1, TimeUnit.HOURS),
+      maxBlockCost = 0L
     )
     val highway = Configuration.Highway(
       enabled = false,


### PR DESCRIPTION
### Overview
Adds an optional `--casper-max-block-cost` setting which can be used to make the block gas limit lower than whatever is in the chainspec.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-42

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
