### PR TITLE
NDSC-65: Wasmless transfer API

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -577,8 +577,8 @@ object ProtoUtil {
     val (sk, pk) = Ed25519.newKeyPair
     val b = Deploy
       .Body()
-      .withSession(Deploy.Code().withWasm(sessionCode))
-      .withPayment(Deploy.Code().withWasm(sessionCode))
+      .withSession(Deploy.Code().withWasmContract(Deploy.Code.WasmContract(sessionCode)))
+      .withPayment(Deploy.Code().withWasmContract(Deploy.Code.WasmContract(sessionCode)))
     val h = Deploy
       .Header()
       .withAccountPublicKey(ByteString.copyFrom(pk))
@@ -641,70 +641,67 @@ object ProtoUtil {
 
     argsF.flatMap { args =>
       val payload = code.contract match {
-        case Deploy.Code.Contract.Wasm(wasm) =>
-          Success(ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(wasm, args)))
-        case Deploy.Code.Contract.StoredContract(StoredContract(address)) =>
-          if (address.isName) {
+        case Deploy.Code.Contract.WasmContract(contract) =>
+          Success(ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(contract.wasm, args)))
+
+        case Deploy.Code.Contract.StoredContract(contract) =>
+          if (contract.address.isName) {
             Success(
               ipc.DeployPayload.Payload.StoredContractName(
                 io.casperlabs.ipc
                   .StoredContractName(
-                    address.name.get,
+                    contract.getName,
                     args,
-                    code.entryPoint
+                    contract.entryPoint
                   )
               )
             )
-          } else if (address.isContractHash) {
+          } else if (contract.address.isContractHash) {
             Success(
               ipc.DeployPayload.Payload.StoredContractHash(
                 io.casperlabs.ipc
                   .StoredContractHash(
-                    address.contractHash.get,
+                    contract.getContractHash,
                     args,
-                    code.entryPoint
+                    contract.entryPoint
                   )
               )
             )
           } else
             Failure(
               new SmartContractEngineError(
-                s"$address is not valid contract pointer. Only hash and named key label are supported."
+                s"${contract.address} is not valid contract pointer. Only hash and named key label are supported."
               )
             )
 
         case Deploy.Code.Contract
-              .StoredVersionedContract(StoredVersionedContract(address, optionalVersion)) =>
-          if (address.isName) {
+              .StoredVersionedContract(contract) =>
+          if (contract.address.isName) {
             Success(
               ipc.DeployPayload.Payload.StoredPackageByName(
                 io.casperlabs.ipc
                   .StoredContractPackage(
-                    address.name.get,
-                    code.entryPoint,
+                    contract.getName,
+                    contract.entryPoint,
                     args,
-                    optionalVersion match {
-                      case StoredVersionedContract.OptionalVersion.Empty =>
-                        ipc.StoredContractPackage.OptionalVersion.Empty
-                      case StoredVersionedContract.OptionalVersion.Version(ver) =>
-                        ipc.StoredContractPackage.OptionalVersion.Version(ver)
+                    contract.version match {
+                      case 0 => ipc.StoredContractPackage.OptionalVersion.Empty
+                      case v => ipc.StoredContractPackage.OptionalVersion.Version(v)
                     }
                   )
               )
             )
-          } else if (address.isPackageHash) {
+          } else if (contract.address.isPackageHash) {
             Success(
               ipc.DeployPayload.Payload.StoredPackageByHash(
                 io.casperlabs.ipc
                   .StoredContractPackageHash(
-                    address.packageHash.get,
-                    code.entryPoint,
+                    contract.getPackageHash,
+                    contract.entryPoint,
                     args,
-                    optionalVersion match {
-                      case StoredVersionedContract.OptionalVersion.Empty =>
-                        ipc.StoredContractPackageHash.OptionalVersion.Empty
-                      case StoredVersionedContract.OptionalVersion.Version(ver) =>
-                        ipc.StoredContractPackageHash.OptionalVersion.Version(ver)
+                    contract.version match {
+                      case 0 => ipc.StoredContractPackageHash.OptionalVersion.Empty
+                      case v => ipc.StoredContractPackageHash.OptionalVersion.Version(v)
                     }
                   )
               )
@@ -712,7 +709,7 @@ object ProtoUtil {
           } else
             Failure(
               new SmartContractEngineError(
-                s"$address is not valid contract pointer. Only hash and named key label are supported."
+                s"${contract.address} is not valid contract pointer. Only hash and named key label are supported."
               )
             )
 

--- a/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/util/ProtoUtil.scala
@@ -713,6 +713,13 @@ object ProtoUtil {
               )
             )
 
+        case Deploy.Code.Contract.TransferContract(_) =>
+          Success(
+            ipc.DeployPayload.Payload.Transfer(
+              io.casperlabs.ipc.Transfer(args)
+            )
+          )
+
         case Deploy.Code.Contract.Empty =>
           Success(ipc.DeployPayload.Payload.DeployCode(ipc.DeployCode(ByteString.EMPTY, args)))
       }

--- a/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
+++ b/casper/src/main/scala/io/casperlabs/mempool/DeployBuffer.scala
@@ -88,7 +88,7 @@ object DeployBuffer {
 
         for {
           _ <- deploy.getBody.session match {
-                case None | Some(Deploy.Code(_, _, Deploy.Code.Contract.Empty)) =>
+                case None | Some(Deploy.Code(_, Deploy.Code.Contract.Empty)) =>
                   illegal(s"Deploy was missing session code.")
                 case _ => ().pure[F]
               }

--- a/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/helper/DeployOps.scala
@@ -33,11 +33,17 @@ object DeployOps extends ArbitraryConsensus {
     }
     def withSessionCode(bytes: ByteString): Deploy =
       rehash(
-        deploy.withBody(deploy.getBody.withSession(Deploy.Code().withWasm(bytes)))
+        deploy.withBody(
+          deploy.getBody
+            .withSession(Deploy.Code().withWasmContract(Deploy.Code.WasmContract(bytes)))
+        )
       )
     def withPaymentCode(bytes: ByteString): Deploy =
       rehash(
-        deploy.withBody(deploy.getBody.withPayment(Deploy.Code().withWasm(bytes)))
+        deploy.withBody(
+          deploy.getBody
+            .withPayment(Deploy.Code().withWasmContract(Deploy.Code.WasmContract(bytes)))
+        )
       )
     def withTimestamp(timestamp: Long): Deploy =
       rehash(

--- a/explorer/grpc/package-lock.json
+++ b/explorer/grpc/package-lock.json
@@ -290,7 +290,7 @@
     },
     "@types/node": {
       "version": "12.7.11",
-      "resolved": "https://registry.npmjs.com/@types/node/-/node-12.7.11.tgz",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.11.tgz",
       "integrity": "sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==",
       "dev": true
     },
@@ -306,13 +306,13 @@
     },
     "ansi-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
@@ -330,19 +330,19 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
     "arg": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.com/arg/-/arg-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
       "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
       "dev": true
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.com/argparse/-/argparse-1.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
@@ -351,13 +351,13 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
@@ -372,7 +372,7 @@
     },
     "buffer-from": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.com/buffer-from/-/buffer-from-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
@@ -390,13 +390,13 @@
     },
     "camelcase": {
       "version": "5.3.1",
-      "resolved": "https://registry.npmjs.com/camelcase/-/camelcase-5.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.com/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
@@ -407,7 +407,7 @@
       "dependencies": {
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.com/supports-color/-/supports-color-5.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
@@ -424,7 +424,7 @@
     },
     "cliui": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.com/cliui/-/cliui-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
       "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
       "dev": true,
       "requires": {
@@ -435,13 +435,13 @@
     },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.com/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.com/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
       "requires": {
@@ -450,25 +450,25 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.com/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.com/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.com/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "concurrently": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.com/concurrently/-/concurrently-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-4.1.2.tgz",
       "integrity": "sha512-Kim9SFrNr2jd8/0yNYqDTFALzUX1tvimmwFWxmp/D4mRI+kbqIIwE2RkBDrxS2ic25O1UgQMI5AtBqdtX3ynYg==",
       "dev": true,
       "requires": {
@@ -494,7 +494,7 @@
     },
     "cross-spawn": {
       "version": "6.0.5",
-      "resolved": "https://registry.npmjs.com/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
@@ -507,13 +507,13 @@
     },
     "date-fns": {
       "version": "1.30.1",
-      "resolved": "https://registry.npmjs.com/date-fns/-/date-fns-1.30.1.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
       "dev": true
     },
     "debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.com/debug/-/debug-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
@@ -522,7 +522,7 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.com/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
@@ -537,7 +537,7 @@
     },
     "diff": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.com/diff/-/diff-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
       "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
     },
@@ -549,7 +549,7 @@
     },
     "end-of-stream": {
       "version": "1.4.4",
-      "resolved": "https://registry.npmjs.com/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
@@ -558,7 +558,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.com/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
@@ -567,25 +567,25 @@
     },
     "es6-error": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.com/es6-error/-/es6-error-4.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.com/esprima/-/esprima-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "execa": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/execa/-/execa-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
@@ -611,7 +611,7 @@
     },
     "find-up": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/find-up/-/find-up-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "dev": true,
       "requires": {
@@ -679,7 +679,7 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
@@ -691,13 +691,13 @@
     },
     "get-caller-file": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.com/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
       "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.com/get-stream/-/get-stream-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
       "dev": true,
       "requires": {
@@ -720,7 +720,7 @@
     },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npmjs.com/globals/-/globals-11.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
@@ -737,7 +737,7 @@
     },
     "has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/has-flag/-/has-flag-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
@@ -761,7 +761,7 @@
     },
     "hosted-git-info": {
       "version": "2.8.4",
-      "resolved": "https://registry.npmjs.com/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
       "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
       "dev": true
     },
@@ -773,7 +773,7 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
@@ -785,7 +785,7 @@
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.com/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -795,31 +795,31 @@
     },
     "inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.com/inherits/-/inherits-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "invert-kv": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/invert-kv/-/invert-kv-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.com/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
@@ -837,7 +837,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -873,7 +873,7 @@
       "dependencies": {
         "semver": {
           "version": "6.3.0",
-          "resolved": "https://registry.npmjs.com/semver/-/semver-6.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
@@ -978,7 +978,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.com/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -996,13 +996,13 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.com/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
-      "resolved": "https://registry.npmjs.com/js-yaml/-/js-yaml-3.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
@@ -1012,13 +1012,13 @@
     },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npmjs.com/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
     },
@@ -1033,7 +1033,7 @@
     },
     "lcid": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/lcid/-/lcid-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
@@ -1042,7 +1042,7 @@
     },
     "locate-path": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/locate-path/-/locate-path-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "dev": true,
       "requires": {
@@ -1052,13 +1052,13 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "https://registry.npmjs.com/lodash/-/lodash-4.17.15.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
@@ -1081,13 +1081,13 @@
     },
     "make-error": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.com/make-error/-/make-error-1.3.5.tgz",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
       "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
       "dev": true
     },
     "map-age-cleaner": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
@@ -1096,7 +1096,7 @@
     },
     "mem": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.com/mem/-/mem-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
@@ -1107,13 +1107,13 @@
     },
     "mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.com/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.com/minimatch/-/minimatch-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
@@ -1128,13 +1128,13 @@
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.com/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.com/nice-try/-/nice-try-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
@@ -1149,7 +1149,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
@@ -1161,7 +1161,7 @@
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.com/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -1170,7 +1170,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -1262,7 +1262,7 @@
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
           "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
           "dev": true
         },
@@ -1298,7 +1298,7 @@
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.com/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
           "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
           "dev": true
         },
@@ -1366,7 +1366,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.com/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -1375,7 +1375,7 @@
     },
     "os-locale": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.com/os-locale/-/os-locale-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
@@ -1386,25 +1386,25 @@
     },
     "p-defer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/p-defer/-/p-defer-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
     "p-is-promise": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.com/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
       "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.com/p-limit/-/p-limit-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
       "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
       "dev": true,
       "requires": {
@@ -1413,7 +1413,7 @@
     },
     "p-locate": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/p-locate/-/p-locate-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "dev": true,
       "requires": {
@@ -1431,7 +1431,7 @@
     },
     "p-try": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.com/p-try/-/p-try-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
@@ -1449,7 +1449,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.com/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -1459,31 +1459,31 @@
     },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.com/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.com/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
     },
     "pify": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/pify/-/pify-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
@@ -1543,7 +1543,7 @@
     },
     "pump": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/pump/-/pump-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "dev": true,
       "requires": {
@@ -1553,7 +1553,7 @@
     },
     "read-pkg": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.com/read-pkg/-/read-pkg-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-4.0.1.tgz",
       "integrity": "sha1-ljYlN48+HE1IyFhytabsfV0JMjc=",
       "dev": true,
       "requires": {
@@ -1564,7 +1564,7 @@
     },
     "release-zalgo": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
       "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
       "dev": true,
       "requires": {
@@ -1573,19 +1573,19 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.com/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.com/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
       "dev": true
     },
     "resolve": {
       "version": "1.12.0",
-      "resolved": "https://registry.npmjs.com/resolve/-/resolve-1.12.0.tgz",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
       "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
@@ -1609,7 +1609,7 @@
     },
     "rxjs": {
       "version": "6.5.3",
-      "resolved": "https://registry.npmjs.com/rxjs/-/rxjs-6.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
       "dev": true,
       "requires": {
@@ -1618,25 +1618,25 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "semver": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.com/semver/-/semver-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.com/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -1645,25 +1645,25 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.com/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.com/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
     "source-map-support": {
       "version": "0.5.13",
-      "resolved": "https://registry.npmjs.com/source-map-support/-/source-map-support-0.5.13.tgz",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
       "dev": true,
       "requires": {
@@ -1673,7 +1673,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npmjs.com/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
@@ -1681,7 +1681,7 @@
     },
     "spawn-command": {
       "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.com/spawn-command/-/spawn-command-0.0.2-1.tgz",
+      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
       "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=",
       "dev": true
     },
@@ -1712,7 +1712,7 @@
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.com/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
       "dev": true,
       "requires": {
@@ -1722,13 +1722,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
@@ -1738,19 +1738,19 @@
     },
     "spdx-license-ids": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
       "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "string-width": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.com/string-width/-/string-width-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
@@ -1760,7 +1760,7 @@
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.com/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
@@ -1775,13 +1775,13 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.com/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
     "supports-color": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.com/supports-color/-/supports-color-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
       "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
       "dev": true,
       "requires": {
@@ -1790,7 +1790,7 @@
       "dependencies": {
         "has-flag": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.com/has-flag/-/has-flag-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
           "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
           "dev": true
         }
@@ -1809,7 +1809,7 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
@@ -1821,7 +1821,7 @@
     },
     "ts-node": {
       "version": "8.4.1",
-      "resolved": "https://registry.npmjs.com/ts-node/-/ts-node-8.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
       "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
       "dev": true,
       "requires": {
@@ -1843,7 +1843,7 @@
     },
     "tslib": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.com/tslib/-/tslib-1.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
       "dev": true
     },
@@ -1864,7 +1864,7 @@
     },
     "typescript": {
       "version": "3.7.4",
-      "resolved": "https://registry.npmjs.com/typescript/-/typescript-3.7.4.tgz",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
       "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
       "dev": true
     },
@@ -1876,7 +1876,7 @@
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
@@ -1886,7 +1886,7 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.com/which/-/which-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
@@ -1895,13 +1895,13 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.com/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -1911,13 +1911,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -1926,7 +1926,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.com/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -1937,7 +1937,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -1948,7 +1948,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.com/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -1966,13 +1966,13 @@
     },
     "y18n": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.com/y18n/-/y18n-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yargs": {
       "version": "12.0.5",
-      "resolved": "https://registry.npmjs.com/yargs/-/yargs-12.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
       "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
       "dev": true,
       "requires": {
@@ -1992,7 +1992,7 @@
     },
     "yargs-parser": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.com/yargs-parser/-/yargs-parser-11.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
       "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
       "dev": true,
       "requires": {
@@ -2002,7 +2002,7 @@
     },
     "yn": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.com/yn/-/yn-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "dev": true
     }

--- a/explorer/sdk/src/lib/DeployUtil.ts
+++ b/explorer/sdk/src/lib/DeployUtil.ts
@@ -66,25 +66,29 @@ export function makeDeploy(
 ): Deploy {
   const sessionCode = new Deploy.Code();
   if (type === ContractType.WASM) {
-    sessionCode.setWasm(session);
+    const wasmContract = new Deploy.Code.WasmContract();
+    wasmContract.setWasm(session);
+    sessionCode.setWasmContract(wasmContract);
   } else if (type === ContractType.Hash) {
     const storedContract = new Deploy.Code.StoredContract();
     storedContract.setContractHash(session);
+    storedContract.setEntryPoint(entryPoint || "");
     sessionCode.setStoredContract(storedContract);
   } else {
     const storedContract = new Deploy.Code.StoredContract();
     storedContract.setName(session as string);
+    storedContract.setEntryPoint(entryPoint || "")
     sessionCode.setStoredContract(storedContract);
   }
   sessionCode.setArgsList(args);
-  if(entryPoint){
-    sessionCode.setEntryPoint(entryPoint)
-  }
+
   if (paymentWasm === null) {
     paymentWasm = Buffer.from('');
   }
+  const paymentContract = new Deploy.Code.WasmContract();
+  paymentContract.setWasm(paymentWasm);
   const payment = new Deploy.Code();
-  payment.setWasm(paymentWasm);
+  payment.setWasmContract(paymentContract);
   payment.setArgsList(Args(['amount', BigIntValue(paymentAmount)]));
 
   const body = new Deploy.Body();
@@ -97,7 +101,7 @@ export function makeDeploy(
   header.setBodyHash(protoHash(body));
   // we will remove gasPrice eventually
   header.setGasPrice(1);
-  header.setDependenciesList(dependencies??[]);
+  header.setDependenciesList(dependencies ?? []);
 
   const deploy = new Deploy();
   deploy.setBody(body);

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -70,28 +70,33 @@ message Deploy {
     // Includes both binary instructions (wasm) and optionally, arguments
     // to those instructions encoded via our ABI
     message Code {
+        // XXX: For the JS serializer the order of fields matters.
+        //      See https://casperlabs.atlassian.net/browse/TNET-45
+
+        // Keyword arguments.
+        repeated Arg args = 1;
+
         oneof contract {
-            // Wasm byte code.
-            bytes wasm = 1;
-            StoredContract stored_contract = 2;
-            StoredVersionedContract stored_versioned_contract = 3;
+            WasmContract wasm_contract = 2;
+            StoredContract stored_contract = 3;
+            StoredVersionedContract stored_versioned_contract = 4;
         }
-        // Keyword arguments. Note that while the execution engine works with the original
-        // positional argument passing style, the order of the arguments matters.
-        repeated Arg args = 4;
-        // Name of the entry method in the contract.
-        string entry_point = 5;
+
+        message WasmContract {
+            bytes wasm = 1;
+        }
 
         message StoredVersionedContract {
             oneof address {
-                bytes package_hash = 1; // Package hash address of already stored contract.
-                // Name of a key that contains a package hash
+                // Package hash address of already stored contract.
+                bytes package_hash = 1;
+                // Name of a key that contains a package hash.
                 string name = 2;
             }
-
-            oneof optional_version {
-                uint32 version = 3;
-            }
+            // Name of the entry method in the contract.
+            string entry_point = 3;
+            // Optionally specify the exact version; 0 means use the highest available.
+            uint32 version = 4;
         }
 
         message StoredContract {
@@ -101,14 +106,14 @@ message Deploy {
                 // Name of a stored contract associated with the executing account (uref or hash).
                 string name = 2;
             }
+            // Name of the entry method in the contract.
+            string entry_point = 3;
         }
     }
 
     message Arg {
         reserved 2; // old state.Value representation of args
         string name = 1;
-        // Note that until the EE doesn't support kwargs directly, missing an Empty values are
-        // not allowed because they would be ambiguous.
         state.CLValueInstance value = 3;
     }
 

--- a/protobuf/io/casperlabs/casper/consensus/consensus.proto
+++ b/protobuf/io/casperlabs/casper/consensus/consensus.proto
@@ -80,6 +80,7 @@ message Deploy {
             WasmContract wasm_contract = 2;
             StoredContract stored_contract = 3;
             StoredVersionedContract stored_versioned_contract = 4;
+            TransferContract transfer_contract = 5;
         }
 
         message WasmContract {
@@ -109,6 +110,9 @@ message Deploy {
             // Name of the entry method in the contract.
             string entry_point = 3;
         }
+
+        // Built-in transfer, bypassing the WASM execution.
+        message TransferContract {}
     }
 
     message Arg {


### PR DESCRIPTION
### Overview
Adds the `Transfer` variant to `Deploy.Code.Contract`. Rearranged the fields in the `Code` so that we don't have to reassign the indices again because of https://casperlabs.atlassian.net/browse/TNET-45 and also because the pure WASM variant didn't support the `entry_point` parameters. Changed `version` so that 0 means latest in the API.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/NDSC-65

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I suppose the Scala client could be updated to not send its built-in transfer wasm any more by I didn't do it since we want to scrap it.