### PR TITLE
TNET-37: Don't join eras with unfinialized key blocks.

### DIFF
--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraRuntimeSpec.scala
@@ -295,6 +295,9 @@ class EraRuntimeSpec extends WordSpec with Matchers with Inspectors with TickUti
       case HighwayEvent.CreatedLambdaMessage(msg: Message.Block) => msg
     }.get
 
+    // Make sure the child era key block is finalized so the validator joins.
+    FS.markAsFinalized(childEra.keyBlockHash, Set.empty, Set.empty)
+
     val childRuntime =
       childEraRuntime(childEra, validator.some, leaderSequencer = mockSequencer(leader))
 

--- a/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/EraSupervisorSpec.scala
@@ -43,15 +43,22 @@ class EraSupervisorSpec
           b4 <- e2.block(messageProducer, b2)
           e3 <- e2.addChildEra(b3)
           e4 <- e2.addChildEra(b4)
-          b5 <- e4.block(messageProducer, b3)
+          b5 <- e4.block(messageProducer, b4)
           e5 <- e4.addChildEra(b5)
+
+          // Make sure all key blocks were finalized. This will set the LFB to b5
+          _ <- List(b1, b2, b3, b4, b5).traverse(db.markAsFinalized(_, Set.empty, Set.empty))
+
           // Wait until where e3 and e4 are voting.
           // Their parent eras will have their voting over, and
           // their children should be active.
-          _      <- sleepUntil(conf.toInstant(Ticks(e3.endTick)) plus postEraVotingDuration / 2)
+          _ <- sleepUntil(conf.toInstant(Ticks(e3.endTick)) plus postEraVotingDuration / 2)
+
           active <- EraSupervisor.collectActiveEras[Task](makeRuntime)
         } yield {
-          active.map(_._1.era) should contain theSameElementsAs List(e3, e4, e5)
+          // b3 is not in the main chain if the LFB is b5, so it won't be considered active.
+          val expected = List(e4, e5).map(_.keyBlockHash)
+          active.map(_._1.era.keyBlockHash) should contain theSameElementsAs expected
         }
     }
   }

--- a/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
+++ b/casper/src/test/scala/io/casperlabs/casper/highway/HighwayFixture.scala
@@ -219,6 +219,7 @@ trait HighwayFixture
                      } else {
                        db.lookupUnsafe(keyBlockHash)
                      }
+
           childEra = randomEra
             .withKeyBlockHash(keyBlock.messageHash)
             .withParentKeyBlockHash(era.keyBlockHash)


### PR DESCRIPTION
### Overview
Validators will not start producing blocks in an era if the key block of the era isn't finalized.

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-37

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
This will stall the network if there's a problem with the LFB but Medha and Andreas said that's fine.
