### PR TITLE
TNET-48: Fix the bootstrap status check.

### DIFF
--- a/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
+++ b/node/src/main/scala/io/casperlabs/node/api/StatusInfo.scala
@@ -199,16 +199,16 @@ object StatusInfo {
     }
 
     def bootstrap[F[_]: Sync: NodeDiscovery](conf: Configuration, genesis: Block) = Check {
-      val bootstrapNodes = conf.server.bootstrap.map(_.withChainId(genesis.blockHash))
-      NodeDiscovery[F].recentlyAlivePeersAscendingDistance.map(_.toSet).map { nodes =>
-        val connected = bootstrapNodes.filter(nodes)
+      val bootstrapNodeIds = conf.server.bootstrap.map(_.withChainId(genesis.blockHash).id)
+      NodeDiscovery[F].recentlyAlivePeersAscendingDistance.map { peers =>
+        val nodeIds   = peers.map(_.id).toSet
+        val connected = bootstrapNodeIds.filter(nodeIds)
         Check(
-          ok = bootstrapNodes.isEmpty || connected.nonEmpty,
-          message =
-            if (bootstrapNodes.nonEmpty)
-              s"Connected to ${connected.size} of the bootstrap node(s) out of the ${bootstrapNodes.size} configured."
-            else
-              "No bootstraps configured.",
+          ok = bootstrapNodeIds.isEmpty || connected.nonEmpty,
+          message = if (bootstrapNodeIds.nonEmpty)
+            s"Connected to ${connected.size} of the bootstrap node(s) out of the ${bootstrapNodeIds.size} configured."
+          else
+            "No bootstraps configured.",
           details = PeerDetails(count = connected.size).some
         )
       }


### PR DESCRIPTION
### Overview
Fixes the check in the `/status` endpoint that counts the number of connected bootstrap nodes to only use the ID, not the whole `Node` structure as it has for example the version number in it which the configured bootstraps don't have.

```console
$ make node-2/status
docker run --rm --network casperlabs appropriate/curl -s http://node-2:40403/status | jq
{
  "version": "CasperLabs node 0.20.0 (4669312e9241db12f8535afcb0f38cdf40dafbae)",
  "ok": true,
  "checklist": {
...
    "bootstrap": {
      "ok": true,
      "message": "Connected to 2 of the bootstrap node(s) out of the 2 configured.",
      "details": {
        "count": 2
      }
    },
...
```

### Which JIRA ticket does this PR relate to?
https://casperlabs.atlassian.net/browse/TNET-48

### Complete this checklist before you submit this PR
- [ ] This PR contains no more than 200 lines of code, excluding test code.
- [ ] This PR meets [CasperLabs coding standards](https://casperlabs.atlassian.net/wiki/spaces/EN/pages/16842753/Coding+Standards).
- [ ] If this PR adds a new feature, it includes tests related to this feature.
- [ ] You assigned one person to review this PR.
- [ ] Your GitHub account is linked with our [Drone CI](https://drone-auto.casperlabs.io/) system. This is necessary to run tests on this PR.
- [ ] Do not forget to run `bors r+` if GitHub policy is not enforced, e.g. when merging into another feature branch. It may be omitted under some circumstances if this PR intentionally assumes that integration tests will fail but will be fixed with the future PRs.

