### PR TITLE
ECO-458: Testing framework to support deploys with a custom block time.

### DIFF
--- a/execution-engine/engine-test-support/src/session.rs
+++ b/execution-engine/engine-test-support/src/session.rs
@@ -104,6 +104,12 @@ impl SessionBuilder {
         self
     }
 
+    /// Returns `self` with the provided block time set.
+    pub fn with_block_time(mut self, block_time: u64) -> Self {
+        self.er_builder = self.er_builder.with_block_time(block_time);
+        self
+    }
+
     /// Returns `self` with the provided gas price set.
     pub fn with_gas_price(mut self, price: u64) -> Self {
         self.di_builder = self.di_builder.with_gas_price(price);


### PR DESCRIPTION
### Overview
This adds the ability to change a block time in the SessionBuilder in testing framework. It publishes already existing function.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-458
