### PR TITLE
NO_TICK Updating Makefile and Dockerfile to fix integration-testing build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,6 @@ cargo-native-packager/%:
 		integration-testing/Dockerfile
 	$(eval IT_PATH = integration-testing)
 	cp -r protobuf $(IT_PATH)/
-	mkdir -p $(IT_PATH)/bundled_contracts
-	cp -r client/src/main/resources/*.wasm $(IT_PATH)/bundled_contracts/
-	mkdir -p $(IT_PATH)/system_contracts
-	cp -r ./execution-engine/target/wasm32-unknown-unknown/release/*.wasm $(IT_PATH)/system_contracts/
 	docker build -f $(IT_PATH)/Dockerfile -t $(DOCKER_USERNAME)/integration-testing:$(DOCKER_LATEST_TAG) $(IT_PATH)/
 	rm -rf $(IT_PATH)/protobuf
 	mkdir -p $(dir $@) && touch $@
@@ -290,10 +286,6 @@ client/src/main/resources/%.wasm: .make/contracts/%
 	mkdir -p $(dir $@)
 	cp execution-engine/target/wasm32-unknown-unknown/release/$*.wasm $@
 
-# Compile a contract and put it in the CLI client so they get packaged with the PyPi package.
-client-py/casperlabs_client/%.wasm: .make/contracts/%
-	cp execution-engine/target/wasm32-unknown-unknown/release/$*.wasm $@
-
 # Compile a contract and put it in the node resources so they get packaged with the JAR.
 node/src/main/resources/chainspec/genesis/%.wasm: .make/contracts/%
 	cp execution-engine/target/wasm32-unknown-unknown/release/$*.wasm $@
@@ -307,7 +299,6 @@ build-client: \
 	.make/sbt-stage/client
 
 build-python-client: \
-	build-client-py-contracts \
 	$(PROTO_SRC) \
 	$(shell find ./client-py/ -name "*.py"|grep -v _grpc.py)
 	client-py/build.sh
@@ -316,11 +307,6 @@ build-client-contracts: \
 	client/src/main/resources/bonding.wasm \
 	client/src/main/resources/unbonding.wasm \
 	client/src/main/resources/transfer_to_account_u512.wasm
-
-build-client-py-contracts: \
-    client-py/casperlabs_client/bonding.wasm \
-    client-py/casperlabs_client/unbonding.wasm \
-    client-py/casperlabs_client/transfer_to_account_u512.wasm
 
 build-node: \
 	.make/sbt-stage/node

--- a/integration-testing/Dockerfile
+++ b/integration-testing/Dockerfile
@@ -17,7 +17,3 @@ COPY ./ /root/integration-testing/
 RUN python3 -m pipenv sync
 RUN mkdir -p /root/protobuf
 COPY ./protobuf/ /root/protobuf/
-RUN mkdir -p /root/bundled_contracts
-COPY ./bundled_contracts/ /root/bundled_contracts/
-RUN mkdir -p /root/system_contracts
-COPY ./system_contracts/ /root/system_contracts/

--- a/integration-testing/client/CasperLabsClient/setup.py
+++ b/integration-testing/client/CasperLabsClient/setup.py
@@ -20,7 +20,6 @@ THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 
 # Directory with Scala client's bundled contracts
 
-CONTRACTS_DIR = f"{THIS_DIRECTORY}/../../../client/src/main/resources"
 PROTOBUF_DIR = f"{THIS_DIRECTORY}/../../../protobuf"
 PROTO_DIR = f"{THIS_DIRECTORY}/casperlabs_client/proto"
 PACKAGE_DIR = f"{THIS_DIRECTORY}/casperlabs_client"


### PR DESCRIPTION
Fixes issues with `make docker-build-all` for integration-testing build.
Removing wasm build for client-py.

- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [x] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

