### PR TITLE
TNET-18: Pass empty sets to EraObservedBehavior.local if validator hasn't produced

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
+++ b/node/src/main/scala/io/casperlabs/node/NodeRuntime.scala
@@ -30,7 +30,7 @@ import io.casperlabs.comm._
 import io.casperlabs.comm.discovery.NodeUtils._
 import io.casperlabs.comm.discovery._
 import io.casperlabs.comm.gossiping.WaitHandle
-import io.casperlabs.comm.gossiping.relaying.BlockRelaying
+import io.casperlabs.comm.gossiping.relaying.{BlockRelaying, DeployRelaying}
 import io.casperlabs.comm.grpc.SslContexts
 import io.casperlabs.comm.rp._
 import io.casperlabs.ipc.ChainSpec
@@ -46,6 +46,7 @@ import io.casperlabs.storage.SQLiteStorage
 import io.casperlabs.storage.block._
 import io.casperlabs.storage.dag._
 import io.casperlabs.storage.deploy.DeployStorageWriter
+import io.casperlabs.storage.era._
 import io.casperlabs.storage.util.fileIO.IOError._
 import io.casperlabs.storage.util.fileIO._
 import io.netty.handler.ssl.ClientAuth
@@ -55,7 +56,6 @@ import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.Location
 
 import scala.concurrent.duration._
-import io.casperlabs.comm.gossiping.relaying.DeployRelaying
 
 class NodeRuntime private[node] (
     conf: Configuration,
@@ -178,7 +178,9 @@ class NodeRuntime private[node] (
                     cache: DagStorage[Task] with DagRepresentation[Task] with FinalityStorage[
                       Task
                     ] with AncestorsStorage[Task]
-                )
+                ),
+              wrapEraStorage = (underlyingEraStorage: EraStorage[Task]) =>
+                CachingEraStorage[Task](underlyingEraStorage)
             )
           )
 

--- a/storage/src/main/scala/io/casperlabs/storage/era/CachingEraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/CachingEraStorage.scala
@@ -1,0 +1,50 @@
+package io.casperlabs.storage.era
+
+import cats._
+import cats.implicits._
+import cats.effect.Sync
+import com.google.common.cache.{Cache, CacheBuilder}
+import java.util.concurrent.TimeUnit
+import io.casperlabs.storage.BlockHash
+import io.casperlabs.casper.consensus.Era
+
+class CachingEraStorage[F[_]: Sync](
+    underlying: EraStorage[F],
+    eraCache: Cache[BlockHash, Era]
+) extends EraStorage[F] {
+  private def cacheEra(era: Era) = Sync[F].delay {
+    eraCache.put(era.keyBlockHash, era)
+  }
+
+  override def addEra(era: Era) =
+    for {
+      isNew <- underlying.addEra(era)
+      _     <- cacheEra(era).whenA(isNew)
+    } yield isNew
+
+  override def getEra(keyBlockHash: BlockHash): F[Option[Era]] =
+    Sync[F].delay(Option(eraCache.getIfPresent(keyBlockHash))) flatMap {
+      case Some(era) => era.some.pure[F]
+      case None =>
+        underlying.getEra(keyBlockHash) flatMap {
+          case Some(era) => cacheEra(era).as(era.some)
+          case None      => none.pure[F]
+        }
+    }
+
+  override def getChildEras(keyBlockHash: BlockHash) =
+    underlying.getChildEras(keyBlockHash)
+
+  override def getChildlessEras =
+    underlying.getChildlessEras
+}
+
+object CachingEraStorage {
+  def apply[F[_]: Sync](underlying: EraStorage[F]): F[CachingEraStorage[F]] = Sync[F].delay {
+    val cache = CacheBuilder
+      .newBuilder()
+      .expireAfterAccess(1, TimeUnit.HOURS)
+      .build[BlockHash, Era]
+    new CachingEraStorage[F](underlying, cache)
+  }
+}

--- a/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
+++ b/storage/src/main/scala/io/casperlabs/storage/era/EraStorage.scala
@@ -11,7 +11,7 @@ import simulacrum.typeclass
 @typeclass
 trait EraStorage[F[_]] {
 
-  /** Persist an era. Return whether it already existed. */
+  /** Persist an era. Return true if the era was new, false if it already existed. */
   def addEra(era: Era): F[Boolean]
 
   /** Retrieve the era, if it exists, by its key block hash. */


### PR DESCRIPTION
### Overview
It probably hasn't caused any issues but it looked like a discrepancy that `EraObservedBehavior.local` expects that validators who haven't produced any messages are also present in the map it's given, but that wasn't the case. The PR changes it so `DagOperations.latestMessagesInEras` puts these empty sets in to start with. To make sure there's no adverse effect on performance eras are now cached.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-18

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
PR opened against `dev` because this isn't a bug that caused any known adverse behaviour, and we're about to do a new release anyway, no need to patch the current release with it.

I considered putting the extra logic into `EraObservedBehavior.apply` but it would require more substantial changes, not sure it's worth it. Also at a [different place](https://github.com/CasperLabs/CasperLabs/blob/7611fdb981562b423d8e1b900bae5218eb283fb3/casper/src/main/scala/io/casperlabs/casper/dag/DagOperations.scala#L667-L668) empty sets are filtered out explicitly.