### PR TITLE
NO-TICKET Client py stream events fix

### DIFF
--- a/client-py/casperlabs_client/casperlabs_client.py
+++ b/client-py/casperlabs_client/casperlabs_client.py
@@ -866,14 +866,11 @@ class CasperLabsClient:
             account_public_key_hashes = []
         if deploy_hashes is None:
             deploy_hashes = []
-
-        deploy_filter = (
-            casper.StreamEventsRequest.DeployFilter(
-                account_public_key_hashes=[
-                    bytes.fromhex(pk) for pk in account_public_key_hashes
-                ],
-                deploy_hashes=[bytes.fromhex(h) for h in deploy_hashes],
-            ),
+        deploy_filter = casper.StreamEventsRequest.DeployFilter(
+            account_public_key_hashes=[
+                bytes.fromhex(pk) for pk in account_public_key_hashes
+            ],
+            deploy_hashes=[bytes.fromhex(h) for h in deploy_hashes],
         )
 
         yield from self.casper_service.StreamEvents_stream(


### PR DESCRIPTION
Correcting stream_events by removing outer tuple.

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.
