### PR TITLE
ECO-482: show error message if user change the active key.

### DIFF
--- a/explorer/sdk/src/@types/casperlabsSigner.d.ts
+++ b/explorer/sdk/src/@types/casperlabsSigner.d.ts
@@ -1,8 +1,13 @@
 interface CasperLabsHelper {
   // whether CasperLabs Sign Helper Plugin is ready
   isConnected: () => boolean;
-  // send base16 encoded message to plugin to sign
-  sign: (messageBase16: string) => Promise<string>;
+  /**
+   * send base16 encoded message to plugin to sign
+   *
+   * @param messageBase16 the base16 encoded message that plugin received to sign
+   * @param publicKeyBase64 the base64 encoded public key used to sign the deploy, if set, we will check whether it is the same as the active key for signing the message, otherwise, we won't check.
+   */
+  sign: (messageBase16: string, publicKeyBase64?: string) => Promise<string>;
   // returns base64 encoded public key of user current selected account.
   getSelectedPublicKeyBase64: () => Promise<string | undefined>;
 }

--- a/explorer/sdk/src/lib/Signer.ts
+++ b/explorer/sdk/src/lib/Signer.ts
@@ -23,13 +23,17 @@ export const getSelectedPublicKeyBase64: () => Promise<string | undefined> = () 
 };
 
 /**
- * Send base16 encoded message to plugin to sign
+ * send base16 encoded message to plugin to sign
+ *
+ * @param messageBase16 the base16 encoded message that plugin received to sign
+ * @param publicKeyBase64 the base64 encoded public key used to sign the deploy, if set, we will check whether it is the same as the active key for signing the message, otherwise, we won't check.
  *
  * @throws Error if haven't connected to CasperLabs Signer browser extension.
+ * @throws Error if publicKeyBase64 is not the same as the key that Signer used to sign the message
  */
-export const sign: (messageBase16: string) => Promise<string> = (messageBase16: string) => {
+export const sign: (messageBase16: string, publicKeyBase64?: string) => Promise<string> = (messageBase16: string, publicKeyBase64?: string) => {
   throwIfNotConnected();
-  return window.casperlabsHelper!.sign(messageBase16);
+  return window.casperlabsHelper!.sign(messageBase16, publicKeyBase64);
 };
 
 const throwIfNotConnected = () => {

--- a/explorer/ui/src/containers/DeployContractsContainer.ts
+++ b/explorer/ui/src/containers/DeployContractsContainer.ts
@@ -283,7 +283,7 @@ export class DeployContractsContainer {
     this.signing = true;
     let sigBase64;
     try {
-      sigBase64 = await Signer.sign(encodeBase16(deploy!.getDeployHash_asU8()));
+      sigBase64 = await Signer.sign(encodeBase16(deploy!.getDeployHash_asU8()), publicKeyBase64);
       this.signing = false;
       let signedDeploy = DeployUtil.setSignature(
         deploy,


### PR DESCRIPTION
### Overview

The signer could change active key when approving, but deployHash is bind to the last active key, so we need to show users a message that he needs to resend the request.  And the related updates in Signer is included in https://github.com/CasperLabs/signer/pull/13.

#### back and forward compatibility
Both are supported. 

If users use old version plugin and Clarity from this branch, Signer just ignores the second argument(`publicKeyBase64`).  Because in JavaScript:

```
const f = (a)=> console.log(a);
f("h", "e") // print 'h' and doesn't throw error. 
```
If users use the plugin from this branch and Clarity without updates, the second argument(`publicKeyBase64`) is undefined, the plugin won't check and works as before. 

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/ECO-482

### Complete this checklist before you submit this PR
- [X] This PR contains no more than 200 lines of code, excluding test code.
- [X] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [X] If this PR adds a new feature, it includes tests related to this feature.
- [X] You assigned one person to review this PR.
- [X] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [X] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

### Notes
_Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else._
