### PR TITLE
NO-TICK: Fix periodic stored faucet check to use account hash

### DIFF
--- a/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
+++ b/casper/src/main/scala/io/casperlabs/casper/finality/votingmatrix/FinalityDetectorVotingMatrix.scala
@@ -95,6 +95,7 @@ class FinalityDetectorVotingMatrix[F[_]: Concurrent: Log: AncestorsStorage] priv
                         .buildString(latestFinalizedBlock)                   -> "latestFinalizedBlock"}"
                     )
                     .void
+                    .whenA(message.parentBlock != latestFinalizedBlock)
               }
         } yield ()
       )

--- a/hack/key-management/docker-gen-keys.sh
+++ b/hack/key-management/docker-gen-keys.sh
@@ -21,13 +21,8 @@ fi
 shift
 
 if [[ -z "$DRONE_BUILD_NUMBER" ]]; then
-    TAG="latest"
-    docker pull casperlabs/key-generator:"$TAG" &> /dev/null || {
-        TAG="dev"
-        #echo "Failed to pull casperlabs/key-generator:latest"
-        #echo "Falling back to casperlabs/key-generator:dev"
-        docker pull casperlabs/key-generator:"$TAG" &> /dev/null
-    }
+    TAG=${CL_VERSION:-"latest"}
+    docker pull casperlabs/key-generator:"$TAG" &> /dev/null
     docker run --rm -it --user $(id -u):$(id -g) -v "$OUTPUT_DIR":/keys casperlabs/key-generator:"$TAG" /keys || {
         echo 'Retrying without overriding UID'
         # Above line doesn't work on macOS + VirtualBox Docker


### PR DESCRIPTION
### Overview
The periodic check which is looking for the presence of the stored faucet contract was using the public key rather than the hash of it, resulting in the following message appearing in the node log every 10 seconds:
```
W 2020-07-09T09:05:46.182  (ErrorInterceptor.scala:44)  …eptor.Forwarder.logAndClose [77:ingress-io-77 ] Closing gRPC call from source=/172.23.0.6:33460 to method=io.casperlabs.node.api.casper.CasperService/GetBlockState with get_code=INVALID_ARGUMENT: desc=Failed to find base key at path: Key::Account(bfa9a7544021e41dcbcf35a891fa845f0f8f8c33e6a167a27ac48da9d675189c): cause=
```

After fixing that I started getting these messages instead:
```
W 2020-07-09T09:43:03.703             (ErrorInterceptor.scala:44)  …eptor.Forwarder.logAndClose [78:ingress-io-78 ] Closing gRPC call from source=/172.23.0.6:35028 to method=io.casperlabs.node.api.casper.CasperService/GetBlockState with get_code=INVALID_ARGUMENT: desc=Name faucet not found in Account at path: Key::Account(440f46e307fbc01d7f6258b49e6fa0109ff37ff680c9c3597cbfd1ec0c308ba4)/faucet: cause=
```

So I changed to logic to submit a deploy to store the faucet contract as soon as we realise it's not present.

### Which JIRA ticket does this PR relate to?
No ticket.

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
I don't understand how the integration tests passed with this bug.
