### PR TITLE
Remove system contracts from named keys, clean up

### DIFF
--- a/execution-engine/contract/src/contract_api/runtime.rs
+++ b/execution-engine/contract/src/contract_api/runtime.rs
@@ -3,14 +3,14 @@
 // Can be removed once https://github.com/rust-lang/rustfmt/issues/3362 is resolved.
 #[rustfmt::skip]
 use alloc::vec;
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::vec::Vec;
 use core::mem::MaybeUninit;
 
 use casperlabs_types::{
     account::PublicKey,
     api_error,
     bytesrepr::{self, FromBytes},
-    contracts::ContractVersion,
+    contracts::{ContractVersion, NamedKeys},
     ApiError, BlockTime, CLTyped, CLValue, ContractHash, ContractPackageHash, Key, Phase,
     RuntimeArgs, URef, BLOCKTIME_SERIALIZED_LENGTH, PHASE_SERIALIZED_LENGTH,
 };
@@ -280,7 +280,7 @@ pub fn remove_key(name: &str) {
 ///
 /// The current context is either the caller's account or a stored contract depending on whether the
 /// currently-executing module is a direct call or a sub-call respectively.
-pub fn list_named_keys() -> BTreeMap<String, Key> {
+pub fn list_named_keys() -> NamedKeys {
     let (total_keys, result_size) = {
         let mut total_keys = MaybeUninit::uninit();
         let mut result_size = 0;
@@ -292,7 +292,7 @@ pub fn list_named_keys() -> BTreeMap<String, Key> {
         (total_keys, result_size)
     };
     if total_keys == 0 {
-        return BTreeMap::new();
+        return NamedKeys::new();
     }
     let bytes = read_host_buffer(result_size).unwrap_or_revert();
     bytesrepr::deserialize(bytes).unwrap_or_revert()

--- a/execution-engine/contract/src/contract_api/storage.rs
+++ b/execution-engine/contract/src/contract_api/storage.rs
@@ -1,17 +1,12 @@
 //! Functions for accessing and mutating local and global state.
 
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    string::String,
-    vec,
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, string::String, vec, vec::Vec};
 use core::{convert::From, mem::MaybeUninit};
 
 use casperlabs_types::{
     api_error,
     bytesrepr::{self, FromBytes, ToBytes},
-    contracts::{ContractVersion, EntryPoints},
+    contracts::{ContractVersion, EntryPoints, NamedKeys},
     AccessRights, ApiError, CLTyped, CLValue, ContractHash, ContractPackageHash, Key, URef,
     UREF_SERIALIZED_LENGTH,
 };
@@ -143,7 +138,7 @@ pub fn new_uref<T: CLTyped + ToBytes>(init: T) -> URef {
 /// if `uref_name` is provided, puts access_uref in current context's named keys under `uref_name`
 pub fn new_contract(
     entry_points: EntryPoints,
-    named_keys: Option<BTreeMap<String, Key>>,
+    named_keys: Option<NamedKeys>,
     hash_name: Option<String>,
     uref_name: Option<String>,
 ) -> (ContractHash, ContractVersion) {
@@ -159,7 +154,7 @@ pub fn new_contract(
 
     let named_keys = match named_keys {
         Some(named_keys) => named_keys,
-        None => BTreeMap::new(),
+        None => NamedKeys::new(),
     };
 
     add_contract_version(contract_package_hash, entry_points, named_keys)
@@ -294,7 +289,7 @@ pub fn remove_contract_user_group(
 pub fn add_contract_version(
     contract_package_hash: ContractPackageHash,
     entry_points: EntryPoints,
-    named_keys: BTreeMap<String, Key>,
+    named_keys: NamedKeys,
 ) -> (ContractHash, ContractVersion) {
     let (contract_package_hash_ptr, contract_package_hash_size, _bytes1) =
         contract_api::to_ptr(contract_package_hash);

--- a/execution-engine/contract/src/contract_api/system.rs
+++ b/execution-engine/contract/src/contract_api/system.rs
@@ -14,11 +14,6 @@ use crate::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 
-/// Name of the reference to the Mint contract in the named keys.
-pub const MINT_NAME: &str = "mint";
-/// Name of the reference to the Proof of Stake contract in the named keys.
-pub const POS_NAME: &str = "pos";
-
 fn get_system_contract(system_contract: SystemContractType) -> ContractHash {
     let system_contract_index = system_contract.into();
     let contract_hash: ContractHash = {

--- a/execution-engine/contracts/client/counter-define/src/main.rs
+++ b/execution-engine/contracts/client/counter-define/src/main.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec, vec::Vec};
+use alloc::{string::String, vec, vec::Vec};
 use core::convert::TryInto;
 
 use alloc::boxed::Box;
@@ -15,6 +15,7 @@ use contract::{
 use types::{
     api_error::{self},
     bytesrepr::{self},
+    contracts::NamedKeys,
     runtime_args, ApiError, CLType, CLValue, ContractPackageHash, EntryPoint, EntryPointAccess,
     EntryPointType, EntryPoints, Key, Parameter, RuntimeArgs, URef,
 };
@@ -71,7 +72,7 @@ pub extern "C" fn call() {
     let entry_points = get_entry_points();
     let count_value_uref = storage::new_uref(0); //initialize counter
     let named_keys = {
-        let mut ret = BTreeMap::new();
+        let mut ret = NamedKeys::new();
         ret.insert(String::from(COUNTER_VALUE_UREF), count_value_uref.into());
         ret
     };

--- a/execution-engine/contracts/integration/list-known-urefs-define/src/main.rs
+++ b/execution-engine/contracts/integration/list-known-urefs-define/src/main.rs
@@ -3,14 +3,14 @@
 
 extern crate alloc;
 
-use alloc::{borrow::ToOwned, collections::BTreeMap, string::String};
+use alloc::borrow::ToOwned;
 use core::iter;
 
 use contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::{ApiError, Key};
+use types::{contracts::NamedKeys, ApiError};
 
 const BAR_KEY: &str = "Bar";
 const FOO_KEY: &str = "Foo";
@@ -24,8 +24,8 @@ pub extern "C" fn list_named_keys_ext() {
     let uref = storage::new_uref(TEST_UREF);
     runtime::put_key(BAR_KEY, uref.clone().into());
     let contracts_named_keys = runtime::list_named_keys();
-    let expected_urefs: BTreeMap<String, Key> = {
-        let mut tmp = BTreeMap::new();
+    let expected_urefs = {
+        let mut tmp = NamedKeys::new();
         tmp.insert(BAR_KEY.to_owned(), uref.into());
         tmp.insert(FOO_KEY.to_owned(), passed_in_uref);
         tmp
@@ -39,8 +39,7 @@ pub extern "C" fn call() {
     let uref = storage::new_uref(1i32);
     runtime::put_key(FOO_KEY, uref.clone().into());
     let _accounts_named_keys = runtime::list_named_keys();
-    let _expected_urefs: BTreeMap<String, Key> =
-        iter::once((FOO_KEY.to_owned(), uref.into())).collect();
+    let _expected_urefs: NamedKeys = iter::once((FOO_KEY.to_owned(), uref.into())).collect();
     // Test that `list_named_keys` returns correct value when called in the context of an account.
     // Store `list_named_keys_ext` to be called in the `call` part of this contract.
     // We don't have to  pass `expected_urefs` to exercise this function but

--- a/execution-engine/contracts/system/mint-install/src/main.rs
+++ b/execution-engine/contracts/system/mint-install/src/main.rs
@@ -1,14 +1,11 @@
 #![no_std]
 #![no_main]
 
-extern crate alloc;
-
-use alloc::collections::BTreeMap;
 use contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
 };
-use types::CLValue;
+use types::{contracts::NamedKeys, CLValue};
 
 const HASH_KEY_NAME: &str = "mint_hash";
 const ACCESS_KEY_NAME: &str = "mint_access";
@@ -41,7 +38,7 @@ pub extern "C" fn install() {
     runtime::put_key(HASH_KEY_NAME, contract_package_hash.into());
     runtime::put_key(ACCESS_KEY_NAME, access_uref.into());
 
-    let named_keys = BTreeMap::new();
+    let named_keys = NamedKeys::new();
 
     let (contract_key, _contract_version) =
         storage::add_contract_version(contract_package_hash, entry_points, named_keys);

--- a/execution-engine/contracts/system/pos-install/src/main.rs
+++ b/execution-engine/contracts/system/pos-install/src/main.rs
@@ -18,7 +18,7 @@ use proof_of_stake::Stakes;
 use types::{
     account::PublicKey,
     contracts::{
-        EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Parameter,
+        EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys, Parameter,
         CONTRACT_INITIAL_VERSION,
     },
     runtime_args,
@@ -80,8 +80,7 @@ pub extern "C" fn install() {
     // For now, we are storing validators in `named_keys` map of the PoS contract
     // in the form: key: "v_{validator_pk}_{validator_stake}", value: doesn't
     // matter.
-    let mut named_keys: BTreeMap<String, Key> =
-        stakes.strings().map(|key| (key, PLACEHOLDER_KEY)).collect();
+    let mut named_keys: NamedKeys = stakes.strings().map(|key| (key, PLACEHOLDER_KEY)).collect();
     let total_bonds: U512 = stakes.total_bonds();
     let bonding_purse = mint_purse(mint_package_hash, total_bonds);
     let payment_purse = mint_purse(mint_package_hash, U512::zero());

--- a/execution-engine/contracts/system/standard-payment-install/src/main.rs
+++ b/execution-engine/contracts/system/standard-payment-install/src/main.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, collections::BTreeMap, string::ToString, vec};
+use alloc::{boxed::Box, string::ToString, vec};
 
 use contract::{
     contract_api::{runtime, storage},
@@ -11,7 +11,7 @@ use contract::{
 };
 use standard_payment::ARG_AMOUNT;
 use types::{
-    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Parameter},
+    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys, Parameter},
     CLType, CLValue,
 };
 
@@ -48,7 +48,7 @@ pub extern "C" fn install() {
     runtime::put_key(HASH_KEY_NAME, contract_package_hash.into());
     runtime::put_key(ACCESS_KEY_NAME, access_uref.into());
 
-    let named_keys = BTreeMap::new();
+    let named_keys = NamedKeys::new();
 
     let (contract_key, _contract_version) =
         storage::add_contract_version(contract_package_hash, entry_points, named_keys);

--- a/execution-engine/contracts/test/contract-context/src/main.rs
+++ b/execution-engine/contracts/test/contract-context/src/main.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+use alloc::{string::ToString, vec::Vec};
 
 use contract::{
     contract_api::{runtime, storage},
@@ -11,7 +11,8 @@ use contract::{
 };
 use types::{
     contracts::{
-        EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, CONTRACT_INITIAL_VERSION,
+        EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys,
+        CONTRACT_INITIAL_VERSION,
     },
     runtime_args, CLType, ContractHash, ContractPackageHash, ContractVersion, Key, RuntimeArgs,
 };
@@ -151,7 +152,7 @@ fn install_version_1(package_hash: ContractPackageHash) -> (ContractHash, Contra
     let contract_named_keys = {
         let contract_variable = storage::new_uref(0);
 
-        let mut named_keys = BTreeMap::new();
+        let mut named_keys = NamedKeys::new();
         named_keys.insert("contract_named_key".to_string(), contract_variable.into());
         named_keys
     };

--- a/execution-engine/contracts/test/do-nothing-stored-upgrader/src/main.rs
+++ b/execution-engine/contracts/test/do-nothing-stored-upgrader/src/main.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::ToString, vec::Vec};
+use alloc::{string::ToString, vec::Vec};
 use contract::{
     contract_api::{runtime, storage},
     unwrap_or_revert::UnwrapOrRevert,
@@ -11,7 +11,7 @@ use contract::{
 use core::convert::TryInto;
 
 use types::{
-    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints},
+    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys},
     CLType, Key, URef,
 };
 
@@ -54,7 +54,7 @@ pub extern "C" fn call() {
     let (contract_hash, contract_version) = storage::add_contract_version(
         do_nothing_package_hash.into_hash().unwrap(),
         entry_points,
-        BTreeMap::new(),
+        NamedKeys::new(),
     );
     runtime::put_key(CONTRACT_VERSION, storage::new_uref(contract_version).into());
     runtime::put_key("end of upgrade", contract_hash.into());

--- a/execution-engine/contracts/test/ee-771-regression/src/main.rs
+++ b/execution-engine/contracts/test/ee-771-regression/src/main.rs
@@ -3,7 +3,7 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::ToString};
+use alloc::string::ToString;
 
 use contract::{
     contract_api::{runtime, storage},
@@ -72,13 +72,13 @@ fn store(named_keys: NamedKeys) -> (ContractHash, ContractVersion) {
 }
 
 fn install() -> Result<ContractHash, ApiError> {
-    let (contract_hash, _contract_version) = store(BTreeMap::new());
+    let (contract_hash, _contract_version) = store(NamedKeys::new());
 
-    let mut keys = BTreeMap::new();
+    let mut keys = NamedKeys::new();
     keys.insert(CONTRACT_KEY.to_string(), contract_hash.into());
     let (contract_hash, _contract_version) = store(keys);
 
-    let mut keys_2 = BTreeMap::new();
+    let mut keys_2 = NamedKeys::new();
     keys_2.insert(CONTRACT_KEY.to_string(), contract_hash.into());
     let (contract_hash, _contract_version) = store(keys_2);
 

--- a/execution-engine/contracts/test/groups/src/main.rs
+++ b/execution-engine/contracts/test/groups/src/main.rs
@@ -4,11 +4,7 @@
 #[macro_use]
 extern crate alloc;
 
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    string::ToString,
-    vec::Vec,
-};
+use alloc::{collections::BTreeSet, string::ToString, vec::Vec};
 
 use contract::{
     contract_api::{runtime, storage},
@@ -16,7 +12,8 @@ use contract::{
 };
 use types::{
     contracts::{
-        EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, CONTRACT_INITIAL_VERSION,
+        EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys,
+        CONTRACT_INITIAL_VERSION,
     },
     runtime_args, CLType, ContractPackageHash, Key, Parameter, RuntimeArgs, URef,
 };
@@ -214,7 +211,7 @@ fn install_version_1(contract_package_hash: ContractPackageHash, restricted_uref
     let contract_named_keys = {
         let contract_variable = storage::new_uref(0);
 
-        let mut named_keys = BTreeMap::new();
+        let mut named_keys = NamedKeys::new();
         named_keys.insert("contract_named_key".to_string(), contract_variable.into());
         named_keys.insert("restricted_uref".to_string(), restricted_uref.into());
         named_keys

--- a/execution-engine/contracts/test/list-named-keys/src/main.rs
+++ b/execution-engine/contracts/test/list-named-keys/src/main.rs
@@ -3,10 +3,10 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use alloc::{string::String, vec::Vec};
 
 use contract::contract_api::runtime;
-use types::Key;
+use types::contracts::NamedKeys;
 
 const ARG_INITIAL_NAMED_KEYS: &str = "initial_named_args";
 const ARG_NEW_NAMED_KEYS: &str = "new_named_keys";
@@ -14,14 +14,13 @@ const ARG_NEW_NAMED_KEYS: &str = "new_named_keys";
 #[no_mangle]
 pub extern "C" fn call() {
     // Account starts with two known named keys: mint uref & pos uref.
-    let expected_initial_named_keys: BTreeMap<String, Key> =
-        runtime::get_named_arg(ARG_INITIAL_NAMED_KEYS);
+    let expected_initial_named_keys: NamedKeys = runtime::get_named_arg(ARG_INITIAL_NAMED_KEYS);
 
     let actual_named_keys = runtime::list_named_keys();
     assert_eq!(expected_initial_named_keys, actual_named_keys);
 
     // Add further named keys and assert that each is returned in `list_named_keys()`.
-    let new_named_keys: BTreeMap<String, Key> = runtime::get_named_arg(ARG_NEW_NAMED_KEYS);
+    let new_named_keys: NamedKeys = runtime::get_named_arg(ARG_NEW_NAMED_KEYS);
     let mut expected_named_keys = expected_initial_named_keys;
 
     for (key, value) in new_named_keys {

--- a/execution-engine/contracts/test/manage-groups/src/main.rs
+++ b/execution-engine/contracts/test/manage-groups/src/main.rs
@@ -6,7 +6,7 @@ extern crate alloc;
 
 use alloc::{
     boxed::Box,
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     string::{String, ToString},
     vec::Vec,
 };
@@ -18,7 +18,7 @@ use contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use types::{
-    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints},
+    contracts::{EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, NamedKeys},
     CLType, ContractPackageHash, Key, Parameter, URef,
 };
 
@@ -151,7 +151,7 @@ fn create_entry_points_1() -> EntryPoints {
 }
 
 fn install_version_1(package_hash: ContractPackageHash) {
-    let contract_named_keys = BTreeMap::new();
+    let contract_named_keys = NamedKeys::new();
 
     let entry_points = create_entry_points_1();
     storage::add_contract_version(package_hash, entry_points, contract_named_keys);

--- a/execution-engine/engine-core/src/engine_state/mod.rs
+++ b/execution-engine/engine-core/src/engine_state/mod.rs
@@ -40,7 +40,7 @@ use engine_wasm_prep::{wasm_costs::WasmCosts, Preprocessor};
 use types::{
     account::PublicKey,
     bytesrepr::{self, ToBytes},
-    contracts::{ENTRY_POINT_NAME_INSTALL, UPGRADE_ENTRY_POINT_NAME},
+    contracts::{NamedKeys, ENTRY_POINT_NAME_INSTALL, UPGRADE_ENTRY_POINT_NAME},
     runtime_args,
     system_contract_errors::mint,
     system_contract_type::PROOF_OF_STAKE,
@@ -69,9 +69,7 @@ use crate::{
     },
     execution::{self, AddressGenerator, AddressGeneratorBuilder, Executor},
     tracking_copy::{TrackingCopy, TrackingCopyExt},
-    KnownKeys,
 };
-use execution::{MINT_NAME, POS_NAME};
 
 // TODO?: MAX_PAYMENT && CONV_RATE values are currently arbitrary w/ real values
 // TBD gas * CONV_RATE = motes
@@ -176,7 +174,7 @@ where
 
         // Spec #3: Create "virtual system account" object.
         let mut virtual_system_account = {
-            let named_keys = BTreeMap::new();
+            let named_keys = NamedKeys::new();
             let purse = URef::new(Default::default(), AccessRights::READ_ADD_WRITE);
             Account::create(SYSTEM_ACCOUNT_ADDR, named_keys, purse)
         };
@@ -371,19 +369,14 @@ where
         //   account (with the exception of its known keys)
         //
         // Create known keys for chainspec accounts
-        let account_named_keys = {
-            let mut ret = BTreeMap::new();
-            ret.insert(MINT_NAME.to_string(), Key::Hash(mint_hash));
-            ret.insert(POS_NAME.to_string(), Key::Hash(proof_of_stake_hash));
-            ret
-        };
+        let account_named_keys = NamedKeys::new();
 
         // Create accounts
         {
             // Collect chainspec accounts and their known keys with the genesis account and its
             // known keys
             let accounts = {
-                let mut ret: Vec<(GenesisAccount, KnownKeys)> = ee_config
+                let mut ret: Vec<(GenesisAccount, NamedKeys)> = ee_config
                     .accounts()
                     .to_vec()
                     .into_iter()
@@ -415,7 +408,7 @@ where
                 };
                 let tracking_copy_exec = Rc::clone(&tracking_copy);
                 let tracking_copy_write = Rc::clone(&tracking_copy);
-                let mut named_keys_exec = BTreeMap::new();
+                let mut named_keys_exec = NamedKeys::new();
                 let base_key = mint_hash;
                 let authorization_keys: BTreeSet<PublicKey> = BTreeSet::new();
                 let account_public_key = account.public_key();

--- a/execution-engine/engine-core/src/execution/executor.rs
+++ b/execution-engine/engine-core/src/execution/executor.rs
@@ -1,8 +1,4 @@
-use std::{
-    cell::RefCell,
-    collections::{BTreeMap, BTreeSet},
-    rc::Rc,
-};
+use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 use log::warn;
 use parity_wasm::elements::Module;
@@ -89,7 +85,7 @@ impl Executor {
         args: RuntimeArgs,
         base_key: Key,
         account: &Account,
-        mut named_keys: BTreeMap<String, Key>,
+        mut named_keys: NamedKeys,
         authorization_keys: BTreeSet<PublicKey>,
         blocktime: BlockTime,
         deploy_hash: [u8; 32],
@@ -230,7 +226,7 @@ impl Executor {
         &self,
         parity_module: Module,
         args: RuntimeArgs,
-        named_keys: &mut BTreeMap<String, Key>,
+        named_keys: &mut NamedKeys,
         base_key: Key,
         account: &Account,
         authorization_keys: BTreeSet<PublicKey>,
@@ -378,7 +374,7 @@ impl Executor {
         module: Module,
         entry_point_type: EntryPointType,
         args: RuntimeArgs,
-        named_keys: &'a mut BTreeMap<String, Key>,
+        named_keys: &'a mut NamedKeys,
         base_key: Key,
         account: &'a Account,
         authorization_keys: BTreeSet<PublicKey>,

--- a/execution-engine/engine-core/src/execution/mod.rs
+++ b/execution-engine/engine-core/src/execution/mod.rs
@@ -10,6 +10,3 @@ pub use self::{
     error::Error,
     executor::Executor,
 };
-
-pub const MINT_NAME: &str = "mint";
-pub const POS_NAME: &str = "pos";

--- a/execution-engine/engine-core/src/lib.rs
+++ b/execution-engine/engine-core/src/lib.rs
@@ -5,15 +5,9 @@ pub mod runtime;
 pub mod runtime_context;
 pub(crate) mod tracking_copy;
 
-use std::collections::BTreeMap;
-
-use types::Key;
-
 pub const ADDRESS_LENGTH: usize = 32;
 pub const DEPLOY_HASH_LENGTH: usize = 32;
 
 pub type Address = [u8; ADDRESS_LENGTH];
 
 pub type DeployHash = [u8; DEPLOY_HASH_LENGTH];
-
-type KnownKeys = BTreeMap<String, Key>;

--- a/execution-engine/engine-core/src/runtime/externals.rs
+++ b/execution-engine/engine-core/src/runtime/externals.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    convert::TryFrom,
-};
+use std::{collections::BTreeSet, convert::TryFrom};
 
 use wasmi::{Externals, RuntimeArgs, RuntimeValue, Trap};
 
@@ -9,7 +6,7 @@ use types::{
     account::PublicKey,
     api_error,
     bytesrepr::{self, ToBytes},
-    contracts::EntryPoints,
+    contracts::{EntryPoints, NamedKeys},
     ContractHash, ContractPackageHash, ContractVersion, Group, Key, TransferredTo, URef, U512,
 };
 
@@ -453,8 +450,7 @@ where
                     self.t_from_mem(contract_package_hash_ptr, contract_package_hash_size)?;
                 let entry_points: EntryPoints =
                     self.t_from_mem(entry_points_ptr, entry_points_size)?;
-                let named_keys: BTreeMap<String, Key> =
-                    self.t_from_mem(named_keys_ptr, named_keys_size)?;
+                let named_keys: NamedKeys = self.t_from_mem(named_keys_ptr, named_keys_size)?;
                 let ret = self.add_contract_version(
                     contract_package_hash,
                     entry_points,

--- a/execution-engine/engine-core/src/runtime_context/mod.rs
+++ b/execution-engine/engine-core/src/runtime_context/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     convert::{TryFrom, TryInto},
     fmt::Debug,
     rc::Rc,
@@ -20,9 +20,11 @@ use types::{
         ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure,
         UpdateKeyFailure, Weight,
     },
-    bytesrepr, AccessRights, BlockTime, CLType, CLValue, Contract, ContractPackage,
-    ContractPackageHash, EntryPointAccess, EntryPointType, Key, Phase, ProtocolVersion,
-    RuntimeArgs, URef, KEY_HASH_LENGTH,
+    bytesrepr,
+    contracts::NamedKeys,
+    AccessRights, BlockTime, CLType, CLValue, Contract, ContractPackage, ContractPackageHash,
+    EntryPointAccess, EntryPointType, Key, Phase, ProtocolVersion, RuntimeArgs, URef,
+    KEY_HASH_LENGTH,
 };
 
 use crate::{
@@ -83,7 +85,7 @@ pub fn validate_entry_point_access_with(
 pub struct RuntimeContext<'a, R> {
     tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
     // Enables look up of specific uref based on human-readable name
-    named_keys: &'a mut BTreeMap<String, Key>,
+    named_keys: &'a mut NamedKeys,
     // Used to check uref is known before use (prevents forging urefs)
     access_rights: HashMap<Address, HashSet<AccessRights>>,
     // Original account for read only tasks taken before execution
@@ -115,7 +117,7 @@ where
     pub fn new(
         tracking_copy: Rc<RefCell<TrackingCopy<R>>>,
         entry_point_type: EntryPointType,
-        named_keys: &'a mut BTreeMap<String, Key>,
+        named_keys: &'a mut NamedKeys,
         access_rights: HashMap<Address, HashSet<AccessRights>>,
         args: RuntimeArgs,
         authorization_keys: BTreeSet<PublicKey>,
@@ -162,11 +164,11 @@ where
         self.named_keys.get(name)
     }
 
-    pub fn named_keys(&self) -> &BTreeMap<String, Key> {
+    pub fn named_keys(&self) -> &NamedKeys {
         &self.named_keys
     }
 
-    pub fn named_keys_mut(&mut self) -> &mut BTreeMap<String, Key> {
+    pub fn named_keys_mut(&mut self) -> &mut NamedKeys {
         &mut self.named_keys
     }
 

--- a/execution-engine/engine-core/src/runtime_context/tests.rs
+++ b/execution-engine/engine-core/src/runtime_context/tests.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     iter::{self, FromIterator},
     rc::Rc,
 };
@@ -23,6 +23,7 @@ use types::{
     account::{
         ActionType, AddKeyFailure, PublicKey, RemoveKeyFailure, SetThresholdFailure, Weight,
     },
+    contracts::NamedKeys,
     AccessRights, BlockTime, CLValue, Contract, EntryPointType, EntryPoints, Key, Phase,
     ProtocolVersion, RuntimeArgs, URef, KEY_HASH_LENGTH,
 };
@@ -68,7 +69,7 @@ fn mock_account_with_purse(public_key: PublicKey, purse: [u8; 32]) -> (Key, Acco
     let associated_keys = AssociatedKeys::new(public_key, Weight::new(1));
     let account = Account::new(
         public_key,
-        BTreeMap::new(),
+        NamedKeys::new(),
         URef::new(purse, AccessRights::READ_ADD_WRITE),
         associated_keys,
         Default::default(),
@@ -111,7 +112,7 @@ fn random_hash<G: RngCore>(entropy_source: &mut G) -> Key {
 fn mock_runtime_context<'a>(
     account: &'a Account,
     base_key: Key,
-    named_keys: &'a mut BTreeMap<String, Key>,
+    named_keys: &'a mut NamedKeys,
     access_rights: HashMap<Address, HashSet<AccessRights>>,
     hash_address_generator: AddressGenerator,
     uref_address_generator: AddressGenerator,
@@ -165,7 +166,7 @@ where
     let deploy_hash = [1u8; 32];
     let (base_key, account) = mock_account(PublicKey::ed25519_from([0u8; 32]));
 
-    let mut named_keys = BTreeMap::new();
+    let mut named_keys = NamedKeys::new();
     let uref_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let hash_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let runtime_context = mock_runtime_context(
@@ -337,7 +338,7 @@ fn contract_key_addable_valid() {
     )));
     tracking_copy.borrow_mut().write(contract_key, contract);
 
-    let mut named_keys = BTreeMap::new();
+    let mut named_keys = NamedKeys::new();
     let uref = create_uref(&mut uref_address_generator, AccessRights::WRITE);
     let uref_name = "NewURef".to_owned();
     let named_uref_tuple =
@@ -408,7 +409,7 @@ fn contract_key_addable_invalid() {
 
     tracking_copy.borrow_mut().write(contract_key, contract);
 
-    let mut named_keys = BTreeMap::new();
+    let mut named_keys = NamedKeys::new();
 
     let uref = create_uref(&mut uref_address_generator, AccessRights::WRITE);
     let uref_name = "NewURef".to_owned();
@@ -800,7 +801,7 @@ fn validate_valid_purse_of_an_account() {
     let deploy_hash = [1u8; 32];
     let (base_key, account) =
         mock_account_with_purse(PublicKey::ed25519_from([0u8; 32]), mock_purse);
-    let mut named_keys = BTreeMap::new();
+    let mut named_keys = NamedKeys::new();
     let hash_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let uref_address_generator = AddressGenerator::new(&deploy_hash, Phase::Session);
     let runtime_context = mock_runtime_context(

--- a/execution-engine/engine-grpc-server/src/engine_server/mappings/state/named_key.rs
+++ b/execution-engine/engine-grpc-server/src/engine_server/mappings/state/named_key.rs
@@ -3,7 +3,7 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
-use types::Key;
+use types::{contracts::NamedKeys, Key};
 
 use crate::engine_server::{mappings::ParsingError, state::NamedKey};
 
@@ -27,16 +27,16 @@ impl TryFrom<NamedKey> for (String, Key) {
 }
 
 /// Thin wrapper to allow us to implement `From` and `TryFrom` helpers to convert to and from
-/// `BTreeMap<String, Key>` and `Vec<NamedKey>`.
+/// `NamedKeys` and `Vec<NamedKey>`.
 #[derive(Clone, PartialEq, Debug)]
-pub(crate) struct NamedKeyMap(BTreeMap<String, Key>);
+pub(crate) struct NamedKeyMap(NamedKeys);
 
 impl NamedKeyMap {
-    pub fn new(inner: BTreeMap<String, Key>) -> Self {
+    pub fn new(inner: NamedKeys) -> Self {
         Self(inner)
     }
 
-    pub fn into_inner(self) -> BTreeMap<String, Key> {
+    pub fn into_inner(self) -> NamedKeys {
         self.0
     }
 }

--- a/execution-engine/engine-shared/src/account.rs
+++ b/execution-engine/engine-shared/src/account.rs
@@ -1,7 +1,7 @@
 mod action_thresholds;
 mod associated_keys;
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 
 use types::{
     account::{
@@ -9,7 +9,8 @@ use types::{
         UpdateKeyFailure, Weight,
     },
     bytesrepr::{self, Error, FromBytes, ToBytes},
-    AccessRights, Key, URef,
+    contracts::NamedKeys,
+    AccessRights, URef,
 };
 
 pub use action_thresholds::ActionThresholds;
@@ -18,7 +19,7 @@ pub use associated_keys::AssociatedKeys;
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Account {
     public_key: PublicKey,
-    named_keys: BTreeMap<String, Key>,
+    named_keys: NamedKeys,
     main_purse: URef,
     associated_keys: AssociatedKeys,
     action_thresholds: ActionThresholds,
@@ -27,7 +28,7 @@ pub struct Account {
 impl Account {
     pub fn new(
         public_key: PublicKey,
-        named_keys: BTreeMap<String, Key>,
+        named_keys: NamedKeys,
         main_purse: URef,
         associated_keys: AssociatedKeys,
         action_thresholds: ActionThresholds,
@@ -41,7 +42,7 @@ impl Account {
         }
     }
 
-    pub fn create(account: PublicKey, named_keys: BTreeMap<String, Key>, main_purse: URef) -> Self {
+    pub fn create(account: PublicKey, named_keys: NamedKeys, main_purse: URef) -> Self {
         let associated_keys = AssociatedKeys::new(account, Weight::new(1));
         let action_thresholds: ActionThresholds = Default::default();
         Account::new(
@@ -53,15 +54,15 @@ impl Account {
         )
     }
 
-    pub fn named_keys_append(&mut self, keys: &mut BTreeMap<String, Key>) {
+    pub fn named_keys_append(&mut self, keys: &mut NamedKeys) {
         self.named_keys.append(keys);
     }
 
-    pub fn named_keys(&self) -> &BTreeMap<String, Key> {
+    pub fn named_keys(&self) -> &NamedKeys {
         &self.named_keys
     }
 
-    pub fn named_keys_mut(&mut self) -> &mut BTreeMap<String, Key> {
+    pub fn named_keys_mut(&mut self) -> &mut NamedKeys {
         &mut self.named_keys
     }
 
@@ -222,7 +223,7 @@ impl ToBytes for Account {
 impl FromBytes for Account {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), Error> {
         let (public_key, rem) = PublicKey::from_bytes(bytes)?;
-        let (named_keys, rem) = BTreeMap::<String, Key>::from_bytes(rem)?;
+        let (named_keys, rem) = NamedKeys::from_bytes(rem)?;
         let (main_purse, rem) = URef::from_bytes(rem)?;
         let (associated_keys, rem) = AssociatedKeys::from_bytes(rem)?;
         let (action_thresholds, rem) = ActionThresholds::from_bytes(rem)?;
@@ -290,10 +291,7 @@ mod proptests {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{BTreeMap, BTreeSet},
-        iter::FromIterator,
-    };
+    use std::{collections::BTreeSet, iter::FromIterator};
 
     use types::{
         account::{
@@ -320,7 +318,7 @@ mod tests {
 
         let account = Account::new(
             PublicKey::ed25519_from([0u8; 32]),
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             keys,
             // deploy: 33 (3*11)
@@ -366,7 +364,7 @@ mod tests {
         };
         let account = Account::new(
             PublicKey::ed25519_from([0u8; 32]),
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             // deploy: 33 (3*11)
@@ -410,7 +408,7 @@ mod tests {
         };
         let account = Account::new(
             PublicKey::ed25519_from([0u8; 32]),
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             // deploy: 33 (3*11)
@@ -458,7 +456,7 @@ mod tests {
         };
         let mut account = Account::new(
             PublicKey::ed25519_from([0u8; 32]),
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             // deploy: 33 (3*11)
@@ -498,7 +496,7 @@ mod tests {
         };
         let mut account = Account::new(
             PublicKey::ed25519_from([0u8; 32]),
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             // deploy: 33 (3*11)
@@ -540,7 +538,7 @@ mod tests {
         let key_management_threshold = Weight::new(deployment_threshold.value() + 1);
         let mut account = Account::new(
             identity_key,
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             // deploy: 33 (3*11)
@@ -598,7 +596,7 @@ mod tests {
 
         let mut account = Account::new(
             identity_key,
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             ActionThresholds::new(Weight::new(1), Weight::new(254))
@@ -633,7 +631,7 @@ mod tests {
 
         let mut account = Account::new(
             identity_key,
-            BTreeMap::new(),
+            NamedKeys::new(),
             URef::new([0u8; 32], AccessRights::READ_ADD_WRITE),
             associated_keys,
             ActionThresholds::new(deployment_threshold, key_management_threshold)

--- a/execution-engine/engine-shared/src/test_utils.rs
+++ b/execution-engine/engine-shared/src/test_utils.rs
@@ -1,15 +1,14 @@
 //! Some functions to use in tests.
-use std::collections::BTreeMap;
 
 use engine_wasm_prep::wasm_costs::WasmCosts;
-use types::{account::PublicKey, AccessRights, Key, URef};
+use types::{account::PublicKey, contracts::NamedKeys, AccessRights, Key, URef};
 
 use crate::{account::Account, stored_value::StoredValue};
 
 /// Returns an account value paired with its key
 pub fn mocked_account(public_key: PublicKey) -> Vec<(Key, StoredValue)> {
     let purse = URef::new([0u8; 32], AccessRights::READ_ADD_WRITE);
-    let account = Account::create(public_key, BTreeMap::new(), purse);
+    let account = Account::create(public_key, NamedKeys::new(), purse);
     vec![(Key::Account(public_key), StoredValue::Account(account))]
 }
 

--- a/execution-engine/engine-shared/src/transform.rs
+++ b/execution-engine/engine-shared/src/transform.rs
@@ -1,6 +1,5 @@
 use std::{
     any,
-    collections::BTreeMap,
     convert::TryFrom,
     default::Default,
     fmt::{self, Display, Formatter},
@@ -11,7 +10,8 @@ use num::traits::{AsPrimitive, WrappingAdd};
 
 use types::{
     bytesrepr::{self, FromBytes, ToBytes},
-    CLType, CLTyped, CLValue, CLValueError, Key, U128, U256, U512,
+    contracts::NamedKeys,
+    CLType, CLTyped, CLValue, CLValueError, U128, U256, U512,
 };
 
 use crate::{stored_value::StoredValue, TypeMismatch};
@@ -58,7 +58,7 @@ pub enum Transform {
     AddUInt128(U128),
     AddUInt256(U256),
     AddUInt512(U512),
-    AddKeys(BTreeMap<String, Key>),
+    AddKeys(NamedKeys),
     Failure(Error),
 }
 
@@ -89,7 +89,7 @@ from_try_from_impl!(u64, AddUInt64);
 from_try_from_impl!(U128, AddUInt128);
 from_try_from_impl!(U256, AddUInt256);
 from_try_from_impl!(U512, AddUInt512);
-from_try_from_impl!(BTreeMap<String, Key>, AddKeys);
+from_try_from_impl!(NamedKeys, AddKeys);
 from_try_from_impl!(Error, Failure);
 
 /// Attempts a wrapping addition of `to_add` to `stored_value`, assuming `stored_value` is
@@ -309,10 +309,11 @@ pub mod gens {
 mod tests {
     use num::{Bounded, Num};
 
-    use types::{account::PublicKey, AccessRights, ContractWasm, URef, U128, U256, U512};
+    use types::{account::PublicKey, AccessRights, ContractWasm, Key, URef, U128, U256, U512};
 
     use super::*;
     use crate::account::{Account, ActionThresholds, AssociatedKeys};
+    use std::collections::BTreeMap;
 
     const ZERO_ARRAY: [u8; 32] = [0; 32];
     const ZERO_PUBLIC_KEY: PublicKey = PublicKey::ed25519_from(ZERO_ARRAY);
@@ -444,7 +445,7 @@ mod tests {
         let uref = URef::new(ZERO_ARRAY, AccessRights::READ);
         let account = StoredValue::Account(Account::new(
             ZERO_PUBLIC_KEY,
-            BTreeMap::new(),
+            NamedKeys::new(),
             uref,
             AssociatedKeys::default(),
             ActionThresholds::default(),

--- a/execution-engine/engine-test-support/src/account.rs
+++ b/execution-engine/engine-test-support/src/account.rs
@@ -1,7 +1,7 @@
-use std::{collections::BTreeMap, convert::TryFrom};
+use std::convert::TryFrom;
 
 use engine_shared::stored_value::StoredValue;
-use types::{account::PublicKey, Key, URef};
+use types::{account::PublicKey, contracts::NamedKeys, URef};
 
 use crate::{Error, Result};
 
@@ -23,7 +23,7 @@ impl Account {
     }
 
     /// Returns the named_keys.
-    pub fn named_keys(&self) -> &BTreeMap<String, Key> {
+    pub fn named_keys(&self) -> &NamedKeys {
         self.inner.named_keys()
     }
 

--- a/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
+++ b/execution-engine/engine-tests/src/test/contract_api/list_named_keys.rs
@@ -1,11 +1,8 @@
-use std::collections::BTreeMap;
-
-use engine_core::execution::{MINT_NAME, POS_NAME};
 use engine_test_support::{
     internal::{ExecuteRequestBuilder, InMemoryWasmTestBuilder, DEFAULT_RUN_GENESIS_REQUEST},
     DEFAULT_ACCOUNT_ADDR,
 };
-use types::{account::PublicKey, runtime_args, Key, RuntimeArgs};
+use types::{account::PublicKey, contracts::NamedKeys, runtime_args, Key, RuntimeArgs};
 
 const CONTRACT_LIST_NAMED_KEYS: &str = "list_named_keys.wasm";
 const NEW_NAME_ACCOUNT: &str = "Account";
@@ -19,23 +16,11 @@ fn should_list_named_keys() {
     let mut builder = InMemoryWasmTestBuilder::default();
     builder.run_genesis(&DEFAULT_RUN_GENESIS_REQUEST);
 
-    let mint_hash = builder.get_mint_contract_hash();
-    let pos_hash = builder.get_pos_contract_hash();
-
-    let initial_named_keys = {
-        let mut named_keys = BTreeMap::new();
-        assert!(named_keys
-            .insert(MINT_NAME.to_string(), Key::Hash(mint_hash))
-            .is_none());
-        assert!(named_keys
-            .insert(POS_NAME.to_string(), Key::Hash(pos_hash))
-            .is_none());
-        named_keys
-    };
+    let initial_named_keys: NamedKeys = NamedKeys::new();
 
     let new_named_keys = {
         let public_key = PublicKey::ed25519_from([1; 32]);
-        let mut named_keys = BTreeMap::new();
+        let mut named_keys = NamedKeys::new();
         assert!(named_keys
             .insert(NEW_NAME_ACCOUNT.to_string(), Key::Account(public_key))
             .is_none());

--- a/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
+++ b/execution-engine/engine-tests/src/test/system_contracts/pos_install.rs
@@ -12,8 +12,8 @@ use engine_test_support::{
     DEFAULT_ACCOUNT_ADDR,
 };
 use types::{
-    account::PublicKey, runtime_args, ContractHash, ContractPackageHash, Key, RuntimeArgs, URef,
-    U512,
+    account::PublicKey, contracts::NamedKeys, runtime_args, ContractHash, ContractPackageHash, Key,
+    RuntimeArgs, URef, U512,
 };
 
 const CONTRACT_TRANSFER_TO_ACCOUNT: &str = "transfer_to_account_u512.wasm";
@@ -129,7 +129,7 @@ fn should_run_pos_install_contract() {
     assert_eq!(rewards_purse_balance, U512::zero());
 }
 
-fn get_purse(named_keys: &BTreeMap<String, Key>, name: &str) -> Option<URef> {
+fn get_purse(named_keys: &NamedKeys, name: &str) -> Option<URef> {
     named_keys
         .get(name)
         .expect("should have named key")

--- a/execution-engine/types/src/contracts.rs
+++ b/execution-engine/types/src/contracts.rs
@@ -551,7 +551,7 @@ impl Contract {
     }
 
     /// Returns a reference to `named_keys`
-    pub fn named_keys(&self) -> &BTreeMap<String, Key> {
+    pub fn named_keys(&self) -> &NamedKeys {
         &self.named_keys
     }
 
@@ -595,7 +595,7 @@ impl FromBytes for Contract {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         let (contract_package_hash, bytes) = <[u8; KEY_HASH_LENGTH]>::from_bytes(bytes)?;
         let (contract_wasm_hash, bytes) = <[u8; KEY_HASH_LENGTH]>::from_bytes(bytes)?;
-        let (named_keys, bytes) = BTreeMap::<String, Key>::from_bytes(bytes)?;
+        let (named_keys, bytes) = NamedKeys::from_bytes(bytes)?;
         let (entry_points, bytes) = EntryPoints::from_bytes(bytes)?;
         let (protocol_version, bytes) = ProtocolVersion::from_bytes(bytes)?;
         Ok((

--- a/execution-engine/types/src/gens.rs
+++ b/execution-engine/types/src/gens.rs
@@ -2,7 +2,7 @@
 //! [`Proptest`](https://crates.io/crates/proptest).
 #![allow(missing_docs)]
 
-use alloc::{boxed::Box, collections::BTreeMap, string::String, vec};
+use alloc::{boxed::Box, string::String, vec};
 
 use proptest::{
     array, bits,
@@ -14,7 +14,7 @@ use proptest::{
 
 use crate::{
     account::{PublicKey, Weight},
-    contracts::{ContractVersions, DisabledVersions, Groups, Parameters},
+    contracts::{ContractVersions, DisabledVersions, Groups, NamedKeys, Parameters},
     AccessRights, CLType, CLValue, Contract, ContractPackage, ContractVersionKey, ContractWasm,
     EntryPoint, EntryPointAccess, EntryPointType, EntryPoints, Group, Key, NamedArg, Parameter,
     Phase, ProtocolVersion, SemVer, URef, U128, U256, U512,
@@ -28,7 +28,7 @@ pub fn u8_slice_32() -> impl Strategy<Value = [u8; 32]> {
     })
 }
 
-pub fn named_keys_arb(depth: usize) -> impl Strategy<Value = BTreeMap<String, Key>> {
+pub fn named_keys_arb(depth: usize) -> impl Strategy<Value = NamedKeys> {
     btree_map("\\PC*", key_arb(), depth)
 }
 

--- a/execution-engine/types/src/system_contract_type.rs
+++ b/execution-engine/types/src/system_contract_type.rs
@@ -22,11 +22,11 @@ pub enum SystemContractType {
 }
 
 /// Name of mint system contract
-pub const MINT: &str = "mint";
+const MINT: &str = "mint";
 /// Name of proof of stake system contract
 pub const PROOF_OF_STAKE: &str = "proof of stake";
 /// Name of standard payment system contract
-pub const STANDARD_PAYMENT: &str = "standard payment";
+const STANDARD_PAYMENT: &str = "standard payment";
 
 impl From<SystemContractType> for u32 {
     fn from(system_contract_type: SystemContractType) -> u32 {


### PR DESCRIPTION
This commit also changes all raw collections into a `NamedKeys` type
alias.
