### PR TITLE
ECO-646 Update documentation for new key formats.

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -46,7 +46,7 @@ It's a better solution with more flexibility.
 install pyenv
 
 ```
-git clone   ~/.pyenv
+git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bash_profile
 echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc

--- a/docs/DEVNET.md
+++ b/docs/DEVNET.md
@@ -65,7 +65,7 @@ casperlabs_client \
         --host localhost \
         deploy \
         --session <path-to-wasm> \
-        --private-key <path-to-account-private-key>
+        --private-key secret_key.pem
 
 casperlabs_client \
         --host localhost \

--- a/docs/DEVNET.md
+++ b/docs/DEVNET.md
@@ -33,48 +33,48 @@ Once the CasperLabs client is installed, compile a contract, see [CONTRACTS.md](
 Use the CasperLabs client `deploy` sub-command (see example below):
 
   - `--session` is the path to the compiled contract
-  - `--private-key` is the path to the private key file downloaded from [clarity.casperlabs.io](https://clarity.casperlabs.io/) during account creation.
+  - `--private-key` is the path to the secret_key.pem file downloaded from [clarity.casperlabs.io](https://clarity.casperlabs.io/) during account creation.
 
 For example:
 ```shell
-casperlabs-client \
+casperlabs_client \
         --host deploy.casperlabs.io \
         deploy \
         --session <path-to-wasm> \
-        --private-key account.private.key
+        --private-key secret_key.pem
 ```
 
 You can query the outcome of deploys using `casperlabs-client`:
 
 ```shell
-casperlabs-client\
+casperlabs_client\
         --host deploy.casperlabs.io \
         --port 40401 show-deploy <deploy-hash>
 ```
 
-For more details on deploys, see the available CLI arguments with `casperlabs-client deploy --help`, and further documentation in [CONTRACTS.md](CONTRACTS.md).
+For more details on deploys, see the available CLI arguments with `casperlabs_client deploy --help`, and further documentation in [CONTRACTS.md](CONTRACTS.md).
 
 ##### Step 4: Bonding
 
-Follow the instructions [here](NODE.md/#running-a-validator-on-the-casperLabs-network) for connecting to the CasperLabs network. Once bonded, you can use the CasperLabs client with your local node to deploy code and propose blocks on the devnet.
+Follow the instructions [here](NODE.md#running-a-node-on-the-casper-testnet) for connecting to the CasperLabs network. Once bonded, you can use the CasperLabs client with your local node to deploy code and propose blocks on the devnet.
 
 For example:
 
 ```shell
-casperlabs-client \
+casperlabs_client \
         --host localhost \
         deploy \
         --session <path-to-wasm> \
         --private-key <path-to-account-private-key>
 
-casperlabs-client \
+casperlabs_client \
         --host localhost \
         propose
 ```
 
 ##### Step 5: Unbonding
 
-Follow instructions [here](NODE.md#stopping-a-bonded-validator) for stopping a bonded validator.
+Follow instructions [here](NODE.md#stopping-the-node) for stopping a bonded validator.
 
 ## Notes
 This quick start gives the simplest set of instructions for getting started on the CasperLabs devnet. More advanced users may wish to take other approaches to some of the steps listed above.

--- a/docs/KEYS.md
+++ b/docs/KEYS.md
@@ -6,16 +6,12 @@ The CasperLabs platform uses three different sets of keys for different function
 2. A validator must provide an `ed25519` keypair for use as their identity.  If these keys are not provided when the node is started, a node will default to read-only mode.
 3. A DApp developer must provide an `ed25519` or `secp256k1` keypair for their account identity and deploying code.
 
+Note: There is no difference between an ed25519 validator key pair or an ed25519 account key pair.
+
 ## Multiple Key Algorithms
 
-In order to use multiple key types in the system, we are using a hash of the public key and algorithm name.  These are
-generated via recommended key generation methods as `[validator|account]-id` and `[validator|account]-id-hex` files.
-Since this filename previously held the public_key, we now generate `[validator|account]-pk` and 
-`[validator|account]-pk-hex` files for users who may have used this file over the PEM files. 
-
-If you wish to use a previously generated key, the `casperlabs_client account-hash` command will return this hash.
-Commands using keys require `--algorithm` argument if not using the default `ed25519` and account-hash is calculated
-from the public or private key when given in a client command. 
+When keys are generated in PEM format, they include DER encoding which records the algorithm used. The hex version of 
+the public key does not have encoding to identify algorithm. We are using a leading byte to record algorithm used.
 
 ## Generating Node Keys and Validator Keys
 
@@ -26,73 +22,23 @@ In order to run a node or validate, you will need the following files:
 |`node.key.pem`         |A `secp256r1` private key                                                                           |
 |`node.certificate.pem` |The `X.509` certificate containing the `secp256r1` public key paired with `node.key.pem`            |
 |`node-id`              |A value that is used to uniquely identify a node on the network, derived from `node.key.pem`        |
-|`validator-private.pem`|An `ed25519` private key                                                                            |
-|`validator-public.pem` |The `ed25519` public key paired with `validator-private.pem`                                        |
-|`validator-id`         |The base-64 representation of hash of the public key and algorithm                                  |
-|`validator-id-hex`     |The base-16 representation of hash of the public key and algorithm                                  |
-
-| Other Files Generated |Contents                                                                                            |
-|-----------------------|----------------------------------------------------------------------------------------------------|
-|`validator-pk`         |The base-64 representation of `validator-public.pem`                                                |
-|`validator-pk-hex`     |The base-16 representation of `validator-public.pem`                                                |
-
-Data contained in `validator-id` and `validator-id-hex` has moved to `validator-pk` and `validator-pk-hex`. The new
-`pk` files are not used by the system, but are generated with our tool in case validators were using the old style `id`
-files in their workflow.
+|`secret_key.pem`       |An `ed25519` private key                                                                            |
+|`public_key.pem`       |The `ed25519` public key                                                                            |
+|`public_key_hex`       |The base-16 representation of public key with algorithm leading byte                                |
 
 Note also that the `accounts.csv` has changed and will use both the public key and algorithm type.
 
-The recommended method for generating keys is to use the [Docker image](/hack/key-management/Dockerfile) that we provide.
+The recommended methods for generating keys are to use the [Python Client](https://pypi.org/project/casperlabs-client/).
 
 More advanced users may prefer to generate keys directly on their host OS.
 
-### Using Docker  (recommended)
+The `public_key_hex` file contains a leading byte (2 hex characters) to indicate the algorithm as follows:
+   - `01` ed25519
+   - `02` secp256k1
 
-#### Prerequisites
-* [Docker](https://docs.docker.com/install/)
+PEM files generated store the algorithm as part of the DER encoding of data.   
 
-#### Instructions
-
-(from the root of this repo)
-
-```
-mkdir keys
-./hack/key-management/docker-gen-keys.sh keys
-```
-
-You should see the following output:
-
-```
-using curve name prime256v1 instead of secp256r1
-read EC key
-Generate keys: Success
-```
-
-### Using OpenSSL and keccak-256sum
-
-#### Prerequisites
-* [OpenSSL](https://www.openssl.org): v1.1.1 or higher
-* [libkeccak](https://github.com/maandree/libkeccak)
-* [sha3sum](https://github.com/maandree/sha3sum)
-
-If you don't know how to install these prerequisites, you should probably use the [above instructions](#using-docker)
-
-#### Instructions
-
-```
-mkdir keys
-./hack/key-management/gen-keys.sh keys
-```
-
-You should see the following output:
-
-```
-using curve name prime256v1 instead of secp256r1
-read EC key
-Generate keys: Success
-```
-
-### Using casperlabs-client
+### Using casperlabs_client
 
 #### Prerequisites
 * [casperlabs_client](https://github.com/CasperLabs/client-py/blob/dev/README.md)
@@ -112,16 +58,18 @@ Keys successfully created in directory: /tmp/keys
 
 ## Generating Account Keys
 
-(for DApp Developers)
+### Using CLarity (for DApp Developers)
 
-Currently, the recommended method for generating account keys is to use the [CasperLabs Explorer](https://clarity.casperlabs.io).
-When generating a key pair in Clarity, you will be prompted to save two files from your browser with default filename shown below:
+Currently, the recommended method for generating account keys is to use [CLarity](https://clarity.casperlabs.io).
+When generating a key pair in Clarity, you will be prompted to save three files from your browser with default filename shown below:
 
-|File                         |Contents                                                                                          |
-|-----------------------------|--------------------------------------------------------------------------------------------------|
-|[key_name_given].private.key | An 'ed25519' private key in base64 format.  No exact equivalent exists in key generated below.   |
-|[key_name_given].public.key  | An 'ed25519' public key in base64 format. Similar to `account-pk` below.                         |
+|File                         |Contents                                                           |
+|-----------------------------|-------------------------------------------------------------------|
+|[key_name]_secret_key.pem    | An 'ed25519' private key in PEM format.                           |
+|[key_name]_public_key.pem    | An 'ed25519' public key in PEM format.                            |
+|[key_name]_public_key_hex    | An 'ed25519' public key in hex format with leading algorithm byte |
 
+### Generating Keys on Local Machine
 
 These instructions are provided for reference and advanced use-cases.
 
@@ -129,27 +77,26 @@ In order to deploy a contract on the network, you will need the following files:
 
 |File                 |Contents                                                                                          |
 |---------------------|--------------------------------------------------------------------------------------------------|
-|`account-private.pem`|An `ed25519` private key                                                                          |
-|`account-public.pem` |The `ed25519` public key paired with `account-private.pem`                                        |
-|`account-id`         |The base-64 representation of hash of public key and algorithm                                    |
-|`account-id-hex`     |The base-16 representation of hash of public key and algorithm                                    |
+|`secret_key.pem`       |An `ed25519` private key                                                                            |
+|`public_key.pem`       |The `ed25519` public key                                                                            |
+|`public_key_hex`       |The base-16 representation of public key with algorithm leading byte                                |
 
-|Other Files Generated|Contents                                                                                          |
-|---------------------|--------------------------------------------------------------------------------------------------|
-|`account-pk`         |The base-64 representation of `account-public.pem`                                                |
-|`account-pk-hex`     |The base-16 representation of `account-public.pem`                                                |
-
-
-### Using Docker
+### Using casperlabs_client
 
 #### Prerequisites
-* [Docker](https://docs.docker.com/install/)
+* [casperlabs_client](https://github.com/CasperLabs/client-py/blob/dev/README.md)
 
 #### Instructions
 
 ```
-mkdir account-keys
-./hack/key-management/docker-gen-account-keys.sh account-keys
+mkdir /tmp/keys
+casperlabs_client validator-keygen /tmp/keys
+```
+
+You should see the following output:
+
+```
+Keys successfully created in directory: /tmp/keys
 ```
 
 ### Using OpenSSL
@@ -160,26 +107,7 @@ mkdir account-keys
 #### Instructions
 
 ```
-openssl genpkey -algorithm Ed25519 -out account-private.pem
-openssl pkey -in account-private.pem -pubout -out account-public.pem
-openssl pkey -outform DER -pubout -in account-private.pem | tail -c +13 | openssl base64 > account-id
-cat account-id | openssl base64 -d | hexdump -ve '/1 "%02x" ' | awk '{print $0}' > account-id-hex
-```
-
-### Using casperlabs-client
-
-#### Prerequisites
-* [casperlabs_client](https://github.com/CasperLabs/client-py/blob/dev/README.md)
-
-#### Instructions
-
-```
-mkdir /tmp/keys
-casperlabs_client keygen /tmp/keys
-```
-
-You should see the following output:
-
-```
-Keys successfully created in directory: /tmp/keys
+openssl genpkey -algorithm Ed25519 -out secret_key.pem
+openssl pkey -in secret_key.pem -pubout -out public_key.pem
+openssl pkey -outform DER -pubout -in secret_key.pem | tail -c +13 | openssl base64 | hexdump -ve '/1 "%02x"' | awk '{print "01" $0}' > public_key_hex
 ```


### PR DESCRIPTION
Correct casperlabs-client to casperlabs_client in examples.
Updated key documentation.
Updated ssl generation instructions to provide leading byte and filenames.
Updated old broken refs.

https://casperlabs.atlassian.net/browse/ECO-646