### PR TITLE
NO-TICKET: fix bug in storage benchmarks

### DIFF
--- a/execution-engine/engine-storage/benches/trie_bench.rs
+++ b/execution-engine/engine-storage/benches/trie_bench.rs
@@ -28,12 +28,12 @@ fn deserialize_trie_leaf(b: &mut Bencher) {
         value: StoredValue::CLValue(CLValue::from_t(42_i32).unwrap()),
     };
     let leaf_bytes = leaf.to_bytes().unwrap();
-    b.iter(|| u8::from_bytes(black_box(&leaf_bytes)))
+    b.iter(|| Trie::<Key, StoredValue>::from_bytes(black_box(&leaf_bytes)));
 }
 
 #[bench]
 fn serialize_trie_node(b: &mut Bencher) {
-    let node = Trie::<String, String>::Node {
+    let node = Trie::<Key, StoredValue>::Node {
         pointer_block: Box::new(PointerBlock::default()),
     };
     b.iter(|| ToBytes::to_bytes(black_box(&node)));
@@ -41,31 +41,31 @@ fn serialize_trie_node(b: &mut Bencher) {
 
 #[bench]
 fn deserialize_trie_node(b: &mut Bencher) {
-    let node = Trie::<String, String>::Node {
+    let node = Trie::<Key, StoredValue>::Node {
         pointer_block: Box::new(PointerBlock::default()),
     };
     let node_bytes = node.to_bytes().unwrap();
 
-    b.iter(|| u8::from_bytes(black_box(&node_bytes)));
+    b.iter(|| Trie::<Key, StoredValue>::from_bytes(black_box(&node_bytes)));
 }
 
 #[bench]
 fn serialize_trie_node_pointer(b: &mut Bencher) {
-    let node = Trie::<String, String>::Extension {
+    let node = Trie::<Key, StoredValue>::Extension {
         affix: (0..255).collect(),
         pointer: Pointer::NodePointer(Blake2bHash::new(&[0; 32])),
     };
 
-    b.iter(|| ToBytes::to_bytes(black_box(&node)))
+    b.iter(|| ToBytes::to_bytes(black_box(&node)));
 }
 
 #[bench]
 fn deserialize_trie_node_pointer(b: &mut Bencher) {
-    let node = Trie::<String, String>::Extension {
+    let node = Trie::<Key, StoredValue>::Extension {
         affix: (0..255).collect(),
         pointer: Pointer::NodePointer(Blake2bHash::new(&[0; 32])),
     };
     let node_bytes = node.to_bytes().unwrap();
 
-    b.iter(|| u8::from_bytes(black_box(&node_bytes)))
+    b.iter(|| Trie::<Key, StoredValue>::from_bytes(black_box(&node_bytes)));
 }


### PR DESCRIPTION
### Overview
This fixes an issue in the storage benchmarks whereby deserialization was being done into a `u8` rather than the type being benchmarked.

It also changes all these benchmarks to use `Trie<Key, StoredValue>` since that's most representative of our actual use case.

### Which JIRA ticket does this PR relate to?
NO-TICKET

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [x] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
