### PR TITLE
OP-1456: removing publishing of the python client

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -692,21 +692,6 @@ steps:
   depends_on:
   - package-sbt-artifacts-merge
 
-- name: package-python-client
-  image: "casperlabs/buildenv:latest"
-  commands:
-  - "make build-python-client"
-  - "cp client-py/dist/casperlabs* artifacts/${DRONE_BRANCH}"
-  when:
-    branch:
-    - dev
-    - release-*
-    - master
-    event:
-    - push
-  depends_on:
-    - package-ee
-
 - name: rsync-artifacts
   image: drillster/drone-rsync
   settings:
@@ -735,7 +720,6 @@ steps:
   depends_on:
   - package-sbt-artifacts-merge
   - package-ee
-  - package-python-client
 
 - name: docker-publish
   commands:
@@ -958,17 +942,6 @@ steps:
   depends_on:
   - package-sbt-artifacts-tag
 
-- name: package-python-client-tag
-  image: "casperlabs/buildenv:latest"
-  commands:
-  - "make build-python-client"
-  - "cp client-py/dist/casperlabs* artifacts/${DRONE_BRANCH}"
-  when:
-    ref:
-    - refs/tags/v*
-  depends_on:
-    - package-ee-tag
-
 - name: build-docker-tag
   image: "casperlabs/buildenv:latest"
   commands:
@@ -1058,25 +1031,7 @@ steps:
     ref:
     - refs/tags/v*
   depends_on:
-  - package-python-client-tag
   - generate-metapackages
-
-- name: pypi-publish
-  image: tvasile1012/pypi:latest
-  failure: "ignore"
-  settings:
-    username:
-      from_secret: pypi_user
-    password:
-      from_secret: pypi_pass
-    setupfile: "client-py/setup.py"
-    dist_dir: "client-py/dist/"
-    skip_build: true
-  when:
-    ref:
-    - refs/tags/v*
-  depends_on:
-  - github_publish_release_artifacts
 
 - name: bintray-publish
   image: "casperlabs/buildenv:latest"


### PR DESCRIPTION
### Overview
Python client has been separated out.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/OP-1456

### Complete this checklist before you submit this PR
- [x] This PR contains no more than 200 lines of code, excluding test code.
- [x] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [x] You assigned one person to review this PR.
- [x] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
