### PR TITLE
TNET-47: Validator identity in status

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
@@ -21,7 +21,7 @@ import io.casperlabs.storage.era.EraStorage
 import io.casperlabs.ipc.ChainSpec
 
 object StatusInfo {
-  import ByteStringPrettyPrinter.byteStringShow
+  import ByteStringPrettyPrinter._
 
   case class Status(
       version: String,
@@ -99,15 +99,21 @@ object StatusInfo {
         genesisLikeBlocks: List[BlockDetails]
     )
 
+    case class ValidatorDetails(
+        publicKeyHash: String
+    )
+
     type Basic     = Check[Unit]
     type LastBlock = Check[BlockDetails]
     type Peers     = Check[PeerDetails]
     type Eras      = Check[ErasDetails]
     type Genesis   = Check[GenesisDetails]
+    type Validator = Check[ValidatorDetails]
   }
 
   case class CheckList(
       database: Check.Basic,
+      validator: Check.Validator,
       peers: Check.Peers,
       bootstrap: Check.Peers,
       initialSynchronization: Check.Basic,
@@ -132,6 +138,7 @@ object StatusInfo {
     ): StateT[F, Boolean, CheckList] =
       for {
         database               <- database[F](readXa)
+        validator              <- validator(maybeValidatorId)
         peers                  <- peers[F](conf)
         bootstrap              <- bootstrap[F](conf, genesis)
         initialSynchronization <- initialSynchronization[F](getIsSynced)
@@ -144,6 +151,7 @@ object StatusInfo {
         genesisBlock           <- genesisBlock[F](genesis)
         checklist = CheckList(
           database = database,
+          validator = validator,
           peers = peers,
           bootstrap = bootstrap,
           initialSynchronization = initialSynchronization,
@@ -162,6 +170,19 @@ object StatusInfo {
       import doobie.implicits._
       sql"""select 1""".query[Int].unique.transact(readXa).map { _ =>
         Check[Unit](ok = true, message = "Database is readable.")
+      }
+    }
+
+    def validator[F[_]: Sync](maybeValidatorId: Option[ValidatorIdentity]) = Check {
+      maybeValidatorId match {
+        case None =>
+          Check[ValidatorDetails](ok = true, "Running in read-only mode.").pure[F]
+        case Some(id) =>
+          Check(
+            ok = true,
+            "Running in validating mode.",
+            details = ValidatorDetails(id.publicKeyHashBS.show).some
+          ).pure[F]
       }
     }
 


### PR DESCRIPTION
### Overview
@TomVasile wants to see the validator identity in the `/status` endpoint. The argument for why this isn't jeopardising security is that validators should not expose the HTTP endpoints to the internet.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-47

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
Added the `publicKeyHash` not the `publicKey` because all API methods want the hash.
Also added the identity of the last received/created block, no point trying to hide them any more.