### PR TITLE
Fixed formatting of README

### DIFF
--- a/explorer/grpc/README.md
+++ b/explorer/grpc/README.md
@@ -5,6 +5,6 @@ There are generated gRPC JavaScript codes and TypeScript declarations that are u
 ## how to build
 On the command line, navigate to root directory of CasperLabs, run 
 
-    ```console
-    make .make/protoc/explorer
-    ```
+```console
+make .make/protoc/explorer
+```


### PR DESCRIPTION
### Overview
Removed the indentation from the markdown as it was causing it to render with the markdown syntax shown instead of the formatted text as intended.

### Which JIRA ticket does this PR relate to?
No Ticket