### PR TITLE
EE-1030 counter-define contract header impl

### DIFF
--- a/execution-engine/Makefile
+++ b/execution-engine/Makefile
@@ -31,11 +31,9 @@ TEST_CONTRACTS      := $(patsubst %, build-contract-rs/%, $(TEST))
 # AssemblyScript Contracts
 CLIENT_CONTRACTS_AS  = $(shell find ./contracts-as/client   -mindepth 1 -maxdepth 1 -type d)
 TEST_CONTRACTS_AS    = $(shell find ./contracts-as/test     -mindepth 1 -maxdepth 1 -type d)
-EXAMPLE_CONTRACTS_AS = $(shell find ./contracts-as/examples -mindepth 1 -maxdepth 1 -type d)
 
 CLIENT_CONTRACTS_AS  := $(patsubst %, build-contract-as/%, $(CLIENT_CONTRACTS_AS))
 TEST_CONTRACTS_AS    := $(patsubst %, build-contract-as/%, $(TEST_CONTRACTS_AS))
-EXAMPLE_CONTRACTS_AS := $(patsubst %, build-contract-as/%, $(EXAMPLE_CONTRACTS_AS))
 
 INTEGRATION += \
 	endless-loop \

--- a/execution-engine/contract-as/README.md
+++ b/execution-engine/contract-as/README.md
@@ -80,7 +80,7 @@ export function call(): void {
     Error.fromErrorCode(ErrorCode.None).revert(); // ErrorCode: 1
 }
 ```
-If you prefer a more complicated first contract, you can look at example contracts on the [CasperLabs](https://github.com/CasperLabs/CasperLabs/tree/master/execution-engine/contracts-as/examples) github repository for inspiration.
+If you prefer a more complicated first contract, you can look at client contracts on the [CasperLabs](https://github.com/CasperLabs/CasperLabs/tree/master/execution-engine/contracts-as/client) github repository for inspiration.
 
 ### Compile to wasm
 To compile your contract to wasm, use npm to run the asbuild script from your project root.

--- a/execution-engine/contract/src/contract_api/mod.rs
+++ b/execution-engine/contract/src/contract_api/mod.rs
@@ -20,7 +20,8 @@ const fn size_align_for_array<T>(n: usize) -> (usize, usize) {
     (n * mem::size_of::<T>(), mem::align_of::<T>())
 }
 
-fn alloc_bytes(n: usize) -> NonNull<u8> {
+/// Allocates bytes
+pub fn alloc_bytes(n: usize) -> NonNull<u8> {
     let (size, align) = size_align_for_array::<u8>(n);
     // We treat allocated memory as raw bytes, that will be later passed to deserializer which also
     // operates on raw bytes.

--- a/execution-engine/contracts/client/counter-define/Cargo.toml
+++ b/execution-engine/contracts/client/counter-define/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "counter-define"
+version = "0.1.0"
+authors = ["Ed Hastings <ed@casperlabs.io>"]
+edition = "2018"
+
+[[bin]]
+name = "counter_define"
+path = "src/main.rs"
+bench = false
+doctest = false
+test = false
+
+[features]
+std = ["contract/std", "types/std"]
+
+[dependencies]
+contract = { path = "../../../contract", package = "casperlabs-contract" }
+types = { path = "../../../types", package = "casperlabs-types" }

--- a/execution-engine/contracts/client/counter-define/src/main.rs
+++ b/execution-engine/contracts/client/counter-define/src/main.rs
@@ -1,0 +1,164 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
+use core::convert::TryInto;
+
+use alloc::boxed::Box;
+use contract::{
+    contract_api::{self, runtime, storage},
+    ext_ffi,
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use types::{
+    api_error::{self},
+    bytesrepr::{self},
+    runtime_args, ApiError, CLType, CLValue, ContractHash, ContractPackageHash, EntryPoint,
+    EntryPointAccess, EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs, URef,
+};
+
+const HASH_KEY_NAME: &str = "counter_package_hash";
+const ACCESS_KEY_NAME: &str = "counter_package_access";
+const ENTRYPOINT_SESSION: &str = "session";
+const ENTRYPOINT_COUNTER: &str = "counter";
+const ARG_COUNTER_METHOD: &str = "method";
+const ARG_CONTRACT_HASH_NAME: &str = "counter_contract_hash";
+const COUNTER_VALUE_UREF: &str = "counter";
+const METHOD_GET: &str = "get";
+const METHOD_INC: &str = "inc";
+
+#[no_mangle]
+pub extern "C" fn counter() {
+    let uref = runtime::get_key(COUNTER_VALUE_UREF)
+        .unwrap_or_revert()
+        .try_into()
+        .unwrap_or_revert();
+
+    let method_name: String = runtime::get_named_arg(ARG_COUNTER_METHOD);
+
+    match method_name.as_str() {
+        METHOD_INC => storage::add(uref, 1),
+        METHOD_GET => {
+            let result: i32 = storage::read_or_revert(uref);
+            let return_value = CLValue::from_t(result).unwrap_or_revert();
+            runtime::ret(return_value);
+        }
+        _ => runtime::revert(ApiError::InvalidArgument),
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn session() {
+    let counter_key = get_counter_key();
+    let contract_hash = counter_key
+        .into_hash()
+        .unwrap_or_revert_with(ApiError::UnexpectedKeyVariant);
+    let entry_point_name = ENTRYPOINT_COUNTER;
+    let runtime_args = runtime_args! { ARG_COUNTER_METHOD => METHOD_INC };
+    runtime::call_contract(contract_hash, entry_point_name, runtime_args)
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let (contract_package_hash, access_uref): (ContractPackageHash, URef) =
+        storage::create_contract_package_at_hash();
+    runtime::put_key(HASH_KEY_NAME, contract_package_hash.into());
+    runtime::put_key(ACCESS_KEY_NAME, access_uref.into());
+
+    let entry_points = get_entry_points();
+    let count_value_uref = storage::new_uref(0); //initialize counter
+    let named_keys = {
+        let mut ret = BTreeMap::new();
+        ret.insert(String::from(COUNTER_VALUE_UREF), count_value_uref.into());
+        ret
+    };
+
+    let contract_hash: ContractHash =
+        storage::add_contract_version(contract_package_hash, entry_points, named_keys);
+    runtime::put_key(ARG_CONTRACT_HASH_NAME, contract_hash.into());
+}
+
+fn get_entry_points() -> EntryPoints {
+    let mut entry_points = EntryPoints::new();
+
+    // actual stored contract
+    // ARG_METHOD -> METHOD_GET or METHOD_INC
+    // ret -> counter value
+    let entry_point = EntryPoint::new(
+        ENTRYPOINT_COUNTER,
+        vec![Parameter::new(ARG_COUNTER_METHOD, CLType::String)],
+        CLType::I32,
+        EntryPointAccess::Public,
+        EntryPointType::Contract,
+    );
+    entry_points.add_entry_point(entry_point);
+
+    // stored session code that call a version of the stored contract
+    // ARG_CONTRACT_HASH -> ContractHash of METHOD_COUNTER
+    let entry_point = EntryPoint::new(
+        ENTRYPOINT_SESSION,
+        vec![Parameter::new(
+            ARG_CONTRACT_HASH_NAME,
+            CLType::FixedList(Box::new(CLType::U8), 32),
+        )],
+        CLType::Unit,
+        EntryPointAccess::Public,
+        EntryPointType::Session,
+    );
+    entry_points.add_entry_point(entry_point);
+
+    entry_points
+}
+
+fn get_counter_key() -> Key {
+    let name = ARG_CONTRACT_HASH_NAME;
+    let arg = {
+        let mut arg_size: usize = 0;
+        let ret = unsafe {
+            ext_ffi::get_named_arg_size(
+                name.as_bytes().as_ptr(),
+                name.len(),
+                &mut arg_size as *mut usize,
+            )
+        };
+        match api_error::result_from(ret) {
+            Ok(_) => {
+                if arg_size == 0 {
+                    None
+                } else {
+                    Some(arg_size)
+                }
+            }
+            Err(ApiError::MissingArgument) => None,
+            Err(e) => runtime::revert(e),
+        }
+    };
+
+    match arg {
+        Some(arg_size) => {
+            let arg_bytes = {
+                let res = {
+                    let data_non_null_ptr = contract_api::alloc_bytes(arg_size);
+                    let ret = unsafe {
+                        ext_ffi::get_named_arg(
+                            name.as_bytes().as_ptr(),
+                            name.len(),
+                            data_non_null_ptr.as_ptr(),
+                            arg_size,
+                        )
+                    };
+                    let data = unsafe {
+                        Vec::from_raw_parts(data_non_null_ptr.as_ptr(), arg_size, arg_size)
+                    };
+                    api_error::result_from(ret).map(|_| data)
+                };
+                res.unwrap_or_revert()
+            };
+
+            bytesrepr::deserialize(arg_bytes).unwrap_or_revert_with(ApiError::InvalidArgument)
+        }
+        None => runtime::get_key(ARG_CONTRACT_HASH_NAME).unwrap_or_revert_with(ApiError::GetKey),
+    }
+}

--- a/execution-engine/engine-tests/src/test/counter.rs
+++ b/execution-engine/engine-tests/src/test/counter.rs
@@ -1,0 +1,197 @@
+use engine_test_support::{
+    internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
+    DEFAULT_ACCOUNT_ADDR,
+};
+use types::{runtime_args, Key, RuntimeArgs};
+
+const CONTRACT_COUNTER_DEFINE: &str = "counter_define.wasm";
+const HASH_KEY_NAME: &str = "counter_package_hash";
+const COUNTER_VALUE_UREF: &str = "counter";
+const ENTRYPOINT_COUNTER: &str = "counter";
+const ENTRYPOINT_SESSION: &str = "session";
+const COUNTER_CONTRACT_HASH_KEY_NAME: &str = "counter_contract_hash";
+const ARG_COUNTER_METHOD: &str = "method";
+const METHOD_INC: &str = "inc";
+
+#[ignore]
+#[test]
+fn should_run_counter_example_contract() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    let exec_request_1 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_COUNTER_DEFINE,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder
+        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .exec(exec_request_1)
+        .expect_success()
+        .commit();
+
+    let account = builder
+        .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+        .expect("should query account")
+        .as_account()
+        .expect("should be account")
+        .clone();
+
+    let counter_contract_hash_key = *account
+        .named_keys()
+        .get(COUNTER_CONTRACT_HASH_KEY_NAME)
+        .expect("should have counter contract hash key");
+
+    let exec_request_2 = ExecuteRequestBuilder::versioned_contract_call_by_hash_key_name(
+        DEFAULT_ACCOUNT_ADDR,
+        HASH_KEY_NAME,
+        None,
+        ENTRYPOINT_SESSION,
+        runtime_args! { COUNTER_CONTRACT_HASH_KEY_NAME => counter_contract_hash_key },
+    )
+    .build();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let value: i32 = builder
+        .query(None, counter_contract_hash_key, &[COUNTER_VALUE_UREF])
+        .expect("should have counter value")
+        .as_cl_value()
+        .expect("should be CLValue")
+        .clone()
+        .into_t()
+        .expect("should cast CLValue to integer");
+
+    assert_eq!(value, 1);
+
+    let exec_request_3 = ExecuteRequestBuilder::versioned_contract_call_by_hash_key_name(
+        DEFAULT_ACCOUNT_ADDR,
+        HASH_KEY_NAME,
+        None,
+        ENTRYPOINT_SESSION,
+        runtime_args! { COUNTER_CONTRACT_HASH_KEY_NAME => counter_contract_hash_key },
+    )
+    .build();
+
+    builder.exec(exec_request_3).expect_success().commit();
+
+    let value: i32 = builder
+        .query(None, counter_contract_hash_key, &[COUNTER_VALUE_UREF])
+        .expect("should have counter value")
+        .as_cl_value()
+        .expect("should be CLValue")
+        .clone()
+        .into_t()
+        .expect("should cast CLValue to integer");
+
+    assert_eq!(value, 2);
+}
+
+#[ignore]
+#[test]
+fn should_default_contract_hash_arg() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    // This test runs a contract that's after every call extends the same key with
+    // more data
+    let exec_request_1 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_COUNTER_DEFINE,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder
+        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .exec(exec_request_1)
+        .expect_success()
+        .commit();
+
+    let exec_request_2 = ExecuteRequestBuilder::versioned_contract_call_by_hash_key_name(
+        DEFAULT_ACCOUNT_ADDR,
+        HASH_KEY_NAME,
+        None,
+        ENTRYPOINT_SESSION,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let value: i32 = {
+        let counter_contract_hash_key = *builder
+            .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+            .expect("should query account")
+            .as_account()
+            .expect("should be account")
+            .clone()
+            .named_keys()
+            .get(COUNTER_CONTRACT_HASH_KEY_NAME)
+            .expect("should have counter contract hash key");
+
+        builder
+            .query(None, counter_contract_hash_key, &[COUNTER_VALUE_UREF])
+            .expect("should have counter value")
+            .as_cl_value()
+            .expect("should be CLValue")
+            .clone()
+            .into_t()
+            .expect("should cast CLValue to integer")
+    };
+
+    assert_eq!(value, 1);
+}
+
+#[ignore]
+#[test]
+fn should_call_counter_contract_directly() {
+    let mut builder = InMemoryWasmTestBuilder::default();
+
+    let exec_request_1 = ExecuteRequestBuilder::standard(
+        DEFAULT_ACCOUNT_ADDR,
+        CONTRACT_COUNTER_DEFINE,
+        RuntimeArgs::new(),
+    )
+    .build();
+
+    builder
+        .run_genesis(&DEFAULT_RUN_GENESIS_REQUEST)
+        .exec(exec_request_1)
+        .expect_success()
+        .commit();
+
+    let exec_request_2 = ExecuteRequestBuilder::versioned_contract_call_by_hash_key_name(
+        DEFAULT_ACCOUNT_ADDR,
+        HASH_KEY_NAME,
+        None,
+        ENTRYPOINT_COUNTER,
+        runtime_args! { ARG_COUNTER_METHOD => METHOD_INC },
+    )
+    .build();
+
+    builder.exec(exec_request_2).expect_success().commit();
+
+    let value: i32 = {
+        let counter_contract_hash_key = *builder
+            .query(None, Key::Account(DEFAULT_ACCOUNT_ADDR), &[])
+            .expect("should query account")
+            .as_account()
+            .expect("should be account")
+            .clone()
+            .named_keys()
+            .get(COUNTER_CONTRACT_HASH_KEY_NAME)
+            .expect("should have counter contract hash key");
+
+        builder
+            .query(None, counter_contract_hash_key, &[COUNTER_VALUE_UREF])
+            .expect("should have counter value")
+            .as_cl_value()
+            .expect("should be CLValue")
+            .clone()
+            .into_t()
+            .expect("should cast CLValue to integer")
+    };
+
+    assert_eq!(value, 1);
+}

--- a/execution-engine/engine-tests/src/test/mod.rs
+++ b/execution-engine/engine-tests/src/test/mod.rs
@@ -1,5 +1,6 @@
 mod contract_api;
 mod contract_context;
+mod counter;
 mod deploy;
 mod explorer;
 mod groups;


### PR DESCRIPTION
This PR restores the counter-define contract and updates it to the contract header model. This contract was originally excised along with the other "example" contracts, but an unexpected dependency on it was discovered in STESTS.

https://casperlabs.atlassian.net/browse/EE-1030

NOTES: also fixed up make file and readme.md