### PR TITLE
TNET-34: GraphQL state query internal error

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/AutoProposer.scala
@@ -82,7 +82,7 @@ class AutoProposer[F[_]: Concurrent: Time: Log: Metrics: MultiParentCasperRef: D
   private def tryPropose(canCreateBallot: Boolean): F[Boolean] =
     BlockAPI.propose(blockApiLock, canCreateBallot).flatMap { blockHash =>
       Log[F].info(s"Proposed ${blockHash.show -> "message"}").as(true)
-    } handleErrorWith {
+    } recoverWith {
       case NonFatal(ex) =>
         Log[F].error(s"Could not propose block: $ex").as(false)
     }

--- a/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/MultiParentCasperImpl.scala
@@ -451,7 +451,7 @@ class MultiParentCasperImpl[F[_]: Concurrent: Log: Metrics: Time: BlockStorage: 
                      }
                    }
                    .timer("blockInstance")
-      } yield result).handleErrorWith {
+      } yield result).recoverWith {
         case ex @ SmartContractEngineError(error) =>
           Log[F]
             .error(

--- a/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/api/BlockAPI.scala
@@ -267,7 +267,7 @@ object BlockAPI {
             .compile
             .toVector
       }
-    } handleErrorWith {
+    } recoverWith {
       case ex: StorageError =>
         MonadThrowable[F].raiseError(InvalidArgument(StorageError.errorMessage(ex)))
       case ex: IllegalArgumentException =>

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -257,7 +257,7 @@ object ProtoUtil {
   def unsafeGetParents[F[_]: MonadThrowable: BlockStorage](b: Block): F[List[Block]] =
     ProtoUtil.parentHashes(b).toList.traverse { parentHash =>
       ProtoUtil.unsafeGetBlock[F](parentHash)
-    } handleErrorWith {
+    } recoverWith {
       case ex: NoSuchElementException =>
         MonadThrowable[F].raiseError {
           new NoSuchElementException(

--- a/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
+++ b/client/src/main/scala/io/casperlabs/client/DeployRuntime.scala
@@ -26,9 +26,9 @@ import io.casperlabs.models.cltype
 import io.casperlabs.models.DeployImplicits._
 import org.apache.commons.io._
 import scalapb_circe.JsonFormat
-
 import scala.concurrent.duration._
 import scala.language.higherKinds
+import scala.util.control.NonFatal
 import scala.util.Try
 
 object DeployRuntime {
@@ -537,9 +537,10 @@ object DeployRuntime {
             DeployService[F].deploy(deploy)
           }
         })
-        .handleError(
-          ex => Left(new RuntimeException(s"Couldn't make deploy, reason: ${ex.getMessage}", ex))
-        ),
+        .recover {
+          case NonFatal(ex) =>
+            Left(new RuntimeException(s"Couldn't make deploy, reason: ${ex.getMessage}", ex))
+        },
       exit,
       ignoreOutput
     )

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/GenesisApprover.scala
@@ -292,7 +292,7 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
       } yield (newApprovals ++ prevApprovals, transitioned)
 
       trySync
-        .handleErrorWith {
+        .recoverWith {
           case NonFatal(ex) =>
             Log[F].warn(
               s"Failed to sync Genesis candidate with bootstrap ${bootstrap.show -> "peer"}: $ex"
@@ -375,7 +375,7 @@ class GenesisApproverImpl[F[_]: Concurrent: Log: Timer](
         _       <- Log[F].debug(s"Relayed an approval for $candidate to ${peer.show -> "peer"}")
       } yield true
 
-      tryRelay.handleErrorWith {
+      tryRelay.recoverWith {
         case NonFatal(ex) =>
           Log[F].warn(s"Could not relay the approval for $candidate to ${peer.show -> "peer"}: $ex") *> false
             .pure[F]

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/downloadmanager/DownloadManager.scala
@@ -609,7 +609,7 @@ trait DownloadManagerImpl[F[_]] extends DownloadManager[F] { self =>
                     s"Scheduling download of ${kind} ${id.show -> "id"} from ${source.show -> "peer"} later, $attempt, $delay"
                   ) *>
                     Timer[F].sleep(delay) *>
-                    tryDownload(item.handle, source, item.relay).handleErrorWith {
+                    tryDownload(item.handle, source, item.relay).recoverWith {
                       case NonFatal(ex) =>
                         val nextAttempt = attempt + 1
                         Metrics[F].incrementCounter("downloads_failed") *>

--- a/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
+++ b/comm/src/main/scala/io/casperlabs/comm/gossiping/synchronization/SynchronizerImpl.scala
@@ -279,7 +279,9 @@ class SynchronizerImpl[F[_]: Concurrent: Log: Metrics](
       backend
         .validate(summary)
         .as(().asRight[SyncError])
-        .handleError(e => (ValidationError(summary, e): SyncError).asLeft[Unit])
+        .recover {
+          case NonFatal(e) => (ValidationError(summary, e): SyncError).asLeft[Unit]
+        }
     )
 
   /** Check that we are not on a loop, that we we haven't seen the same summary in this

--- a/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/GrpcCasperService.scala
@@ -154,7 +154,7 @@ object GrpcCasperService {
                   err => SmartContractEngineError(s"Error with EE response $storedValue:\n$err")
                 )
             }
-            value <- Concurrent[F].fromEither(protoValue).handleErrorWith {
+            value <- Concurrent[F].fromEither(protoValue).recoverWith {
                       case SmartContractEngineError(msg) =>
                         MonadThrowable[F].raiseError(InvalidArgument(msg))
                     }
@@ -227,7 +227,7 @@ object GrpcCasperService {
       keyType: StateQuery.KeyVariant,
       keyValue: String
   ): F[state.Key] =
-    Utils.toKey[F](keyType.name, keyValue).handleErrorWith {
+    Utils.toKey[F](keyType.name, keyValue).recoverWith {
       case ex: java.lang.IllegalArgumentException =>
         MonadThrowable[F].raiseError(InvalidArgument(ex.getMessage))
     }


### PR DESCRIPTION
### Overview
There were a couple of problems with error handling in GraphQL:
* `handleError` needs a total function, but was used as if it was partial, like `recover`
* The error message from EE when the account is not found is different, wasn't handled.
* Errors weren't logged.
* Sangria doesn't let unknown errors bubble out, it returns "Internal Server Error" and prints the stack trace.

Changed it so that there's always some logging for the state queries and input errors are turned into `UserFacingError` so the message does appear in the results, like so:
```json
{
  "data": null,
  "errors": [
    {
      "message": "BlockHash prefix must be >= 4 and <= 64 base16 characters (2 to 32 bytes) long",
      "path": [
        "globalState"
      ],
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ]
    }
  ]
}
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-34

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I don't know what the original content was under the keys in the ticket so I can't say if that will result in an error that will only appear in the logs, probably yes. 

I also didn't go through every other endpoint to see if their error handling is any better.
